### PR TITLE
[609] enabling task: add route for accessing recruitment cycle timetables as html or json

### DIFF
--- a/app/components/publications/recruitment_cycle_timetable_card.html.erb
+++ b/app/components/publications/recruitment_cycle_timetable_card.html.erb
@@ -1,0 +1,32 @@
+<%= govuk_summary_card(title: title_text) do |card| %>
+  <%= card.with_summary_list(actions: false) do |summary_list| %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.academic_year_range_name') } %>
+      <%= row.with_value { timetable.academic_year_range_name } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.find_opens_at') } %>
+      <%= row.with_value { timetable.find_opens_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.apply_opens_at') } %>
+      <%= row.with_value { timetable.apply_opens_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.apply_deadline_at') } %>
+      <%= row.with_value { timetable.apply_deadline_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.reject_by_default_at') } %>
+      <%= row.with_value { timetable.reject_by_default_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.decline_by_default_at') } %>
+      <%= row.with_value { timetable.decline_by_default_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { t('.find_closes_at') } %>
+      <%= row.with_value { timetable.find_closes_at.to_fs(:govuk_date_and_time) } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/publications/recruitment_cycle_timetable_card.rb
+++ b/app/components/publications/recruitment_cycle_timetable_card.rb
@@ -1,0 +1,23 @@
+module Publications
+  class RecruitmentCycleTimetableCard < ViewComponent::Base
+    def initialize(timetable)
+      @timetable = timetable
+    end
+
+    attr_reader :timetable
+
+    def title_text
+      current_year = RecruitmentCycleTimetable.current_year
+      additional_text = if timetable.recruitment_cycle_year == current_year
+                          t('.current_year')
+                        elsif timetable.recruitment_cycle_year > current_year + 1
+                          t('.proposed_timetable')
+                        elsif timetable.recruitment_cycle_year == current_year + 1
+                          t('.next_year')
+                        elsif timetable.recruitment_cycle_year == current_year - 1
+                          t('.previous_year')
+                        end
+      "#{additional_text} #{timetable.cycle_range_name}".strip
+    end
+  end
+end

--- a/app/controllers/publications/recruitment_cycle_timetables_controller.rb
+++ b/app/controllers/publications/recruitment_cycle_timetables_controller.rb
@@ -1,0 +1,59 @@
+module Publications
+  class RecruitmentCycleTimetablesController < ApplicationController
+    def index
+      respond_to do |format|
+        format.json do
+          render json: { data: Publications::RecruitmentCycleTimetablesPresenter.new(timetables).call }
+        end
+
+        format.html do
+          @timetables = timetables
+        end
+      end
+    end
+
+    def show
+      respond_to do |format|
+        format.json do
+          if timetable.present?
+            render json: { data: Publications::RecruitmentCycleTimetablesPresenter.new(timetable).call }
+          else
+            years = RecruitmentCycleTimetable.all.pluck(:recruitment_cycle_year)
+            render json: { errors: [{
+              error: 'NotFound',
+              message: "Recruitment cycle year should be between #{years.min} and #{years.max}",
+            }] }, status: :not_found
+          end
+        end
+
+        format.html do
+          if timetable.present?
+            @timetable = timetable
+          else
+            render 'errors/not_found', status: :not_found
+          end
+        end
+      end
+    end
+
+  private
+
+    def timetables
+      RecruitmentCycleTimetable.all.order(recruitment_cycle_year: :desc)
+    end
+
+    def timetable
+      if recruitment_cycle_year_param == 'current'
+        RecruitmentCycleTimetable.current_timetable
+      else
+        timetables.find_by(
+          recruitment_cycle_year: recruitment_cycle_year_param,
+        )
+      end
+    end
+
+    def recruitment_cycle_year_param
+      params[:recruitment_cycle_year]
+    end
+  end
+end

--- a/app/models/recruitment_cycle_timetable.rb
+++ b/app/models/recruitment_cycle_timetable.rb
@@ -41,6 +41,10 @@ class RecruitmentCycleTimetable < ApplicationRecord
     "#{recruitment_cycle_year - 1} to #{recruitment_cycle_year}"
   end
 
+  def academic_year_range_name
+    "#{recruitment_cycle_year} to #{recruitment_cycle_year + 1}"
+  end
+
   def relative_next_timetable
     self.class.find_by(recruitment_cycle_year: recruitment_cycle_year + 1)
   end

--- a/app/presenters/publications/recruitment_cycle_timetables_presenter.rb
+++ b/app/presenters/publications/recruitment_cycle_timetables_presenter.rb
@@ -1,0 +1,36 @@
+module Publications
+  class RecruitmentCycleTimetablesPresenter
+    def initialize(timetables)
+      @timetables = Array.wrap(timetables)
+    end
+
+    def call
+      @timetables.map do |timetable|
+        attributes = timetable.attributes
+        attributes.delete('id')
+        attributes.delete('created_at')
+
+        attributes.each do |key, value|
+          attributes[key] = value.iso8601 if value.respond_to?(:iso8601)
+        end
+
+        if timetable.christmas_holiday_range.present?
+          attributes['christmas_holiday_range'] = [
+            timetable.christmas_holiday_range.first.iso8601,
+            timetable.christmas_holiday_range.last.iso8601,
+          ].compact
+
+        end
+
+        if timetable.easter_holiday_range.present?
+          attributes['easter_holiday_range'] = [
+            timetable.easter_holiday_range.first.iso8601,
+            timetable.easter_holiday_range.last.iso8601,
+          ].compact
+        end
+
+        attributes
+      end
+    end
+  end
+end

--- a/app/views/publications/recruitment_cycle_timetables/index.html.erb
+++ b/app/views/publications/recruitment_cycle_timetables/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t('.heading') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t('.heading') %>
+    </h1>
+    <% @timetables.each do |timetable| %>
+      <%= render Publications::RecruitmentCycleTimetableCard.new(timetable) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publications/recruitment_cycle_timetables/show.html.erb
+++ b/app/views/publications/recruitment_cycle_timetables/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, t('.heading', recruitment_cycle_year: @timetable.recruitment_cycle_year) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t('.heading', recruitment_cycle_year: @timetable.recruitment_cycle_year) %>
+    </h1>
+    <%= render Publications::RecruitmentCycleTimetableCard.new(@timetable) %>
+  </div>
+</div>

--- a/config/locales/components/publications/recruitment_cycle_timetable_card.yml
+++ b/config/locales/components/publications/recruitment_cycle_timetable_card.yml
@@ -1,0 +1,16 @@
+en:
+  publications:
+    recruitment_cycle_timetable_card:
+      academic_year_range_name: Recruitment for academic year
+      find_opens_at: Find opens
+      apply_opens_at: Apply opens
+      christmas_holiday_range: Christmas holidays
+      easter_holiday_range: Easter holidays
+      apply_deadline_at: Application deadline
+      reject_by_default_at: Reject by default
+      decline_by_default_at: Decline by default
+      find_closes_at: Find closes
+      current_year: Current year —
+      proposed_timetable: Proposed timetable for
+      next_year: Next year —
+      previous_year: Previous year —

--- a/config/locales/publications/recruitment_cycle_timetables.yml
+++ b/config/locales/publications/recruitment_cycle_timetables.yml
@@ -1,0 +1,8 @@
+en:
+  publications:
+    recruitment_cycle_timetables:
+      index:
+        heading: Recruitment cycle timetables
+      show:
+        heading: Recruitment cycle timetable for %{recruitment_cycle_year}
+        timetables: Timetables

--- a/config/routes/publications.rb
+++ b/config/routes/publications.rb
@@ -5,4 +5,7 @@ namespace :publications, path: '/publications' do
   get '/monthly-statistics/ITT(:year)' => 'monthly_statistics#by_year', as: :monthly_report_itt
   get '/monthly-statistics/:month' => 'monthly_statistics#by_month', as: :monthly_report_at
   get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+
+  get '/recruitment-cycle-timetables' => 'recruitment_cycle_timetables#index', as: :recruitment_cycle_timetables
+  get '/recruitment-cycle-timetables/:recruitment_cycle_year' => 'recruitment_cycle_timetables#show', as: :recruitment_cycle_timetable
 end

--- a/spec/requests/publications/recruitment_cycle_timetables_spec.rb
+++ b/spec/requests/publications/recruitment_cycle_timetables_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'RecruitmentCycleTimetables' do
+  let(:response_body) { response.parsed_body }
+
+  describe '#index', seed_timetables do
+    let(:data) { response_body['data'] }
+
+    it 'returns all recruitment cycle timetables in descending order' do
+      get('/publications/recruitment-cycle-timetables', params: { format: 'json' })
+      expect(response).to have_http_status(:ok)
+      years_in_response = data.map { |timetable| timetable['recruitment_cycle_year'] }
+      expect(years_in_response).to match(RecruitmentCycleTimetable.pluck(:recruitment_cycle_year).sort.reverse)
+    end
+
+    it 'does not include timestamps or id' do
+      get('/publications/recruitment-cycle-timetables', params: { format: 'json' })
+      expect(response).to have_http_status(:ok)
+      expect(data.map { |timetable| timetable['created_at'] }.compact).to eq []
+      expect(data.map { |timetable| timetable['id'] }.compact).to eq []
+    end
+  end
+
+  describe '#show', seed_timetables do
+    let(:data) { response_body['data'].first }
+
+    context 'valid year' do
+      it 'returns expected timetable' do
+        year = RecruitmentCycleTimetable.pluck(:recruitment_cycle_year).sample
+        get("/publications/recruitment-cycle-timetables/#{year}", params: { format: 'json' })
+        expect(response).to have_http_status(:ok)
+        recruitment_cycle_timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: year)
+        expect(data['recruitment_cycle_year']).to eq recruitment_cycle_timetable.recruitment_cycle_year
+      end
+    end
+
+    context 'current year' do
+      it 'returns the current recruitment cycle timetable' do
+        get('/publications/recruitment-cycle-timetables/current', params: { format: 'json' })
+        expect(response).to have_http_status(:ok)
+        recruitment_cycle_timetable = RecruitmentCycleTimetable.current_timetable
+        expect(data['recruitment_cycle_year']).to eq recruitment_cycle_timetable.recruitment_cycle_year
+      end
+
+      it 'returns ranges as array of start and end dates' do
+        get('/publications/recruitment-cycle-timetables/current', params: { format: 'json' })
+        expect(response).to have_http_status(:ok)
+
+        christmas_holiday_range = RecruitmentCycleTimetable.current_timetable.christmas_holiday_range
+        expect(data['christmas_holiday_range'])
+          .to eq([christmas_holiday_range.first.to_s, christmas_holiday_range.last.to_s])
+
+        easter_holiday_range = RecruitmentCycleTimetable.current_timetable.easter_holiday_range
+        expect(data['easter_holiday_range'])
+          .to eq([easter_holiday_range.first.to_s, easter_holiday_range.last.to_s])
+      end
+    end
+
+    context 'invalid year' do
+      it 'returns 404 with error message' do
+        get('/publications/recruitment-cycle-timetables/2018', params: { format: 'json' })
+        expect(response).to have_http_status(:not_found)
+        years = RecruitmentCycleTimetable.pluck(:recruitment_cycle_year)
+        expect(response_body['errors'].first['message']).to eq "Recruitment cycle year should be between #{years.min} and #{years.max}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is an enabling task for using the RecruitmentCycleTimetable model in the cycle switcher. In order to 'switch back to production dates', we need to be able to get the production dates. The easiest way to do that is to expose them as json in a public page. 

There is also an html rendering for reference

## Changes proposed in this pull request

Endpoint for rendering all or one recruitment cycle timetable

## Guidance to review

Check the following end points in the review app:
`publications/recruitment-cycle-timetables?format=json`
`publications/recruitment-cycle-timetables/current?format=json`
`publications/recruitment-cycle-timetables/an-invalid-year-like-2018?format=json`
`publications/recruitment-cycle-timetables/2023?format=json`

And then all again, but without the `format=json` param to see the html response


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
