### PR TITLE
Allow providers to csv export all their application choices

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -32,6 +32,7 @@ module ProviderInterface
               current_course_option: %i[course site],
               application_form: %i[candidate english_proficiency application_qualifications],
             ],
+            recruitment_cycle_year: RecruitmentCycleTimetable.pluck(:recruitment_cycle_year),
           )
 
         application_choices = FilterApplicationChoicesForProviders.call(

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -15,6 +15,14 @@ module ProviderInterface
       recruitment_cycle_years.compact_blank
     end
 
+    def years_to_export
+      choices = GetApplicationChoicesForProviders.call(
+        providers: providers_that_actor_belongs_to,
+        recruitment_cycle_year: RecruitmentCycleTimetable.pluck(:recruitment_cycle_year),
+      )
+      choices.map(&:current_recruitment_cycle_year).uniq.sort
+    end
+
     def providers_that_actor_belongs_to
       @_providers_that_actor_belongs_to ||= current_provider_user.providers
     end

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -16,9 +16,11 @@
         <%= t('page_titles.provider.export_application_data') %>
       </h1>
 
-      <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Recruitment cycle', size: 'm' } do %>
-        <% RecruitmentCycle.years_visible_to_providers.each_with_index do |year, index| %>
-          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle.cycle_string(year) }, link_errors: index.zero? %>
+      <% if @application_data_export_form.years_to_export.any? %>
+        <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Recruitment cycle', size: 'm' } do %>
+          <% @application_data_export_form.years_to_export.each_with_index do |year, index| %>
+            <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle.cycle_string(year) }, link_errors: index.zero? %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -22,6 +22,9 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     email_address: candidate.email_address,
   )
 
+  puts 'Creating all RecruitmentCycleTimetables'
+  DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase.new.change
+
   puts 'Creating various provider users...'
   CreateExampleProviderUsersWithPermissions.call
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
+# Run data migrations before specs
+DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase.new.change
+
 Faker::Config.locale = 'en-GB'
 
 RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
     then_the_downloaded_file_includes_applications_all_years_of_deferred_and_accepted_offers_for_the_first_provider
   end
 
+  scenario 'downloads a CSV of old applications' do
+    given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
+    and_my_organisation_has_old_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_export_applications_page
+
+    and_i_fill_out_the_form_for_2022_applications
+    then_the_downloaded_file_includes_2022_applications
+  end
+
   scenario 'experiences an error during the download' do
     given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
     and_my_organisation_has_courses_with_applications
@@ -88,6 +99,22 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
              current_course_option: create(:course_option, course: course))
   end
 
+  def and_my_organisation_has_old_courses_with_applications
+    @current_provider_user = ProviderUser.last
+    providers = @current_provider_user.providers
+    course_2022 = create(:course, provider: providers.first, recruitment_cycle_year: 2022)
+    course_option = create(:course_option, course: course_2022)
+
+    @application_accepted_2022 = create(:application_choice, :accepted, course_option:)
+
+    course_2021 = create(:course, recruitment_cycle_year: 2021, provider: providers.first)
+    @application_deferred_submitted_2021_previous_cycle_offered_2022 =
+      create(:application_choice,
+             :accepted,
+             course_option: create(:course_option, course: course_2021),
+             current_course_option: create(:course_option, course: course_2022))
+  end
+
   def when_i_visit_the_export_applications_page
     visit provider_interface_new_application_data_export_path
   end
@@ -114,6 +141,14 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
     click_export_data
   end
 
+  def and_i_fill_out_the_form_for_2022_applications
+    check 2022
+    choose 'All statuses'
+    check @current_provider_user.providers.first.name
+
+    click_export_data
+  end
+
   def then_the_downloaded_file_includes_applications_this_year_of_any_status_for_the_first_provider
     csv_data = CSV.parse(page.body, headers: true)
     expect_export_to_include_data_for_application(csv_data, @application_accepted)
@@ -123,6 +158,12 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
     expect_export_to_include_data_for_application(csv_data, @application_deferred_submitted_previous_cycle_offered_current_cycle)
     expect(csv_data['Application number']).not_to include(@application_accepted_previous_cycle.id.to_s)
     expect(csv_data['Application number']).not_to include(@application_second_provider.id.to_s)
+  end
+
+  def then_the_downloaded_file_includes_2022_applications
+    csv_data = CSV.parse(page.body, headers: true)
+    expect_export_to_include_data_for_application(csv_data, @application_accepted_2022)
+    expect_export_to_include_data_for_application(csv_data, @application_deferred_submitted_2021_previous_cycle_offered_2022)
   end
 
   def and_i_fill_out_the_form_for_applications_all_years_of_deferred_and_accepted_offers_for_the_first_provider


### PR DESCRIPTION
## Context

Previously, we allowed providers to only export their applications
choices only from the current and previous cycle

This commit allows them to export every recruitment cycle they have
application choices for.

## Changes proposed in this pull request

Application export

## Guidance to review

Go on review app, log as a provider and export applications that are at least 3 cycles ago.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
