### PR TITLE
[595] Data migration to remove the `show_reference_confidentiality_status` feature flag

### DIFF
--- a/app/services/data_migrations/remove_show_reference_confidentiality_status_feature_flag.rb
+++ b/app/services/data_migrations/remove_show_reference_confidentiality_status_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveShowReferenceConfidentialityStatusFeatureFlag
+    TIMESTAMP = 20250211105529
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :show_reference_confidentiality_status)&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveShowReferenceConfidentialityStatusFeatureFlag',
   'DataMigrations::AddRecruitmentCycleYearToPerformanceReports',
   'DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase',
   'DataMigrations::RemoveOneLoginPreReleaseBannersFeatureFlag',

--- a/spec/services/data_migrations/remove_show_reference_confidentiality_status_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_show_reference_confidentiality_status_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveShowReferenceConfidentialityStatusFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'show_reference_confidentiality_status')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'show_reference_confidentiality_status')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Usages were removed in #10363. 

## Changes proposed in this pull request

Remove the feature flag from the database.