### PR TITLE
Initial Candidate Pool spike

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -25,6 +25,9 @@ class Candidate < ApplicationRecord
   belongs_to :course_from_find, class_name: 'Course', optional: true
   belongs_to :duplicate_match, foreign_key: 'fraud_match_id', optional: true
 
+  has_many :pool_dismissals, dependent: :destroy, class_name: 'Pool::Dismissal'
+  has_many :pool_invites, dependent: :destroy, class_name: 'Pool::Invite'
+
   PUBLISHED_FIELDS = %w[email_address].freeze
 
   enum :account_recovery_status, {
@@ -32,6 +35,17 @@ class Candidate < ApplicationRecord
     recovered: 'recovered',
     dismissed: 'dismissed',
   }, prefix: true
+
+  enum :pool_status, {
+    not_set: 'not_set',
+    opt_in: 'opt_in',
+    opt_out: 'opt_out',
+  }, prefix: true
+
+
+  def invited?
+    invited || false
+  end
 
   after_create do
     update!(candidate_api_updated_at: Time.zone.now)

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -1,0 +1,5 @@
+module Pool
+  def self.table_name_prefix
+    "pool_"
+  end
+end

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,0 +1,14 @@
+module Pool::Candidates
+  def self.for_provider(provider:)
+    dismissed_candidates = Candidate.joins(:pool_dismissals).where(pool_dismissals: { provider: provider })
+
+    Candidate
+      # .for_current_cycle
+      .pool_status_opt_in
+      .excluding(dismissed_candidates)
+      # .where_eligible_for_pool # this still needs definition - is it only rejected/withdrawn candidates?
+      .joins("LEFT OUTER JOIN pool_invites on pool_invites.candidate_id = candidates.id and pool_invites.provider_id = #{provider.id}")
+      .distinct
+      .select('candidates.*, case when pool_invites.id is null then false else true end as invited')
+  end
+end

--- a/app/models/pool/dismissal.rb
+++ b/app/models/pool/dismissal.rb
@@ -1,0 +1,5 @@
+class Pool::Dismissal < ApplicationRecord
+  belongs_to :candidate
+  belongs_to :provider
+  belongs_to :dismissed_by, class_name: 'ProviderUser'
+end

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -1,0 +1,6 @@
+class Pool::Invite < ApplicationRecord
+  belongs_to :candidate
+  belongs_to :provider
+  belongs_to :invited_by, class_name: 'ProviderUser'
+  belongs_to :course
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,4 +1,19 @@
 shared:
+  :pool_invites:
+    - id
+    - candidate_id
+    - provider_id
+    - invited_by_id
+    - course_id
+    - created_at
+    - updated_at
+  :pool_dismissals:
+    - id
+    - candidate_id
+    - provider_id
+    - dismissed_by_id
+    - created_at
+    - updated_at
   candidates:
     - account_recovery_status
     - candidate_api_updated_at
@@ -11,6 +26,7 @@ shared:
     - sign_up_email_bounced
     - updated_at
     - email_address
+    - pool_status
   one_login_auths:
     - id
     - candidate_id

--- a/db/migrate/20250122164506_add_pool_status_to_candidates.rb
+++ b/db/migrate/20250122164506_add_pool_status_to_candidates.rb
@@ -1,0 +1,5 @@
+class AddPoolStatusToCandidates < ActiveRecord::Migration[8.0]
+  def change
+    add_column :candidates, :pool_status, :string, null: false, default: 'not_set'
+  end
+end

--- a/db/migrate/20250122164721_create_pool_dismissals.rb
+++ b/db/migrate/20250122164721_create_pool_dismissals.rb
@@ -1,0 +1,11 @@
+class CreatePoolDismissals < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pool_dismissals do |t|
+      t.references :candidate, null: false, foreign_key: true
+      t.references :provider, null: false, foreign_key: true
+      t.references :dismissed_by, null: false, foreign_key: { to_table: :provider_users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250122164839_create_pool_invites.rb
+++ b/db/migrate/20250122164839_create_pool_invites.rb
@@ -1,0 +1,12 @@
+class CreatePoolInvites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pool_invites do |t|
+      t.references :candidate, null: false, foreign_key: true
+      t.references :provider, null: false, foreign_key: true
+      t.references :invited_by, null: false, foreign_key: { to_table: :provider_users }
+      t.references :course, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_09_085508) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_22_164839) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -400,6 +400,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_09_085508) do
     t.boolean "submission_blocked", default: false, null: false
     t.boolean "account_locked", default: false, null: false
     t.string "account_recovery_status", default: "not_started", null: false
+    t.string "pool_status", default: "not_set", null: false
     t.index ["account_locked"], name: "index_candidates_on_account_locked"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["fraud_match_id"], name: "index_candidates_on_fraud_match_id"
