### PR TITLE
[2201] Fix convert-kubeconfig for workload identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ production-cluster:
 
 get-cluster-credentials: set-azure-account
 	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
-	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
+	kubelogin convert-kubeconfig -l $(if ${AAD_LOGIN_METHOD},${AAD_LOGIN_METHOD},azurecli)
 
 maintenance-image-push: ## Build and push maintenance page image: make production maintenance-image-push GITHUB_TOKEN=x [MAINTENANCE_IMAGE_TAG=y]
 	$(if ${GITHUB_TOKEN},, $(error Provide a valid Github token with write:packages permissions as GITHUB_TOKEN variable))


### PR DESCRIPTION
## Context
kubelogin should use workload identity when running in a workflow. The AAD_LOGIN_METHOD variable has the right value.

## Changes proposed in this pull request
Use $AAD_LOGIN_METHOD in get-cluster-credentials

## Guidance to review
Check review app

