### PR TITLE
[373] Inform providers when the weekly performance report will start appearing for their 2024-25 cycle

### DIFF
--- a/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
@@ -3,7 +3,9 @@ module ProviderInterface
     class RecruitmentPerformanceReportsController < ProviderInterfaceController
       def show
         @provider = current_user.providers.find(provider_id)
-        @provider_report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).order(:cycle_week).last
+        report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).order(:cycle_week).last
+        @provider_report = report.present? ? Publications::ProviderRecruitmentPerformanceReportPresenter.new(report) : nil
+
         @provider_data = @provider_report&.statistics
         @national_data = national_report&.statistics
       end

--- a/app/models/publications/national_recruitment_performance_report.rb
+++ b/app/models/publications/national_recruitment_performance_report.rb
@@ -1,5 +1,6 @@
 module Publications
   class NationalRecruitmentPerformanceReport < ApplicationRecord
     validates :cycle_week, :publication_date, presence: true
+    has_one :recruitment_cycle_timetable, primary_key: :recruitment_cycle_year, foreign_key: :recruitment_cycle_year
   end
 end

--- a/app/models/publications/national_recruitment_performance_report_generator.rb
+++ b/app/models/publications/national_recruitment_performance_report_generator.rb
@@ -4,18 +4,27 @@ module Publications
                 :generation_date,
                 :publication_date,
                 :report_expected_time,
-                :cycle_week
+                :cycle_week,
+                :recruitment_cycle_year
 
