### PR TITLE
Switch candidate system specs to use one login

### DIFF
--- a/spec/support/test_helpers/one_login_helper.rb
+++ b/spec/support/test_helpers/one_login_helper.rb
@@ -34,4 +34,5 @@ module OneLoginHelper
     visit candidate_interface_create_account_or_sign_in_path
     click_link_or_button 'Continue'
   end
+  alias i_am_signed_in_with_one_login :given_i_am_signed_in_with_one_login
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
   include CandidateHelper
 
   it 'displays the adviser sign up CTA when eligible' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_enqueued_jobs_are_not_performed
     and_the_adviser_sign_up_feature_flag_is_disabled
     and_analytics_is_enabled
@@ -22,11 +22,6 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
     when_i_remove_my_degrees
     and_i_visit_the_application_form_page
     then_i_do_not_see_the_adviser_cta
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
   end
 
   def and_enqueued_jobs_are_not_performed
@@ -62,7 +57,7 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
   end
 
   def when_i_have_an_eligible_application
-    create(:application_form_eligible_for_adviser, candidate: @candidate)
+    create(:application_form_eligible_for_adviser, candidate: @current_candidate)
   end
 
   def then_i_do_see_the_adviser_cta
@@ -74,7 +69,7 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
   end
 
   def when_i_remove_my_degrees
-    @candidate.current_application.application_qualifications.degrees.destroy_all
+    @current_candidate.current_application.application_qualifications.degrees.destroy_all
   end
 
   def then_i_do_not_see_the_adviser_cta

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   include CandidateHelper
 
   it 'redirects back to review their application' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_rails_cache_is_enabled
     and_analytics_is_enabled
     and_enqueued_jobs_are_not_performed
@@ -31,11 +31,6 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
     and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
     and_an_adviser_sign_up_job_is_enqueued
     and_the_sign_up_is_tracked
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
   end
 
   def and_rails_cache_is_enabled
@@ -72,7 +67,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def and_i_have_an_eligible_application
-    @application_form = create(:application_form_eligible_for_adviser, candidate: @candidate)
+    @application_form = create(:application_form_eligible_for_adviser, candidate: @current_candidate)
   end
 
   def and_i_visit_your_details_page

--- a/spec/system/candidate_interface/application_choices_page/rejected_applications/reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/application_choices_page/rejected_applications/reasons_for_rejection_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
   include CandidateHelper
 
   scenario 'Application rejected with reasons_for_rejection is visible' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_a_rejected_application
 
     when_i_visit_my_applications
@@ -13,12 +13,8 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
     and_i_see_the_rejection_feedback_form
   end
 
-  def given_i_am_signed_in
-    login_as(@candidate = create(:candidate))
-  end
-
   def and_i_have_a_rejected_application
-    @application_choice = create(:application_choice, :reasons_for_rejection, application_form: create(:application_form, candidate: @candidate))
+    @application_choice = create(:application_choice, :reasons_for_rejection, application_form: create(:application_form, candidate: @current_candidate))
   end
 
   def then_i_see_my_application_shows_the_application_rejection_reason

--- a/spec/system/candidate_interface/application_choices_page/rejected_applications/rejection_reason_spec.rb
+++ b/spec/system/candidate_interface/application_choices_page/rejected_applications/rejection_reason_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
   include CandidateHelper
 
   scenario 'Application rejected with rejection_reason is visible' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_a_rejected_application
     when_i_visit_my_applications
     and_i_click_to_view_my_application
@@ -12,12 +12,8 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
     and_i_see_the_rejection_feedback_form
   end
 
-  def given_i_am_signed_in
-    login_as(@candidate = create(:candidate))
-  end
-
   def and_i_have_a_rejected_application
-    @application_choice = create(:application_choice, :rejected_reason, application_form: create(:application_form, candidate: @candidate))
+    @application_choice = create(:application_choice, :rejected_reason, application_form: create(:application_form, candidate: @current_candidate))
   end
 
   def then_i_see_my_application_shows_the_application_rejection_reason

--- a/spec/system/candidate_interface/application_choices_page/rejected_applications/rejection_reasons_spec.rb
+++ b/spec/system/candidate_interface/application_choices_page/rejected_applications/rejection_reasons_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
   include CandidateHelper
 
   scenario 'Application rejected with rejection_reasons is visible' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_a_rejected_application
     when_i_visit_my_applications
     and_i_click_to_view_my_application
@@ -12,12 +12,8 @@ RSpec.describe 'CandidateInterface ApplicationChoice index' do
     and_i_see_the_rejection_feedback_form
   end
 
-  def given_i_am_signed_in
-    login_as(@candidate = create(:candidate))
-  end
-
   def and_i_have_a_rejected_application
-    @application_choice = create(:application_choice, :rejected_reasons, application_form: create(:application_form, candidate: @candidate))
+    @application_choice = create(:application_choice, :rejected_reasons, application_form: create(:application_form, candidate: @current_candidate))
   end
 
   def then_i_see_my_application_shows_the_application_rejection_reason

--- a/spec/system/candidate_interface/candidate_session_timeout_spec.rb
+++ b/spec/system/candidate_interface/candidate_session_timeout_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe 'Candidate viewing booked interviews' do
   include ActiveSupport::Testing::TimeHelpers
 
   scenario 'Candidate is signed out after 7 days if they are not active' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_seven_days_pass
     when_i_click_on_your_details
     then_i_see_the_login_page
   end
 
   scenario 'The Candidate is signed out 7 days after they are last active' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_three_days_pass
     when_i_click_on_your_details
     then_i_see_my_details
@@ -24,11 +24,6 @@ RSpec.describe 'Candidate viewing booked interviews' do
     and_seven_days_pass
     when_i_click_on_your_details
     then_i_see_the_login_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-    visit candidate_interface_details_path
   end
 
   def and_seven_days_pass

--- a/spec/system/candidate_interface/candidate_viewing_booked_interviews_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_booked_interviews_spec.rb
@@ -4,17 +4,13 @@ RSpec.describe 'Candidate viewing booked interviews' do
   include CandidateHelper
 
   scenario 'Candidate has submitted their application and has interview slots booked' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_interviews_booked
     and_i_have_interviews_cancelled
     when_i_visit_my_applications
     and_i_click_to_view_my_application
     then_i_can_see_details_about_my_booked_interviews
     and_i_can_not_see_the_cancelled_interviews
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_interviews_booked

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
   end
 
   def when_i_sign_in_again
-    given_i_am_signed_in_with_one_login
+    click_link_or_button 'Sign out'
+    i_am_signed_in_with_one_login
   end
 
   def and_i_visit_the_application_dashboard

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
   include CandidateHelper
 
   it 'Candidate can submit in next cycle with cycle switcher after apply opens' do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     when_i_have_an_unsubmitted_application_without_a_course
     and_the_cycle_switcher_set_to_apply_opens
 
@@ -29,11 +29,6 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
     and_my_application_is_awaiting_provider_decision
   end
 
-  def given_i_am_signed_in_as_a_candidate
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def when_i_have_an_unsubmitted_application_without_a_course
     @application_form = create(
       :completed_application_form,
@@ -41,7 +36,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
       :with_degree,
       date_of_birth: Date.new(1964, 9, 1),
       submitted_at: nil,
-      candidate: @candidate,
+      candidate: @current_candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
       references_count: 0,
     )
@@ -65,8 +60,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
   end
 
   def when_i_sign_in_again
-    logout
-    login_as(@candidate)
+    given_i_am_signed_in_with_one_login
   end
 
   def and_i_visit_the_application_dashboard
@@ -140,7 +134,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
   end
 
   def and_my_application_is_awaiting_provider_decision
