### PR TITLE
[417] Update interview preference label and add hint text

### DIFF
--- a/app/views/candidate_interface/interview_availability/_form.html.erb
+++ b/app/views/candidate_interface/interview_availability/_form.html.erb
@@ -12,7 +12,7 @@ Tell providers if you cannot be available for interviews at certain times. For e
 
 <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { text: t('application_form..interview_preferences.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-    <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.interview_preferences.yes_label'), size: 's' }, rows: 8, max_words: 200 %>
+    <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.interview_preferences.yes_label'), size: 's' }, hint: { text: t('application_form.interview_preferences.yes_hint') }, rows: 8, max_words: 200 %>
   <% end %>
 
   <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>

--- a/config/locales/candidate_interface/interview_preferences.yml
+++ b/config/locales/candidate_interface/interview_preferences.yml
@@ -2,7 +2,8 @@ en:
   application_form:
     interview_preferences:
       label: Do you have any times you cannot be available for interviews?
-      yes_label: Give details of your interview availability
+      yes_label: Give details of times or dates that you are not available for interviews
+      yes_hint: For example, Wednesdays after 2pm or Monday 1 June to Friday 5 June.
       no_value: 'No' # No is evaluated as false in YAML
       change_action: interview availability
       any_preferences:

--- a/spec/components/utility/interview_preferences_component_spec.rb
+++ b/spec/components/utility/interview_preferences_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe InterviewPreferencesComponent do
       )
       result = render_inline(described_class.new(application_form:))
       expect(result.text).to include('Do you have any times you cannot be available for interviews?No')
-      expect(result.text).not_to include('Give details of your interview availability')
+      expect(result.text).not_to include('Give details of times or dates that you are not available for interviews')
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe InterviewPreferencesComponent do
       )
       result = render_inline(described_class.new(application_form:))
       expect(result.text).to include('Do you have any times you cannot be available for interviews?No')
-      expect(result.text).not_to include('Give details of your interview availability')
+      expect(result.text).not_to include('Give details of times or dates that you are not available for interviews')
     end
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'A candidate can edit some sections after first submission' do
   def and_i_can_edit_the_section_interview_availability
     click_link_or_button 'Change interview availability', match: :first
     choose 'Yes'
-    fill_in 'Give details of your interview availability', with: 'Quis et enim.'
+    fill_in 'Give details of times or dates that you are not available for interviews', with: 'Quis et enim.'
     when_i_save_and_continue
 
     expect(current_candidate.current_application.reload.interview_preferences).to eq('Quis et enim.')

--- a/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'A candidate can not edit some sections after first submission' d
   def and_i_can_not_the_section_interview_availability
     click_link_or_button 'Change interview availability', match: :first
     choose 'Yes'
-    fill_in 'Give details of your interview availability', with: 'Quis et enim.'
+    fill_in 'Give details of times or dates that you are not available for interviews', with: 'Quis et enim.'
     when_i_save_and_continue
 
     expect(current_candidate.current_application.reload.interview_preferences).to eq('Quis et enim.')


### PR DESCRIPTION
## Context

Updated interview availability guidance to reduce confusion for candidates and providers. 

## Changes proposed in this pull request

- Update interview preference label
- Add interview preference hint text

| Before  | After  |
|---------|--------|
| <img width="691" alt="image" src="https://github.com/user-attachments/assets/f697be4e-5856-450b-ba99-3b5c377474f9" />|<img width="645" alt="image" src="https://github.com/user-attachments/assets/824d6c5e-1253-41ca-b141-6d4a39a21176" />|