### PR TITLE
Push email address of oneloginauth record to BigQuery

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -16,6 +16,7 @@ shared:
     - candidate_id
     - created_at
     - updated_at
+    - email_address
   account_recovery_request_codes:
     - id
     - account_recovery_request_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -160,7 +160,6 @@
   - email_address
   - phone_number
   :one_login_auths:
-  - email_address
   - token
   :interviews:
   - additional_details

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -15,3 +15,6 @@ shared:
     - user_id
   emails:
     - subject
+  one_login_auths:
+    - candidate_id
+    - email_address


### PR DESCRIPTION
## Context

The analitycs team want us to surface almost all the information in the OneLoginAuth table.
The only thing we didn't push was email_address and token. They don't care about token so this just pushes the email and alos makes the candidate id hidden pii along with the email.

## Changes proposed in this pull request

Analytics yml files

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