-    application_choice = @candidate.current_application.application_choices.first
+    application_choice = @current_candidate.current_application.application_choices.first
     expect(application_choice.status).to eq('awaiting_provider_decision')
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe 'Carry over unsubmitted application' do
   include CandidateHelper
 
   scenario 'Candidate carries over their application to the new cycle' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_unsubmitted_application_with_references
 
     when_the_apply_deadline_passes
     and_i_sign_in_again
-    and_i_visit_the_application_dashboard
     and_i_have_to_carry_my_application_over
     then_i_see_the_references_section
     and_references_is_marked_as_incomplete
@@ -21,13 +20,8 @@ RSpec.describe 'Carry over unsubmitted application' do
     then_i_am_on_your_details_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_unsubmitted_application_with_references
-    @application_form = create(:completed_application_form, recruitment_cycle_year: 2024, submitted_at: nil, candidate: @candidate)
+    @application_form = create(:completed_application_form, recruitment_cycle_year: 2024, submitted_at: nil, candidate: @current_candidate)
 
     @pending_reference = create(:reference, :feedback_requested, application_form: @application_form)
     @declined_reference = create(:reference, :feedback_refused, application_form: @application_form)
@@ -40,9 +34,9 @@ RSpec.describe 'Carry over unsubmitted application' do
   end
 
   def and_i_sign_in_again
-    logout
+    click_link_or_button 'Sign out'
 
-    login_as(@candidate)
+    given_i_am_signed_in_with_one_login
   end
 
   def and_i_have_to_carry_my_application_over
@@ -62,10 +56,9 @@ RSpec.describe 'Carry over unsubmitted application' do
     click_link_or_button 'References to be requested if you accept an offer'
   end
 
-  def and_i_visit_the_application_dashboard
-    visit root_path
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_interstitial_path
   end
-  alias_method :when_i_visit_the_application_dashboard, :and_i_visit_the_application_dashboard
 
   def and_references_is_marked_as_incomplete
     expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer incomplete')

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -73,6 +73,7 @@ private
   end
 
   def when_i_sign_in_again
+    click_link_or_button 'Sign out'
     given_i_am_signed_in_with_one_login
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Carry over application and submit new application choices', time
   include CandidateHelper
 
   it 'Candidate carries over unsubmitted application with a course to new cycle' do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends
     and_the_cancel_unsubmitted_applications_worker_runs
@@ -36,11 +36,6 @@ RSpec.describe 'Carry over application and submit new application choices', time
 
 private
 
-  def given_i_am_signed_in_as_a_candidate
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def when_i_have_an_unsubmitted_application
     @application_form = create(
       :completed_application_form,
@@ -48,7 +43,7 @@ private
       :with_gcses,
       :with_degree,
       submitted_at: nil,
-      candidate: @candidate,
+      candidate: @current_candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
       references_count: 0,
     )
@@ -78,9 +73,7 @@ private
   end
 
   def when_i_sign_in_again
-    logout
-    login_as(@candidate)
-    visit root_path
+    given_i_am_signed_in_with_one_login
   end
 
   def and_i_visit_the_application_dashboard
@@ -200,6 +193,6 @@ private
   end
 
   def application_choice
-    @candidate.current_application.application_choices.first
+    @current_candidate.current_application.application_choices.first
   end
 end

--- a/spec/system/candidate_interface/course_selection/backlinks_spec.rb
+++ b/spec/system/candidate_interface/course_selection/backlinks_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate edits course choices' do
   include CourseOptionHelpers
 
   it 'Candidate edit their applications' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_is_a_course_with_one_course_option
     and_there_is_a_course_with_multiple_course_options
     and_there_is_a_course_with_both_study_modes_but_one_site
@@ -22,10 +22,6 @@ RSpec.describe 'Candidate edits course choices' do
     # back during form choice
     and_i_click_the_back_to_application_link
     then_i_see_the_application_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_there_is_a_course_with_one_course_option

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_course_confirm_selection_page
@@ -39,10 +39,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_the_course_confirm_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_full_course_path
@@ -44,10 +44,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_the_full_course_path

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_course_confirm_selection_page
@@ -62,10 +62,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_the_course_confirm_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_course_confirm_selection_page
@@ -74,10 +74,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_the_course_confirm_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_already_have_this_application
 
     when_i_follow_a_link_from_find
@@ -45,10 +45,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_your_applications_tab

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_already_have_max_applications
 
     when_i_follow_a_link_from_find
@@ -42,10 +42,6 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
       providerCode: @provider.code,
       courseCode: @course.code,
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_am_redirected_to_your_applications_tab

--- a/spec/system/candidate_interface/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Changing a course' do
   include CandidateHelper
 
   it 'Candidate changes course to one they have already been rejected from twice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
     and_i_have_two_rejected_applications_to_a_course
 
@@ -20,11 +20,6 @@ RSpec.describe 'Changing a course' do
     then_i_am_on_the_reached_reapplication_limit_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
-  end
-
   def and_there_are_course_options
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
@@ -34,8 +29,8 @@ RSpec.describe 'Changing a course' do
   end
 
   def and_i_have_two_rejected_applications_to_a_course
-    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
-    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @current_candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @current_candidate.current_application)
   end
 
   def and_i_choose_the_same_provider

--- a/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate edits their choice section' do
   include CandidateHelper
 
   it 'Candidate deletes and adds additional courses' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_applications
 
     when_i_visit_the_course_choices_page
@@ -19,7 +19,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   it 'Candidate deletes course choice from the review page' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_applications
 
     when_i_visit_the_course_choice_review_page
@@ -37,13 +37,8 @@ RSpec.describe 'Candidate edits their choice section' do
     and_my_submitted_choice_is_displayed
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_applications
-    @application_form = create(:application_form, candidate: @candidate, course_choices_completed: true)
+    @application_form = create(:application_form, candidate: @current_candidate, course_choices_completed: true)
     @first_application_choice = create(:application_choice, :unsubmitted, application_form: @application_form)
     @second_application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
     @application_choice = @first_application_choice

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate edits course choices' do
   include CourseOptionHelpers
 
   it 'Candidate edit their applications' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_is_a_course_with_one_course_option
     and_there_is_a_course_with_multiple_course_options
     and_there_is_a_course_with_both_full_time_and_part_time_but_one_site
@@ -70,10 +70,6 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_choose_part_time
     then_i_am_on_the_application_choice_review_page
     and_i_see_the_updated_full_time_or_part_time_section_for_the_third_choice
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_there_is_a_course_with_one_course_option

--- a/spec/system/candidate_interface/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already been rejected from twice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
     and_i_have_two_rejected_application_to_a_course
 
@@ -20,11 +20,6 @@ RSpec.describe 'Selecting a course' do
     then_i_am_on_the_course_choice_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
-  end
-
   def and_there_are_course_options
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
@@ -32,8 +27,8 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_have_two_rejected_application_to_a_course
-    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
-    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @current_candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @current_candidate.current_application)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_reapplying_to_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_reapplying_to_a_course_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they are reapplying to' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_is_one_course_option
     and_i_have_a_rejected_application
 
@@ -16,10 +16,6 @@ RSpec.describe 'Selecting a course' do
 
     and_i_choose_the_same_course
     then_i_am_on_the_application_choice_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate(candidate: current_candidate)
   end
 
   def and_there_is_one_course_option

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course choice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     when_i_visit_the_site
@@ -45,10 +45,6 @@ RSpec.describe 'Selecting a course' do
     then_i_see_the_provider_name_in_caption
     then_the_course_choices_am_a_dropdown
     and_the_select_box_has_no_value_selected
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_there_are_course_options

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a study mode' do
   include CandidateHelper
 
   scenario 'Candidate selects different study modes' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     when_i_select_a_part_time_course
