### PR TITLE
Replace sign into with sign in to throughout

### DIFF
--- a/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
+++ b/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
@@ -13,7 +13,7 @@
     </p>
     <p class="govuk-body">
       <%= govuk_link_to(
-        'Sign into Apply for teacher training',
+        'Sign in to Apply for teacher training',
         HostingEnvironment::PRODUCTION_URL,
       ) %>
     </p>

--- a/app/views/candidate_mailer/application_deadline_has_passed.text.erb
+++ b/app/views/candidate_mailer/application_deadline_has_passed.text.erb
@@ -8,7 +8,7 @@ The application deadline has passed for teacher training courses starting in the
 
 You can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
 
-[Sign into your account to update your details](<%= sign_in_link %>).
+[Sign in to your account to update your details](<%= sign_in_link %>).
 
 # Get help
 

--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -4,7 +4,7 @@ To give yourself the best chance of success, you can apply to another training p
 
 Candidates who apply for 4 or more courses are more likely to receive an offer.
 
-[Sign into your account](<%= application_choices_link %>) to apply for another course.
+[Sign in to your account](<%= application_choices_link %>) to apply for another course.
 
 You can also contact <%= @provider_name %> to check on your application.
 

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -10,7 +10,7 @@ While you wait for a response on these applications, you can apply to <%= @choic
 
 Candidates who apply for 4 or more courses are more likely to receive an offer.
 
-[Sign into your account](<%= application_choices_link %>) to apply for another course.
+[Sign in to your account](<%= application_choices_link %>) to apply for another course.
 
 <%= render 'understand_your_professional_strengths' %>
 

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -2,14 +2,14 @@ Dear <%= @application_form.first_name %>
 
 You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
 
-You can sign into your account to:
+You can sign in to your account to:
 
 - send them an email to remind them that you have asked for a reference
 - cancel the request for a reference
 - ask someone else for a reference
 
 
-[Sign into your account](<%= sign_in_link %>).
+[Sign in to your account](<%= sign_in_link %>).
 
 <%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
 

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -4,14 +4,14 @@ You asked <%= @referee.name %> for a reference for your teacher training applica
 
 <%= @provider_name %> needs to check your references before they can confirm your place on the course.
 
-You can sign into your account to:
+You can sign in to your account to:
 
 - ask someone else for a reference
 - send them an email to remind them that you have asked for a reference
 - cancel the request for a reference
 
 
-[Sign into your account](<%= sign_in_link %>).
+[Sign in to your account](<%= sign_in_link %>).
 
 Contact <%= @provider_name %> if you need help getting references or choosing who to ask.
 

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -4,13 +4,13 @@ Dear <%= @application_form.first_name %>
 
 They’ll let you know if they need further information before you can start training. Contact them if you have any questions.
 
-You can sign into your account if you need to check the progress of your reference requests.
+You can sign in to your account if you need to check the progress of your reference requests.
 
 <% if RecruitedWithPendingConditions.new(application_choice: @application_choice).call %>
 Remember to complete your subject knowledge enhancement (SKE) course to meet the conditions of this offer.
 <% end %>
 
-[Sign into your account](<%= sign_in_link %>).
+[Sign in to your account](<%= sign_in_link %>).
 
 #If you are unable to start training in <%= @start_date %>
 

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 
 <%= "You must submit your application by #{l(CycleTimetable.apply_deadline.to_date, format: :no_year)} if you want to start teacher training this year." %>
 
-[Sign into your account to submit your application](<%= application_choices_link %>).
+[Sign in to your account to submit your application](<%= application_choices_link %>).
 
 Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.
 

--- a/app/views/candidate_mailer/new_cycle_has_started.text.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.text.erb
@@ -6,7 +6,7 @@ You can now apply for teacher training courses that start in the <%= @academic_y
 
 Courses can fill up quickly, so apply as soon as you are ready.
 