-    def initialize(cycle_week:, generation_date: Time.zone.now, publication_date: nil)
+    def initialize(cycle_week:, generation_date: Time.zone.now, publication_date: nil, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
       @cycle_week = cycle_week
       @generation_date = generation_date
       @publication_date = publication_date.presence || @generation_date
+      @recruitment_cycle_year = recruitment_cycle_year
       @report_expected_time = 1.week.until(@generation_date).end_of_week
+      @recruitment_cycle_year = recruitment_cycle_year
       @client = DfE::Bigquery::ApplicationMetricsByProvider.new(cycle_week:)
     end
 
     def call
-      Publications::NationalRecruitmentPerformanceReport.create!(statistics: data, cycle_week:, publication_date:, generation_date:)
+      Publications::NationalRecruitmentPerformanceReport.create!(
+        statistics: data,
+        cycle_week:,
+        publication_date:,
+        generation_date:,
+        recruitment_cycle_year:,
+      )
     end
 
     def data

--- a/app/models/publications/national_recruitment_performance_report_generator.rb
+++ b/app/models/publications/national_recruitment_performance_report_generator.rb
@@ -13,7 +13,6 @@ module Publications
       @publication_date = publication_date.presence || @generation_date
       @recruitment_cycle_year = recruitment_cycle_year
       @report_expected_time = 1.week.until(@generation_date).end_of_week
-      @recruitment_cycle_year = recruitment_cycle_year
       @client = DfE::Bigquery::ApplicationMetricsByProvider.new(cycle_week:)
     end
 

--- a/app/models/publications/provider_recruitment_performance_report.rb
+++ b/app/models/publications/provider_recruitment_performance_report.rb
@@ -2,9 +2,14 @@ module Publications
   class ProviderRecruitmentPerformanceReport < ApplicationRecord
     belongs_to :provider
     validates :cycle_week, :publication_date, presence: true
+    has_one :recruitment_cycle_timetable, primary_key: :recruitment_cycle_year, foreign_key: :recruitment_cycle_year
 
     def reporting_end_date
-      CycleTimetable.cycle_week_date_range(cycle_week).last.to_date
+      recruitment_cycle_timetable.cycle_week_date_range(cycle_week).last.to_date
+    end
+
+    def previous_cycle?
+      recruitment_cycle_year < RecruitmentCycleTimetable.current_year
     end
   end
 end

--- a/app/models/publications/provider_recruitment_performance_report_generator.rb
+++ b/app/models/publications/provider_recruitment_performance_report_generator.rb
@@ -5,13 +5,15 @@ module Publications
                 :generation_date,
                 :publication_date,
                 :report_expected_time,
-                :cycle_week
+                :cycle_week,
+                :recruitment_cycle_year
 
-    def initialize(provider_id:, cycle_week:, generation_date: Time.zone.today, publication_date: nil)
+    def initialize(provider_id:, cycle_week:, generation_date: Time.zone.today, publication_date: nil, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
       @provider_id = provider_id
       @generation_date = generation_date
       @publication_date = publication_date.presence || @generation_date
       @report_expected_time = 1.week.until(@generation_date).end_of_week
+      @recruitment_cycle_year = recruitment_cycle_year
       @cycle_week = cycle_week
       @client = DfE::Bigquery::ApplicationMetricsByProvider.new(cycle_week:, provider_id:)
     end
@@ -22,7 +24,14 @@ module Publications
         return
       end
 
-      Publications::ProviderRecruitmentPerformanceReport.create!(provider_id:, statistics: data, cycle_week:, publication_date:, generation_date:)
+      Publications::ProviderRecruitmentPerformanceReport.create!(
+        provider_id:,
+        statistics: data,
+        cycle_week:,
+        publication_date:,
+        generation_date:,
+        recruitment_cycle_year:,
+      )
     end
 
     def data

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -1,6 +1,6 @@
 module Publications
   class RecruitmentPerformanceReportScheduler
-    def initialize(cycle_week: CycleTimetable.current_cycle_week.pred)
+    def initialize(cycle_week: RecruitmentCycleTimetable.current_cycle_week.pred)
       @cycle_week = cycle_week
     end
 

--- a/app/models/recruitment_cycle_timetable.rb
+++ b/app/models/recruitment_cycle_timetable.rb
@@ -28,6 +28,35 @@ class RecruitmentCycleTimetable < ApplicationRecord
     current_year - 1
   end
 
+  def self.next_year
+    current_year + 1
+  end
+
+  def self.current_cycle_week
+    weeks = (Time.zone.now - current_timetable.find_opens_at.beginning_of_week).seconds.in_weeks.to_i
+    (weeks % 53).succ
+  end
+
+  def cycle_range_name
+    "#{recruitment_cycle_year - 1} to #{recruitment_cycle_year}"
+  end
+
+  def relative_next_timetable
+    self.class.find_by(recruitment_cycle_year: recruitment_cycle_year + 1)
+  end
+
+  def relative_previous_timetable
+    self.class.find_by(recruitment_cycle_year: recruitment_cycle_year - 1)
+  end
+
+  def cycle_week_date_range(cycle_week)
+    cycle_week %= 52
+    cycle_week -= 1
+
+    start_of_week = find_opens_at + cycle_week.weeks
+    start_of_week.all_week
+  end
+
 private
 
   def christmas_holiday_validation

--- a/app/presenters/publications/provider_recruitment_performance_report_presenter.rb
+++ b/app/presenters/publications/provider_recruitment_performance_report_presenter.rb
@@ -1,0 +1,49 @@
+module Publications
+  class ProviderRecruitmentPerformanceReportPresenter < SimpleDelegator
+    delegate :cycle_range_name,
+             :relative_next_timetable,
+             :relative_previous_timetable,
+             :cycle_week_date_range,
+             :find_opens_at,
+             :find_closes_at, to: :recruitment_cycle_timetable
+
+    def next_reporting_start_date
+      relative_next_timetable
+      .cycle_week_date_range(RecruitmentPerformanceReportTimetable::FIRST_CYCLE_WEEK_REPORT)
+      .first
+      .to_fs(:govuk_date)
+    end
+
+    def next_cycle_range_name
+      relative_next_timetable.cycle_range_name
+    end
+
+    def report_starting_date
+      cycle_week_date_range(RecruitmentPerformanceReportTimetable::FIRST_CYCLE_WEEK_REPORT)
+        .first
+        .to_fs(:govuk_date)
+    end
+
+    def report_show_data_from_date
+      find_opens_at.to_date.to_fs(:govuk_date)
+    end
+
+    def report_show_data_to_date
+      find_closes_at.to_fs(:govuk_date)
+    end
+
+    def last_cycle_start_date
+      relative_previous_timetable
+        .find_opens_at
+        .to_fs(:govuk_date)
+    end
+
+    def this_cycle_start_date
+      find_opens_at.to_fs(:govuk_date)
+    end
+
+    def show_changes_section?
+      recruitment_cycle_year == 2024
+    end
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -142,19 +142,6 @@ class CycleTimetable
     (weeks % 52).succ
   end
 
-  def self.cycle_week_date_range(cycle_week, time = Time.zone.now)
-    year = current_year(time)
-    cycle_week %= 52
-    cycle_week -= 1
-
-    start_of_week = find_opens(year) + cycle_week.weeks
-    start_of_week.all_week
-  end
-
-  def self.start_of_cycle_week(...)
-    cycle_week_date_range(...).first
-  end
-
   #
   # cycle_schedule methods
   #

--- a/app/services/recruitment_performance_report_timetable.rb
+++ b/app/services/recruitment_performance_report_timetable.rb
@@ -3,7 +3,11 @@ module RecruitmentPerformanceReportTimetable
   LAST_CYCLE_WEEK_REPORT = 51
 
   def self.report_season?
-    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT)
+    RecruitmentCycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT)
+  end
+
+  def self.first_publication_date
+    RecruitmentCycleTimetable.current_timetable.cycle_week_date_range(FIRST_CYCLE_WEEK_REPORT).first.to_date
   end
 
   # Generation and Publication date are the same (today) for now until we

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -10,6 +10,15 @@
       <h2 class="govuk-heading-m">
         <%= t('.performance_report_heading') %>
       </h2>