@@ -18,10 +18,6 @@ RSpec.describe 'Selecting a study mode' do
     and_i_visit_my_course_choices_page
     then_the_site_is_resolved_automatically_and_i_see_the_course_choice
     and_the_application_is_not_school_placement_auto_selected
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_there_are_course_options

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course that is closed' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_the_course_has_been_closed
 
     when_i_visit_the_site
@@ -22,11 +22,6 @@ RSpec.describe 'Selecting a course' do
 
     when_i_click_back
     then_i_be_on_the_course_choice_page
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
   end
 
   def and_the_course_has_been_closed

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
   include CandidateHelper
 
   it 'Candidate skips the school selection' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     when_i_visit_the_site
@@ -17,10 +17,6 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
 
     then_i_am_on_the_application_choice_review_page
     and_the_application_is_school_placement_auto_selected
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course with multiple sites' do
   include CandidateHelper
 
   it 'Candidate selects a course choice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     when_i_visit_the_site
@@ -22,10 +22,6 @@ RSpec.describe 'Selecting a course with multiple sites' do
     and_i_choose_a_location
 
     then_i_am_on_the_application_choice_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course with multiple study modes and sites when the 
   include CandidateHelper
 
   it 'Candidate skips the school selection', time: CycleTimetableHelper.mid_cycle(2025) do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     when_i_visit_the_site
@@ -17,10 +17,6 @@ RSpec.describe 'Selecting a course with multiple study modes and sites when the 
     and_i_choose_part_time
 
     then_i_am_on_the_application_choice_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_site_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_site_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Selecting a course', :js do
 
   # Regression test for DuplicateCourseSelection to avoid ActiveRecord::RecordInvalid
   it 'Candidate selects a course they have already applied to' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
 
     window_1 = windows.first
@@ -35,11 +35,6 @@ RSpec.describe 'Selecting a course', :js do
 
   def then_i_am_on_the_application_choice_duplicate_page
     expect(page).to have_content('You already have an application for')
-  end
-
-  def given_i_am_signed_in
-    @current_candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @current_candidate)
   end
 
   def and_there_are_course_options

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already applied to' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
     and_i_have_an_application_to_a_course
 
@@ -20,11 +20,6 @@ RSpec.describe 'Selecting a course' do
     then_i_am_on_the_course_choice_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
-  end
-
   def and_there_are_course_options
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
@@ -36,7 +31,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_have_an_application_to_a_course
-    create(:application_choice, :unsubmitted, course_option: @course.course_options.first, application_form: @candidate.current_application)
+    create(:application_choice, :unsubmitted, course_option: @course.course_options.first, application_form: @current_candidate.current_application)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already applied to when editing' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
     and_i_have_two_applications
 
@@ -17,11 +17,6 @@ RSpec.describe 'Selecting a course' do
 
     when_i_click_back
     then_i_am_on_the_course_choice_page
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
   end
 
   def and_i_click_to_change_course
@@ -46,8 +41,8 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_have_two_applications
-    @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @candidate.current_application)
-    @application_two = create(:application_choice, :unsubmitted, course_option: @course_two.course_options.first, application_form: @candidate.current_application)
+    @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @current_candidate.current_application)
+    @application_two = create(:application_choice, :unsubmitted, course_option: @course_two.course_options.first, application_form: @current_candidate.current_application)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate is redirected when visiting later steps on a duplicate course selection' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
+
     and_there_is_one_course_option_with_both_study_modes_and_two_sites
     and_i_have_an_unsubmitted_application_to_the_course
 
@@ -22,11 +23,6 @@ RSpec.describe 'Selecting a course' do
     then_i_am_redirected_to_the_duplicate_course_selection_step
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    create_and_sign_in_candidate(candidate: @candidate)
-  end
-
   def and_there_is_one_course_option_with_both_study_modes_and_two_sites
     provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
 
@@ -37,7 +33,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_have_an_unsubmitted_application_to_the_course
-    @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @candidate.current_application)
+    @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @current_candidate.current_application)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Add Other qualification' do
   include EFLHelper
 
   scenario 'Candidate completes EFL section with details of a qualification type we do not provide an option for' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
@@ -14,10 +14,6 @@ RSpec.describe 'Add Other qualification' do
     then_i_can_review_my_qualification
     and_i_can_edit_my_qualification
     and_i_can_complete_this_section
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_select_the_options_for_other_qualification

--- a/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe 'Candidate account locking' do
     then_i_am_redirected_to_the_account_locked_page
   end
 
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
   def and_i_visit_the_site
     visit candidate_interface_details_path
   end

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering "Why do you want to be a teacher?"' do
   include CandidateHelper
 
   scenario 'Candidate submits why they want to be a teacher' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_becoming_a_teacher
@@ -24,10 +24,6 @@ RSpec.describe 'Entering "Why do you want to be a teacher?"' do
 
     when_i_click_on_becoming_a_teacher
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate updates their contact information from an internationa
   include CandidateHelper
 
   scenario 'Candidate submits their contact information' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_already_filled_in_an_international_address
     and_i_visit_the_site
 
@@ -14,10 +14,6 @@ RSpec.describe 'Candidate updates their contact information from an internationa
     when_i_change_to_an_international_address
     and_i_click_the_back_button
     then_i_do_not_have_the_option_to_complete
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_already_filled_in_an_international_address

--- a/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe 'Candidate changing UK GCSE to international qualification' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
-    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -46,10 +45,6 @@ RSpec.describe 'Candidate changing UK GCSE to international qualification' do
     then_i_see_the_review_page_with_new_details
   end
 
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
   def and_i_click_on_the_maths_gcse_link
     click_link_or_button 'Maths GCSE or equivalent'
   end
@@ -60,10 +55,6 @@ RSpec.describe 'Candidate changing UK GCSE to international qualification' do
 
   def and_i_click_save_and_continue
     click_link_or_button t('save_and_continue')
-  end
-
-  def when_i_visit_the_candidate_application_page
-    visit root_path
   end
 
   def then_i_see_the_add_gcse_maths_page

--- a/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe 'Candidate changing their GCSE type' do
   include CandidateHelper
 
   scenario 'Candidate completes their maths GCSE and then changes the type to missing and then back to a GCSE' do
-    given_i_am_signed_in
-
-    when_i_visit_the_candidate_application_page
+    given_i_am_signed_in_with_one_login
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -31,10 +29,6 @@ RSpec.describe 'Candidate changing their GCSE type' do
     when_i_select_gcse_option
     and_i_click_save_and_continue
     then_i_see_add_grade_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_candidate_application_page

--- a/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe 'Candidate changing their GCSE type' do
     then_i_see_add_grade_page
   end
 
-  def when_i_visit_the_candidate_application_page
-    visit root_path
-  end
-
   def and_i_click_on_the_maths_gcse_link
     click_link_or_button 'Maths GCSE or equivalent'
   end

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Choosing no volunteering and school experience' do
   include CandidateHelper
 
   scenario 'Candidate chooses no volunteering and school experience' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_volunteering_with_children_and_young_people
@@ -16,10 +16,6 @@ RSpec.describe 'Choosing no volunteering and school experience' do
     when_i_choose_no_experience
     and_i_submit_the_volunteering_experience_form
     then_i_see_how_to_get_school_experience
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidates academic and other relevant qualifications' do
   include CandidateHelper
 
   scenario 'Candidate updates and deletes qualifications in a completed academic and other relevant qualifications section' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_other_qualifications_section
 
     when_i_visit_the_application_page
