### PR TITLE
Reapply "Updated Sign In Candidate"

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -3,7 +3,7 @@ class AuthenticationMailer < ApplicationMailer
     @magic_link = candidate_interface_authenticate_url(magic_link_params(token))
 
     notify_email(
-      to: candidate.email_address,
+      to: candidate.authentication_email_address,
       subject: t('authentication.sign_up.email.subject'),
       reference: "#{HostingEnvironment.environment_name}-sign_up_email-#{candidate.id}-#{SecureRandom.hex}",
     )
@@ -14,7 +14,7 @@ class AuthenticationMailer < ApplicationMailer
     @application_form = candidate.current_application
 
     notify_email(
-      to: candidate.email_address,
+      to: candidate.authentication_email_address,
       subject: t('authentication.sign_in.email.subject'),
     )
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -52,6 +52,10 @@ class Candidate < ApplicationRecord
     application_forms.where(recruitment_cycle_year: RecruitmentCycle.current_year).touch_all
   end
 
+  def authentication_email_address
+    one_login_auth&.email_address || email_address
+  end
+
   def self.for_email(email)
     find_or_initialize_by(email_address: email.downcase) if email
   end

--- a/app/services/candidate_interface/sign_in_candidate.rb
+++ b/app/services/candidate_interface/sign_in_candidate.rb
@@ -16,14 +16,15 @@ module CandidateInterface
     )
 
     def call
-      candidate = Candidate.for_email email
+      sign_in = SignInCandidateForm.new(email_address: email)
+      candidate = sign_in.candidate
 
-      if candidate.persisted?
+      if sign_in.potential_sign_in?
         update_course_from_find(candidate)
         CandidateInterface::RequestMagicLink.for_sign_in(candidate:)
         controller.set_user_context(candidate.id)
         redirect_to candidate_interface_check_email_sign_in_path
-      elsif candidate.valid?
+      elsif sign_in.potential_sign_up?
         AuthenticationMailer.sign_in_without_account_email(to: candidate.email_address).deliver_now
         redirect_to candidate_interface_check_email_sign_in_path
       else

--- a/app/services/candidate_interface/sign_in_candidate_form.rb
+++ b/app/services/candidate_interface/sign_in_candidate_form.rb
@@ -1,0 +1,32 @@
+class CandidateInterface::SignInCandidateForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :email_address, :string
+
+  validates :email_address, presence: true, length: { maximum: 100 }, valid_for_notify: true
+
+  def candidate
+    if potential_sign_in?
+      return potential_candidate_for_sign_in
+    end
+
+    candidate = Candidate.new(email_address:)
+
+    unless potential_sign_up?
+      candidate.errors.add(:email_address, 'Not viable for sign-in or sign-up')
+    end
+
+    candidate
+  end
+
+  def potential_candidate_for_sign_in
+    Candidate.joins(:one_login_auth).find_by(one_login_auth: { email_address: }).presence || Candidate.where.missing(:one_login_auth).find_by(email_address:).presence
+  end
+
+  alias potential_sign_in? potential_candidate_for_sign_in
+
+  def potential_sign_up?
+    valid? && OneLoginAuth.find_by(email_address:).nil? && Candidate.find_by(email_address:).nil?
+  end
+end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe Candidate do
     end
   end
 
+  describe '#authentication_email_address' do
+    it 'returns the candidate email address' do
+      candidate = build(:candidate, email_address: 'candidate@email.address')
+
+      expect(candidate.authentication_email_address).to eq('candidate@email.address')
+    end
+
+    it 'returns the one login email address if present' do
+      candidate = build(:candidate,
+                        email_address: 'candidate@email.address',
+                        one_login_auth: build(:one_login_auth,
+                                              email_address: 'one_login@email.address'))
+
+      expect(candidate.authentication_email_address).to eq('one_login@email.address')
+    end
+  end
+
   describe '#current_application' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Candidate do
   end
 
   context 'scopes' do
-    describe '#for_transaction_emails' do
+    describe '.for_transaction_emails' do
       let!(:unsubscribed_from_emails) { create(:candidate, unsubscribed_from_emails: true) }
       let!(:submission_blocked) { create(:candidate, submission_blocked: true) }
       let!(:account_locked) { create(:candidate, account_locked: true) }
@@ -303,7 +303,7 @@ RSpec.describe Candidate do
       end
     end
 
-    describe '#for_marketing_or_nudge_emails' do
+    describe '.for_marketing_or_nudge_emails' do
       let!(:unsubscribed_from_emails) { create(:candidate, unsubscribed_from_emails: true) }
       let!(:submission_blocked) { create(:candidate, submission_blocked: true) }
       let!(:account_locked) { create(:candidate, account_locked: true) }

