### PR TITLE
Log current_candidate as audit user in candidate_interface

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,7 +10,6 @@ module CandidateInterface
     before_action :check_cookie_preferences
     before_action :check_account_locked
     layout 'application'
-    alias audit_user current_candidate
 
     def current_user
       current_candidate
@@ -19,6 +18,7 @@ module CandidateInterface
     def current_candidate
       super || Current.session&.candidate
     end
+    alias audit_user current_candidate
 
     def set_user_context(candidate_id = current_candidate&.id)
       Sentry.set_user(id: "candidate_#{candidate_id}")

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
 
-  scenario 'Candidate with a completed application' do
+  scenario 'Candidate with a completed application', :with_audited do
     given_i_am_signed_in_with_one_login
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
@@ -46,6 +46,7 @@ RSpec.describe 'Candidate submits the application' do
 
     when_one_of_my_applications_becomes_inactive
     then_i_am_able_to_add_another_choice
+    and_audits_are_created_correctly
   end
 
   scenario 'Candidate with a primary application missing the science GCSE' do
@@ -214,5 +215,11 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_am_on_science_gcse_section
     expect(page).to have_current_path(candidate_interface_gcse_details_new_type_path(subject: 'science'))
+  end
+
+  def and_audits_are_created_correctly
+    expect(
+      @application_choice.audits.where(user_id: @current_candidate.id).any?,
+    ).to be_truthy
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

With the introduction of one login we accidentally introduced a bug in our audits.

Some of our audits have the user_id nil because the alias that sets the audit user was on the wrong line in the candidate_interface controller.

This commit fixes this. I've also added a spec to make sure this doesn't happen.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review and log in as dev-candidate and edit the form.

Then login as support and view the changes of that candidate in the history tab for the dev-candidate candidate.


https://github.com/user-attachments/assets/97caac0f-734d-454d-8bdb-2391a4242b3e

Production
![Screenshot from 2025-02-10 15-12-23](https://github.com/user-attachments/assets/82290841-473d-46c2-9d84-83e2fb42ba57)
Review app
![Screenshot from 2025-02-10 15-12-42](https://github.com/user-attachments/assets/4f8134ad-53cf-4347-8edd-d4f969817679)





## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
