### PR TITLE
Add documentation to support for dismissing a one login recovery banner

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -709,6 +709,36 @@ Check logs in Kibana. If there is a 422 Unprocessable Entity response for this u
 > If this problem persists please get in touch and we will investigate further.
 
 
+## One Login account recovery dismissal
+
+If a candidate dismisses the banner for linking their GOV.UK One Login to an existing candidate account (one they created with magic link authentication)
+
+Check the Candidate `account_recovery_status`.
+If `candidate.account_recovery_status == 'dismissed'`
+- No problem, they just clicked the button.
+```ruby
+candidate.account_recovery_request.destroy
+candidate.update(account_recovery_status: 'not_started')
+```
+
+Now the candidate should be able to see the banner and proceed as expected.
+Note that if the candidate has submitted any application choices on their new account, they will not be able to link it with an old account.
+
+If `candidate.account_recovery_status == 'recovered'`
+- Only proceed if `!candidate.application_choices_submitted?`
+- Confirm with support what this candidate wants to do, because we might have a data breach problem if they have managed to link themselves to the wrong candidate.
+- You might also need to confirm with policy as it is not clear how a candidate would get into the state.
+
+Assuming there is a good reason for it:
+
+```ruby
+candidate.one_login_auth.destroy
+candidate.account_recovery_request.destroy
+candidate.update(account_recovery_status: 'not_started')
+```
+
+Now they will have to start the whole One Login journey over again.
+
 ## Switch email addresses
 
 ```ruby


### PR DESCRIPTION
## Context

If a candidate dismisses the banner about account recovery, they don't currently have a way to return to the recovery path. It's been decided that rather than build a support UI for this, it will be handled by the developer until we see how much of a problem it is.

## Changes proposed in this pull request

Some guidance in the support playbook for when / how to allow the user to see the account recovery banner again. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