@@ -33,13 +33,8 @@ RSpec.describe 'Candidates academic and other relevant qualifications' do
     then_the_other_qualifications_section_is_marked_as_incomplete
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_completed_the_other_qualifications_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @current_candidate)
     create(:other_qualification, application_form: @application_form)
     @application_form.update!(other_qualifications_completed: true)
   end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate edits their volunteering section' do
   include CandidateHelper
 
   scenario 'Candidate adds or deletes a role after completing the section' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_volunteering_section
 
     when_i_visit_the_application_page
@@ -32,13 +32,8 @@ RSpec.describe 'Candidate edits their volunteering section' do
     then_i_will_be_see_the_volunteering_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_completed_the_volunteering_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @current_candidate)
     create(:application_volunteering_experience, experienceable: @application_form)
     @application_form.update!(volunteering_completed: true)
   end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate edits their volunteering section' do
   include CandidateHelper
 
   scenario 'Candidate adds or deletes a role after completing the section' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_volunteering_section
 
     when_i_visit_the_application_page
@@ -34,13 +34,8 @@ RSpec.describe 'Candidate edits their volunteering section' do
     then_i_will_be_prompted_to_add_new_experience
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_completed_the_volunteering_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @current_candidate)
     create(:application_volunteering_experience,
            experienceable: @application_form,
            start_date: 10.months.ago,

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their contact information' do
   include CandidateHelper
 
   scenario 'Candidate submits their contact information' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_contact_information
@@ -53,10 +53,6 @@ RSpec.describe 'Entering their contact information' do
 
     when_i_click_on_contact_information
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their disability information' do
   include CandidateHelper
 
   scenario 'Candidate submits their disability information' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_enter_equality_and_diversity_section
@@ -32,10 +32,6 @@ RSpec.describe 'Entering their disability information' do
 
     when_i_click_on_training_with_a_disability
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate entering GCSE English details' do
   include CandidateHelper
 
   scenario 'Candidate submits their GCSE English qualification' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_wish_to_apply_to_a_course_that_requires_gcse_english
     and_i_visit_the_site
 
@@ -48,10 +48,6 @@ RSpec.describe 'Candidate entering GCSE English details' do
 
     when_i_enter_a_new_grade
     then_i_see_my_new_grade_on_the_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_wish_to_apply_to_a_course_that_requires_gcse_english

--- a/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe 'Entering their equality and diversity information' do
   end
 
   def given_i_am_signed_in
-    create_and_sign_in_candidate
-    current_candidate.current_application.update!(first_nationality: 'British', date_of_birth: Time.zone.now)
+    given_i_am_signed_in_with_one_login
+    @current_candidate.current_application.update!(first_nationality: 'British', date_of_birth: Time.zone.now)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate entering GCSE Science details' do
   include CandidateHelper
 
   scenario 'Candidate submits their Science GCSE award' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_wish_to_apply_to_a_course_that_requires_gcse_science
     and_i_visit_the_site
 
@@ -29,10 +29,6 @@ RSpec.describe 'Candidate entering GCSE Science details' do
     when_i_fill_in_the_year
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_new_details
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_wish_to_apply_to_a_course_that_requires_gcse_science

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate specifies GCSE maths with "Other UK qualification" type' do
-    given_i_am_signed_in
-    and_i_visit_the_candidate_application_page
+    given_i_am_signed_in_with_one_login
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -17,10 +16,6 @@ RSpec.describe 'Candidate entering GCSE details' do
     and_i_visit_the_gcse_review_page
 
     then_i_see_the_review_page_with_correct_details
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_click_on_the_maths_gcse_link

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate entering GCSE Science details' do
   include CandidateHelper
 
   scenario 'Candidate submits their Science GCSE award' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_wish_to_apply_to_a_course_that_requires_gcse_science
     and_i_visit_the_site
 
@@ -27,10 +27,6 @@ RSpec.describe 'Candidate entering GCSE Science details' do
     then_i_enter_a_valid_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_year_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_wish_to_apply_to_a_course_that_requires_gcse_science

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -73,10 +73,6 @@ RSpec.describe 'Candidate entering GCSE details' do
 
   def when_i_do_not_select_any_gcse_option; end
 
-  def when_i_visit_the_candidate_application_page
-    visit root_path
-  end
-
   def then_i_see_the_add_gcse_maths_page
     expect(page).to have_content 'What type of qualification in maths do you have?'
   end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
-    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -58,10 +57,6 @@ RSpec.describe 'Candidate entering GCSE details' do
 
     when_i_choose_to_return_later
     then_i_am_returned_to_the_application_form_details
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_click_on_the_maths_gcse_link

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate submits' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
-    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     and_i_select_i_do_not_have_yet
     and_i_click_save_and_continue
@@ -30,14 +29,6 @@ RSpec.describe 'Candidate entering GCSE details' do
     and_i_provide_my_details
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_the_updated_details
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
-  def when_i_visit_the_candidate_application_page
-    visit root_path
   end
 
   def given_i_am_not_signed_in; end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -51,10 +51,6 @@ RSpec.describe 'Candidate entering GCSE details but without a pass grade' do
     click_link_or_button t('save_and_continue')
   end
 
-  def when_i_visit_the_candidate_application_page
-    visit root_path
-  end
-
   def then_i_see_the_add_gcse_maths_page
     expect(page).to have_content 'What type of qualification in maths do you have?'
   end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe 'Candidate entering GCSE details but without a pass grade' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
-    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -34,10 +33,6 @@ RSpec.describe 'Candidate entering GCSE details but without a pass grade' do
     when_i_click_to_change_grade
     and_i_change_to_a_fail_grade
     then_i_am_prompted_to_explain_how_i_can_improve_this_grade
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_click_on_the_maths_gcse_link

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe 'Candidate entering Non UK GCSE equivalency details' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths Non UK GCSE equivalency details and then updates them' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
-    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -54,15 +53,7 @@ RSpec.describe 'Candidate entering Non UK GCSE equivalency details' do
     then_i_see_the_maths_gcse_is_completed
   end
 
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
   def given_i_am_not_signed_in; end
-
-  def when_i_visit_the_candidate_application_page
-    visit root_path
-  end
 
   def and_i_click_on_the_maths_gcse_link
     click_link_or_button 'Maths GCSE or equivalent'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering interview preferences' do
   include CandidateHelper
 
   scenario 'Candidate submits their interview preferences' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_interview_preferences
@@ -30,10 +30,6 @@ RSpec.describe 'Entering interview preferences' do
 
     when_i_click_on_interview_preferences
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their other qualifications' do
   include CandidateHelper
 
   scenario 'Candidate submits their BTEC qualification' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_other_qualifications
@@ -27,10 +27,6 @@ RSpec.describe 'Entering their other qualifications' do
 
     when_i_submit_gcse_details
     then_i_see_my_gcse_on_the_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their other qualifications' do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications after choosing not to provide any' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
     then_i_see_the_other_qualifications_section_is_incomplete
 
@@ -41,10 +41,6 @@ RSpec.describe 'Entering their other qualifications' do
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
     then_i_see_that_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their other qualifications', :mid_cycle do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_other_qualifications
@@ -97,10 +97,6 @@ RSpec.describe 'Entering their other qualifications', :mid_cycle do
 
     when_i_click_back_to_your_details
     then_i_see_the_your_details_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their personal details' do
   include CandidateHelper
 
   scenario 'Candidate submits their personal details' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_personal_information
@@ -38,10 +38,6 @@ RSpec.describe 'Entering their personal details' do
 
     when_i_click_on_personal_information
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their suitability to work with children' do
   include CandidateHelper
 
   scenario 'Candidate declares any safeguarding issues' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_visit_the_site
     then_i_see_declaring_any_safeguarding_issues
 
@@ -29,10 +29,6 @@ RSpec.describe 'Entering their suitability to work with children' do
     when_i_mark_the_section_as_completed
     and_i_click_on_continue
     then_i_see_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering volunteering experience' do
   include CandidateHelper
 
   scenario 'Candidate adds volunteering experience' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_unpaid_experience
@@ -29,10 +29,6 @@ RSpec.describe 'Entering volunteering experience' do
 
     when_i_mark_this_section_as_completed
     then_i_see_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering "Personal statement"' do
   include CandidateHelper
 
   scenario 'Candidate submits personal statement' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_personal_statement
@@ -35,10 +35,6 @@ RSpec.describe 'Entering "Personal statement"' do
 
     when_i_click_on_personal_statement
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
@@ -4,14 +4,10 @@ RSpec.describe 'Candidate updating english proficiency' do
   include CandidateHelper
 
   scenario 'When application form does not have an english proficiency associations' do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     and_i_do_not_have_an_english_proficiency_attached_to_my_application_form
     when_i_visit_the_english_proficiency_edit_path
     then_i_am_able_to_create_an_english_proficiency_record
-  end
-
-  def given_i_am_signed_in_as_a_candidate
-    create_and_sign_in_candidate
   end
 
   def and_i_do_not_have_an_english_proficiency_attached_to_my_application_form

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate viewing Science GCSE' do
   include CandidateHelper
 
   it 'Candidate views a Science GCSE only when a primary course is chosen' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_am_on_your_application_page
     then_i_dont_see_science_gcse
 
@@ -23,10 +23,6 @@ RSpec.describe 'Candidate viewing Science GCSE' do
 
     when_i_go_to_view_my_application
     then_i_do_not_see_a_science_gcse_validation_error
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_complete_science_gcse

--- a/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Change GCSE' do
   include CandidateHelper
 
   scenario 'Candidate changes their GCSE qualification type' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_have_a_completed_english_gcse
     and_i_visit_the_english_review_page
     then_i_click_to_change_the_english_qualification_type
@@ -20,10 +20,6 @@ RSpec.describe 'Change GCSE' do
     and_i_fill_in_the_qualification_year
     and_click_save_and_continue
     then_i_see_the_review_page_with_correct_details
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_have_a_completed_english_gcse

--- a/spec/system/candidate_interface/entering_details/change_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/change_qualification_spec.rb
@@ -5,17 +5,13 @@ RSpec.describe 'Change qualification' do
   include EFLHelper
 
   scenario 'Candidate changes their IELTS to a TOEFL' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
     and_i_have_an_ielts_qualification
     when_i_visit_the_review_page
     then_i_can_change_my_qualification
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_an_ielts_qualification

--- a/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
@@ -5,17 +5,13 @@ RSpec.describe 'Declare no EFL qualification' do
   include EFLHelper
 
   scenario 'Candidate declares they have no qualification and provides more detail' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
     when_i_declare_i_have_no_qualification
     then_i_see_the_review_page
     and_i_can_complete_this_section
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_declare_i_have_no_qualification

--- a/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
@@ -5,17 +5,13 @@ RSpec.describe 'Declare EFL qualification not required' do
   include EFLHelper
 
   scenario 'Candidate declares that English is not a foreign language to them' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
     when_i_declare_that_english_is_not_foreign_to_me
     then_i_see_the_review_page
     and_i_can_complete_this_section
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_declare_that_english_is_not_foreign_to_me

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering a degree' do
   include CandidateHelper
 
   scenario 'Candidate enters their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -64,10 +64,6 @@ RSpec.describe 'Entering a degree' do
     and_that_the_section_is_completed
     when_i_click_on_degree
     then_i_can_check_my_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Non-uk Other qualifications', mid_cycle: false do
   include CandidateHelper
 
   scenario 'International candidate enters their other non-uk qualification' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
     and_i_am_an_international_candidate
 
@@ -75,10 +75,6 @@ RSpec.describe 'Non-uk Other qualifications', mid_cycle: false do
     and_i_click_continue
     then_i_see_the_form
     and_that_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_can_add_jobs_if_they_have_a_submitted_application_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_can_add_jobs_if_they_have_a_submitted_application_spec.rb
@@ -4,15 +4,11 @@ RSpec.describe 'Trying to enter work history' do
   include CandidateHelper
 
   scenario 'Candidate does see Add job or Add another job buttons' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_work_history
     and_i_have_a_submitted_application
     when_i_view_work_history
     then_i_do_see_an_option_to_add_another_job
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_completed_work_history

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_deleting_work_history_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_deleting_work_history_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their work history' do
   include CandidateHelper
 
   scenario 'Candidate deleting their only job entry should also remove any breaks entered' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -30,10 +30,6 @@ RSpec.describe 'Entering their work history' do
     and_i_add_a_job_that_covers_the_last_4_years_and_9_months
     then_i_see_a_two_month_break_between_my_job_and_now
     and_i_do_not_see_my_previous_break_entry
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_restructured_work_history_add_job_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_restructured_work_history_add_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate submits restructured work history' do
   include CandidateHelper
 
   scenario 'Candidate adds job details' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -20,10 +20,6 @@ RSpec.describe 'Candidate submits restructured work history' do
 
     when_i_fill_in_the_job_form_with_valid_details
     then_i_see_the_work_history_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering reasons for their work history breaks' do
   include CandidateHelper
 
   scenario 'Candidate enters a reason for a work break' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -43,10 +43,6 @@ RSpec.describe 'Entering reasons for their work history breaks' do
     and_i_click_to_delete_my_first_break
     and_i_confirm_i_want_to_delete_my_first_break
     then_i_no_longer_see_my_reason_on_the_review_page
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their work history' do
   include CandidateHelper
 
   scenario 'Candidate submits their work history as full time education' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -19,10 +19,6 @@ RSpec.describe 'Entering their work history' do
     and_i_click_on_continue
     then_i_see_the_form
     and_that_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_not_worked_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering their work history' do
   include CandidateHelper
 
   scenario 'Candidate submits their work history when they have none' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_visit_the_restructured_work_history_flow
     then_i_see_the_start_page
@@ -23,10 +23,6 @@ RSpec.describe 'Entering their work history' do
     and_i_click_on_continue
     then_i_see_the_form
     and_that_the_section_is_completed
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_visit_the_restructured_work_history_flow

--- a/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'View EFL form' do
   include EFLHelper
 
   scenario 'Candidate navigates to EFL form' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     then_i_cannot_see_the_efl_section_link
     when_i_declare_a_non_english_nationality
@@ -13,10 +13,6 @@ RSpec.describe 'View EFL form' do
 
     when_i_click_on_the_efl_section_link
     then_i_see_the_efl_form
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def then_i_cannot_see_the_efl_section_link

--- a/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Your IELTS result' do
   include EFLHelper
 
   scenario 'Candidate completes EFL section with details of their IELTS' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
@@ -14,10 +14,6 @@ RSpec.describe 'Your IELTS result' do
     then_i_can_review_my_qualification
     and_i_can_edit_my_qualification
     and_i_can_complete_this_section
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_select_the_options_for_ielts

--- a/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Your TOEFL result' do
   include EFLHelper
 
   scenario 'Candidate completes EFL section with details of their TOEFL' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality
     and_i_click_on_the_efl_section_link
 
@@ -14,10 +14,6 @@ RSpec.describe 'Your TOEFL result' do
     then_i_can_review_my_qualification
     and_i_can_edit_my_qualification
     and_i_can_complete_this_section
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_select_the_options_for_toefl

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe 'Candidate provides feedback during the application process' do
   end
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application = @candidate.current_application
+    given_i_am_signed_in_with_one_login
+    @application = @current_candidate.current_application
   end
 
   def when_i_visit_the_site
@@ -43,7 +42,7 @@ RSpec.describe 'Candidate provides feedback during the application process' do
       t('application_section_feedback.details_label', section: 'the references'),
       with: 'Me no understand.',
     )
