### PR TITLE
[594] Surface whether candidate has a one login account on support

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -25,6 +25,7 @@ module SupportInterface
         subsequent_application_row,
         average_distance_row,
         editable_extension_row,
+        one_login_account_row,
       ].compact
     end
 
@@ -85,6 +86,13 @@ module SupportInterface
       }
     end
 
+    def one_login_account_row
+      {
+        key: 'Has One Login account',
+        value: one_login? ? 'Yes' : 'No',
+      }
+    end
+
     def state_row
       {
         key: 'State',
@@ -138,6 +146,10 @@ module SupportInterface
       name = I18n.t!("candidate_flow_application_states.#{candidate_flow_state}.name")
       desc = I18n.t!("candidate_flow_application_states.#{candidate_flow_state}.description")
       "<strong>#{name}</strong><br>#{desc}".html_safe
+    end
+
+    def one_login?
+      application_form.candidate.one_login_auth.present?
     end
 
     attr_reader :application_form

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -7,6 +7,7 @@ module SupportInterface
              :submitted_at,
              :submitted?,
              :updated_at,
+             :candidate,
              to: :application_form
 
     def initialize(application_form:)
@@ -149,7 +150,7 @@ module SupportInterface
     end
 
     def one_login?
-      application_form.candidate.one_login_auth.present?
+      candidate.one_login_connected?
     end
 
     attr_reader :application_form

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -121,6 +121,10 @@ class Candidate < ApplicationRecord
       !application_choices_submitted?
   end
 
+  def one_login_connected?
+    one_login_auth.present?
+  end
+
 private
 
   def downcase_email

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -47,5 +47,53 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
         expect(result.css('.govuk-summary-list__key').text).not_to include('Is this application editable')
       end
     end
+
+    context 'when the candidate has a OneLogin account' do
+      it 'displays "Yes" for the One Login account row' do
+        candidate = create(:candidate)
+        candidate.create_one_login_auth!(
+          token: '123',
+          email_address: candidate.email_address,
+        )
+        application_form = create(:completed_application_form, candidate:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__value').text).to include('Yes')
+      end
+    end
+
+    context 'when the candidate does not have a OneLogin account' do
+      it 'displays "No" for the One Login account row' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, candidate:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__value').text).to include('No')
+      end
+    end
+
+    context 'when the candidate had a OneLogin account but it was deleted' do
+      it 'displays "No" for the One Login account row' do
+        candidate = create(:candidate)
+        one_login_auth = candidate.create_one_login_auth!(
+          token: '123',
+          email_address: candidate.email_address,
+        )
+
+        one_login_auth.delete
+        candidate.reload
+
+        application_form = create(:completed_application_form, candidate:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__value').text).to include('No')
+      end
+    end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -404,4 +404,22 @@ RSpec.describe Candidate do
       end
     end
   end
+
+  describe '#one_login_connected?' do
+    let(:candidate) { create(:candidate) }
+
+    context 'when the candidate has a OneLoginAuth record' do
+      before { create(:one_login_auth, candidate:) }
+
+      it 'returns true' do
+        expect(candidate.one_login_connected?).to be true
+      end
+    end
+
+    context 'when the candidate does not have a OneLoginAuth record' do
+      it 'returns false' do
+        expect(candidate.one_login_connected?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We’re about to go live with One Login. It could be very helpful for Support users to be able to confirm via the support console if a given candidate’s Apply account is associated/linked to a One Login account. 

This may aid with support queries.

## Changes proposed in this pull request

Surface whether a candidate has a one login account or not using `one_login_auth.present?`

## Guidance to review

Will this work in practice? Is there a better check?
