### PR TITLE
[593] Edit email subscription status (support functionality)

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -27,6 +27,7 @@ module SupportInterface
         average_distance_row,
         editable_extension_row,
         one_login_account_row,
+        unsubscribed_from_emails,
       ].compact
     end
 
@@ -94,6 +95,17 @@ module SupportInterface
       }
     end
 
+    def unsubscribed_from_emails
+      {
+        key: 'Subscribed to emails',
+        value: unsubscribed_from_emails? ? 'Yes' : 'No',
+        action: {
+          href: support_interface_email_subscription_path(application_form),
+          visually_hidden_text: 'Subscribed to emails',
+        },
+      }
+    end
+
     def state_row
       {
         key: 'State',
@@ -151,6 +163,10 @@ module SupportInterface
 
     def one_login?
       candidate.one_login_connected?
+    end
+
+    def unsubscribed_from_emails?
+      candidate.unsubscribed_from_emails
     end
 
     attr_reader :application_form

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -98,10 +98,10 @@ module SupportInterface
     def unsubscribed_from_emails
       {
         key: 'Subscribed to emails',
-        value: unsubscribed_from_emails? ? 'Yes' : 'No',
+        value: subscribed_to_emails? ? 'Yes' : 'No',
         action: {
           href: support_interface_email_subscription_path(application_form),
-          visually_hidden_text: 'Subscribed to emails',
+          visually_hidden_text: 'applicant email subscription status',
         },
       }
     end
@@ -165,8 +165,8 @@ module SupportInterface
       candidate.one_login_connected?
     end
 
-    def unsubscribed_from_emails?
-      candidate.unsubscribed_from_emails
+    def subscribed_to_emails?
+      candidate.subscribed_to_emails?
     end
 
     attr_reader :application_form

--- a/app/controllers/support_interface/application_forms/email_subscription_controller.rb
+++ b/app/controllers/support_interface/application_forms/email_subscription_controller.rb
@@ -14,7 +14,7 @@ module SupportInterface
           flash_success
           redirect_to support_interface_application_form_path(@application_form)
         else
-          render :edit
+          render :edit, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/support_interface/application_forms/email_subscription_controller.rb
+++ b/app/controllers/support_interface/application_forms/email_subscription_controller.rb
@@ -1,0 +1,32 @@
+module SupportInterface
+  module ApplicationForms
+    class EmailSubscriptionController < SupportInterfaceController
+     
+      before_action :set_application_form
+    
+      def edit
+        @email_subscription_form = EmailSubscriptionForm.build_from_application(@application_form)
+      end
+
+      def update
+        @email_subscription_form = EmailSubscriptionForm.new(unsubscribed_from_emails_params)
+
+        if @email_subscription_form.save(@application_form)
+          redirect_to support_interface_application_form_path(@application_form)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def unsubscribed_from_emails_params
+        params.require(:support_interface_email_subscription_form).permit(:unsubscribed_from_emails)
+      end
+
+      def set_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/email_subscription_controller.rb
+++ b/app/controllers/support_interface/application_forms/email_subscription_controller.rb
@@ -1,9 +1,8 @@
 module SupportInterface
   module ApplicationForms
     class EmailSubscriptionController < SupportInterfaceController
-     
       before_action :set_application_form
-    
+
       def edit
         @email_subscription_form = EmailSubscriptionForm.build_from_application(@application_form)
       end
@@ -18,10 +17,10 @@ module SupportInterface
         end
       end
 
-      private
+    private
 
       def unsubscribed_from_emails_params
-        params.require(:support_interface_email_subscription_form).permit(:unsubscribed_from_emails)
+        params.require(:support_interface_email_subscription_form).permit(:unsubscribed_from_emails, :audit_comment)
       end
 
       def set_application_form

--- a/app/controllers/support_interface/application_forms/email_subscription_controller.rb
+++ b/app/controllers/support_interface/application_forms/email_subscription_controller.rb
@@ -11,6 +11,7 @@ module SupportInterface
         @email_subscription_form = EmailSubscriptionForm.new(unsubscribed_from_emails_params)
 
         if @email_subscription_form.save(@application_form)
+          flash_success
           redirect_to support_interface_application_form_path(@application_form)
         else
           render :edit
@@ -25,6 +26,10 @@ module SupportInterface
 
       def set_application_form
         @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+
+      def flash_success
+        flash[:success] = "The candidate will #{@application_form.candidate.subscribed_to_emails? ? 'now' : 'no longer'} receive marketing emails"
       end
     end
   end

--- a/app/forms/support_interface/email_subscription_form.rb
+++ b/app/forms/support_interface/email_subscription_form.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class EmailSubscriptionForm
+    include ActiveModel::Model
+
+    attr_accessor :unsubscribed_from_emails
+
+    validates :unsubscribed_from_emails, presence: true
+
+    def save(application_form)
+      return false unless valid?
+      application_form.candidate.update!(unsubscribed_from_emails:,
+      )
+    end
+
+    def self.build_from_application(application_form)
+      new(
+        unsubscribed_from_emails: application_form.candidate.unsubscribed_from_emails,
+      )
+    end
+  end
+end

--- a/app/forms/support_interface/email_subscription_form.rb
+++ b/app/forms/support_interface/email_subscription_form.rb
@@ -2,14 +2,15 @@ module SupportInterface
   class EmailSubscriptionForm
     include ActiveModel::Model
 
-    attr_accessor :unsubscribed_from_emails
+    attr_accessor :unsubscribed_from_emails, :audit_comment
 
     validates :unsubscribed_from_emails, presence: true
+    validates :audit_comment, presence: true
 
     def save(application_form)
       return false unless valid?
-      application_form.candidate.update!(unsubscribed_from_emails:,
-      )
+
+      application_form.candidate.update!(unsubscribed_from_emails:, audit_comment:)
     end
 
     def self.build_from_application(application_form)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -125,6 +125,10 @@ class Candidate < ApplicationRecord
     one_login_auth.present?
   end
 
+  def subscribed_to_emails?
+    !unsubscribed_from_emails
+  end
+
 private
 
   def downcase_email

--- a/app/views/support_interface/application_forms/email_subscription/edit.html.erb
+++ b/app/views/support_interface/application_forms/email_subscription/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :browser_title, title_with_error_prefix(t('support_interface.page_titles.email_subscription_setting'), nil) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with model: @email_subscription_form, url: support_interface_email_subscription_path, method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :unsubscribed_from_emails, legend: { text: t('support_interface.page_titles.email_subscription_setting'), size: 'l', tag: 'h1' } do %>
+
+      <p class="govuk-body">Marketing emails are also known as <%= govuk_link_to('subscription messages', t('support_interface.links.service_manual.subscription_messages')) %>. They relate to something the user has asked to be updated about, for example reminders about submitting their application.</p>
+
+      <p class="govuk-body">Changing this selection does not unsubscribe the user from transactional messages, which relate to something they have done in the service, for example confirmation we have received their application.</p>
+
+        <%= f.govuk_radio_button :unsubscribed_from_emails, 'false', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :unsubscribed_from_emails, 'true', label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_submit t('update') %>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/support_interface/application_forms/email_subscription/edit.html.erb
+++ b/app/views/support_interface/application_forms/email_subscription/edit.html.erb
@@ -15,6 +15,12 @@
         <%= f.govuk_radio_button :unsubscribed_from_emails, 'true', label: { text: 'No' } %>
       <% end %>
 
+            <%= f.govuk_text_field(
+            :audit_comment,
+            label: { text: 'Audit log comment', size: 'm' },
+            hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' },
+          ) %>
+
       <%= f.govuk_submit t('update') %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     safe_choice_update_validator:
       error_message: The application must be in the current cycle %{current_cycle}
   continue: Continue
+  update: Update
   save_and_continue: Save and continue
   save: Save
   cancel: Cancel

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -158,6 +158,12 @@ en:
           attributes:
             further_conditions:
               too_long: '%{name} must be %{limit} characters or fewer'
+        support_interface/email_subscription_form:
+          attributes:
+            unsubscribed_from_emails:
+              blank: You must choose an option
+            audit_comment:
+              blank: You must provide an audit comment
         support_interface/application_forms/edit_applicant_details_form:
           attributes:
             phone_number:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -6,7 +6,7 @@ en:
         false: Yes, if they request it.
     page_titles:
       visa_or_immigration_status: Edit applicant visa or immigration status
-
+      email_subscription_setting: Should the applicant receive marketing emails?
     support_user:
       confirm_remove: Are you sure you want to remove support user %{email}?
       confirm_restore: Are you sure you want to restore support user %{email}?
@@ -73,6 +73,9 @@ en:
       ske_reasons:
         different_degree: Their degree subject was not %{degree_subject}
         outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
+    links: 
+      service_manual:
+        subscription_messages: https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#subscription-messages
   activemodel:
     errors:
       models:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -12,6 +12,9 @@ namespace :support_interface, path: '/support' do
     get '/editable-extension' => 'application_forms/editable_extension#edit'
     post '/editable-extension' => 'application_forms/editable_extension#update'
 
+    get '/email-subscription' => 'application_forms/email_subscription#edit'
+    patch '/email-subscription' => 'application_forms/email_subscription#update'
+
     get '/audit' => 'application_forms#audit', as: :application_form_audit
     get '/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
     post '/comments' => 'application_forms/comments#create', as: :application_form_comments

--- a/spec/forms/support_interface/email_subscription_form_spec.rb
+++ b/spec/forms/support_interface/email_subscription_form_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::EmailSubscriptionForm, type: :model do
+  subject(:form) { described_class.new(form_data) }
+
+  let(:form_data) do
+    {
+      unsubscribed_from_emails: true,
+      audit_comment: 'too much spam',
+    }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:unsubscribed_from_emails) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+  end
+
+  describe '.build_from_application' do
+    let(:application_form) { create(:application_form, candidate: create(:candidate, unsubscribed_from_emails: true)) }
+
+    it 'creates an object based on the provided ApplicationForm' do
+      form = described_class.build_from_application(application_form)
+      expect(form.unsubscribed_from_emails).to be(true)
+    end
+  end
+
+  describe '#save', :with_audited do
+    let(:candidate) { create(:candidate, unsubscribed_from_emails: false) }
+    let(:application_form) { create(:application_form, candidate:) }
+
+    context 'when form is invalid' do
+      it 'returns false' do
+        form = described_class.new
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when form is valid' do
+      it 'updates the candidate with the new value and audits' do
+        expect(form.save(application_form)).to be(true)
+        expect(application_form.candidate.reload.unsubscribed_from_emails).to be(true)
+
+        audit = candidate.audits.find do |a|
+          a.audited_changes == { 'unsubscribed_from_emails' => [false, true] }
+        end
+
+        expect(audit.comment).to eq('too much spam')
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/editing_email_subscription_status_spec.rb
+++ b/spec/system/support_interface/editing_email_subscription_status_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Editing email subscription status' do
   include DfESignInHelpers
 
