### PR TITLE
Fix sandbox page redirect

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -23,9 +23,20 @@ private
   end
 
   def resume_session
+    if !one_login_enabled?
+      terminate_session
+      return nil
+    end
+
     session = Current.session ||= find_session_by_cookie
-    session.touch if session.present?
-    session
+
+    if session.present?
+      session.touch
+      session
+    else
+      terminate_session
+      nil
+    end
   end
 
   def find_session_by_cookie


### PR DESCRIPTION
## Context

On sandbox, when we log out the user. We redirect them to
contents#sandbox.

This controller is not properly setup to deal with one login, especially
when the one login feature is turned off.

Redirects from the page of this controller hit the Authentication. The
concern returns true that the candidate is signed but with db backed
session, not devise. So the user is stuck in a loop because devise
thinks the user is not signed in but our DB backed session concern says
it is.

Clearing the session fixes this issue.

In reality this should not happen because we don't attempt to use the db
session login when one login is off, in any of our other controllers.
But requests from this controller accesses the Authentication concern.

This commit tries to fix this by just clearing the session if one login
feature is not enabled, this will fix this issue. Ideally we would want
to not have this controller send requests to the Authentication concern
if one login is not enabled.

## Changes proposed in this pull request

Authentication concern

## Guidance to review

Only possible to test on sadbox. Or locally if you're really motivated


https://github.com/user-attachments/assets/5db07e89-993a-4a0a-9ec5-41eea14796dc



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
