### PR TITLE
Remove error logging from `auth/failure` endpoint

### DIFF
--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -90,20 +90,8 @@ class OneLoginController < ApplicationController
   end
 
   def failure
-    # This action will catch all OAuth failures
-    # from all strategies i.e. OneLogin and DfE Sign-in
-    return unless params[:strategy] == 'one_login'
-
-    session_error = SessionError.create!(
-      body: "One login failure with #{params[:message]}",
-    )
-    Sentry.capture_message(
-      "#{session_error.body}, check session_error record #{session_error.id}",
-      level: :error,
-    )
-
-    session[:session_error_id] = session_error.id if session_error.present?
-    redirect_to auth_one_login_sign_out_path
+    terminate_session
+    redirect_to internal_server_error_path
   end
 
 private

--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -91,7 +91,7 @@ class OneLoginController < ApplicationController
 
   def failure
     terminate_session
-    redirect_to internal_server_error_path
+    redirect_to root_path
   end
 
 private

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -215,12 +215,12 @@ RSpec.describe 'OneLoginController' do
   end
 
   describe 'GET /auth/one-login/failure' do
-    it 'redirects to internal_server_error_path' do
+    it 'redirects to the root_path' do
       allow(Sentry).to receive(:capture_message)
 
       get auth_failure_path(params: { message: 'error_message', strategy: 'one_login' })
 
-      expect(response).to redirect_to(internal_server_error_path)
+      expect(response).to redirect_to(root_path)
     end
   end
 end

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -215,23 +215,10 @@ RSpec.describe 'OneLoginController' do
   end
 
   describe 'GET /auth/one-login/failure' do
-    it 'redirects to auth_failure_path with one login error' do
+    it 'redirects to internal_server_error_path' do
       allow(Sentry).to receive(:capture_message)
-      get auth_one_login_callback_path # set the session variables
 
-      expect {
-        get auth_failure_path(params: { message: 'error_message', strategy: 'one_login' })
-      }.to change(SessionError, :count).by(1)
-
-      expect(Sentry).to have_received(:capture_message).with(
-        "One login failure with error_message, check session_error record #{SessionError.last.id}",
-        level: :error,
-      )
-      expect(session[:session_error_id]).to eq(SessionError.last.id)
-      expect(response).to redirect_to(auth_one_login_sign_out_path)
-
-      # a failure will need to call sign_out_complete
-      get auth_one_login_sign_out_complete_path
+      get auth_failure_path(params: { message: 'error_message', strategy: 'one_login' })
 
       expect(response).to redirect_to(internal_server_error_path)
     end


### PR DESCRIPTION
## Context

We have an overwhelming number of (probably legit) errors clogging up error reporting. This endpoint is also capturing issues from DfE Sign in. 
We have decided to remove the error logging from this endpoint. 
We still want to terminate any session data, in order to help real users sign in later. 

## Changes proposed in this pull request

Auth failures attempt to clear the session before redirecting to the internal error path

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
