### PR TITLE
Enable `PERMANENT_SETTINGS` in CI tests

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,12 +23,12 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for upcoming vendor API releases', 'Abeer Salameh'],
     [:adviser_sign_up, 'Allow candidates to sign up for a teacher training adviser', 'Ross Oliver'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
-    [:one_login_candidate_sign_in, 'Use one login to authenticate candidates. When turned off we will default to magic link authentification', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:show_reference_confidentiality_status, 'Control whether the confidentiality status of references is explicitly communicated to candidates, referees and providers', 'Avin Hurry'],
+    [:one_login_candidate_sign_in, 'Use one login to authenticate candidates. When turned off we will default to magic link authentification', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We don't enable the `PERMANENT_SETTINGS` in CI unless they are explicitly enabled in the tests, we do this for `TEMPORARY_FEATURE_FLAGS`.

This PR is experimenting with these tests.