-[Sign into your account to apply for courses](<%= sign_in_link %>).
+[Sign in to your account to apply for courses](<%= sign_in_link %>).
 
 # Get a teacher training adviser
 

--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -22,6 +22,6 @@ The training provider will usually pay for the criminal records checks.
 
 Contact <%= @provider_name %> if you have any questions about this.
 
-[Sign into your account to respond to your offer](<%= application_choices_link %>).
+[Sign in to your account to respond to your offer](<%= application_choices_link %>).
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -12,7 +12,7 @@ Your request did not reach <%= @reference.name %>. This could be because:
 
 It is important that <%= @provider_name %> receives your references as soon as possible.
 
-You can sign into your account to:
+You can sign in to your account to:
 
 - request the reference again - check the email address before you do this
 - ask someone else for a reference
@@ -24,7 +24,7 @@ You can sign into your account to:
 
 It is important that <%= @provider_name %> receives your references as soon as possible.
 
-You can sign into your account to request a reference from someone else.
+You can sign in to your account to request a reference from someone else.
 
 <% else %>
 
@@ -32,7 +32,7 @@ You asked <%= @reference.name %> for a reference for your teacher training appli
 
 It is important that <%= @provider_name %> receives your references as soon as possible.
 
-You can sign into your account to:
+You can sign in to your account to:
 
 - send them an email to remind them that you have asked for a reference
 - cancel the request for a reference
@@ -40,7 +40,7 @@ You can sign into your account to:
 
 
 <% end %>
-[Sign into your account](<%= sign_in_link %>).
+[Sign in to your account](<%= sign_in_link %>).
 
 <%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -2,7 +2,7 @@ Hello <%= @application_form.first_name %>
 
 You have not applied to any teacher training courses yet.
 
-[Sign into your account to apply for up to 4 courses](<%= application_choices_link %>).
+[Sign in to your account to apply for up to 4 courses](<%= application_choices_link %>).
 
 Popular courses fill up quickly and places are allocated as soon as people apply. Submit your application as soon as you are ready to avoid missing out on a limited number of course places.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
@@ -4,7 +4,7 @@ You have not completed the references section of your teacher training applicati
 
 You need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 
-[Sign into your account to complete the references section](<%= @references_link %>).
+[Sign in to your account to complete the references section](<%= @references_link %>).
 
 # Who to choose to give you a reference
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -7,6 +7,6 @@ Your place will be confirmed when:
 - <%= @provider_name %> has received and checked your references
 - you have met your offer conditions
 
-[Sign into your account](<%= sign_in_link %>) to check the progress of your reference requests and offer conditions.
+[Sign in to your account](<%= sign_in_link %>) to check the progress of your reference requests and offer conditions.
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -3,13 +3,13 @@ Dear <%= @application_form.first_name %>
 <% if @application_form.recruited? %>
 <%= @reference.application_form.application_choices.recruited.first&.provider&.name %> has received a reference for you from <%= @reference.name%>.
 
-You can sign into your account to check the progress of your reference requests.
+You can sign in to your account to check the progress of your reference requests.
 <% else %>
 <%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> has received a reference for you from <%= @reference.name%>.
 
-You can sign into your account to check the progress of your reference requests and offer conditions.
+You can sign in to your account to check the progress of your reference requests and offer conditions.
 <% end %>
 
-[Sign into your account](<%= sign_in_link %>).
+[Sign in to your account](<%= sign_in_link %>).
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -9,9 +9,9 @@ The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year)
 <% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 
-  Sign into your account to check the progress of your offer conditions.
+  Sign in to your account to check the progress of your offer conditions.
 
-  [Sign into your account](<%= sign_in_link %>).
+  [Sign in to your account](<%= sign_in_link %>).
 <% end %>
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/reject_by_default_explainer.text.erb
@@ -10,7 +10,7 @@ This is because the provider did not respond before their deadline. If you have 
 
 You can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
 
-[Sign into your account to update your details](<%= sign_in_link %>).
+[Sign in to your account to update your details](<%= sign_in_link %>).
 
 # Get help
 