-    choose t('application_feedback.consent_to_be_contacted.yes', email_address: @candidate.email_address)
+    choose t('application_feedback.consent_to_be_contacted.yes', email_address: @current_candidate.email_address)
 
     click_link_or_button t('application_feedback.submit')
   end

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 RSpec.describe 'Primary Navigation' do
   include CandidateHelper
   scenario 'highlights the primary navigation for pre continuous applications' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
+
     and_i_have_pre_continuous_applications_submitted
     when_i_visit_the_application_dashboard
     then_i_see_your_application_as_active
   end
 
   scenario 'highlights the primary navigation correct item for continuous applications' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_submitted_applications
     when_i_visit_the_application_dashboard
     then_i_see_your_details_as_active
@@ -29,10 +30,6 @@ RSpec.describe 'Primary Navigation' do
 
     when_i_visit_guidance_page_without_referer
     then_i_see_your_details_as_active
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_pre_continuous_applications_submitted

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate is redirected when tries to see your details after acc
   include CandidateHelper
 
   scenario 'Candidate views their application on the post offer dashboard' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer
 
     when_i_visit_the_application_dashboard
@@ -22,13 +22,8 @@ RSpec.describe 'Candidate is redirected when tries to see your details after acc
     then_i_see_the_post_offer_dashboard
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_accepted_offer
-    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2024)
+    @application_form = create(:completed_application_form, candidate: @current_candidate, recruitment_cycle_year: 2024)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and accepts', time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_today_is_the_last_day_of_the_cycle
     and_i_have_2_offers_on_my_choices
     and_1_choice_that_is_awaiting_provider_decision
