### PR TITLE
[621] Fix footer links redirecting on `CandidateInterface`

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class ContentController < CandidateInterfaceController
     include ContentHelper
     skip_before_action :authenticate_candidate!
+    skip_before_action :require_authentication
     skip_before_action :set_user_context
 
     def accessibility

--- a/app/controllers/candidate_interface/errors_controller.rb
+++ b/app/controllers/candidate_interface/errors_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class ErrorsController < CandidateInterfaceController
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_candidate!
-    allow_unauthenticated_access only: [:wrong_email_address]
+    skip_before_action :require_authentication, only: [:wrong_email_address]
 
     def account_locked
       render 'errors/account_locked', status: :forbidden, formats: :html

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_application_if_signed_in
     before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited, if: :candidate_signed_in?
     skip_before_action :authenticate_candidate!
-    allow_unauthenticated_access only: %i[create_account_or_sign_in create_account_or_sign_in_handler]
+    skip_before_action :require_authentication, only: %i[create_account_or_sign_in create_account_or_sign_in_handler]
 
     def create_account_or_sign_in
       @create_account_or_sign_in_form = CreateAccountOrSignInForm.new

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -6,12 +6,6 @@ module Authentication
     helper_method :authenticated?
   end
 
-  class_methods do
-    def allow_unauthenticated_access(**options)
-      skip_before_action :require_authentication, **options
-    end
-  end
-
 private
 
   def authenticated?

--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -2,7 +2,7 @@ class OneLoginController < ApplicationController
   include Authentication
 
   before_action :redirect_to_candidate_sign_in_unless_one_login_enabled
-  allow_unauthenticated_access
+  skip_before_action :require_authentication
 
   def callback
     auth = request.env['omniauth.auth']

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate content' do
 
   scenario 'Candidate views the content pages' do
     given_i_am_on_the_start_page
+    and_the_one_login_candidate_feature_flag_is_enabled
     when_i_click_on_accessibility
     then_i_can_see_the_accessibility_statement
     and_i_can_see_the_cookie_banner
@@ -25,6 +26,10 @@ RSpec.describe 'Candidate content' do
 
     when_i_click_on_the_privacy_policy
     then_i_can_see_the_privacy_policy
+  end
+
+  def and_the_one_login_candidate_feature_flag_is_enabled
+    FeatureFlag.activate(:one_login_candidate_sign_in)
   end
 
   def when_click_on_guidance_for_using_ai


### PR DESCRIPTION
## Context

There is an issue where users on the candidate interface cannot access the footer links without authentication. These links should be accessible to everyone.

## Changes proposed in this pull request

- Fixes an issue where footer links redirect to sign-in

- Simplifies logic by removing the allow_unauthenticated_access class method

- Uses skip_before_action :require_authentication directly in controllers inste

## Guidance to review

Attempt to access the footer links on the review app.