+
+      <% unless RecruitmentPerformanceReportTimetable.report_season? %>
+        <%= t(
+              '.available_in_the_future_html',
+              current_cycle_range: RecruitmentCycleTimetable.current_timetable.cycle_range_name,
+              first_publication_date: RecruitmentPerformanceReportTimetable.first_publication_date.to_fs(:govuk_date),
+              first_publication_date_no_year: RecruitmentPerformanceReportTimetable.first_publication_date.to_fs(:day_and_month),
+            ) %>
+      <% end %>
     <% end %>
 
     <% @providers.select { _1.performance_reports.any? }.each do |provider| %>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
@@ -5,17 +5,19 @@
   </h2>
 
   <h3 class="govuk-heading-s">
-    <%= t('about_this_data_section.subsection_heading_one', cycle_range: RecruitmentCycle.cycle_name) %>
+    <% if @provider_report.show_changes_section? %>
+      <%= t('about_this_data_section.subsection_heading_one', cycle_range: @provider_report.cycle_range_name) %>
+      <p class="govuk-body">
+        <%= t('about_this_data_section.whats_new_in_2024_paragraph_one') %>
+      </p>
+      <p class="govuk-body">
+        <%= t('about_this_data_section.whats_new_in_2024_paragraph_two') %>
+      </p>
+      <p class="govuk-body">
+        <%= t('about_this_data_section.whats_new_in_2024_paragraph_three') %>
+      </p>
+    <% end %>
   </h3>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_one_paragraph_one') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_one_paragraph_two') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_one_paragraph_three') %>
-  </p>
 
   <h3 class="govuk-heading-s">
     <%= t('about_this_data_section.subsection_heading_two') %>
@@ -57,8 +59,8 @@
   <p class="govuk-body">
     <%= t(
           'about_this_data_section.subsection_four_paragraph_two',
-          last_cycle_start_date: CycleTimetable.find_opens(CycleTimetable.current_year - 1).to_fs(:govuk_date),
-          this_cycle_start_date: CycleTimetable.find_opens.to_fs(:govuk_date),
+          last_cycle_start_date: @provider_report.last_cycle_start_date,
+          this_cycle_start_date: @provider_report.this_cycle_start_date,
         ) %>
   </p>
   <p class="govuk-body">