@@ -115,14 +115,8 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
     then_i_see_the_new_dashboard_content
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_sign_in
-    login_as(@candidate)
-    visit root_path
+    given_i_am_signed_in_with_one_login
   end
 
   def and_i_have_2_offers_on_my_choices
@@ -130,7 +124,7 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
       :completed_application_form,
       first_name: 'Harry',
       last_name: 'Potter',
-      candidate: @candidate,
+      candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
     )
@@ -456,7 +450,7 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
   end
 
   def and_the_candidate_has_received_an_email
-    open_email(@candidate.email_address)
+    open_email(@current_candidate.email_address)
     expect(current_email.subject).to have_content "You have accepted #{@course_option.course.provider.name}’s offer to study #{@course_option.course.name_and_code}"
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate accepts an offer' do
   include CandidateHelper
 
   scenario 'Candidate views an offer and accepts' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_2_offers_on_my_choices
     and_1_choice_that_is_awaiting_provider_decision
 
@@ -117,17 +117,12 @@ RSpec.describe 'Candidate accepts an offer' do
     then_i_be_redirected_to_the_offer_dashboard
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_2_offers_on_my_choices
     @application_form = create(
       :completed_application_form,
       first_name: 'Harry',
       last_name: 'Potter',
-      candidate: @candidate,
+      candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
       recruitment_cycle_year: 2024,
@@ -442,7 +437,7 @@ RSpec.describe 'Candidate accepts an offer' do
   end
 
   def and_the_candidate_has_received_an_email
-    open_email(@candidate.email_address)
+    open_email(@current_candidate.email_address)
     expect(current_email.subject).to have_content "You have accepted #{@course_option.course.provider.name}’s offer to study #{@course_option.course.name_and_code}"
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate declines an offer' do
   include CandidateHelper
 
   scenario 'Candidate views an offer and declines' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_multiple_offers
 
     when_i_visit_my_applications
@@ -24,18 +24,13 @@ RSpec.describe 'Candidate declines an offer' do
     then_the_candidate_is_sent_an_email
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_multiple_offers
     @application_form = create(
       :application_form,
       :completed,
       first_name: 'Harry',
       last_name: 'Potter',
-      candidate: @candidate,
+      candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
     )

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_defers_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_defers_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate is redirected when tries to see your details after def
   include CandidateHelper
 
   scenario 'Candidate views their deferred offer on the post offer dashboard' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_a_deferred_offer
 
     when_i_visit_the_application_dashboard
@@ -22,13 +22,8 @@ RSpec.describe 'Candidate is redirected when tries to see your details after def
     then_i_see_the_post_offer_dashboard
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_a_deferred_offer
-    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2024)
+    @application_form = create(:completed_application_form, candidate: @current_candidate, recruitment_cycle_year: 2024)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate accepts an offer' do
   include CandidateHelper
 
   scenario 'Candidate views offer and changes referee email address to personal email address and ignores advice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_offer
 
     when_i_visit_my_applications
@@ -24,7 +24,7 @@ RSpec.describe 'Candidate accepts an offer' do
   end
 
   scenario 'Candidate views offer and changes referee email address to personal email address and heeds advice' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_offer
 
     when_i_visit_my_applications
@@ -42,7 +42,7 @@ RSpec.describe 'Candidate accepts an offer' do
   end
 
   scenario 'Candidate views offer and changes character reference email to personal email address' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_offer
     and_my_references_are_character_references
 
@@ -59,20 +59,15 @@ RSpec.describe 'Candidate accepts an offer' do
 
 private
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_offer
     @application_form = create(
       :completed_application_form,
       first_name: 'Harry',
       last_name: 'Potter',
-      candidate: @candidate,
+      candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
-      recruitment_cycle_year: 2024,
+      recruitment_cycle_year: RecruitmentCycle.current_year,
     )
 
     @application_form.application_references.each do |ref|

--- a/spec/system/candidate_interface/post_offer/offer_deferred_spec.rb
+++ b/spec/system/candidate_interface/post_offer/offer_deferred_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Post-offer dashboard' do
   include PostOfferHelper
 
   scenario 'Candidate offer is deferred' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer_deferred
 
     when_i_visit_the_application_dashboard
@@ -19,7 +19,7 @@ RSpec.describe 'Post-offer dashboard' do
   end
 
   def and_i_have_an_accepted_offer_deferred
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/post_offer/pending_conditions_spec.rb
+++ b/spec/system/candidate_interface/post_offer/pending_conditions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Post-offer dashboard' do
   include PostOfferHelper
 
   scenario 'Candidate offer is pending conditions' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer_pending_conditions
 
     when_i_visit_the_application_dashboard
@@ -19,7 +19,7 @@ RSpec.describe 'Post-offer dashboard' do
   end
 
   def and_i_have_an_accepted_offer_pending_conditions
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/post_offer/recruited_spec.rb
+++ b/spec/system/candidate_interface/post_offer/recruited_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Post-offer dashboard' do
   include PostOfferHelper
 
   scenario 'Candidate is recruited' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_been_recruited
 
     when_i_visit_the_application_dashboard
@@ -19,7 +19,7 @@ RSpec.describe 'Post-offer dashboard' do
   end
 
   def and_i_have_been_recruited
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/references/backlinks_spec.rb
+++ b/spec/system/candidate_interface/references/backlinks_spec.rb
@@ -68,9 +68,8 @@ RSpec.describe 'References' do
   end
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application = @candidate.current_application
+    given_i_am_signed_in_with_one_login
+    @application = @current_candidate.current_application
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_add_references_spec.rb
@@ -106,9 +106,8 @@ RSpec.describe 'References' do
   end
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application = @candidate.current_application
+    given_i_am_signed_in_with_one_login
+    @application = @current_candidate.current_application
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate adding incomplete referees' do
   include CandidateHelper
 
   it 'Candidate adds incomplete referees and then completes them' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_provided_my_personal_details
 
     when_i_provide_a_referee_type_only