@@ -651,6 +652,30 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_09_085508) do
     t.integer "award_year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "pool_dismissals", force: :cascade do |t|
+    t.bigint "candidate_id", null: false
+    t.bigint "provider_id", null: false
+    t.bigint "dismissed_by_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["candidate_id"], name: "index_pool_dismissals_on_candidate_id"
+    t.index ["dismissed_by_id"], name: "index_pool_dismissals_on_dismissed_by_id"
+    t.index ["provider_id"], name: "index_pool_dismissals_on_provider_id"
+  end
+
+  create_table "pool_invites", force: :cascade do |t|
+    t.bigint "candidate_id", null: false
+    t.bigint "provider_id", null: false
+    t.bigint "invited_by_id", null: false
+    t.bigint "course_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["candidate_id"], name: "index_pool_invites_on_candidate_id"
+    t.index ["course_id"], name: "index_pool_invites_on_course_id"
+    t.index ["invited_by_id"], name: "index_pool_invites_on_invited_by_id"
+    t.index ["provider_id"], name: "index_pool_invites_on_provider_id"
   end
 
   create_table "provider_agreements", force: :cascade do |t|
@@ -964,6 +989,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_09_085508) do
   add_foreign_key "offer_conditions", "offers", on_delete: :cascade
   add_foreign_key "offers", "application_choices", on_delete: :cascade
   add_foreign_key "one_login_auths", "candidates", on_delete: :cascade
+  add_foreign_key "pool_dismissals", "candidates"
+  add_foreign_key "pool_dismissals", "provider_users", column: "dismissed_by_id"
+  add_foreign_key "pool_dismissals", "providers"
+  add_foreign_key "pool_invites", "candidates"
+  add_foreign_key "pool_invites", "courses"
+  add_foreign_key "pool_invites", "provider_users", column: "invited_by_id"
+  add_foreign_key "pool_invites", "providers"
   add_foreign_key "provider_agreements", "provider_users"
   add_foreign_key "provider_agreements", "providers"
   add_foreign_key "provider_recruitment_performance_reports", "providers"

--- a/spec/factories/pool_dismissal.rb
+++ b/spec/factories/pool_dismissal.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :pool_dismissal, class: 'Pool::Dismissal' do
+    candidate factory: %i[candidate]
+    provider factory: %i[provider]
+    dismissed_by factory: %i[provider_user]
+  end
+end
+
+FactoryBot.define do
+  factory :pool_invite, class: 'Pool::Invite' do
+    candidate factory: %i[candidate]
+    provider factory: %i[provider]
+    invited_by factory: %i[provider_user]
+    course factory: %i[course]
+  end
+end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Pool::Candidates do
+  describe '.for_provider' do
+    it 'returns candidates who have not been dismissed by the provider' do
+      provider = create(:provider)
+      opt_in_candidate = create(:candidate, pool_status: 'opt_in')
+      _opt_out_candidate = create(:candidate, pool_status: 'opt_out')
+      invited_candidate = create(:candidate, pool_status: 'opt_in')
+      dismissed_candidate = create(:candidate, pool_status: 'opt_in')
+
+      create(:pool_invite, provider: provider, candidate: invited_candidate)
+      create(:pool_dismissal, provider: provider, candidate: dismissed_candidate)
+
+      candidates = described_class.for_provider(provider: provider)
+
+      expect(candidates).to contain_exactly(opt_in_candidate, invited_candidate)
+      opt_in_pool_candidate = candidates.to_a.find { |c| c.id == opt_in_candidate.id }
+      invited_pool_candidate = candidates.to_a.find { |c| c.id == invited_candidate.id }
+      expect(opt_in_pool_candidate).not_to be_invited
+      expect(invited_pool_candidate).to be_invited
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Planning

```mermaid
erDiagram
    Candidate {
        string pool_status "opt_in | opt_out | not_set"
    }
    
    PoolDismissal {
        int candidate_id
        int provider_id
        int dismissed_by_id "Provider User ID"
    }
    
    PoolInvite {
        int candidate_id
        int provider_id
        int invited_by_id "Provider User ID"
        int course_id
    }
   
    PoolDismissal }o--|| Candidate : ""
    PoolDismissal }o--|| Provider : ""
    PoolInvite }o--|| Candidate : ""
    PoolInvite }o--|| Provider : ""
```

```ruby
class Pool::Candidate
  def self.for_provider(provider:)
    dismissed_candidates = Candidate.joins(:pool_dismissals).where(pool_dismissals: { provider: provider })
    
    Candidate
      .for_current_cycle
      .where(pool_status: 'opt_in')
      .excluding(dismissed_candidates)
      .where_eligible_for_pool # this still needs definition - is it only rejected/withdrawn candidates?
      .left_joins(:pool_invites).where(pool_invites: { provider: provider })
      .distinct
      .select('candidates.*, EXISTS(pool_invites.id) as invited')
  end
end
```


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
