### PR TITLE
Checks for the strategy parameter before acting

### DIFF
--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -90,6 +90,10 @@ class OneLoginController < ApplicationController
   end
 
   def failure
+    # This action will catch all OAuth failures
+    # from all strategies i.e. OneLogin and DfE Sign-in
+    return unless params[:strategy] == 'one_login'
+
     session_error = SessionError.create!(
       body: "One login failure with #{params[:message]}",
     )

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe 'OneLoginController' do
       get auth_one_login_callback_path # set the session variables
 
       expect {
-        get auth_failure_path(params: { message: 'error_message' })
+        get auth_failure_path(params: { message: 'error_message', strategy: 'one_login' })
       }.to change(SessionError, :count).by(1)
 
       expect(Sentry).to have_received(:capture_message).with(


### PR DESCRIPTION
## Context

While investigating [Sentry Errors](https://dfe-teacher-services.sentry.io/issues/6201934770/?referrer=slack&notification_uuid=b340fc3a-c496-4b37-b18c-6d6163f9abb6&environment=production&alert_rule_id=4434951&alert_type=issue) we identified that the `auth/failure` endpoint was capturing both OneLogin and DfE Sign in errors. 

## Changes proposed in this pull request

Update the controller to do nothing if the endpoint is not hit by the OneLogin strategy

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