--- a/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
@@ -4,7 +4,7 @@
 
 You have been offered a place on a teacher training course. If you want to accept this place, you must do so by <%= @decline_by_default_deadline %>.
 
-[Sign into your account to accept your place on a teacher training course](<%= application_choices_link %>).
+[Sign in to your account to accept your place on a teacher training course](<%= application_choices_link %>).
 
 # Your other applications
 
@@ -18,7 +18,7 @@ If you want to accept your offer of a place on a teacher training course, you mu
 
 If you do not want to accept this offer, you can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
 
-[Sign into your account to update your details](<%= application_choices_link %>).
+[Sign in to your account to update your details](<%= application_choices_link %>).
 
 # Get help
 

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -6,6 +6,6 @@ You have accepted <%= @provider_name %>’s offer to study <%= @course_name_and_
 
 They’ll let you know if they need further information before you can start training.
 
-[Sign into your account](<%= sign_in_link %>) to check the progress of your reference requests.
+[Sign in to your account](<%= sign_in_link %>) to check the progress of your reference requests.
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/provider_mailer/respond_to_applications_before_reject_by_default_date.text.erb
+++ b/app/views/provider_mailer/respond_to_applications_before_reject_by_default_date.text.erb
@@ -6,7 +6,7 @@ This includes candidates you are interviewing.
 
 If you do not make an offer by <%= @reject_by_default_date %>, any applications marked as ‘received’ or ‘interviewing’ will be automatically rejected. This means you may miss out on high quality candidates.
 
-[Sign into your account to review your applications](<%= @applications_url %>)
+[Sign in to your account to review your applications](<%= @applications_url %>)
 
 If you offer a candidate a place, they will have until <%= @decline_by_default_date %> to accept it.
 

--- a/config/locales/candidate_interface/account_recovery_requests.yml
+++ b/config/locales/candidate_interface/account_recovery_requests.yml
@@ -3,7 +3,7 @@ en:
     account_recovery_requests:
       new:
         form:
-          content: Enter the email address you have used to sign into Apply for teacher training in the past. We will send an email with a code to that address.
+          content: Enter the email address you have used to sign in to Apply for teacher training in the past. We will send an email with a code to that address.
           email_address:
             label: Email address
           submit: Send email

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -22,7 +22,7 @@ en:
       button: Email me a new link
     confirm_authentication:
       heading: Create an account to apply for teacher training
-    successful_account_recovery_html: Profiles connected<br><p>You have connected your Apply for teacher training profile to the email address you use for GOV.UK One Login.<br> You should use your GOV.UK One Login email address to sign into Apply for teacher training in future.</p>
+    successful_account_recovery_html: Profiles connected<br><p>You have connected your Apply for teacher training profile to the email address you use for GOV.UK One Login.<br> You should use your GOV.UK One Login email address to sign in to Apply for teacher training in future.</p>
   activemodel:
     errors:
       models:
@@ -45,7 +45,7 @@ en:
               wrong_length: The code must be 6 characters and only contain numbers 0 to 9
               expired: This code has expired, you can request a new one
               not_found: This code is not recognised, you can request a new one
-              one_login_already_present: The account you are trying to claim is already linked to a GOV.UK One Login. Use that email address to sign into Apply for teacher training.
+              one_login_already_present: The account you are trying to claim is already linked to a GOV.UK One Login. Use that email address to sign in to Apply for teacher training.
         candidate_interface/account_recovery_request_form:
           attributes:
             previous_account_email_address:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -96,4 +96,4 @@ en:
     apply_to_course_after_inactivity:
       subject: Increase your chances of receiving an offer for teacher training
     one_login_is_coming:
-      subject: How you sign into Apply for teacher training is changing 
+      subject: How you sign in to Apply for teacher training is changing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,7 +132,7 @@ en:
     sign_up: Create an account
     sign_in: Sign in
     email_address_not_recognised: Your email address is not recognised