--- a/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
@@ -1,11 +1,19 @@
 <div class="govuk-grid-column-two-thirds">
-  <p class="govuk-body"><%= t('show.last_updated', date: l(@provider_report.generation_date.to_date, format: :long)) %></p>
+  <p class="govuk-body"><%= t('show.last_updated', date: @provider_report.generation_date.to_date.to_fs(:govuk_date)) %></p>
   <p class="govuk-body">
     <%= t('show.this_report_shows',
-          date: l(CycleTimetable.find_opens.to_date, format: :long)) %>
+          cycle_name: @provider_report.cycle_range_name,
+          start_date: @provider_report.report_show_data_from_date,
+          end_date: @provider_report.report_show_data_to_date) %>
   </p>
   <p class="govuk-body">
-    <%= t('show.this_report_will_update', date: CycleTimetable.start_of_cycle_week(34).to_fs(:govuk_date)) %>
+    <% if @provider_report.previous_cycle? %>
+      <%= t('show.next_reports_will_be_available',
+            next_cycle_name: @provider_report.next_cycle_range_name,
+            next_reporting_start_date: @provider_report.next_reporting_start_date) %>
+    <% else %>
+      <%= t('show.this_report_will_update', date: @provider_report.report_starting_date) %>
+    <% end %>
   </p>
   <p class="govuk-body"><%= t('show.this_report_compares') %></p>
   <h2 class="govuk-heading-m"><%= t('show.contents') %></h2>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
@@ -1,12 +1,12 @@
-<%= content_for :title, t('show.title', cycle_year_range: RecruitmentCycle.cycle_name) %>
-<%= content_for :before_content,
-                breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.heading', cycle_year_range: RecruitmentCycle.cycle_name) => nil) %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('show.heading', cycle_year_range: RecruitmentCycle.cycle_name) %></h1>
-  </div>
+<% if @national_data.present? && @provider_data.present? %>
+  <%= content_for :title, t('show.title', cycle_year_range: @provider_report.cycle_range_name) %>
+  <%= content_for :before_content,
+                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.heading', cycle_year_range: @provider_report.cycle_range_name) => nil) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t('show.heading', cycle_year_range: @provider_report.cycle_range_name) %></h1>
+    </div>
 
-  <% if @national_data.present? && @provider_data.present? %>
     <%= render 'provider_interface/reports/recruitment_performance_reports/report_description' %>
     <%= render 'provider_interface/reports/recruitment_performance_reports/about_this_data_section' %>
     <%= render ProviderInterface::RecruitmentPerformanceReport::SubmittedApplicationsTableComponent.new(@provider, @provider_data, @national_data) %>
@@ -16,7 +16,15 @@
     <%= render ProviderInterface::RecruitmentPerformanceReport::DeferralsTableComponent.new(@provider, @provider_data, @national_data) %>
     <%= render ProviderInterface::RecruitmentPerformanceReport::CandidatesRejectedTableComponent.new(@provider, @provider_data, @national_data) %>
     <%= render ProviderInterface::RecruitmentPerformanceReport::ProportionWithInactiveApplicationsTableComponent.new(@provider, @provider_data, @national_data) %>
-  <% else %>
-    <p class="govuk-body"><%= t('show.not_ready_to_view') %></p>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <%= content_for :title, t('show.empty_report_title') %>
+  <%= content_for :before_content,
+                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.empty_report_heading') => nil) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t('show.empty_report_heading') %></h1>
+      <p class="govuk-body"><%= t('show.not_ready_to_view') %></p>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/provider_interface/recruitment_performance_reports.yml
+++ b/config/locales/provider_interface/recruitment_performance_reports.yml
@@ -1,16 +1,20 @@
 en:
   show:
     title: Recruitment performance weekly report %{cycle_year_range} - Apply for teacher training - GOV.UK
+    empty_report_title: Recruitment performance weekly report - Apply for teacher training - GOV.UK
     contents: Contents
     heading: Recruitment performance weekly report %{cycle_year_range}
