### PR TITLE
Add one login email address to what support users can see about a candidate

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -90,7 +90,7 @@ module SupportInterface
     def one_login_account_row
       {
         key: 'Has One Login account',
-        value: one_login? ? 'Yes' : 'No',
+        value: one_login? ? "Yes (#{candidate.one_login_auth.email_address})" : 'No',
       }
     end
 

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
         candidate = create(:candidate)
         candidate.create_one_login_auth!(
           token: '123',
-          email_address: candidate.email_address,
+          email_address: 'some_other_email_address@gmail.com',
         )
         application_form = create(:completed_application_form, candidate:)
 
         result = render_inline(described_class.new(application_form:))
 
         expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
-        expect(result.css('.govuk-summary-list__value').text).to include('Yes')
+        expect(result.css('.govuk-summary-list__value').text).to include('Yes (some_other_email_address@gmail.com)')
       end
     end
 


### PR DESCRIPTION
## Context

When working out why a candidate might be experiencing one login difficulties, it will be useful to see what email address they use for one login at a glance form the support console. 

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="1170" alt="image" src="https://github.com/user-attachments/assets/018db619-9bcf-4090-b422-e1c45c5740f3" /> | <img width="1221" alt="image" src="https://github.com/user-attachments/assets/57293186-95b3-40b0-b9d3-01a0e473f9b5" /> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