--- a/spec/services/candidate_interface/sign_in_candidate_form_spec.rb
+++ b/spec/services/candidate_interface/sign_in_candidate_form_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SignInCandidateForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
+  end
+
+  describe '#candidate' do
+    context 'when no Candidates exist' do
+      it 'returns a new Candidate' do
+        sign_in = described_class.new(email_address: 'candidate@email.address')
+
+        sign_in_candidate = sign_in.candidate
+        expect(sign_in_candidate).to be_a(Candidate)
+        expect(sign_in_candidate).to be_new_record
+        expect(sign_in_candidate.email_address).to eq('candidate@email.address')
+        expect(sign_in_candidate).to be_valid
+      end
+    end
+
+    context 'when Candidate exists without OneLoginAuth' do
+      it 'returns the Candidate' do
+        candidate = create(:candidate, email_address: 'candidate@email.address')
+        sign_in = described_class.new(email_address: 'candidate@email.address')
+
+        sign_in_candidate = sign_in.candidate
+        expect(sign_in_candidate).to eq(candidate)
+        expect(sign_in_candidate).to be_valid
+      end
+    end
+
+    context 'when Candidate exists with a OneLoginAuth with matching email addresses' do
+      it 'returns the Candidate' do
+        candidate = create(:candidate, email_address: 'one_login@email.address')
+        create(:one_login_auth, email_address: 'one_login@email.address', candidate: candidate)
+
+        sign_in = described_class.new(email_address: 'one_login@email.address')
+
+        sign_in_candidate = sign_in.candidate
+        expect(sign_in_candidate).to eq(candidate)
+        expect(sign_in_candidate).to be_valid
+      end
+    end
+
+    context 'when Candidate exists with a OneLoginAuth with different email addresses' do
+      it 'returns the Candidate' do
+        candidate = create(:candidate, email_address: 'candidate@email.address')
+        create(:one_login_auth, email_address: 'one_login@email.address', candidate: candidate)
+
+        sign_in = described_class.new(email_address: 'one_login@email.address')
+
+        sign_in_candidate = sign_in.candidate
+        expect(sign_in_candidate).to eq(candidate)
+        expect(sign_in_candidate).to be_valid
+      end
+    end
+
+    context 'when Candidate exists with a OneLoginAuth with different email addresses, with old email address' do
+      it 'returns a new Candidate with errors' do
+        candidate = create(:candidate, email_address: 'candidate@email.address')
+        create(:one_login_auth, email_address: 'one_login@email.address', candidate: candidate)
+
+        sign_in = described_class.new(email_address: 'candidate@email.address')
+
+        sign_in_candidate = sign_in.candidate
+        expect(sign_in_candidate).not_to eq(candidate)
+        expect(sign_in_candidate).to be_new_record
+        expect(sign_in_candidate.email_address).to eq('candidate@email.address')
+        expect(sign_in_candidate.errors[:email_address]).to include('Not viable for sign-in or sign-up')
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/sign_in_candidate_spec.rb
+++ b/spec/services/candidate_interface/sign_in_candidate_spec.rb
@@ -4,39 +4,121 @@ RSpec.describe CandidateInterface::SignInCandidate do
   let(:controller_double) do
     instance_double(
       CandidateInterface::SignInController,
-      params: {
-        providerCode: course.provider.code,
-        courseCode: course.code,
-      },
+      params: {},
       set_user_context: true,
       candidate_interface_check_email_sign_in_path: true,
       redirect_to: true,
+      track_validation_error: true,
+      render: true,
     )
   end
 
-  context 'course is in the current cycle' do
-    let(:course) { create(:course, recruitment_cycle_year: RecruitmentCycle.current_year) }
+  it 'renders the sign - in page again with errors when the email address is invalid' do
+    email = 'not-an-email-address'
 
-    it 'is sets the candidates `course_from_find_id` to the course.id' do
-      candidate = create(:candidate)
-      create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate:)
+    described_class.new(email, controller_double).call
 
-      described_class.new(candidate.email_address, controller_double).call
+    expect(controller_double).to have_received(:track_validation_error).with(kind_of(Candidate))
+    expect(controller_double).to have_received(:render).with('candidate_interface/sign_in/new', locals: { candidate: kind_of(Candidate) })
+  end
 