+    empty_report_heading: Recruitment performance weekly report
     last_updated: 'Last updated: %{date}'
     not_ready_to_view: This report is not ready to view.
     this_report_shows: >
-      This report shows your organisation’s initial teacher training (ITT) recruitment performance so far this
-      recruitment cycle, starting on %{date}.
+      This report shows your organisation’s initial teacher training (ITT) recruitment performance for the %{cycle_name}
+      recruitment cycle, starting on %{start_date}, ending on %{end_date}.
     this_report_will_update: >
       This report will update weekly on a Monday, starting from %{date}. You will only be able to view
       data from the most recent week.
+    next_reports_will_be_available: >
+      The weekly reports for the %{next_cycle_name} recruitment cycle will be available from %{next_reporting_start_date}.
     this_report_compares: >
       The report compares your organisation’s recruitment data this cycle, to the same time last recruitment cycle.
       It also includes national level data.
@@ -26,17 +30,17 @@ en:
   about_this_data_section:
     section_heading: 1. About this data
     subsection_heading_one: Changes for the %{cycle_range} recruitment cycle
-    subsection_one_paragraph_one: >
+    whats_new_in_2024_paragraph_one: >
       These statistics cover applications in the 2023 to 2024 recruitment cycle for courses in England starting in the
       2024 to 2025 academic year. To allow for comparison, statistics covering the 2022 to 2023 recruitment cycle 2023
       to 2024 academic year are also included.
-    subsection_one_paragraph_two: >
+    whats_new_in_2024_paragraph_two: >
       New definitions and methodology have been introduced for the 2023 to 2024 recruitment cycle  to 2025 academic year
       because candidates can now submit applications to courses individually up to a maximum of 4 open applications at
       a time. Previously, candidates submitted one application form with up to 4 course choices at the same time. All 4
       course choices had to receive a decision before the candidate could submit another application form in the same
       recruitment cycle.
-    subsection_one_paragraph_three: >
+    whats_new_in_2024_paragraph_three: >
       Improvements have also been made for clarity.
     subsection_heading_two: Data which is excluded from these reports
     subsection_two_paragraph_one: "The following types of applications are not included in these reports:"

--- a/config/locales/provider_interface/reports.yml
+++ b/config/locales/provider_interface/reports.yml
@@ -4,6 +4,9 @@ en:
       index:
         performance_report_heading: Weekly recruitment performance report
         application_data_heading: Application data for this recruitment cycle
+        available_in_the_future_html:
+          <p class="govuk-body">The reports for the %{current_cycle_range} recruitment cycle are not available until %{first_publication_date}.</p>
+          <p class="govuk-body">From %{first_publication_date_no_year} you will be able to see new reports each week on a Monday until the end of the cycle.</p>
         download_export_heading: Download and export
       hesa:
         diversity_text: Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it.

--- a/spec/models/publications/national_recruitment_performance_report_spec.rb
+++ b/spec/models/publications/national_recruitment_performance_report_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Publications::NationalRecruitmentPerformanceReport do
+  describe 'associations' do
+    it { is_expected.to have_one :recruitment_cycle_timetable }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of :publication_date }
     it { is_expected.to validate_presence_of :cycle_week }

--- a/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReportGenerator do
   let(:provider_id) { create(:provider).id }
   let(:generation_date) { Time.zone.today }
 
