### PR TITLE
Redirect the candidate to the correct error page

### DIFF
--- a/app/models/session_error.rb
+++ b/app/models/session_error.rb
@@ -1,3 +1,8 @@
 class SessionError < ApplicationRecord
   belongs_to :candidate, optional: true
+
+  enum :error_type, {
+    internal: 'internal',
+    wrong_email_address: 'wrong_email_address',
+  }
 end

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -229,6 +229,11 @@ RSpec.describe 'OneLoginController' do
       )
       expect(session[:session_error_id]).to eq(SessionError.last.id)
       expect(response).to redirect_to(auth_one_login_sign_out_path)
+
+      # a failure will need to call sign_out_complete
+      get auth_one_login_sign_out_complete_path
+
+      expect(response).to redirect_to(internal_server_error_path)
     end
   end
 end


### PR DESCRIPTION
## Context

There are two types of errors the candidate can encounter when using one
login. Typical 500 errors and when a user uses the wrong email address

We need to know what error the candidate gets to redirect them to the
correct page.

Prior to this change we are redirecting the candidate to wrong_email
error page even if it's a 500 error page.

This will go after https://github.com/DFE-Digital/apply-for-teacher-training/pull/10298

This commit redirects the user to the correct error page
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Very tricky to test on local or review app. This needs to be tested on sandbox or QA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
