### PR TITLE
[575] Change login page title when One Login is active

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -28,5 +28,14 @@ module CandidateInterface
     def create_account_or_sign_in_params
       strip_whitespace params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)
     end
+
+    def create_account_page_title
+      if FeatureFlag.active?(:one_login_candidate_sign_in)
+        t('page_titles.create_a_gov_uk_one_login_or_sign_in')
+      else
+        t('page_titles.create_account_or_sign_in')
+      end
+    end
+    helper_method :create_account_page_title
   end
 end

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.create_account_or_sign_in'), @create_account_or_sign_in_form.errors.any?) %>
+<% title = FeatureFlag.active?(:one_login_candidate_sign_in) ? t('page_titles.create_a_gov_uk_one_login_or_sign_in') : t('page_titles.create_account_or_sign_in') %>
+<% content_for :title, title_with_error_prefix(title, @create_account_or_sign_in_form.errors.any?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 
@@ -6,11 +7,12 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render CandidateInterface::OneLoginPreReleaseSignInBannerComponent.new %>
 
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.create_account_or_sign_in') %>
-    </h1>
-
     <% if FeatureFlag.active?(:one_login_candidate_sign_in) %>
+
+      <h1 class="govuk-heading-xl">
+        <%= title %>
+      </h1>
+
       <p class="govuk-body">
         <%= t('govuk.one_login_account_guidance') %>
       </p>
@@ -23,6 +25,10 @@
         method: :post,
       ) do |f| %>
         <%= f.govuk_error_summary %>
+
+        <h1 class="govuk-heading-xl">
+          <%= title %>
+        </h1>
 
         <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
           <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' }, link_errors: true do %>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -1,5 +1,4 @@
-<% title = FeatureFlag.active?(:one_login_candidate_sign_in) ? t('page_titles.create_a_gov_uk_one_login_or_sign_in') : t('page_titles.create_account_or_sign_in') %>
-<% content_for :title, title_with_error_prefix(title, @create_account_or_sign_in_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(create_account_page_title, @create_account_or_sign_in_form.errors.any?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 
@@ -10,7 +9,7 @@
     <% if FeatureFlag.active?(:one_login_candidate_sign_in) %>
 
       <h1 class="govuk-heading-xl">
-        <%= title %>
+        <%= create_account_page_title %>
       </h1>
 
       <p class="govuk-body">
@@ -27,7 +26,7 @@
         <%= f.govuk_error_summary %>
 
         <h1 class="govuk-heading-xl">
-          <%= title %>
+          <%= create_account_page_title %>
         </h1>
 
         <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
     unsubmitted_previous_application: Your previously unsubmitted application
     submitted_application: Your submitted application
     create_account_or_sign_in: Create an account or sign in
+    create_a_gov_uk_one_login_or_sign_in: Create a GOV.UK One Login or sign in
     sign_up: Create an account
     sign_in: Sign in
     email_address_not_recognised: Your email address is not recognised

--- a/lib/tasks/jmeter.rake
+++ b/lib/tasks/jmeter.rake
@@ -34,7 +34,7 @@ def generate_plan(host:, thread_count:, token:)
       end
 
       visit name: 'GET candidate account page', url: "#{host}/candidate/account" do
-        assert contains: 'Create an account or sign in'
+        assert contains: FeatureFlag.active?(:one_login_candidate_sign_in) ? 'Create a GOV.UK One Login or sign in' : 'Create an account or sign in'
       end
 
       header name: 'COOKIE', value: "_apply_for_postgraduate_teacher_training_session=#{token}"

--- a/spec/system/candidate_interface/candidate_session_timeout_spec.rb
+++ b/spec/system/candidate_interface/candidate_session_timeout_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate viewing booked interviews' do
+RSpec.describe 'Candidate session timeout' do
   include CandidateHelper
   include ActiveSupport::Testing::TimeHelpers
 
@@ -47,7 +47,7 @@ RSpec.describe 'Candidate viewing booked interviews' do
   end
 
   def then_i_see_the_login_page
-    expect(page).to have_content 'Create an account or sign in'
+    expect(page).to have_content 'Create a GOV.UK One Login or sign in'
   end
 
 private

--- a/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
@@ -65,7 +65,7 @@ private
   end
 
   def then_i_am_logged_out
-    expect(page).to have_title 'Create an account or sign in'
+    expect(page).to have_title 'Create a GOV.UK One Login or sign in'
     expect(page).to have_content 'You need a GOV.UK One Login to sign in to this service. You can create one if you do not already have one.'
     expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path
   end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Candidate tries to sign in without an account' do
   include SignInHelper
 
+  before  { FeatureFlag.deactivate :one_login_candidate_sign_in }
+
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_i_am_a_candidate_without_an_account
 


### PR DESCRIPTION
## Context

As an existing Apply user I might think 'I already have an account with Apply' so it is confusing (unless I read the smaller text on the page) why I'm being asked to create an account. Especially as the 'Apply for teacher training' service name is displayed.

## Changes proposed in this pull request
- Change the title of the page
- Also moved the heading below the error summary (accessibility fix while I'm here)

| With magic link | With One Login |
| --------------- | --------------- |
| <img width="778" alt="image" src="https://github.com/user-attachments/assets/4b9dec59-ad23-45c4-8ea0-4466dbbdc147" /> | <img width="681" alt="image" src="https://github.com/user-attachments/assets/a4ede9ff-3256-4b28-a74f-a26cffab8e93" /> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/02DkpuXs

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
