### PR TITLE
Performance report bug fix - not showing the latest reports

### DIFF
--- a/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
@@ -3,8 +3,7 @@ module ProviderInterface
     class RecruitmentPerformanceReportsController < ProviderInterfaceController
       def show
         @provider = current_user.providers.find(provider_id)
-        report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).order(:cycle_week).last
-        @provider_report = report.present? ? Publications::ProviderRecruitmentPerformanceReportPresenter.new(report) : nil
+        @provider_report = latest_report.present? ? Publications::ProviderRecruitmentPerformanceReportPresenter.new(latest_report) : nil
 
         @provider_data = @provider_report&.statistics
         @national_data = national_report&.statistics
@@ -19,6 +18,13 @@ module ProviderInterface
               cycle_week: @provider_report.cycle_week,
             ).last
         end
+      end
+
+      def latest_report
+        Publications::ProviderRecruitmentPerformanceReport
+          .where(provider: @provider)
+          .order(:recruitment_cycle_year, :cycle_week)
+          .last
       end
 
       def provider_id

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -25,7 +25,7 @@
       <% if @providers.many? %>
         <h3 class="govuk-heading-s"><%= provider.name %></h3>
       <% end %>
-      <% report = provider.performance_reports.last %>
+      <% report = provider.performance_reports.order(:recruitment_cycle_year, :cycle_week).last %>
       <ul class="govuk-list govuk-list--spaced">
         <li><%= govuk_link_to("Weekly report for week ending #{report.reporting_end_date.to_fs(:govuk_date)}", provider_interface_reports_provider_recruitment_performance_report_path(provider.id)) %></li>
       </ul>

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe 'Visit provider recruitment performance report page' do
     given_a_provider_and_provider_user_exists
     and_a_provider_recruitment_performance_report_has_been_generated
     and_national_recruitment_performance_report_has_been_generated
+    and_reports_from_a_later_week_were_generated_for_last_year
     and_i_am_signed_in_as_provider_user
     and_i_visit_the_provider_recruitment_report_page
-    then_i_see_the_report
+    then_i_see_the_report_for_the_current_year
     and_i_can_navigate_to_report_sections
   end
 
@@ -28,18 +29,23 @@ private
   end
 
   def and_a_provider_recruitment_performance_report_has_been_generated
-    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, provider: @provider)
+    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, cycle_week: 31, provider: @provider)
   end
 
   def and_national_recruitment_performance_report_has_been_generated
-    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
+    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, cycle_week: 31)
+  end
+
+  def and_reports_from_a_later_week_were_generated_for_last_year
+    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, cycle_week: 43, provider: @provider)
+    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, cycle_week: 43)
   end
 
   def and_i_visit_the_provider_recruitment_report_page
     visit provider_interface_reports_provider_recruitment_performance_report_path(provider_id: @provider.id)
   end
 
-  def then_i_see_the_report
+  def then_i_see_the_report_for_the_current_year
     year = RecruitmentCycleTimetable.current_year
     cycle_name = "#{year - 1} to #{year}"
     expect(page).to have_content("Recruitment performance weekly report #{cycle_name}")


### PR DESCRIPTION
## Context

The controller had the reports being ordered by cycle week rather than recruitment_cycle_year, so we would have shown the user a report from last year with a later cycle week, rather than this year. 

## Changes proposed in this pull request

Order reports by `recruitment_cycle_year`, than `cycle_week` when looking for the latest report.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