-  scenario 'Support user edits email subscription status' do
+  scenario 'Support user edits email subscription status', :with_audited do
     given_i_am_a_support_user
     and_an_application_exists
     when_i_visit_the_application_page
@@ -13,11 +13,19 @@ RSpec.describe 'Editing email subscription status' do
     and_i_update
     then_i_am_subscribed_to_emails
 
-
     given_i_click_the_change_link_for_applicant_email_status
     and_i_choose_no
     and_i_update
     then_i_am_unsubscribed_from_emails
+    and_i_have_an_audit_of_the_changes
+  end
+
+  def and_i_have_an_audit_of_the_changes
+    audit = @form.candidate.audits.find do |a|
+      a.audited_changes == { 'unsubscribed_from_emails' => [false, true] }
+    end
+
+    expect(audit.comment).to eq('too much spam')
   end
 
   def and_i_am_on_the_edit_page
@@ -74,12 +82,12 @@ RSpec.describe 'Editing email subscription status' do
 
   def and_i_choose_yes
     choose 'Yes'
-    # fill_in 'support_interface_application_forms_immigration_right_to_work_form[audit_comment]', with: 'Updated as part of Zendesk ticket #12345'
+    fill_in 'support_interface_email_subscription_form[audit_comment]', with: 'not enough spam'
   end
 
   def and_i_choose_no
     choose 'No'
