### PR TITLE
Add Api tokens counters to support api token index page

### DIFF
--- a/app/controllers/support_interface/api_tokens_controller.rb
+++ b/app/controllers/support_interface/api_tokens_controller.rb
@@ -5,6 +5,7 @@ module SupportInterface
         VendorAPIToken.arel_table[:last_used_at].desc.nulls_last,
         created_at: :desc,
       )
+      @api_tokens_last_3_months_count = @api_tokens.where('last_used_at >= ?', 3.months.ago).count
     end
 
     def new

--- a/app/controllers/support_interface/api_tokens_controller.rb
+++ b/app/controllers/support_interface/api_tokens_controller.rb
@@ -5,7 +5,7 @@ module SupportInterface
         VendorAPIToken.arel_table[:last_used_at].desc.nulls_last,
         created_at: :desc,
       )
-      @api_tokens_last_3_months_count = @api_tokens.where('last_used_at >= ?', 3.months.ago).count
+      @api_tokens_last_3_months_count = VendorAPIToken.used_in_last_3_months.count
     end
 
     def new

--- a/app/models/vendor_api_token.rb
+++ b/app/models/vendor_api_token.rb
@@ -3,6 +3,8 @@ class VendorAPIToken < ApplicationRecord
 
   audited associated_with: :provider
 
+  scope :used_in_last_3_months, -> { where('last_used_at >= ?', 3.months.ago) }
+
   def self.create_with_random_token!(provider:)
     unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
     create!(hashed_token:, provider:)

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -2,6 +2,25 @@
 
 <%= govuk_button_link_to 'Add a token', new_support_interface_api_token_path %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(
+      count: @api_tokens.count,
+      label: 'API tokens issued',
+      colour: :blue,
+      href: '#not-connected',
+    ) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(
+      count: @api_tokens_last_3_months_count,
+      label: 'API tokens used in the last 3 months',
+      colour: :blue,
+      href: '#not-synced',
+    ) %>
+  </div>
+</div>
+
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -3,7 +3,7 @@
 <%= govuk_button_link_to 'Add a token', new_support_interface_api_token_path %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
+  <div class="govuk-grid-column-one-half">
     <%= render SupportInterface::TileComponent.new(
       count: @api_tokens.count,
       label: 'API tokens issued',
@@ -11,7 +11,7 @@
       href: '#not-connected',
     ) %>
   </div>
-  <div class="govuk-grid-column-one-quarter">
+  <div class="govuk-grid-column-one-half">
     <%= render SupportInterface::TileComponent.new(
       count: @api_tokens_last_3_months_count,
       label: 'API tokens used in the last 3 months',

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -8,7 +8,6 @@
       count: @api_tokens.count,
       label: 'API tokens issued',
       colour: :blue,
-      href: '#not-connected',
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
@@ -16,7 +15,6 @@
       count: @api_tokens_last_3_months_count,
       label: 'API tokens used in the last 3 months',
       colour: :blue,
-      href: '#not-synced',
     ) %>
   </div>
 </div>

--- a/spec/system/support_interface/api_tokens/view_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens/view_tokens_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'API tokens' do
     given_i_am_signed_in
     and_api_tokens_exist
     when_i_visit_the_tokens_page
-    then_i_see_all_the_providers_with_api_tokens
+    then_i_see_the_count_of_providers_with_api_tokens
   end
 
   def given_i_am_signed_in
@@ -27,7 +27,7 @@ RSpec.describe 'API tokens' do
     visit support_interface_api_tokens_path
   end
 
-  def then_i_see_all_the_providers_with_api_tokens
+  def then_i_see_the_count_of_providers_with_api_tokens
     expect(page).to have_content '2 API tokens issued'
     expect(page).to have_content '1 API tokens used in the last 3 months'
 

--- a/spec/system/support_interface/api_tokens/view_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens/view_tokens_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'API tokens' do
+  include DfESignInHelpers
+
+  scenario 'Support views vendors with api tokens' do
+    given_i_am_signed_in
+    and_api_tokens_exist
+    when_i_visit_the_tokens_page
+    then_i_see_all_the_providers_with_api_tokens
+  end
+
+  def given_i_am_signed_in
+    sign_in_as_support_user
+  end
+
+  def and_api_tokens_exist
+    vendor = create(:vendor, name: 'vendor_1')
+    provider_1 = create(:provider, name: 'Provider 1', vendor:)
+    provider_2 = create(:provider, name: 'Provider 2', vendor:)
+
+    create(:vendor_api_token, provider: provider_1, last_used_at: 1.month.ago)
+    create(:vendor_api_token, provider: provider_2)
+  end
+
+  def when_i_visit_the_tokens_page
+    visit support_interface_api_tokens_path
+  end
+
+  def then_i_see_all_the_providers_with_api_tokens
+    expect(page).to have_content '2 API tokens issued'
+    expect(page).to have_content '1 API tokens used in the last 3 months'
+
+    within '.govuk-table' do
+      expect(page).to have_content 'Provider 1'
+      expect(page).to have_content 'Provider 2'
+      expect(page).to have_content 'vendor_1'
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want more information at a glace on the support API tokens page.

This PR will add a counter of all the API tokens for our provider and a counter of the tokens used in the last 3 mounths.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Support API token index page

## Guidance to review

![Screenshot from 2025-01-22 16-28-22](https://github.com/user-attachments/assets/acfb62ec-8bc8-4985-9268-70e890b13efc)



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
