### PR TITLE
Increase sandbox memory to 1.5 gb

### DIFF
--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -9,7 +9,7 @@
     "sandbox.apply-for-teacher-training.service.gov.uk",
     "sandbox.apply-for-teacher-training.education.gov.uk"
   ],
-  "webapp_memory_max": "1024Mi",
+  "webapp_memory_max": "1536Mi",
   "worker_memory_max": "1024Mi",
   "secondary_worker_memory_max": "1024Mi",
   "clock_worker_memory_max": "1024Mi",


### PR DESCRIPTION
## Context

We see a lot of restarts of the sandbox webapp pods. They are all OMM killed because sandbox is using too much memory.

This commit just increases the memory limit to 1.5 gb.

Don't really know what caused the pods to hit the limit but considering that production is 3 gb and sandbox is supposed to be a production like env, seems reasonable to increase it.

There might be more traffic to sandbox lately 🤷🏻 Though logs in logit are flat

## Changes proposed in this pull request

Terraform config

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