-    # fill_in 'support_interface_application_forms_immigration_right_to_work_form[audit_comment]', with: 'Updated as part of Zendesk ticket #12345'
+    fill_in 'support_interface_email_subscription_form[audit_comment]', with: 'too much spam'
   end
 
   def and_i_update

--- a/spec/system/support_interface/editing_email_subscription_status_spec.rb
+++ b/spec/system/support_interface/editing_email_subscription_status_spec.rb
@@ -12,12 +12,26 @@ RSpec.describe 'Editing email subscription status' do
     and_i_choose_yes
     and_i_update
     then_i_am_subscribed_to_emails
+    and_i_see_the_flash_message_to_show_the_i_am_subscribed
 
     given_i_click_the_change_link_for_applicant_email_status
     and_i_choose_no
     and_i_update
     then_i_am_unsubscribed_from_emails
     and_i_have_an_audit_of_the_changes
+    and_i_see_the_flash_message_to_show_the_i_am_not_subscribed
+  end
+
+  def and_i_see_the_flash_message_to_show_the_i_am_subscribed
+    within('.govuk-notification-banner__content') do
+      expect(page).to have_text('The candidate will now receive marketing emails')
+    end
+  end
+
+  def and_i_see_the_flash_message_to_show_the_i_am_not_subscribed
+    within('.govuk-notification-banner__content') do
+      expect(page).to have_text('The candidate will no longer receive marketing emails')
+    end
   end
 
   def and_i_have_an_audit_of_the_changes

