### PR TITLE
Remove Trello Heading from PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,6 @@
 
 <!-- How could someone else check this work? Which parts do you want more feedback on? -->
 
-## Link to Trello card
-
-<!-- Paste the anonymised Trello link here. Avoid sharing the full card URL that reveals card details. -->
 
 ## Things to check
 
@@ -20,7 +17,7 @@
 - [ ] This code does not rely on migrations in the same Pull Request
 - [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
 - [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
-- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
+- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
 - [ ] API release notes have been updated if necessary
 - [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
 - [ ] Attach the PR to the Trello card


### PR DESCRIPTION
## Context

Github/Trello integration is working again

We no longer need the heading for a trello card on the PR template as we attach the PR to the trello card, which automatically links it to the PR.