@@ -40,13 +40,13 @@ RSpec.describe 'Candidate adding incomplete referees' do
   end
 
   def when_the_reference_doesnt_have_a_referee_type
-    @reference = @candidate.current_application.application_references.first
-    @candidate.current_application.update(references_completed: nil, references_completed_at: nil)
+    @reference = @current_candidate.current_application.application_references.first
+    @current_candidate.current_application.update(references_completed: nil, references_completed_at: nil)
     @reference.update(referee_type: nil)
   end
 
   def and_the_references_are_ready_to_be_submitted
-    create(:reference, :feedback_provided, application_form: @candidate.current_application)
+    create(:reference, :feedback_provided, application_form: @current_candidate.current_application)
   end
 
   def when_i_visit_the_references_review_page
@@ -79,13 +79,8 @@ RSpec.describe 'Candidate adding incomplete referees' do
     expect(page).to have_current_path candidate_interface_details_path
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_provided_my_personal_details
-    @candidate.current_application.update!(first_name: 'Michael', last_name: 'Antonio')
+    @current_candidate.current_application.update!(first_name: 'Michael', last_name: 'Antonio')
   end
 
   def when_i_provide_a_referee_type_only

--- a/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_post_offer_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_post_offer_spec.rb
@@ -65,13 +65,12 @@ RSpec.describe 'Creating references with personal email addresses after an offer
 private
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    given_i_am_signed_in_with_one_login
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
   end
 
   def and_i_have_an_accepted_offer
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 
@@ -83,7 +82,7 @@ private
   end
 
   def and_i_navigate_to_add_another_reference
-    visit root_path
+    visit candidate_interface_application_offer_dashboard_path
     click_on 'Request another reference'
     click_on 'Continue'
   end

--- a/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_spec.rb
@@ -50,13 +50,11 @@ RSpec.describe 'Creating references with personal email addresses' do
 private
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application = @candidate.current_application
+    given_i_am_signed_in_with_one_login
+    @application = @current_candidate.current_application
   end
 
   def and_i_navigate_to_add_a_reference
-    visit root_path
     click_on 'Your details'
     click_on 'References'
     click_on 'Add reference'

--- a/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe 'References' do
   end
 
   def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-    @application = @candidate.current_application
+    given_i_am_signed_in_with_one_login
+    @application = @current_candidate.current_application
   end
 
   def and_i_have_provided_my_personal_details
-    @candidate.current_application.update!(first_name: 'Mr', last_name: 'Bot')
+    @current_candidate.current_application.update!(first_name: 'Mr', last_name: 'Bot')
   end
 
   def and_i_have_three_reference_requests_pending

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   scenario 'when an unsuccessful candidate returns in the next recruitment cycle they can re-apply by carrying over their original application' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_application_with_a_rejection_and_references
 
     when_a_new_cycle_starts
@@ -21,13 +21,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     then_i_see_the_new_states_of_my_references
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_application_with_a_rejection_and_references
-    @application_form = create(:application_form, :with_completed_references, candidate: @candidate)
+    @application_form = create(:application_form, :with_completed_references, candidate: @current_candidate)
     create(:application_choice, :rejected, application_form: @application_form)
 
     create(
@@ -42,8 +37,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_visit_my_application_complete_page
-    logout
-    login_as(@candidate)
+    click_link_or_button 'Sign out'
+    given_i_am_signed_in_with_one_login
     visit candidate_interface_details_path
   end
 

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'New References', :with_audited do
   include CandidateHelper
 
   scenario 'Candidate request their references on the post offer dashboard' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer
 
     when_i_visit_the_application_dashboard
@@ -56,13 +56,8 @@ RSpec.describe 'New References', :with_audited do
     then_the_back_link_point_to_the_offer_dashboard_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_accepted_offer
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_from_previous_cycle_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetable.appl
   include CandidateHelper
 
   scenario 'Candidate views their references on the post offer dashboard' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer_from_previous_cycle
 
     when_i_visit_the_application_dashboard
@@ -32,13 +32,8 @@ RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetable.appl
     then_i_see_the_status_change
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_accepted_offer_from_previous_cycle
-    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2023)
+    @application_form = create(:completed_application_form, candidate: @current_candidate, recruitment_cycle_year: 2023)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetableHelpe
   include CandidateHelper
 
   scenario 'Candidate views their references on the post offer dashboard' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer
 
     when_i_visit_the_application_dashboard
@@ -33,13 +33,8 @@ RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetableHelpe
     then_i_see_the_status_change
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_an_accepted_offer
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @current_candidate)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
 

--- a/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
-  include SignInHelper
   before do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
   end
 
   scenario 'Candidate with incomplete application seeing the error message' do
@@ -24,13 +23,11 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   def and_i_have_incomplete_sections_on_my_personal_statement
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, :minimum_info, submitted_at: nil, becoming_a_teacher: 'I want to teach')
+    @current_candidate.application_forms << build(:application_form, :minimum_info, submitted_at: nil, becoming_a_teacher: 'I want to teach')
   end
 
   def and_i_have_incomplete_sections_which_is_not_science_gcse
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, :completed, science_gcse_completed: true, degrees_completed: false, submitted_at: nil)
+    @current_candidate.application_forms << build(:application_form, :completed, science_gcse_completed: true, degrees_completed: false, submitted_at: nil)
   end
 
   def and_i_have_a_primary_and_secondary_application_choice

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Candidate with submitted applications' do
   include CandidateHelper
 
   scenario 'Application becomes inactive' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_submitted_applications
     when_one_of_my_applications_becomes_inactive
     when_i_visit_my_applications
@@ -17,10 +17,6 @@ RSpec.describe 'Candidate with submitted applications' do
     when_i_visit_my_applications
     when_i_click_to_view_my_application
     then_i_can_not_see_the_inactive_warning_text
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_submitted_applications

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate is redirected correctly' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates personal details section' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_have_completed_my_application
     and_i_review_my_application
     then_i_see_all_sections_are_complete
@@ -66,10 +66,6 @@ RSpec.describe 'Candidate is redirected correctly' do
     when_i_update_my_address
     then_i_redirected_to_the_contact_information_review_page
     and_i_see_my_updated_address
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_have_completed_my_application

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
-  include SignInHelper
 
   scenario 'Candidate with a completed application' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
 
@@ -50,7 +49,7 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate with a primary application missing the science GCSE' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     when_i_have_not_completed_science_gcse
@@ -63,7 +62,7 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate with a primary application missing the science GCSE and missing other sections' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_an_incomplete_application_and_have_added_primary_as_a_course_choice
     when_i_have_not_completed_science_gcse
@@ -100,8 +99,7 @@ RSpec.describe 'Candidate submits the application' do
     )
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: 'I want to teach')
+    @current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: 'I want to teach')
     @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate submits the application with interruption pages' do
   include CandidateHelper
-  include SignInHelper
 
   scenario 'Candidate submits an application with all applications having an enic_reason of not_needed and personal statement less than 500 words', :js, time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_not_needed_qualification
     and_i_continue_with_my_application
@@ -23,7 +22,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement less than 500 words', :js, time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification
     and_i_continue_with_my_application
@@ -41,7 +40,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement of 500 words', :js, time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification_and_personal_statement_500_words
     and_i_continue_with_my_application