--- a/spec/system/support_interface/editing_email_subscription_status_spec.rb
+++ b/spec/system/support_interface/editing_email_subscription_status_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe 'Editing email subscription status' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits email subscription status' do
+    given_i_am_a_support_user
+    and_an_application_exists
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_for_applicant_email_status
+    and_i_am_on_the_edit_page
+    and_i_choose_yes
+    and_i_update
+    then_i_am_subscribed_to_emails
+
+
+    given_i_click_the_change_link_for_applicant_email_status
+    and_i_choose_no
+    and_i_update
+    then_i_am_unsubscribed_from_emails
+  end
+
+  def and_i_am_on_the_edit_page
+    expect(page).to have_link('subscription messages', href: 'https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#subscription-messages')
+    expect(page).to have_text('Marketing emails are also known as subscription messages')
+    expect(page).to have_text('Changing this selection does not unsubscribe the user from transactional messages')
+  end
+
+  def then_i_am_subscribed_to_emails
+    expect(@form.candidate.subscribed_to_emails?).to be(true)
+
+    within('dt.govuk-summary-list__key', text: 'Subscribed to emails') do
+      expect(page).to have_css('~ dd.govuk-summary-list__value p.govuk-body', text: 'Yes')
+    end
+  end
+
+  def then_i_am_unsubscribed_from_emails
+    expect(@form.candidate.reload.subscribed_to_emails?).to be(false)
+
+    within('dt.govuk-summary-list__key', text: 'Subscribed to emails') do
+      expect(page).to have_css('~ dd.govuk-summary-list__value p.govuk-body', text: 'No')
+    end
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_for_applicant_email_status
+    click_link_or_button('Change applicant email subscription status')
+  end
+
+  alias_method :given_i_click_the_change_link_for_applicant_email_status, :and_i_click_the_change_link_for_applicant_email_status
+
+  def and_i_choose_yes
+    choose 'Yes'
+    # fill_in 'support_interface_application_forms_immigration_right_to_work_form[audit_comment]', with: 'Updated as part of Zendesk ticket #12345'
+  end
+
+  def and_i_choose_no
+    choose 'No'
+    # fill_in 'support_interface_application_forms_immigration_right_to_work_form[audit_comment]', with: 'Updated as part of Zendesk ticket #12345'
+  end
+
+  def and_i_update
+    click_link_or_button 'Update'
+  end
+end