-  describe 'when a normal response is received' do
+  describe 'when a normal response is received', seed_timetables do
     before do
       stub_bigquery_application_metrics_by_provider_request(
         rows: [[

--- a/spec/models/publications/provider_recruitment_performance_report_spec.rb
+++ b/spec/models/publications/provider_recruitment_performance_report_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Publications::ProviderRecruitmentPerformanceReport do
   describe 'associations' do
     it { is_expected.to belong_to :provider }
+    it { is_expected.to have_one :recruitment_cycle_timetable }
   end
 
   describe 'validations' do
@@ -11,9 +12,14 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReport do
   end
 
   describe '#reporting_end_date' do
-    it 'returns the date of the last day of the cycle week', time: Time.zone.local(2024, 6, 6) do
-      report = create(:provider_recruitment_performance_report, cycle_week: 35)
+    it "returns the date of the last day of the cycle week based on the report's recruitment cycle 2024" do
+      report = build(:provider_recruitment_performance_report, cycle_week: 35, recruitment_cycle_year: 2024)
       expect(report.reporting_end_date).to eq(Date.new(2024, 6, 2))
+    end
+
+    it "returns the date of the last day of the cycle week based on the report's recruitment cycle 2025" do
+      report = build(:provider_recruitment_performance_report, cycle_week: 35, recruitment_cycle_year: 2025)
+      expect(report.reporting_end_date).to eq(Date.new(2025, 6, 1))
     end
   end
 end

--- a/spec/models/recruitment_cycle_timetable_spec.rb
+++ b/spec/models/recruitment_cycle_timetable_spec.rb
@@ -106,4 +106,69 @@ RSpec.describe RecruitmentCycleTimetable do
       end
     end
   end
+
+  describe '#current_cycle_week' do
+    context 'the first day of the cycle' do
+      it 'returns 1' do
+        travel_temporarily_to(described_class.current_timetable.find_opens_at + 1.second) do
+          expect(described_class.current_cycle_week).to eq 1
+        end
+      end
+    end
+
+    context 'sunday after find opens' do
+      it 'is the first week of the cycle' do
+        travel_temporarily_to(described_class.current_timetable.find_opens_at.sunday) do
+          expect(described_class.current_cycle_week).to eq 1
+        end
+      end
+    end
+
+    context 'monday after find opens' do
+      it 'is the second week of the cycle' do
+        travel_temporarily_to(described_class.current_timetable.find_opens_at.sunday + 1.day) do
+          expect(described_class.current_cycle_week).to eq 2
+        end
+      end
+    end
+
+    context 'after find closes, before it reopens' do
+      it 'returns last week in cycle' do
+        travel_temporarily_to(described_class.current_timetable.find_closes_at + 1.second) do
+          expect(described_class.current_cycle_week).to eq 53
+        end
+      end
+    end
+  end
+
+  describe '#cycle_range_name' do
+    it 'returns a string describing the recruitment cycle year range' do
+      timetable = described_class.find_by(recruitment_cycle_year: 2024)
+      expect(timetable.cycle_range_name).to eq '2023 to 2024'
+    end
+  end
+
+  describe '#relative_next_timetable' do
+    it 'returns nil if no next timetable exists' do
+      timetable = described_class.all.order(:recruitment_cycle_year).last
+      expect(timetable.relative_next_timetable).to be_nil
+    end
+
+    it 'returns the timetable with the next consecutive cycle year if it exists' do
+      timetable = described_class.current_timetable
+      expect(timetable.relative_next_timetable.recruitment_cycle_year).to eq timetable.recruitment_cycle_year + 1
+    end
+  end
+
+  describe '#relative_previous_timetable' do
+    it 'returns nil if no previous timetable exists' do
+      timetable = described_class.all.order(:recruitment_cycle_year).first
+      expect(timetable.relative_previous_timetable).to be_nil
+    end
+
+    it 'returns the timetable with the next consecutive cycle year if it exists' do
+      timetable = described_class.current_timetable
+      expect(timetable.relative_previous_timetable.recruitment_cycle_year).to eq timetable.recruitment_cycle_year - 1
+    end
+  end
 end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe CycleTimetable do
   let(:one_hour_before_find_closes) { described_class.find_closes(this_year) - 1.hour }
   let(:one_hour_after_find_closes) { described_class.find_closes(this_year) + 1.hour }
   let(:one_hour_after_find_opens) { described_class.find_opens(this_year) + 1.hour }
-  let(:one_hour_after_find_reopens) { described_class.find_reopens(this_year) + 1.hour }
-  let(:three_days_before_find_reopens) { described_class.find_reopens(this_year) - 3.days }
-  let(:twenty_days_after_next_year_cycle_opens) { 20.business_days.after(described_class.apply_opens(next_year)).end_of_day }
 
   describe '.current_year' do
     it 'is this_year if we are in the middle of the this_year cycle' do
@@ -452,48 +449,6 @@ RSpec.describe CycleTimetable do
     context 'when the first week of the next cycle passed explicitly' do
       it 'returns 1' do
         expect(described_class.current_cycle_week(date + 53.weeks)).to be 1
-      end
-    end
-  end
-
-  describe '#cycle_week_date_range' do
-    let(:date) { Time.zone.local(2023, 10, 30) }
-
-    before { TestSuiteTimeMachine.travel_permanently_to(date) }
-
-    it 'returns the correct date range for cycle_week 5' do
-      cycle_week_date_range = described_class.cycle_week_date_range(5)
-
-      expect(cycle_week_date_range).to eql(date.all_week)
-    end
-  end
-
-  describe '#start_of_cycle_week' do
-    context 'without time argument' do
-      let(:date) { Time.zone.local(2023, 10, 30) }
-
-      before { TestSuiteTimeMachine.travel_permanently_to(date) }
-
-      it 'returns this monday when given current_cycle_week' do
-        start_of_current_cycle_week = described_class.start_of_cycle_week(described_class.current_cycle_week)
-        expect(start_of_current_cycle_week.to_date).to eq '2023-10-30'.to_date
-        expect(start_of_current_cycle_week.wday).to eq 1
-      end
-
-      it 'returns the monday of the cycle week in the current cycle year' do
-        start_of_week_10 = described_class.start_of_cycle_week(10)
-        expect(start_of_week_10.to_date).to eq '2023-12-04'.to_date
-        expect(start_of_week_10.wday).to eq 1
-      end
-
-      it 'returns the monday before find_opens for the first week of the cycle' do
-        start_of_week_one = described_class.start_of_cycle_week(1)
-        expect(start_of_week_one.to_date).to eq described_class.find_opens.beginning_of_week.to_date
-      end
-
-      it 'only returns dates in current cycle year' do
-        start_of_week_65 = described_class.start_of_cycle_week(65)
-        expect(start_of_week_65).to eq described_class.start_of_cycle_week(13)
       end
     end
   end

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Provider with two providers reports index' do
   include DfESignInHelpers
 
-  scenario 'when provider user has multiple provider with performance report', time: mid_cycle(2024) do
+  scenario 'when provider user has multiple provider with performance report', time: mid_cycle do
     given_a_provider_user_with_two_providers_exists
     and_a_provider_has_a_recruitment_performance_report
     and_i_am_signed_in_as_provider_user
@@ -17,7 +17,11 @@ RSpec.describe 'Provider with two providers reports index' do
   end
 
   def and_a_provider_has_a_recruitment_performance_report
-    create(:provider_recruitment_performance_report, provider: @provider)
+    @report = create(
+      :provider_recruitment_performance_report,
+      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+      provider: @provider,
+    )
   end
 
   def given_a_provider_user_with_two_providers_exists
@@ -30,7 +34,7 @@ RSpec.describe 'Provider with two providers reports index' do
   def then_the_page_has_the_right_content
     expect(page).to have_css('h1', text: 'Reports')
     expect(page).to have_css('h2', text: 'Weekly recruitment performance report')
-    expect(page).to have_link('Weekly report for week ending 5 May 2024', href: provider_interface_reports_provider_recruitment_performance_report_path(@provider))
+    expect(page).to have_link("Weekly report for week ending #{@report.reporting_end_date.to_fs(:govuk_date)}", href: provider_interface_reports_provider_recruitment_performance_report_path(@provider))
     expect(page).to have_css('h2', text: 'Application data for this recruitment cycle')
     expect(page).to have_link('Export application data', href: provider_interface_new_application_data_export_path)
     expect(page).to have_link('Export data for Higher Education Statistics Agency (HESA)', href: provider_interface_reports_hesa_exports_path)

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Visit provider recruitment performance report page' do
   include DfESignInHelpers
 
-  scenario 'provider report has been generated', time: mid_cycle(2024) do
+  scenario 'provider report has been generated', time: mid_cycle do
     given_a_provider_and_provider_user_exists
     and_a_provider_recruitment_performance_report_has_been_generated
     and_national_recruitment_performance_report_has_been_generated
@@ -13,7 +13,7 @@ RSpec.describe 'Visit provider recruitment performance report page' do
     and_i_can_navigate_to_report_sections
   end
 
-  scenario 'provider report has not been generated', mid_cycle(2024) do
+  scenario 'provider report has not been generated', mid_cycle do
     given_a_provider_and_provider_user_exists
     and_i_am_signed_in_as_provider_user
     and_i_visit_the_provider_recruitment_report_page
@@ -28,11 +28,11 @@ private
   end
 
   def and_a_provider_recruitment_performance_report_has_been_generated
-    create(:provider_recruitment_performance_report, provider: @provider)
+    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, provider: @provider)
   end
 
   def and_national_recruitment_performance_report_has_been_generated
-    create(:national_recruitment_performance_report)
+    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
   end
 
   def and_i_visit_the_provider_recruitment_report_page
@@ -40,8 +40,13 @@ private
   end
 
   def then_i_see_the_report
-    expect(page).to have_content('Recruitment performance weekly report 2023 to 2024')
-    expect(page).to have_content('This report shows your organisation’s initial teacher training (ITT) recruitment performance so far this recruitment cycle, starting on 3 October 2023.')
+    year = RecruitmentCycleTimetable.current_year
+    cycle_name = "#{year - 1} to #{year}"
+    expect(page).to have_content("Recruitment performance weekly report #{cycle_name}")
+    cycle_start = RecruitmentCycleTimetable.current_timetable.find_opens_at.to_date.to_fs(:govuk_date)
+    cycle_end = RecruitmentCycleTimetable.current_timetable.find_closes_at.to_date.to_fs(:govuk_date)
+    description = "This report shows your organisation’s initial teacher training (ITT) recruitment performance for the #{cycle_name} recruitment cycle, starting on #{cycle_start}, ending on #{cycle_end}."
+    expect(page).to have_content(description)
   end
 
   def and_i_can_navigate_to_report_sections
@@ -109,8 +114,7 @@ private
   end
 
   def then_i_see_no_report_message
-    year_range = RecruitmentCycle.cycle_name(CycleTimetable.current_year)
-    expect(page).to have_content("Recruitment performance weekly report #{year_range}")
+    expect(page).to have_content('Recruitment performance weekly report')
     expect(page).to have_content('This report is not ready to view.')
   end
 


### PR DESCRIPTION
## Context

There were a lot of references to cycle dates / ranges throughout the report. We were using the current CycleTimetable to get these dates, rather than the recruitment_cycle_year for which the report was generated.

As a result, the language is really confusing during this gap between the start of the cycle and when the reports start being generated again. 

## Changes proposed in this pull request

- Associate a report with a given recruitment cycle timetable, so the dates are clear. 
- Conditionally render letting people know when the next reports are going to be generated if we are in the gap.
- Conditional render the section about 'changes this cycle' since that section is only for 2024. 

| 2024 report before | 2024 report after |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/dc71e24b-cd9d-41ca-9683-1894b44f2745) | ![image](https://github.com/user-attachments/assets/254b9adf-b9d1-4d1c-a7c4-18013749307e) |

| 2025 report before | 2025 report after |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/004edca5-03e7-4066-b4df-b4552d818ce9) | ![image](https://github.com/user-attachments/assets/ab19ab95-ea24-4a3a-b2ed-f302cb84a1bb) |

## Guidance to review

I have generated 2025 report for UCL (though they won't be generated yet in reality) and a 2024 report for Keele, so you can login as Cameron Carrot, you can view both side-by-side.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
