### PR TITLE
[612] Release Vendor API version `1.6` in production

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
@@ -37,6 +37,10 @@ module APIDocs
         spec(version: VendorAPI::VERSION_1_5)
       end
 
+      def spec_1_6
+        spec(version: VendorAPI::VERSION_1_6)
+      end
+
     private
 
       def spec(**)

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -7,7 +7,7 @@ module VendorAPI
   VERSION_1_3 = '1.3'.freeze
   VERSION_1_4 = '1.4'.freeze
   VERSION_1_5 = '1.5'.freeze
-  VERSION_1_6 = '1.6pre'.freeze
+  VERSION_1_6 = '1.6'.freeze
   VERSION = VERSION_1_6
 
   VERSIONS = {
@@ -66,7 +66,7 @@ module VendorAPI
       Changes::V15::AddApplicationSentToProviderDatetime,
       Changes::V15::AddReferenceFeedbackProvidedAtDatetime,
     ],
-    '1.6pre' => [
+    '1.6' => [
       Changes::V16::AddConfidentialToReference,
       Changes::V16::AddInactiveToApplicationAttributeStatuses,
     ],

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## v1.6 — 4th February 2025
+
+Minor Version Upgrade:
+
+Release API version `v1.6` to production. Please refer to the [API Reference](/api-docs/v1.6/reference) for details.
+
 ## v1.5 — 10th July 2024
 
 Minor Version Upgrade:

--- a/config/vendor_api/v1.5.yml
+++ b/config/vendor_api/v1.5.yml
@@ -12,9 +12,9 @@ info:
     Experimental endpoints prefixed with `/test-data` may change or be removed.
 servers:
   - description: Sandbox (test environment for vendors)
-    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.5pre
+    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.5
   - description: Production
-    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5pre
+    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5
 components:
   schemas:
     ApplicationAttributes:

--- a/config/vendor_api/v1.6.yml
+++ b/config/vendor_api/v1.6.yml
@@ -22,6 +22,7 @@ components:
         inactive:
           type: boolean
           description: Indicates whether the application is inactive, based on time-sensitive criteria. If true, the application is considered inactive; otherwise, it remains active.
+          example: true
           enum:
           - true
           - false

--- a/config/vendor_api/v1.6.yml
+++ b/config/vendor_api/v1.6.yml
@@ -1,0 +1,40 @@
+---
+openapi: 3.0.0
+info:
+  version: v1.6
+  title: Apply API
+  contact:
+    name: DfE
+    email: becomingateacher@digital.education.gov.uk
+  description: |
+    API for DfE’s Apply for teacher training service.
+    Endpoints with the `/applications` prefix are considered stable.
+    Experimental endpoints prefixed with `/test-data` may change or be removed.
+servers:
+- description: Sandbox (test environment for vendors)
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.6
+- description: Production
+  url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.6
+components:
+  schemas:
+    ApplicationAttributes:
+      properties:
+        inactive:
+          type: boolean
+          description: Indicates whether the application is inactive, based on time-sensitive criteria. If true, the application is considered inactive; otherwise, it remains active.
+          enum:
+          - true
+          - false
+    Reference:
+      type: object
+      properties:
+        confidential:
+          type: boolean
+          description: The confidentiality status selected by the referee for the reference
+          example: true
+          enum:
+          - true
+          - false
+          - null
+      required:
+        - confidential

--- a/spec/requests/vendor_api/v1.6/get_confidential_from_reference_spec.rb
+++ b/spec/requests/vendor_api/v1.6/get_confidential_from_reference_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.6/applications/:application_id' do
+  include VendorAPISpecHelpers
+
+  let(:application_form) { create(:completed_application_form, application_references: [reference]) }
+  let(:application_choice) { create_application_choice_for_currently_authenticated_provider(attributes) }
+  let(:attributes) { { status: 'offer', application_form: } }
+
+  before { get_api_request "/api/v1.6/applications/#{application_choice.id}" }
+
+  context 'when the referee has said the reference is confidential' do
+    let(:reference) { create(:reference, :feedback_provided, confidential: true) }
+
+    it 'returns true' do
+      expect(response).to have_http_status(:ok)
+      references = parsed_response['data']['attributes']['references']
+      expect(references.detect { |ref| ref['id'] == reference.id }['confidential']).to be(true)
+    end
+  end
+
+  context 'when the referee has said the reference is not confidential' do
+    let(:reference) { create(:reference, :feedback_provided, confidential: false) }
+
+    it 'returns false' do
+      expect(response).to have_http_status(:ok)
+      references = parsed_response['data']['attributes']['references']
+      expect(references.detect { |ref| ref['id'] == reference.id }['confidential']).to be(false)
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.6/get_inactive_from_application_spec.rb
+++ b/spec/requests/vendor_api/v1.6/get_inactive_from_application_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.6/applications/:application_id' do
+  include VendorAPISpecHelpers
+
+  let(:application_form) { create(:completed_application_form) }
+  let(:application_choice) { create_application_choice_for_currently_authenticated_provider(attributes) }
+  let(:attributes) { { status:, application_form: } }
+
+  before { get_api_request "/api/v1.6/applications/#{application_choice.id}" }
+
+  context 'when the application choice is inactive' do
+    let(:status) { :inactive }
+
+    it 'returns true' do
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response.dig('data', 'attributes', 'inactive')).to be(true)
+    end
+  end
+
+  context 'when the application choice is not inactive' do
+    %w[
+      awaiting_provider_decision
+      offer
+      pending_conditions
+      recruited
+      rejected
+      declined
+      withdrawn
+      conditions_not_met
+      offer_deferred
+    ].each do |status|
+      context "when status is #{status}" do
+        let(:status) { status }
+
+        it 'returns false' do
+          expect(response).to have_http_status(:ok)
+          expect(parsed_response.dig('data', 'attributes', 'inactive')).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Vendors have been testing version 1.6 of the vendor API in sandbox for over a week and no issues have been reported.

## Changes proposed in this pull request

Turn the 1.6 pre release into an official release in production.

## Guidance to review

- Use the Vendor API on the review app or locally. In particular, check the `confidential` column on references. 

- Use the Vendor API on the review app or locally. In particular, check the `status` on `ApplicationAttribute` for an application choice which has a status of `inactive`.

- Alternatively you could inspect the `MultipleApplicationsResponse` on the API release document below.
  - [release documentation](https://apply-review-10335.test.teacherservices.cloud/api-docs/v1.6/reference).


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
