### PR TITLE
[588] part 2, delete One Login pre release banners flag from features

### DIFF
--- a/app/services/data_migrations/remove_one_login_pre_release_banners_feature_flag.rb
+++ b/app/services/data_migrations/remove_one_login_pre_release_banners_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveOneLoginPreReleaseBannersFeatureFlag
+    TIMESTAMP = 20250120150435
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :one_login_pre_release_banners).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveOneLoginPreReleaseBannersFeatureFlag',
   'DataMigrations::RemoveNewWithdrawalReasonsFeatureFlag',
   'DataMigrations::RemoveUnusedFeatureFlags',
   'DataMigrations::RemoveTdaFlag',

--- a/spec/services/data_migrations/remove_one_login_pre_release_banners_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_one_login_pre_release_banners_feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveOneLoginPreReleaseBannersFeatureFlag do
+  context 'when the feature flag exist' do
+    it 'removes the relevant feature flags' do
+      create(:feature, name: 'one_login_pre_release_banners')
+      create(:feature, name: 'some_other_feature_flag')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'one_login_pre_release_banners')).to be_none
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR removes an unused Feature flag from the code base. See [earlier PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10280) for full context.

## Changes proposed in this pull request

No UI changes, just removing a feature from the database.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/m4unLeJX

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