@@ -57,7 +56,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an teacher degree apprenticeship course having a personal statement less than 500 words and a degree', :js, time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_have_completed_application_to_primary_course_choice_with_short_personal_statement
     and_course_choice_is_undergraduate
     and_i_have_a_degree
@@ -77,7 +76,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an teacher degree apprenticeship course having a degree with long personal statement and with ENIC', :js, time: mid_cycle do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_have_completed_application_to_primary_course_choice_with_long_personal_statement
     and_i_have_a_degree
     and_course_choice_is_undergraduate
@@ -151,9 +150,8 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     )
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: Faker::Lorem.words(number: personal_statement_words))
-    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
+    @current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: Faker::Lorem.words(number: personal_statement_words))
+    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: @current_candidate.current_application)
   end
 
   def add_not_needed_qualification

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
-  include SignInHelper
 
   scenario 'Candidate with a completed application' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_undergraduate_primary_as_a_course_choice
     and_i_continue_with_my_application
@@ -25,7 +24,7 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate with a primary application missing the science GCSE' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_undergraduate_primary_as_a_course_choice
     when_i_have_not_completed_science_gcse
@@ -62,8 +61,7 @@ RSpec.describe 'Candidate submits the application' do
     )
     @course = create(:course, :teacher_degree_apprenticeship, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, completed_section_trait, university_degree: false)
+    @current_candidate.application_forms << build(:application_form, completed_section_trait, university_degree: false)
     @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Candidate submits an application up to 4 choices' do
   before { given_courses_exist }
 
   scenario 'when candidate has a conditions not met and only one free slot' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_a_conditions_not_met_application_and_one_free_slot_to_submit
     when_i_visit_my_applications
     then_i_can_see_i_have_one_choice_left
@@ -14,10 +14,6 @@ RSpec.describe 'Candidate submits an application up to 4 choices' do
     when_i_submit_a_new_application
     then_i_can_see_my_application_has_been_successfully_submitted
     and_i_am_unable_to_add_any_further_choices
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_i_have_a_conditions_not_met_application_and_one_free_slot_to_submit

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
 
   scenario 'Candidate with more than the max unsuccessful apps' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_19_unsuccessful_applications
 
     when_i_have_completed_my_application_and_added_primary_as_course_choice
@@ -16,14 +16,9 @@ RSpec.describe 'Candidate submits the application' do
     then_i_am_unable_to_add_any_further_choices
   end
 
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
   def and_i_have_19_unsuccessful_applications
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << create(:application_form, :completed, :with_degree)
-    current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
+    @current_candidate.application_forms << create(:application_form, :completed, :with_degree)
+    @current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
   end
 
   def when_i_have_completed_my_application_and_added_primary_as_course_choice
@@ -41,7 +36,7 @@ RSpec.describe 'Candidate submits the application' do
     )
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
-    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
+    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: @current_candidate.current_application)
   end
 
   def and_i_go_to_submit_my_application

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate tries to submit an application choice when the course is unavailable' do
-  include SignInHelper
   include CandidateHelper
   before do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_one_application_in_draft
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Submitting a postgraduate course' do
 
   before do
     given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
   end
 
   scenario 'Candidate does not have a degree' do
@@ -29,10 +29,6 @@ RSpec.describe 'Submitting a postgraduate course' do
     )
   end
 
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
-
   def given_there_are_postgraduate_courses
     create(
       :course,
@@ -47,8 +43,7 @@ RSpec.describe 'Submitting a postgraduate course' do
   end
 
   def and_i_have_all_sections_completed_except_degrees
-    current_candidate.application_forms.delete_all
-    current_candidate.application_forms << create(
+    @current_candidate.application_forms << create(
       :application_form,
       :completed,
       degrees_completed: false,

--- a/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Candidate with no right to work or study' do
   include CandidateHelper
 
   before do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_there_are_course_options
   end
 
@@ -39,10 +39,6 @@ RSpec.describe 'Candidate with no right to work or study' do
     then_i_do_not_see_an_error_message_that_the_course_does_not_sponsor_visa
     and_i_submit_the_application
     then_i_can_see_my_application_has_been_successfully_submitted
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def and_there_are_course_options

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'International candidate submits the application' do
   include EFLHelper
 
   it 'International candidate completes and submits an application' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
 
     when_i_have_completed_everything_except_the_efl_and_other_qualifications_section
     when_i_review_my_details
@@ -27,10 +27,6 @@ RSpec.describe 'International candidate submits the application' do
     when_i_submit_my_application
 
     then_i_can_see_my_application_has_been_successfully_submitted
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_submit_my_application

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
   include WithdrawalReasonsTestHelpers
 
   scenario 'successful withdrawal', time: mid_cycle do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     and_i_have_multiple_application_choice_awaiting_provider_decision
 
     when_i_visit_my_applications
@@ -25,7 +25,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
   end
 
   scenario 'withdrawing after the apply deadline', time: after_apply_deadline do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     and_i_have_one_application_choice_awaiting_provider_decision
 
     when_i_visit_my_applications
@@ -37,7 +37,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
   end
 
   scenario 'withdrawal for application choice with interviewing status', time: mid_cycle do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     and_i_have_an_application_choice_with_the_status_interviewing
 
     when_i_visit_my_applications
@@ -48,10 +48,6 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     and_i_click_on('Yes I’m sure – withdraw this application')
     then_i_have_withdrawn_from_the_course(@interviewing_application_choice)
     and_the_interviews_have_been_cancelled
-  end
-
-  def given_i_am_signed_in_as_a_candidate
-    create_and_sign_in_candidate
   end
 
   def and_i_have_multiple_application_choice_awaiting_provider_decision

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'A candidate withdraws with upcoming interviews' do
   include WithdrawalReasonsTestHelpers
 
   scenario 'successful withdrawal' do
-    given_i_am_signed_in_as_a_candidate
+    given_i_am_signed_in_with_one_login
     and_i_have_an_application_choice_with_an_upcoming_interview
 
     when_i_visit_the_application_dashboard
@@ -19,12 +19,8 @@ RSpec.describe 'A candidate withdraws with upcoming interviews' do
     and_i_received_an_interview_cancelled_email
   end
 
-  def given_i_am_signed_in_as_a_candidate
-    create_and_sign_in_candidate
-  end
-
   def and_i_have_an_application_choice_with_an_upcoming_interview
-    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
+    form = create(:completed_application_form, :with_completed_references, candidate: @current_candidate)
     @application_choice = create(:application_choice, :interviewing, application_form: form)
     create(:application_choice, :awaiting_provider_decision, application_form: form)
     @provider_user = create(:provider_user, :with_notifications_enabled)
@@ -56,7 +52,7 @@ RSpec.describe 'A candidate withdraws with upcoming interviews' do
   end
 
   def and_i_received_an_interview_cancelled_email
-    open_email(current_candidate.email_address)
+    open_email(@current_candidate.email_address)
     expect(current_email.subject).to have_content('Interview cancelled')
     expect(current_email.text).to have_content('You withdrew your application.')
   end


### PR DESCRIPTION
## Context

We are close to releasing one login and it would be good if we switch our way of signing in the candidate in candidate system specs.

With one login, we also introduced DB backed sessions, this becomes the normal way to sign in. Our system specs should replicate this behaviour. This way we can catch bugs easier. Having the specs like this might have helped us catch this bug https://github.com/DFE-Digital/apply-for-teacher-training/pull/10270

I have left a few system specs specifically related to magic link that still used the old way of signing in.

## Changes proposed in this pull request

Changed the way we sign in in system specs.

## Guidance to review

## Link to Trello card

<!-- Paste the anonymised Trello link here. Avoid sharing the full card URL that reveals card details. -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