-    external_sign_up_forbidden: Only DfE users can sign into this website
+    external_sign_up_forbidden: Only DfE users can sign in to this website
     unauthorized: Your account is not authorized
     sandbox: Use our sandbox to test Apply for teacher training
     start_new_application: Start a new application

--- a/spec/forms/candidate_interface/account_recovery_form_spec.rb
+++ b/spec/forms/candidate_interface/account_recovery_form_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CandidateInterface::AccountRecoveryForm, type: :model do
       expect(form).not_to be_valid
       expect(form.errors[:code]).to eq(
         ['The account you are trying to claim is already linked to a GOV.UK One Login. ' \
-         'Use that email address to sign into Apply for teacher training.'],
+         'Use that email address to sign in to Apply for teacher training.'],
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Hello Fred',
       'offer_details' => 'Congratulations! You have an offer from Arithmetic College to study Mathematics (M101)',
       'contact' => 'Contact Arithmetic College if you have any questions about this',
-      'sign in link' => 'Sign into your account to respond to your offer',
+      'sign in link' => 'Sign in to your account to respond to your offer',
     )
 
     it 'does not render offer deadline text' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_accepted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_accepted_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateMailer do
       'You have accepted Arithmetic College’s offer to study Mathematics (M101)',
       'greeting' => 'Hello Fred',
       'offer_details' => 'You have accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'sign in link' => 'Sign into your account',
+      'sign in link' => 'Sign in to your account',
     )
 
     it 'includes reference text' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_reference_received_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_reference_received_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateMailer do
 
       it 'includes content related to pending conditions' do
         expect(email.body).to include('Arithmetic College has received a reference for you from Scott Knowles')
-        expect(email.body).to include('You can sign into your account to check the progress of your reference requests and offer conditions.')
+        expect(email.body).to include('You can sign in to your account to check the progress of your reference requests and offer conditions.')
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe CandidateMailer do
 
       it 'does not inlude content related to pending conditions' do
         expect(email.body).to include('Arithmetic College has received a reference for you from Scott Knowles')
-        expect(email.body).to include('You can sign into your account to check the progress of your reference requests.')
+        expect(email.body).to include('You can sign in to your account to check the progress of your reference requests.')
       end
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_unconditional_offer_accepted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_unconditional_offer_accepted_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateMailer do
       'You have accepted Arithmetic College’s offer to study Mathematics (M101)',
       'greeting' => 'Hello Fred',
       'offer_details' => 'You have accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'sign in link' => 'Sign into your account',
+      'sign in link' => 'Sign in to your account',
     )
   end
 end

--- a/spec/system/candidate_interface/account_recovery/candidate_recovers_their_account_spec.rb
+++ b/spec/system/candidate_interface/account_recovery/candidate_recovers_their_account_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'Candidate recovers their account' do
   def and_i_see_a_success_message
     expect(page).to have_content(
       'You have connected your Apply for teacher training profile to the email address you use for GOV.UK One Login. ' \
-      'You should use your GOV.UK One Login email address to sign into Apply for teacher training in future.',
+      'You should use your GOV.UK One Login email address to sign in to Apply for teacher training in future.',
     )
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Candidate cannot sign up to a test environment (e.g. qa) without
 
   def then_i_see_an_access_forbidden_page
     expect(page).to have_current_path(candidate_interface_external_sign_up_forbidden_path)
-    expect(page).to have_content('Only DfE users can sign into this website')
+    expect(page).to have_content('Only DfE users can sign in to this website')
   end
 
   def and_i_submit_my_email_address


### PR DESCRIPTION
## Context

This was flagged at the bug party -- sometimes we were saying "sign into", and sometimes we were saying "sign in to". We have confirmed that the correct form of words is "sign in to", so this corrects throughout.

## Changes proposed in this pull request


## Guidance to review


## Link to Trello card

https://trello.com/c/9W5QJgEQ

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
