### PR TITLE
Introduce candidate to wrong email address page 

### DIFF
--- a/app/controllers/candidate_interface/errors_controller.rb
+++ b/app/controllers/candidate_interface/errors_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class ErrorsController < CandidateInterfaceController
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_candidate!
+    allow_unauthenticated_access only: [:wrong_email_address]
 
     def account_locked
       render 'errors/account_locked', status: :forbidden, formats: :html
@@ -9,6 +10,10 @@ module CandidateInterface
 
     def not_found
       render 'errors/not_found', status: :not_found, formats: :html
+    end
+
+    def wrong_email_address
+      render 'errors/wrong_email_address_used_for_candidate', status: :forbidden, formats: :html
     end
   end
 end

--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -74,7 +74,7 @@ class OneLoginController < ApplicationController
   def sign_out_complete
     if session[:session_error_id].present?
       reset_session
-      redirect_to internal_server_error_path
+      redirect_to candidate_interface_wrong_email_address_path
     else
       redirect_to candidate_interface_create_account_or_sign_in_path
     end

--- a/app/views/errors/wrong_email_address_used_for_candidate.html.erb
+++ b/app/views/errors/wrong_email_address_used_for_candidate.html.erb
@@ -1,0 +1,23 @@
+<%= content_for :title, t('page_titles.there_is_a_problem') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.there_is_a_problem') %></h1>
+    <div class="govuk-body">
+      <%= t(
+        '.body_html',
+        button_link: render(
+          ButtonToAsLinkComponent.new(
+            name: t('.sign_in'),
+            path: OneLogin.bypass? ? '/auth/one-login-developer' : '/auth/one_login',
+          ),
+        ),
+      ) %>
+    </div>
+
+    <p class="govuk-body">
+      If you have any questions, please email us at
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+    </p>
+  </div>
+</div>

--- a/app/views/errors/wrong_email_address_used_for_candidate.html.erb
+++ b/app/views/errors/wrong_email_address_used_for_candidate.html.erb
@@ -17,7 +17,7 @@
 
     <p class="govuk-body">
       If you have any questions, please email us at
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>
+      <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %>
     </p>
   </div>
 </div>

--- a/config/locales/candidate_interface/errors.yml
+++ b/config/locales/candidate_interface/errors.yml
@@ -1,0 +1,5 @@
+en:
+  errors:
+    wrong_email_address_used_for_candidate:
+      body_html: You should use the email address you use for GOV.UK One Login to %{button_link}.
+      sign_in: sign in to Apply for teacher training

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
     get_your_details_back: Get your details back
     dismiss: Dismiss
   page_titles:
+    there_is_a_problem: There is a problem
     account_recovery: Enter the code we sent to %{email}
     account_recovery_resend_email: Enter the new code we sent to %{email}
     account_recovery_request: Get your account details back

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -608,6 +608,7 @@ namespace :candidate_interface, path: '/candidate' do
   end
 
   get '/account-locked', to: 'errors#account_locked'
+  get '/wrong-email-address', to: 'errors#wrong_email_address'
 
   get '/about-the-teacher-training-application-process', to: 'guidance#index', as: :guidance
 

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'OneLoginController' do
           "One login session error, check session_error record #{SessionError.last.id}",
           level: :error,
         )
-        expect(response).to redirect_to(internal_server_error_path)
+        expect(response).to redirect_to(candidate_interface_wrong_email_address_path)
       end
     end
 


### PR DESCRIPTION
## Context

If a candidate tries to login with the candidate email address and they have a one login email address that is different from the candidate email address. We will not allow the user to login, with one login.

We will redirect the user to the wrong_email_address page. From here the user can try to login again.

Previously we would have redirected the user to 500 error page. This page is intended to have more content helping the candidate to unstuck themselves rather than contacting support

## Changes proposed in this pull request

New candidate wrong email page

## Guidance to review


https://github.com/user-attachments/assets/d1e1ddb4-662f-4894-88e7-f5da525af122



## Link to Trello card

https://trello.com/c/mZLgSj2z

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