-      expect(candidate.reload.course_from_find_id).to eq course.id
+  it "sends an email to the address when there's no matching Candidate" do
+    allow(AuthenticationMailer).to receive(:sign_in_without_account_email).and_call_original
+    email = 'someone@email.address'
+
+    described_class.new(email, controller_double).call
+
+    expect(AuthenticationMailer).to have_received(:sign_in_without_account_email).with(to: email)
+  end
+
+  it 'sends a magic link to the candidate' do
+    allow(CandidateInterface::RequestMagicLink).to receive(:for_sign_in).and_call_original
+    email = 'candidate@email.address'
+    candidate = create(:candidate, email_address: email)
+
+    described_class.new(email, controller_double).call
+
+    expect(CandidateInterface::RequestMagicLink).to have_received(:for_sign_in).with(candidate: candidate)
+  end
+
+  context 'when Candidate email address is used but the Candidate is connected to a OneLoginAuth with a different email address' do
+    # Candidate has used the Account Recovery feature to sign in with a different email address
+    # Their old email address should not be used to sign in
+
+    it 'renders the sign-in page again with errors when the old email address is used' do
+      candidate = create(:candidate, email_address: 'candidate@email.address')
+      _one_login_auth = create(:one_login_auth, email_address: 'one_login@email.address', candidate: candidate)
+
+      described_class.new('candidate@email.address', controller_double).call
+
+      expect(controller_double).to have_received(:track_validation_error).with(kind_of(Candidate))
+      expect(controller_double).to have_received(:render).with('candidate_interface/sign_in/new', locals: { candidate: kind_of(Candidate) })
+    end
+
+    it 'sends a magic link to the candidate when the new email address is used' do
+      allow(CandidateInterface::RequestMagicLink).to receive(:for_sign_in).and_call_original
+      candidate = create(:candidate, email_address: 'candidate@email.address')
+      _one_login_auth = create(:one_login_auth, email_address: 'one_login@email.address', candidate: candidate)
+
+      described_class.new('one_login@email.address', controller_double).call
+
+      expect(CandidateInterface::RequestMagicLink).to have_received(:for_sign_in).with(candidate: candidate)
     end
   end
 
-  context 'course is in the previous cycle' do
-    let(:course) {  create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+  context 'when Candidate email address is used with a connected to a OneLoginAuth' do
+    # Candidate has set up OneLogin with the same email address
 
-    it 'is does not set the candidates `course_from_find_id` if the course is not in the current cycle' do
-      candidate = create(:candidate)
-      create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate:)
+    it 'sends a magic link to the candidate' do
+      allow(CandidateInterface::RequestMagicLink).to receive(:for_sign_in).and_call_original
+      email = 'one_login@email.address'
+      candidate = create(:candidate, email_address: email)
+      _one_login_auth = create(:one_login_auth, email_address: email, candidate: candidate)
 
-      described_class.new(candidate.email_address, controller_double).call
+      described_class.new(email, controller_double).call
 
-      expect(candidate.reload.course_from_find_id).to be_nil
+      expect(CandidateInterface::RequestMagicLink).to have_received(:for_sign_in).with(candidate: candidate)
+    end
+  end
+
+  context 'Candidate has been redirected from Find' do
+    let(:controller_double) do
+      instance_double(
+        CandidateInterface::SignInController,
+        params: {
+          providerCode: course.provider.code,
+          courseCode: course.code,
+        },
+        set_user_context: true,
+        candidate_interface_check_email_sign_in_path: true,
+        redirect_to: true,
+      )
+    end
+
+    context 'course is in the current cycle' do
+      let(:course) { create(:course, recruitment_cycle_year: RecruitmentCycle.current_year) }
+
+      it 'is sets the candidates `course_from_find_id` to the course.id' do
+        candidate = create(:candidate)
+        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate:)
+
+        described_class.new(candidate.email_address, controller_double).call
+
+        expect(candidate.reload.course_from_find_id).to eq course.id
+      end
+    end
+
+    context 'course is in the previous cycle' do
+      let(:course) { create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+
+      it 'is does not set the candidates `course_from_find_id` if the course is not in the current cycle' do
+        candidate = create(:candidate)
+        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, candidate:)
+
+        described_class.new(candidate.email_address, controller_double).call
+
+        expect(candidate.reload.course_from_find_id).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

After OneLogin has been enabled, we should only allow OneLogin email addresses to be used when authenticating with the fallback (magic links)

## Changes proposed in this pull request

- We have added `Candidate#authentication_email_address` which returns the email address of an attached OneLoginAuth or the Candidate email address if OneLoginAuth has not been connected. 
- We have updated the `SignInCandidate` service to send the appropriate emails or return appropriate errors
  -  This is a poorly named service that does not sign the candidate in 🤦‍♂️

## Guidance to review

- Without OneLogin enabled, in the Review app, you should be able to sign up and sign in using Magic Links without any noticeable changes. 
- If you create a OneLoginAuth with a different email address to the Candidate, you should only be able to login using the email address from the OneLoginAuth - you also should not be able to signup with either email address

## Link to Trello card

https://trello.com/c/BWEajuXS

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