--- a/spec/system/support_interface/editing_email_subscription_status_spec.rb
+++ b/spec/system/support_interface/editing_email_subscription_status_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Editing email subscription status' do
   end
 
   def and_i_have_an_audit_of_the_changes
-    audit = @form.candidate.audits.find do |a|
+    audit = @application_form.candidate.audits.find do |a|
       a.audited_changes == { 'unsubscribed_from_emails' => [false, true] }
     end
 
@@ -49,7 +49,7 @@ RSpec.describe 'Editing email subscription status' do
   end
 
   def then_i_am_subscribed_to_emails
-    expect(@form.candidate.subscribed_to_emails?).to be(true)
+    expect(@application_form.candidate.subscribed_to_emails?).to be(true)
 
     within('dt.govuk-summary-list__key', text: 'Subscribed to emails') do
       expect(page).to have_css('~ dd.govuk-summary-list__value p.govuk-body', text: 'Yes')
@@ -57,7 +57,7 @@ RSpec.describe 'Editing email subscription status' do
   end
 
   def then_i_am_unsubscribed_from_emails
-    expect(@form.candidate.reload.subscribed_to_emails?).to be(false)
+    expect(@application_form.candidate.reload.subscribed_to_emails?).to be(false)
 
     within('dt.govuk-summary-list__key', text: 'Subscribed to emails') do
       expect(page).to have_css('~ dd.govuk-summary-list__value p.govuk-body', text: 'No')
@@ -69,11 +69,11 @@ RSpec.describe 'Editing email subscription status' do
   end
 
   def and_an_application_exists
-    @form = create(:completed_application_form)
+    @application_form = create(:completed_application_form)
   end
 
   def when_i_visit_the_application_page
-    visit support_interface_application_form_path(@form)
+    visit support_interface_application_form_path(@application_form)
   end
 
   def given_i_am_a_support_user
@@ -81,11 +81,11 @@ RSpec.describe 'Editing email subscription status' do
   end
 
   def and_an_application_exists
-    @form = create(:completed_application_form)
+    @application_form = create(:completed_application_form)
   end
 
   def when_i_visit_the_application_page
-    visit support_interface_application_form_path(@form)
+    visit support_interface_application_form_path(@application_form)
   end
 
   def and_i_click_the_change_link_for_applicant_email_status


### PR DESCRIPTION
## Context

We anticipate that going forward the Support team (and ourselves) will find it useful be able to see if a candidate is unsubscribed, and perhaps also edit this on their behalf should they change their mind, or request it direct via a support query rather than using an unsubscribe link.

## Changes proposed in this pull request

 - Surface the candidate email subscription status on the support index page
 - Add the ability to update the status by clicking the change button

## Screenshot

<img width="1393" alt="Screenshot 2025-01-29 at 21 11 43" src="https://github.com/user-attachments/assets/b9cac056-7a00-4225-8e8e-7c7ee7627584" />

<img width="860" alt="image" src="https://github.com/user-attachments/assets/57651281-de3a-42f4-84b7-0cbd21cd18fc" />




## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
