### PR TITLE
[633] Remove `Changes to the service` link

### DIFF
--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -32,9 +32,6 @@
     <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.roadmap'), provider_interface_roadmap_path, class: 'govuk-footer__link' %>
-  </li>
-  <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,7 +394,6 @@ en:
       guidance_for_using_ai: Guidance for using AI
       privacy_policy: Privacy
       privacy: Privacy
-      roadmap: Changes to this service
       not_logged_in: candidate_not_logged_in
   support_interface:
     providers:

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe 'Provider content' do
     when_click_on_guidance_for_using_ai
     then_i_can_see_the_ai_guidance
 
-    when_i_click_on_the_roadmap
-    then_i_can_see_the_roadmap
-
     when_i_click_on_privacy
     then_i_see_the_privacy_notice_page
   end
@@ -82,13 +79,5 @@ RSpec.describe 'Provider content' do
 
   def then_i_can_see_the_service_guidance_provider
     expect(page).to have_content(t('page_titles.service_guidance_provider'))
-  end
-
-  def when_i_click_on_the_roadmap
-    within('.govuk-footer') { click_link_or_button t('layout.support_links.roadmap') }
-  end
-
-  def then_i_can_see_the_roadmap
-    expect(page).to have_content(t('page_titles.roadmap'))
   end
 end


### PR DESCRIPTION
## Context

We are removing the link to the `Changes to the service` page because it is outdated. We are keeping the page because we are thinking about how we want to use this in the future.

## Changes proposed in this pull request

Remove the link to `Changes to the service`

## Guidance to review

Try and get to the page from the service via a link.


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
