### PR TITLE
Implement post-release one login banner for sign in page

### DIFF
--- a/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.html.erb
+++ b/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: t('.title')) do |banner| %>
+  <% banner.with_heading(text: t('.heading')) %>
+  <%= t('.text_html') %>
+<% end %>

--- a/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.rb
+++ b/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class OneLoginPostReleaseSignInBannerComponent < ViewComponent::Base
+    def render?
+      FeatureFlag.active?(:one_login_candidate_sign_in)
+    end
+  end
+end

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -5,6 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render CandidateInterface::OneLoginPreReleaseSignInBannerComponent.new %>
+    <%= render CandidateInterface::OneLoginPostReleaseSignInBannerComponent.new %>
 
     <% if FeatureFlag.active?(:one_login_candidate_sign_in) %>
 

--- a/config/locales/components/candidate_interface/one_login_post_release_sign_in_banner_component.yml
+++ b/config/locales/components/candidate_interface/one_login_post_release_sign_in_banner_component.yml
@@ -1,0 +1,8 @@
+en:
+  candidate_interface:
+    one_login_post_release_sign_in_banner_component:
+      title: Important
+      heading: How you sign in has changed
+      text_html:
+        <p class="govuk-body">Sign in using your GOV.UK One Login. If you do not have one you can create one.</p>
+        <p class="govuk-body">If you have signed in to Apply for teacher training before, you should use the same email address to create your GOV.UK One Login.</p>

--- a/spec/components/candidate_interface/one_login_post_release_sign_in_banner_component_spec.rb
+++ b/spec/components/candidate_interface/one_login_post_release_sign_in_banner_component_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::OneLoginPostReleaseSignInBannerComponent do
+  context 'One login is deactivated' do
+    before do
+      FeatureFlag.deactivate(:one_login_candidate_sign_in)
+    end
+
+    it 'does not renders the component' do
+      result = render_inline(described_class.new)
+      expect(result.content).to be_empty
+    end
+  end
+
+  context 'One login is activated' do
+    before do
+      FeatureFlag.activate(:one_login_candidate_sign_in)
+    end
+
+    it 'does render the component' do
+      result = render_inline(described_class.new)
+      expect(result).to have_content 'How you sign in has changed'
+      expect(result).to have_content 'Sign in using your GOV.UK One Login. If you do not have one you can create one.'
+      expect(result).to have_content 'If you have signed in to Apply for teacher training before, you should use the same email address to create your GOV.UK One Login.'
+    end
+  end
+end

--- a/spec/components/previews/candidate_interface/one_login_pre_release_banners_preview.rb
+++ b/spec/components/previews/candidate_interface/one_login_pre_release_banners_preview.rb
@@ -7,5 +7,9 @@ module CandidateInterface
     def one_login_pre_release_sign_in_banner_component
       render(CandidateInterface::OneLoginPreReleaseSignInBannerComponent.new)
     end
+
+    def one_login_post_release_sign_in_banner_component
+      render CandidateInterface::OneLoginPostReleaseSignInBannerComponent.new
+    end
   end
 end


### PR DESCRIPTION
## Context

We are currently displaying a service banner letting people know that one login is coming on the sign in page. Once it is live, we want to show a different banner. 

## Changes proposed in this pull request

| Pre-release | Post-release | 
| ------ | ------ |
| <img width="835" alt="image" src="https://github.com/user-attachments/assets/71172b07-a646-4e74-b8d0-7f85e10ae39e" /> | <img width="839" alt="image" src="https://github.com/user-attachments/assets/ff984c52-b830-400e-bd71-dcd4d668d7a0" /> |

## Guidance to review

Can be viewed locally or on the review app at `/rails/view_components/candidate_interface/one_login_pre_release_banners/one_login_post_release_sign_in_banner_component`, or if the one login feature is turned on, at `/candidate/account`

## Link to Trello card

https://trello.com/c/oXhetRk7

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
