### PR TITLE
[445] Update referee emails to include confidentiality statement

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -3,6 +3,7 @@ class RefereeMailer < ApplicationMailer
     @application_form = reference.application_form
     @reference = reference
     @candidate_name = @application_form.full_name
+    @candidate_first_name = @application_form.first_name
     @unhashed_token = reference.refresh_feedback_token!
     @referee_type = @reference.referee_type
     @provider_name = @application_form.application_choices.select(&:accepted_choice?).first.provider.name
@@ -20,6 +21,7 @@ class RefereeMailer < ApplicationMailer
     @application_form = application_form
     @reference = reference
     @candidate_name = @application_form.full_name
+    @candidate_first_name = @application_form.first_name
     @unhashed_token = reference.refresh_feedback_token!
     @referee_type = @reference.referee_type
     @provider_name = @application_form.application_choices.select(&:accepted_choice?).first.provider.name
@@ -59,6 +61,7 @@ class RefereeMailer < ApplicationMailer
     @application_form = reference.application_form
     @reference = reference
     @candidate_name = @application_form.full_name
+    @candidate_first_name = @application_form.first_name
     @unhashed_token = reference.refresh_feedback_token!
     @referee_type = @reference.referee_type
     @provider_name = @application_form.application_choices.select(&:accepted_choice?).first.provider.name

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -9,6 +9,10 @@ You will need to:
 -say whether you have any concerns about them working with children
 -give factual information which can be used to check their application, for example about <%= t("referee_mailer.guidance.#{@referee_type}") %>
 
+<% if FeatureFlag.active?(:show_reference_confidentiality_status) %>
+You can choose whether <%= @candidate_first_name %> will be able to see your reference or if it should be kept confidential.
+<% end %>
+
 Use this link to give the reference or to say you cannot give one:
 
 <%= referee_interface_url(token: @unhashed_token) %>

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RefereeMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        I18n.t('referee_mailer.reference_request.subject', candidate_name: 'Elliot Alderson'),
+        'Teacher training reference needed for Elliot Alderson',
         'heading' => 'Dear Jane',
         'details' => 'Elliot Alderson has accepted an offer from University of Warwick for a place on a teacher training course',
         'further guidance' => 'whether you have any concerns about them working with children',
@@ -94,7 +94,7 @@ RSpec.describe RefereeMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        I18n.t('referee_mailer.reference_request.subject', candidate_name: 'Elliot Alderson'),
+        'Teacher training reference needed for Elliot Alderson',
         'heading' => 'Dear Jane',
         'details' => 'Elliot Alderson has accepted an offer from University of Warwick for a place on a teacher training course',
         'further guidance' => 'whether you have any concerns about them working with children',
@@ -125,7 +125,7 @@ RSpec.describe RefereeMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t('reference_confirmation_email.subject', candidate_name: 'Elliot Alderson'),
+      'Teacher training reference submitted for Elliot Alderson',
       'heading' => 'Dear Jane',
     )
   end
@@ -139,7 +139,7 @@ RSpec.describe RefereeMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t('reference_cancelled_email.subject', candidate_name: 'Elliot Alderson'),
+      'Teacher training reference no longer needed for Elliot Alderson',
       'heading' => 'Dear Jane',
     )
   end
@@ -157,7 +157,7 @@ RSpec.describe RefereeMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        I18n.t('referee_mailer.reference_request.subject', candidate_name: 'Elliot Alderson'),
+        'Teacher training reference needed for Elliot Alderson',
         'heading' => 'Dear Jane',
         'reference link' => '/reference?token=raw_token',
         'details' => 'Elliot Alderson has accepted an offer from University of Warwick for a place on a teacher training course',


### PR DESCRIPTION
## Context

We recently made changes to our references process to allow referees to indicate whether a reference should be kept confidential from the candidate.

We need to update our emails to reflect this change.


## Guidance to review

Have a look at these emails: 

- https://apply-review-10291.test.teacherservices.cloud/rails/mailers/referee_mailer/reference_request_email
- https://apply-review-10291.test.teacherservices.cloud/rails/mailers/referee_mailer/reference_request_chaser_email
- https://apply-review-10291.test.teacherservices.cloud/rails/mailers/referee_mailer/reference_request_chase_again_email

Switch on/off the `Show reference confidentiality status` feature flag here: https://apply-review-10291.test.teacherservices.cloud/support/settings/feature-flags

The new content should only render when the feature flag is on.
