### PR TITLE
[570] Add job to delete expired sessions

### DIFF
--- a/app/workers/delete_expired_sessions_worker.rb
+++ b/app/workers/delete_expired_sessions_worker.rb
@@ -1,0 +1,9 @@
+class DeleteExpiredSessionsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform
+    Session.where('updated_at < ?', 7.days.ago).delete_all
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -26,6 +26,7 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
   # Daily jobs
+  every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_async }
   every(1.day, 'DeleteDraftWithdrawalReasonRecordsWorker', at: '4:01') { DeleteDraftWithdrawalReasonRecordsWorker.perform_async }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
 

--- a/spec/workers/delete_expired_sessions_worker_spec.rb
+++ b/spec/workers/delete_expired_sessions_worker_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DeleteExpiredSessionsWorker do
+  describe '#perform' do
+    it 'deletes sessions that have not been updated in over 7 days' do
+      should_delete = create(:session)
+      should_not_delete = create(:session)
+
+      advance_time_to 3.5.days.from_now
+      should_not_delete.touch
+      advance_time_to 4.days.from_now
+
+      expect { described_class.new.perform }.to change { Session.count }.by(-1)
+      expect { should_delete.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Sessions expire after 7 days. We want to run a job daily to deletes any session that is passed the expiry date.

## Changes proposed in this pull request

- job and spec for deleting the sessions
- schedule in clock for running the job

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
