### PR TITLE
Implement params.expect along with rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,7 +88,13 @@ Rails/WhereRange:
   Enabled: false
 
 Rails/StrongParametersExpect:
-  Enabled: false
+  Enabled: true
+  Exclude:
+    - app/controllers/vendor_api/confirm_deferred_offers_controller.rb
+    - app/controllers/vendor_api/decisions_controller.rb
+    - app/controllers/vendor_api/interviews_controller.rb
+    - app/controllers/vendor_api/notes_controller.rb
+    - app/controllers/candidate_interface/other_qualifications/details_controller.rb
 
 Rails/CreateTableWithTimestamps:
   Exclude:

--- a/app/controllers/candidate_interface/account_recovery_controller.rb
+++ b/app/controllers/candidate_interface/account_recovery_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
 
     def permitted_params
       strip_whitespace(
-        params.require(:candidate_interface_account_recovery_form).permit(:code),
+        params.expect(candidate_interface_account_recovery_form: [:code]),
       )
     end
 

--- a/app/controllers/candidate_interface/account_recovery_requests_controller.rb
+++ b/app/controllers/candidate_interface/account_recovery_requests_controller.rb
@@ -24,8 +24,8 @@ module CandidateInterface
 
     def permitted_params
       strip_whitespace(
-        params.require(:candidate_interface_account_recovery_request_form).permit(
-          :previous_account_email_address,
+        params.expect(
+          candidate_interface_account_recovery_request_form: [:previous_account_email_address],
         ),
       )
     end

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -26,10 +26,10 @@ module CandidateInterface
   private
 
     def feedback_params
-      strip_whitespace params.require(:candidate_interface_application_feedback_form).permit(
-        :path, :page_title,
-        :feedback, :consent_to_be_contacted,
-        :original_controller
+      strip_whitespace params.expect(
+        candidate_interface_application_feedback_form: %i[path page_title
+                                                          feedback consent_to_be_contacted
+                                                          original_controller],
       )
     end
   end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -43,8 +43,8 @@ module CandidateInterface
     end
 
     def contact_details_params
-      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(
-        :address_line1, :address_line2, :address_line3, :address_line4, :postcode
+      strip_whitespace params.expect(
+        candidate_interface_contact_details_form: %i[address_line1 address_line2 address_line3 address_line4 postcode],
       )
     end
   end

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -43,9 +43,9 @@ module CandidateInterface
     end
 
     def address_type_params
-      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(
-        :address_type,
-        :country,
+      strip_whitespace params.expect(
+        candidate_interface_contact_details_form: %i[address_type
+                                                     country],
       )
     end
   end

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -42,7 +42,7 @@ module CandidateInterface
     end
 
     def contact_details_params
-      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(:phone_number)
+      strip_whitespace params.expect(candidate_interface_contact_details_form: [:phone_number])
     end
   end
 end

--- a/app/controllers/candidate_interface/degrees/degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree_controller.rb
@@ -91,11 +91,11 @@ module CandidateInterface
 
       def degree_params
         if params[:candidate_interface_degree_wizard].present?
-          strip_whitespace params.require(:candidate_interface_degree_wizard).permit(
-            :uk_or_non_uk, :country, :subject, :subject_raw, :degree_level, :equivalent_level,
-            :type, :international_type, :other_type, :other_type_raw, :university, :university_raw,
-            :completed, :grade, :other_grade, :other_grade_raw, :start_year, :award_year,
-            :enic_reference, :comparable_uk_degree, :enic_reason
+          strip_whitespace params.expect(
+            candidate_interface_degree_wizard: %i[uk_or_non_uk country subject subject_raw degree_level equivalent_level
+                                                  type international_type other_type other_type_raw university university_raw
+                                                  completed grade other_grade other_grade_raw start_year award_year
+                                                  enic_reference comparable_uk_degree enic_reason],
           )
         else
           {}

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -40,8 +40,7 @@ module CandidateInterface
 
       def completion_params
         strip_whitespace params
-          .require(:candidate_interface_section_complete_form)
-          .permit(:completed)
+          .expect(candidate_interface_section_complete_form: [:completed])
       end
     end
   end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -110,7 +110,7 @@ module CandidateInterface
     end
 
     def disabilities_params
-      params.require(:candidate_interface_equality_and_diversity_disabilities_form).permit(:other_disability, disabilities: []).tap do |dp|
+      params.expect(candidate_interface_equality_and_diversity_disabilities_form: [:other_disability, disabilities: []]).tap do |dp|
         dp.delete(:disabilities) if dp[:disabilities] == ['']
       end
     end
@@ -120,7 +120,7 @@ module CandidateInterface
     end
 
     def ethnic_background_param
-      params.require(:candidate_interface_equality_and_diversity_ethnic_background_form).permit(:ethnic_background, :other_background)
+      params.expect(candidate_interface_equality_and_diversity_ethnic_background_form: %i[ethnic_background other_background])
     end
 
     def free_school_meals_param

--- a/app/controllers/candidate_interface/feedback_form_controller.rb
+++ b/app/controllers/candidate_interface/feedback_form_controller.rb
@@ -20,8 +20,8 @@ module CandidateInterface
   private
 
     def feedback_params
-      strip_whitespace params.require(:candidate_interface_feedback_form).permit(
-        :satisfaction_level, :suggestions
+      strip_whitespace params.expect(
+        candidate_interface_feedback_form: %i[satisfaction_level suggestions],
       )
     end
   end

--- a/app/controllers/candidate_interface/find_feedback_controller.rb
+++ b/app/controllers/candidate_interface/find_feedback_controller.rb
@@ -26,8 +26,8 @@ module CandidateInterface
   private
 
     def feedback_params
-      params.require(:candidate_interface_find_feedback_form).permit(
-        :path, :find_controller, :hidden_feedback_field, :feedback, :email_address
+      params.expect(
+        candidate_interface_find_feedback_form: %i[path find_controller hidden_feedback_field feedback email_address],
       )
     end
   end

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -50,8 +50,7 @@ module CandidateInterface
 
     def english_details_params
       strip_whitespace params
-        .require(:candidate_interface_english_gcse_grade_form)
-        .permit([
+        .expect(candidate_interface_english_gcse_grade_form: [
           :english_single_award,
           :grade_english_single,
           :english_double_award,

--- a/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_explanation_controller.rb
@@ -56,8 +56,7 @@ module CandidateInterface
 
     def grade_explanation_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_grade_explanation_form)
-        .permit(:currently_completing_qualification, :missing_explanation)
+        .expect(candidate_interface_gcse_grade_explanation_form: %i[currently_completing_qualification missing_explanation])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -36,8 +36,7 @@ module CandidateInterface
 
     def institution_country_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_institution_country_form)
-        .permit(:institution_country)
+        .expect(candidate_interface_gcse_institution_country_form: [:institution_country])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -52,8 +52,7 @@ module CandidateInterface
 
     def maths_params
       strip_whitespace params
-                        .require(:candidate_interface_maths_gcse_grade_form)
-                        .permit(%i[grade award_year other_grade])
+                        .expect(candidate_interface_maths_gcse_grade_form: %i[grade award_year other_grade])
                         .merge!(qualification_type: current_qualification.qualification_type)
     end
 

--- a/app/controllers/candidate_interface/gcse/missing_qualification_controller.rb
+++ b/app/controllers/candidate_interface/gcse/missing_qualification_controller.rb
@@ -42,8 +42,7 @@ module CandidateInterface
 
     def qualification_missing_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_missing_form)
-        .permit(:missing_explanation)
+        .expect(candidate_interface_gcse_missing_form: [:missing_explanation])
     end
 
     def set_back_link

--- a/app/controllers/candidate_interface/gcse/not_completed_qualification_controller.rb
+++ b/app/controllers/candidate_interface/gcse/not_completed_qualification_controller.rb
@@ -46,8 +46,7 @@ module CandidateInterface
 
     def qualification_not_completed_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_not_completed_form)
-        .permit(:not_completed_explanation, :currently_completing_qualification)
+        .expect(candidate_interface_gcse_not_completed_form: %i[not_completed_explanation currently_completing_qualification])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -68,8 +68,7 @@ module CandidateInterface
 
     def science_details_params
       strip_whitespace params
-        .require(:candidate_interface_science_gcse_grade_form)
-        .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade other_grade])
+        .expect(candidate_interface_science_gcse_grade_form: %i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade other_grade])
     end
 
     def science_gcse_grade_form

--- a/app/controllers/candidate_interface/gcse/statement_comparability_controller.rb
+++ b/app/controllers/candidate_interface/gcse/statement_comparability_controller.rb
@@ -48,8 +48,7 @@ module CandidateInterface
 
     def enic_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_enic_form)
-        .permit(:enic_reference, :comparable_uk_qualification)
+        .expect(candidate_interface_gcse_enic_form: %i[enic_reference comparable_uk_qualification])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -73,8 +73,7 @@ module CandidateInterface
 
     def qualification_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_qualification_type_form)
-        .permit(:qualification_type, :other_uk_qualification_type, :not_completed_explanation, :non_uk_qualification_type)
+        .expect(candidate_interface_gcse_qualification_type_form: %i[qualification_type other_uk_qualification_type not_completed_explanation non_uk_qualification_type])
         .merge!(
           subject: subject_param,
           level: ApplicationQualification.levels[:gcse],

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -44,8 +44,7 @@ module CandidateInterface
 
     def year_params
       strip_whitespace params
-        .require(:candidate_interface_gcse_year_form)
-        .permit(:award_year)
+        .expect(candidate_interface_gcse_year_form: [:award_year])
         .merge!(qualification_type: current_qualification.qualification_type)
     end
 

--- a/app/controllers/candidate_interface/interview_availability_controller.rb
+++ b/app/controllers/candidate_interface/interview_availability_controller.rb
@@ -54,8 +54,8 @@ module CandidateInterface
   private
 
     def interview_preferences_params
-      strip_whitespace params.require(:candidate_interface_interview_preferences_form).permit(
-        :any_preferences, :interview_preferences
+      strip_whitespace params.expect(
+        candidate_interface_interview_preferences_form: %i[any_preferences interview_preferences],
       )
     end
 

--- a/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
@@ -40,11 +40,9 @@ module CandidateInterface
     private
 
       def status_params
-        strip_whitespace params.require(
-          :candidate_interface_immigration_status_form,
-        ).permit(
-          :immigration_status,
-          :right_to_work_or_study_details,
+        strip_whitespace params.expect(
+          candidate_interface_immigration_status_form: %i[immigration_status
+                                                          right_to_work_or_study_details],
         )
       end
     end

--- a/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
@@ -39,9 +39,9 @@ module CandidateInterface
 
       def personal_details_params
         strip_whitespace(
-          params.require(:candidate_interface_personal_details_form).permit(
-            :first_name, :last_name,
-            :'date_of_birth(3i)', :'date_of_birth(2i)', :'date_of_birth(1i)'
+          params.expect(
+            candidate_interface_personal_details_form: %i[first_name last_name
+                                                          date_of_birth(3i) date_of_birth(2i) date_of_birth(1i)],
           ).transform_keys { |key| dob_field_to_attribute(key) },
         )
       end

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -56,9 +56,8 @@ module CandidateInterface
 
       def nationalities_params
         strip_whitespace params
-          .require(:candidate_interface_nationalities_form)
-          .permit(
-            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
+          .expect(
+            candidate_interface_nationalities_form: [:first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []],
           )
       end
 

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -80,8 +80,8 @@ module CandidateInterface
     end
 
     def becoming_a_teacher_params
-      strip_whitespace params.require(:candidate_interface_becoming_a_teacher_form).permit(
-        :becoming_a_teacher,
+      strip_whitespace params.expect(
+        candidate_interface_becoming_a_teacher_form: [:becoming_a_teacher],
       )
     end
 

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -43,7 +43,7 @@ module CandidateInterface
       end
 
       def referee_name_param
-        strip_whitespace params.require(:candidate_interface_reference_referee_name_form).permit(:name)
+        strip_whitespace params.expect(candidate_interface_reference_referee_name_form: [:name])
       end
 
       def verify_name_is_editable

--- a/app/controllers/candidate_interface/references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/references/relationship_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
       end
 
       def references_relationship_params
-        strip_whitespace params.require(:candidate_interface_reference_referee_relationship_form).permit(:relationship)
+        strip_whitespace params.expect(candidate_interface_reference_referee_relationship_form: [:relationship])
       end
     end
   end

--- a/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
@@ -69,10 +69,10 @@ module CandidateInterface
 
     def work_history_break_params
       strip_whitespace(
-        params.require(:candidate_interface_restructured_work_history_work_history_break_form)
-        .permit(
-          :'start_date(3i)', :'start_date(2i)', :'start_date(1i)',
-          :'end_date(3i)', :'end_date(2i)', :'end_date(1i)', :reason
+        params
+        .expect(
+          candidate_interface_restructured_work_history_work_history_break_form: %i[start_date(3i) start_date(2i) start_date(1i)
+                                                                                    end_date(3i) end_date(2i) end_date(1i) reason],
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/controllers/candidate_interface/restructured_work_history/jobs_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/jobs_controller.rb
@@ -76,21 +76,21 @@ module CandidateInterface
 
     def job_form_params
       strip_whitespace(
-        params.require(:candidate_interface_restructured_work_history_job_form)
-              .permit(
-                :role,
-                :organisation,
-                :commitment,
-                :'start_date(3i)',
-                :'start_date(2i)',
-                :'start_date(1i)',
-                :start_date_unknown,
-                :currently_working,
-                :'end_date(3i)',
-                :'end_date(2i)',
-                :'end_date(1i)',
-                :end_date_unknown,
-                :relevant_skills,
+        params
+              .expect(
+                candidate_interface_restructured_work_history_job_form: %i[role
+                                                                           organisation
+                                                                           commitment
+                                                                           start_date(3i)
+                                                                           start_date(2i)
+                                                                           start_date(1i)
+                                                                           start_date_unknown
+                                                                           currently_working
+                                                                           end_date(3i)
+                                                                           end_date(2i)
+                                                                           end_date(1i)
+                                                                           end_date_unknown
+                                                                           relevant_skills],
               )
               .transform_keys { |key| start_date_field_to_attribute(key) }
               .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -52,8 +52,7 @@ module CandidateInterface
 
     def safeguarding_params
       strip_whitespace params
-        .require(:candidate_interface_safeguarding_issues_declaration_form)
-        .permit(:share_safeguarding_issues, :safeguarding_issues)
+        .expect(candidate_interface_safeguarding_issues_declaration_form: %i[share_safeguarding_issues safeguarding_issues])
     end
 
     def form_params

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -92,7 +92,7 @@ module CandidateInterface
   private
 
     def candidate_params
-      params.require(:candidate).permit(:email_address)
+      params.expect(candidate: [:email_address])
     end
 
     def redirect_to_sign_in_if_one_login_enabled

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -48,7 +48,7 @@ module CandidateInterface
     end
 
     def candidate_sign_up_form_params
-      params.require(:candidate_interface_sign_up_form).permit(:email_address).merge(course_from_find_id: course_id)
+      params.expect(candidate_interface_sign_up_form: [:email_address]).merge(course_from_find_id: course_id)
     end
 
     def course_id

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
   private
 
     def create_account_or_sign_in_params
-      strip_whitespace params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)
+      strip_whitespace params.expect(candidate_interface_create_account_or_sign_in_form: %i[existing_account email])
     end
 
     def create_account_page_title

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -53,8 +53,7 @@ module CandidateInterface
 
     def training_with_a_disability_params
       strip_whitespace params
-        .require(:candidate_interface_training_with_a_disability_form)
-        .permit(:disclose_disability, :disability_disclosure)
+        .expect(candidate_interface_training_with_a_disability_form: %i[disclose_disability disability_disclosure])
     end
 
     def section_complete_form_params

--- a/app/controllers/candidate_interface/volunteering/roles_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/roles_controller.rb
@@ -39,22 +39,22 @@ module CandidateInterface
 
     def volunteering_role_params
       strip_whitespace(
-        params.require(:candidate_interface_volunteering_role_form)
-        .permit(
-          :id,
-          :role,
-          :organisation,
-          :details,
-          :working_with_children,
-          :'start_date(3i)',
-          :'start_date(2i)',
-          :'start_date(1i)',
-          :start_date_unknown,
-          :currently_working,
-          :'end_date(3i)',
-          :'end_date(2i)',
-          :'end_date(1i)',
-          :end_date_unknown,
+        params
+        .expect(
+          candidate_interface_volunteering_role_form: %i[id
+                                                         role
+                                                         organisation
+                                                         details
+                                                         working_with_children
+                                                         start_date(3i)
+                                                         start_date(2i)
+                                                         start_date(1i)
+                                                         start_date_unknown
+                                                         currently_working
+                                                         end_date(3i)
+                                                         end_date(2i)
+                                                         end_date(1i)
+                                                         end_date_unknown],
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/controllers/candidate_interface/volunteering/start_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/start_controller.rb
@@ -28,8 +28,8 @@ module CandidateInterface
     def volunteering_experience_form_params
       return nil unless params.key?(:candidate_interface_volunteering_experience_form)
 
-      strip_whitespace params.require(:candidate_interface_volunteering_experience_form).permit(
-        :experience,
+      strip_whitespace params.expect(
+        candidate_interface_volunteering_experience_form: [:experience],
       )
     end
   end

--- a/app/controllers/candidate_interface/withdrawal_reasons/level_one_reasons_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/level_one_reasons_controller.rb
@@ -37,7 +37,7 @@ module CandidateInterface
     private
 
       def form_params
-        params.require(:candidate_interface_withdrawal_reasons_level_one_reasons_form).permit(:level_one_reason, :comment)
+        params.expect(candidate_interface_withdrawal_reasons_level_one_reasons_form: %i[level_one_reason comment])
       end
 
       def set_draft_reason

--- a/app/controllers/candidate_interface/withdrawal_reasons/level_two_reasons_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/level_two_reasons_controller.rb
@@ -22,8 +22,8 @@ module CandidateInterface
     private
 
       def form_params
-        params.require(:candidate_interface_withdrawal_reasons_level_two_reasons_form)
-              .permit(:comment, :personal_circumstances_reasons_comment, level_two_reasons: [], personal_circumstances_reasons: [])
+        params
+              .expect(candidate_interface_withdrawal_reasons_level_two_reasons_form: [:comment, :personal_circumstances_reasons_comment, level_two_reasons: [], personal_circumstances_reasons: []])
               .merge({ level_one_reason: })
       end
 

--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -57,7 +57,7 @@ module ProviderInterface
   private
 
     def application_data_export_params
-      params.require(:provider_interface_application_data_export_form).permit(:application_status_choice, statuses: [], provider_ids: [], recruitment_cycle_years: [])
+      params.expect(provider_interface_application_data_export_form: [:application_status_choice, statuses: [], provider_ids: [], recruitment_cycle_years: []])
     end
   end
 end

--- a/app/controllers/provider_interface/condition_statuses_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses_controller.rb
@@ -42,8 +42,7 @@ module ProviderInterface
 
     def condition_statuses_params
       params
-        .require(:provider_interface_confirm_conditions_wizard)
-        .permit(statuses: {})
+        .expect(provider_interface_confirm_conditions_wizard: [statuses: {}])
     end
 
     def condition_statuses_store

--- a/app/controllers/provider_interface/courses/courses_controller.rb
+++ b/app/controllers/provider_interface/courses/courses_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
     private
 
       def course_params
-        params.require(:provider_interface_course_wizard).permit(:course_id)
+        params.expect(provider_interface_course_wizard: [:course_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/courses/locations_controller.rb
+++ b/app/controllers/provider_interface/courses/locations_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
     private
 
       def course_option_params
-        params.require(:provider_interface_course_wizard).permit(:course_option_id)
+        params.expect(provider_interface_course_wizard: [:course_option_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/courses/providers_controller.rb
+++ b/app/controllers/provider_interface/courses/providers_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
     private
 
       def provider_params
-        params.require(:provider_interface_course_wizard).permit(:provider_id)
+        params.expect(provider_interface_course_wizard: [:provider_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/courses/study_modes_controller.rb
+++ b/app/controllers/provider_interface/courses/study_modes_controller.rb
@@ -29,7 +29,7 @@ module ProviderInterface
     private
 
       def study_mode_params
-        params.require(:provider_interface_course_wizard).permit(:study_mode)
+        params.expect(provider_interface_course_wizard: [:study_mode])
       end
 
       def available_study_modes(course)

--- a/app/controllers/provider_interface/interviews/cancel_controller.rb
+++ b/app/controllers/provider_interface/interviews/cancel_controller.rb
@@ -44,7 +44,7 @@ module ProviderInterface
       end
 
       def cancellation_params
-        params.require(:provider_interface_cancel_interview_wizard).permit(:cancellation_reason)
+        params.expect(provider_interface_cancel_interview_wizard: [:cancellation_reason])
       end
 
       def interview_id

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -109,8 +109,7 @@ module ProviderInterface
 
     def interview_params
       params
-        .require(:provider_interface_interview_wizard)
-        .permit(:date, :time, :location, :additional_details, :provider_id)
+        .expect(provider_interface_interview_wizard: %i[date time location additional_details provider_id])
         .transform_values(&:strip)
         .merge(interview_form_context_params)
     end

--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -29,7 +29,7 @@ module ProviderInterface
   private
 
     def note_params
-      params.require(:provider_interface_new_note_form).permit(:message, :referer)
+      params.expect(provider_interface_new_note_form: %i[message referer])
         .merge(application_choice: @application_choice, user: current_provider_user)
     end
   end

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -16,8 +16,8 @@ module ProviderInterface
     def notification_preferences_params
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
-      params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+      params
+        .expect(provider_user_notification_preferences: ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -51,12 +51,11 @@ module ProviderInterface
 
       def conditions_params
         params
-          .require(:provider_interface_offer_wizard)
-          .permit(
-            :require_references,
-            :references_description,
-            further_conditions: {},
-            standard_conditions: [],
+          .expect(
+            provider_interface_offer_wizard: [:require_references,
+                                              :references_description,
+                                              further_conditions: {},
+                                              standard_conditions: []],
           )
       end
 

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     private
 
       def course_params
-        params.require(:provider_interface_offer_wizard).permit(:course_id, :course_option_id)
+        params.expect(provider_interface_offer_wizard: %i[course_id course_option_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/offer/locations_controller.rb
+++ b/app/controllers/provider_interface/offer/locations_controller.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     private
 
       def course_option_params
-        params.require(:provider_interface_offer_wizard).permit(:course_option_id)
+        params.expect(provider_interface_offer_wizard: [:course_option_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/offer/providers_controller.rb
+++ b/app/controllers/provider_interface/offer/providers_controller.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     private
 
       def provider_params
-        params.require(:provider_interface_offer_wizard).permit(:provider_id)
+        params.expect(provider_interface_offer_wizard: [:provider_id])
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/offer/study_modes_controller.rb
+++ b/app/controllers/provider_interface/offer/study_modes_controller.rb
@@ -54,7 +54,7 @@ module ProviderInterface
     private
 
       def study_mode_params
-        params.require(:provider_interface_offer_wizard).permit(:study_mode)
+        params.expect(provider_interface_offer_wizard: [:study_mode])
       end
 
       def available_study_modes(course)

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -35,10 +35,10 @@ module ProviderInterface
     def permissions_params
       return {} unless params.key?(:provider_relationship_permissions)
 
-      params.require(:provider_relationship_permissions)
-            .permit(make_decisions: [],
-                    view_safeguarding_information: [],
-                    view_diversity_information: []).to_h
+      params
+            .expect(provider_relationship_permissions: [make_decisions: [],
+                                                        view_safeguarding_information: [],
+                                                        view_diversity_information: []]).to_h
     end
 
     def new_relationship_permissions

--- a/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_setup_controller.rb
@@ -141,10 +141,10 @@ module ProviderInterface
     def permissions_params
       return {} unless params.key?(:provider_relationship_permissions)
 
-      params.require(:provider_relationship_permissions)
-            .permit(make_decisions: [],
-                    view_safeguarding_information: [],
-                    view_diversity_information: []).to_h
+      params
+            .expect(provider_relationship_permissions: [make_decisions: [],
+                                                        view_safeguarding_information: [],
+                                                        view_diversity_information: []]).to_h
     end
 
     class NoPermissionsToSetUp < StandardError; end

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -35,10 +35,10 @@ module ProviderInterface
   private
 
     def provider_agreement_params
-      params.require(:provider_agreement).permit(
-        :accept_agreement,
-        :agreement_type,
-        :provider_id,
+      params.expect(
+        provider_agreement: %i[accept_agreement
+                               agreement_type
+                               provider_id],
       )
     end
   end

--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -83,8 +83,8 @@ module ProviderInterface
     def reconfirm_deferred_offer_params
       return {} unless params.key?(:provider_interface_reconfirm_deferred_offer_wizard)
 
-      params.require(:provider_interface_reconfirm_deferred_offer_wizard)
-            .permit(:conditions_status, :course_option_id)
+      params
+            .expect(provider_interface_reconfirm_deferred_offer_wizard: %i[conditions_status course_option_id])
     end
 
     def wizard_for_step(step = nil)

--- a/app/controllers/provider_interface/rejections_controller.rb
+++ b/app/controllers/provider_interface/rejections_controller.rb
@@ -68,7 +68,7 @@ module ProviderInterface
     end
 
     def rejection_reasons_params
-      params.require(:provider_interface_rejections_wizard).permit(*wizard_class.single_attribute_names, collection_attributes)
+      params.expect(provider_interface_rejections_wizard: [*wizard_class.single_attribute_names, collection_attributes])
     end
 
     def collection_attributes

--- a/app/controllers/provider_interface/user_invitation/permissions_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/permissions_controller.rb
@@ -20,7 +20,7 @@ module ProviderInterface
     private
 
       def permissions_params
-        params.require(:provider_interface_invite_user_wizard).permit(permissions: [])
+        params.expect(provider_interface_invite_user_wizard: [permissions: []])
       end
     end
   end

--- a/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
+++ b/app/controllers/provider_interface/user_invitation/personal_details_controller.rb
@@ -30,7 +30,7 @@ module ProviderInterface
     private
 
       def personal_details_params
-        params.require(:provider_interface_invite_user_wizard).permit(:first_name, :last_name, :email_address)
+        params.expect(provider_interface_invite_user_wizard: %i[first_name last_name email_address])
       end
 
       def wizard_flow_controllers

--- a/app/controllers/provider_interface/user_permissions_controller.rb
+++ b/app/controllers/provider_interface/user_permissions_controller.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     end
 
     def provider_permissions_params
-      params.require(:provider_interface_edit_user_permissions_wizard).permit(permissions: [])
+      params.expect(provider_interface_edit_user_permissions_wizard: [permissions: []])
     end
 
     def previous_page_path

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -225,17 +225,17 @@ module RefereeInterface
     end
 
     def questionnaire_params
-      params.require(:referee_interface_questionnaire_form).permit(*QuestionnaireForm::FORM_KEYS)
+      params.expect(referee_interface_questionnaire_form: [*QuestionnaireForm::FORM_KEYS])
     end
 
     def relationship_params
-      params.require(:referee_interface_reference_relationship_form)
-            .permit(:relationship_correction, :relationship_confirmation)
+      params
+            .expect(referee_interface_reference_relationship_form: %i[relationship_correction relationship_confirmation])
     end
 
     def safeguarding_params
-      params.require(:referee_interface_reference_safeguarding_form)
-            .permit(:any_safeguarding_concerns, :safeguarding_concerns)
+      params
+            .expect(referee_interface_reference_safeguarding_form: %i[any_safeguarding_concerns safeguarding_concerns])
     end
 
     def refused_params

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -52,8 +52,7 @@ module SupportInterface
 
     def condition_params
       params
-        .require(:support_interface_conditions_form)
-        .permit(:application_choice_id, :audit_comment_ticket, :confirm_make_unconditional, further_conditions: {}, standard_conditions: [], ske_conditions: {})
+        .expect(support_interface_conditions_form: [:application_choice_id, :audit_comment_ticket, :confirm_make_unconditional, further_conditions: {}, standard_conditions: [], ske_conditions: {}])
         .to_h
         .with_indifferent_access
     end

--- a/app/controllers/support_interface/application_forms/address_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_details_controller.rb
@@ -24,9 +24,8 @@ module SupportInterface
 
       def address_details_params
         StripWhitespace.from_hash params
-          .require(:support_interface_application_forms_edit_address_details_form)
-          .permit(
-            :address_line1, :address_line2, :address_line3, :address_line4, :postcode, :audit_comment
+          .expect(
+            support_interface_application_forms_edit_address_details_form: %i[address_line1 address_line2 address_line3 address_line4 postcode audit_comment],
           )
       end
 

--- a/app/controllers/support_interface/application_forms/address_type_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_type_controller.rb
@@ -19,9 +19,9 @@ module SupportInterface
     private
 
       def address_type_params
-        params.require(:support_interface_application_forms_edit_address_details_form).permit(
-          :address_type,
-          :country,
+        params.expect(
+          support_interface_application_forms_edit_address_details_form: %i[address_type
+                                                                            country],
         )
       end
 

--- a/app/controllers/support_interface/application_forms/applicant_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/applicant_details_controller.rb
@@ -25,10 +25,8 @@ module SupportInterface
     private
 
       def edit_application_params
-        params.require(
-          :support_interface_application_forms_edit_applicant_details_form,
-        ).permit(:first_name, :last_name, :email_address, :'date_of_birth(3i)', :'date_of_birth(2i)',
-                 :'date_of_birth(1i)', :phone_number, :audit_comment)
+        params.expect(support_interface_application_forms_edit_applicant_details_form: %i[first_name last_name email_address date_of_birth(3i) date_of_birth(2i)
+                                                                                          date_of_birth(1i) phone_number audit_comment])
           .transform_keys { |key| dob_field_to_attribute(key) }
           .transform_values(&:strip)
       end

--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -78,8 +78,8 @@ module SupportInterface
       private
 
         def course_search_params
-          params.require(:support_interface_application_forms_course_search_form)
-                .permit(:course_code)
+          params
+                .expect(support_interface_application_forms_course_search_form: [:course_code])
         end
 
         def course_option_id
@@ -91,7 +91,7 @@ module SupportInterface
         end
 
         def confirm_offered_course_option_params
-          params.require(:support_interface_application_forms_update_offered_course_option_form).permit(:course_option_id, :audit_comment, :accept_guidance, :confirm_course_change, :checkbox_rendered)
+          params.expect(support_interface_application_forms_update_offered_course_option_form: %i[course_option_id audit_comment accept_guidance confirm_course_change checkbox_rendered])
         end
 
         def redirect_to_application_form_unless_accepted

--- a/app/controllers/support_interface/application_forms/application_choices/reinstate_declined_offer_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/reinstate_declined_offer_controller.rb
@@ -22,7 +22,7 @@ module SupportInterface
       private
 
         def reinstate_offer_params
-          params.require(:support_interface_application_forms_reinstate_declined_offer_form).permit(:status, :audit_comment_ticket, :accept_guidance)
+          params.expect(support_interface_application_forms_reinstate_declined_offer_form: %i[status audit_comment_ticket accept_guidance])
         end
 
         def redirect_to_application_form_unless_declined

--- a/app/controllers/support_interface/application_forms/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices_controller.rb
@@ -67,19 +67,19 @@ module SupportInterface
     private
 
       def reinstate_offer_params
-        params.require(:support_interface_application_forms_reinstate_declined_offer_form).permit(:status, :audit_comment_ticket, :accept_guidance)
+        params.expect(support_interface_application_forms_reinstate_declined_offer_form: %i[status audit_comment_ticket accept_guidance])
       end
 
       def revert_rejection_params
-        params.require(:support_interface_application_forms_revert_rejection_form).permit(:audit_comment_ticket, :accept_guidance)
+        params.expect(support_interface_application_forms_revert_rejection_form: %i[audit_comment_ticket accept_guidance])
       end
 
       def revert_withdrawal_params
-        params.require(:support_interface_application_forms_revert_withdrawal_form).permit(:audit_comment_ticket, :accept_guidance)
+        params.expect(support_interface_application_forms_revert_withdrawal_form: %i[audit_comment_ticket accept_guidance])
       end
 
       def revert_to_pending_conditions_params
-        params.require(:support_interface_application_forms_revert_to_pending_conditions_form).permit(:audit_comment_ticket, :accept_guidance)
+        params.expect(support_interface_application_forms_revert_to_pending_conditions_form: %i[audit_comment_ticket accept_guidance])
       end
 
       def build_application_form

--- a/app/controllers/support_interface/application_forms/comments_controller.rb
+++ b/app/controllers/support_interface/application_forms/comments_controller.rb
@@ -24,8 +24,8 @@ module SupportInterface
       end
 
       def application_comment_params
-        params.require(:support_interface_application_comment_form).permit(
-          :comment,
+        params.expect(
+          support_interface_application_comment_form: [:comment],
         )
       end
     end

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -61,13 +61,13 @@ module SupportInterface
       end
 
       def course_search_params
-        params.require(:support_interface_application_forms_course_search_form)
-              .permit(:course_code)
+        params
+              .expect(support_interface_application_forms_course_search_form: [:course_code])
       end
 
       def change_course_choice_params
-        params.require(:support_interface_application_forms_change_course_choice_form)
-              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :recruitment_cycle_year, :audit_comment_ticket, :accept_guidance, :confirm_course_change, :checkbox_rendered)
+        params
+              .expect(support_interface_application_forms_change_course_choice_form: %i[application_choice_id provider_code course_code study_mode site_code recruitment_cycle_year audit_comment_ticket accept_guidance confirm_course_change checkbox_rendered])
       end
 
       def application_form_id

--- a/app/controllers/support_interface/application_forms/degrees_controller.rb
+++ b/app/controllers/support_interface/application_forms/degrees_controller.rb
@@ -25,9 +25,7 @@ module SupportInterface
     private
 
       def edit_application_params
-        params.require(
-          :support_interface_application_forms_edit_degree_form,
-        ).permit(:start_year, :award_year, :audit_comment)
+        params.expect(support_interface_application_forms_edit_degree_form: %i[start_year award_year audit_comment])
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/delete_application_controller.rb
+++ b/app/controllers/support_interface/application_forms/delete_application_controller.rb
@@ -20,8 +20,8 @@ module SupportInterface
     private
 
       def delete_application_params
-        params.require(:support_interface_application_forms_delete_application_form)
-              .permit(:accept_guidance, :audit_comment_ticket)
+        params
+              .expect(support_interface_application_forms_delete_application_form: %i[accept_guidance audit_comment_ticket])
       end
 
       def find_application_form

--- a/app/controllers/support_interface/application_forms/email_subscription_controller.rb
+++ b/app/controllers/support_interface/application_forms/email_subscription_controller.rb
@@ -21,7 +21,7 @@ module SupportInterface
     private
 
       def unsubscribed_from_emails_params
-        params.require(:support_interface_email_subscription_form).permit(:unsubscribed_from_emails, :audit_comment)
+        params.expect(support_interface_email_subscription_form: %i[unsubscribed_from_emails audit_comment])
       end
 
       def set_application_form

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -26,15 +26,11 @@ module SupportInterface
     private
 
       def edit_award_year_params
-        params.require(
-          :support_interface_application_forms_edit_gcse_award_year_form,
-        ).permit(:award_year, :audit_comment)
+        params.expect(support_interface_application_forms_edit_gcse_award_year_form: %i[award_year audit_comment])
       end
 
       def edit_grade_params
-        params.require(
-          :support_interface_application_forms_edit_gcse_grade_form,
-        ).permit(:grade, :constituent_grades, :index, :audit_comment)
+        params.expect(support_interface_application_forms_edit_gcse_grade_form: %i[grade constituent_grades index audit_comment])
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/immigration_right_to_work_controller.rb
+++ b/app/controllers/support_interface/application_forms/immigration_right_to_work_controller.rb
@@ -24,8 +24,8 @@ module SupportInterface
       end
 
       def right_to_work_params
-        StripWhitespace.from_hash params.require(:support_interface_application_forms_immigration_right_to_work_form).permit(
-          :right_to_work_or_study, :right_to_work_or_study_details, :audit_comment
+        StripWhitespace.from_hash params.expect(
+          support_interface_application_forms_immigration_right_to_work_form: %i[right_to_work_or_study right_to_work_or_study_details audit_comment],
         )
       end
     end

--- a/app/controllers/support_interface/application_forms/immigration_status_controller.rb
+++ b/app/controllers/support_interface/application_forms/immigration_status_controller.rb
@@ -24,9 +24,7 @@ module SupportInterface
       end
 
       def immigration_status_params
-        params.require(
-          :support_interface_application_forms_immigration_status_form,
-        ).permit(:immigration_status, :right_to_work_or_study_details, :audit_comment)
+        params.expect(support_interface_application_forms_immigration_status_form: %i[immigration_status right_to_work_or_study_details audit_comment])
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/jobs_controller.rb
+++ b/app/controllers/support_interface/application_forms/jobs_controller.rb
@@ -37,22 +37,22 @@ module SupportInterface
 
       def job_form_params
         StripWhitespace.from_hash(
-          params.require(:support_interface_application_forms_job_form)
-                .permit(
-                  :role,
-                  :organisation,
-                  :commitment,
-                  :'start_date(3i)',
-                  :'start_date(2i)',
-                  :'start_date(1i)',
-                  :start_date_unknown,
-                  :currently_working,
-                  :'end_date(3i)',
-                  :'end_date(2i)',
-                  :'end_date(1i)',
-                  :end_date_unknown,
-                  :relevant_skills,
-                  :audit_comment,
+          params
+                .expect(
+                  support_interface_application_forms_job_form: %i[role
+                                                                   organisation
+                                                                   commitment
+                                                                   start_date(3i)
+                                                                   start_date(2i)
+                                                                   start_date(1i)
+                                                                   start_date_unknown
+                                                                   currently_working
+                                                                   end_date(3i)
+                                                                   end_date(2i)
+                                                                   end_date(1i)
+                                                                   end_date_unknown
+                                                                   relevant_skills
+                                                                   audit_comment],
                 )
                 .transform_keys { |key| start_date_field_to_attribute(key) }
                 .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/controllers/support_interface/application_forms/nationalities_controller.rb
+++ b/app/controllers/support_interface/application_forms/nationalities_controller.rb
@@ -39,10 +39,9 @@ module SupportInterface
 
       def nationalities_params
         StripWhitespace.from_hash params
-          .require(:support_interface_application_forms_nationalities_form)
-          .permit(
-            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2,
-            :other_nationality3, :audit_comment, nationalities: []
+          .expect(
+            support_interface_application_forms_nationalities_form: [:first_nationality, :second_nationality, :other_nationality1, :other_nationality2,
+                                                                     :other_nationality3, :audit_comment, nationalities: []],
           )
       end
 

--- a/app/controllers/support_interface/application_forms/personal_statement_controller.rb
+++ b/app/controllers/support_interface/application_forms/personal_statement_controller.rb
@@ -22,8 +22,7 @@ module SupportInterface
 
       def becoming_a_teacher_params
         StripWhitespace.from_hash params
-          .require(:support_interface_application_forms_edit_becoming_a_teacher_form)
-          .permit(:becoming_a_teacher, :audit_comment)
+          .expect(support_interface_application_forms_edit_becoming_a_teacher_form: %i[becoming_a_teacher audit_comment])
       end
 
       def build_application_form

--- a/app/controllers/support_interface/application_forms/references_controller.rb
+++ b/app/controllers/support_interface/application_forms/references_controller.rb
@@ -35,11 +35,11 @@ module SupportInterface
     private
 
       def edit_reference_details_params
-        params.require(:support_interface_application_forms_edit_reference_details_form).permit(:name, :email_address, :relationship, :audit_comment)
+        params.expect(support_interface_application_forms_edit_reference_details_form: %i[name email_address relationship audit_comment])
       end
 
       def edit_reference_feedback_params
-        params.require(:support_interface_application_forms_edit_reference_feedback_form).permit(:feedback, :audit_comment, :send_emails)
+        params.expect(support_interface_application_forms_edit_reference_feedback_form: %i[feedback audit_comment send_emails])
       end
 
       def send_emails

--- a/app/controllers/support_interface/application_forms/volunteering_roles_controller.rb
+++ b/app/controllers/support_interface/application_forms/volunteering_roles_controller.rb
@@ -36,23 +36,23 @@ module SupportInterface
 
       def volunteering_role_form_params
         StripWhitespace.from_hash(
-          params.require(:support_interface_application_forms_volunteering_role_form)
-                .permit(
-                  :id,
-                  :role,
-                  :organisation,
-                  :details,
-                  :working_with_children,
-                  :'start_date(3i)',
-                  :'start_date(2i)',
-                  :'start_date(1i)',
-                  :start_date_unknown,
-                  :currently_working,
-                  :'end_date(3i)',
-                  :'end_date(2i)',
-                  :'end_date(1i)',
-                  :end_date_unknown,
-                  :audit_comment,
+          params
+                .expect(
+                  support_interface_application_forms_volunteering_role_form: %i[id
+                                                                                 role
+                                                                                 organisation
+                                                                                 details
+                                                                                 working_with_children
+                                                                                 start_date(3i)
+                                                                                 start_date(2i)
+                                                                                 start_date(1i)
+                                                                                 start_date_unknown
+                                                                                 currently_working
+                                                                                 end_date(3i)
+                                                                                 end_date(2i)
+                                                                                 end_date(1i)
+                                                                                 end_date_unknown
+                                                                                 audit_comment],
                 )
                 .transform_keys { |key| start_date_field_to_attribute(key) }
                 .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/controllers/support_interface/bulk_upload/permissions_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/permissions_controller.rb
@@ -60,13 +60,13 @@ module SupportInterface
       end
 
       def provider_user_params
-        params.require(:support_interface_create_single_provider_user_form)
-              .permit(:email_address, :first_name, :last_name, :provider_id, :index)
+        params
+              .expect(support_interface_create_single_provider_user_form: %i[email_address first_name last_name provider_id index])
       end
 
       def provider_permissions_params
-        params.require(:support_interface_create_single_provider_user_form)
-              .permit(provider_permissions_form: {})
+        params
+              .expect(support_interface_create_single_provider_user_form: [provider_permissions_form: {}])
               .fetch(:provider_permissions_form, {})
               .to_h
       end

--- a/app/controllers/support_interface/bulk_upload/provider_users_details_controller.rb
+++ b/app/controllers/support_interface/bulk_upload/provider_users_details_controller.rb
@@ -30,7 +30,7 @@ module SupportInterface
     private
 
       def form_params
-        params.require(:support_interface_multiple_provider_users_wizard).permit(:provider_users)
+        params.expect(support_interface_multiple_provider_users_wizard: [:provider_users])
       end
 
       def provider_id_param

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -91,7 +91,7 @@ module SupportInterface
 
     def candidate_account_status_params
       { candidate: @candidate }.merge(
-        params.require(:support_interface_candidate_account_status_form).permit(:status),
+        params.expect(support_interface_candidate_account_status_form: [:status]),
       )
     end
   end

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -20,8 +20,8 @@ module SupportInterface
     def notification_preferences_params
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
-      params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+      params
+        .expect(provider_user_notification_preferences: [ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES])
     end
   end
 end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -79,8 +79,8 @@ module SupportInterface
     end
 
     def relationships_params
-      params.require(:support_interface_provider_relationships_form)
-        .permit(relationships: {})
+      params
+        .expect(support_interface_provider_relationships_form: [relationships: {}])
     end
 
     def applications

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -47,8 +47,8 @@ module SupportInterface
     end
 
     def delete_reference_params
-      params.require(:support_interface_application_forms_delete_reference_form)
-            .permit(:accept_guidance, :audit_comment_ticket)
+      params
+            .expect(support_interface_application_forms_delete_reference_form: %i[accept_guidance audit_comment_ticket])
     end
   end
 end

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -85,7 +85,7 @@ module SupportInterface
     end
 
     def confirmed_environment
-      @confirmation = SupportInterface::ConfirmEnvironment.new(params.require(:support_interface_confirm_environment).permit(:from, :environment))
+      @confirmation = SupportInterface::ConfirmEnvironment.new(params.expect(support_interface_confirm_environment: %i[from environment]))
 
       if @confirmation.valid?
         session[:confirmed_environment_at] = Time.zone.now

--- a/app/controllers/support_interface/single_provider_user_notifications_controller.rb
+++ b/app/controllers/support_interface/single_provider_user_notifications_controller.rb
@@ -21,8 +21,8 @@ module SupportInterface
     def notification_preferences_params
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
-      params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+      params
+        .expect(provider_user_notification_preferences: ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/support_interface/single_provider_users_controller.rb
+++ b/app/controllers/support_interface/single_provider_users_controller.rb
@@ -64,20 +64,20 @@ module SupportInterface
     end
 
     def provider_user_params
-      params.require(:support_interface_create_single_provider_user_form)
-            .permit(:email_address, :first_name, :last_name, :provider_id)
+      params
+            .expect(support_interface_create_single_provider_user_form: %i[email_address first_name last_name provider_id])
     end
 
     def create_provider_permissions_params
-      params.require(:support_interface_create_single_provider_user_form)
-            .permit(provider_permissions_form: {})
+      params
+            .expect(support_interface_create_single_provider_user_form: [provider_permissions_form: {}])
             .fetch(:provider_permissions_form, {})
             .to_h
     end
 
     def edit_providers_permissions_params
-      params.require(:support_interface_edit_single_provider_user_form)
-            .permit(provider_permissions_forms: {})
+      params
+            .expect(support_interface_edit_single_provider_user_form: [provider_permissions_forms: {}])
             .fetch(:provider_permissions_forms, {})
             .to_h
     end

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -45,7 +45,7 @@ module SupportInterface
   private
 
     def support_user_params
-      params.require(:support_user).permit(:email_address, :dfe_sign_in_uid)
+      params.expect(support_user: %i[email_address dfe_sign_in_uid])
     end
   end
 end

--- a/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::Interviews::CancelController do
     it 'tracks validation errors on create' do
       expect {
         post provider_interface_application_choice_interview_cancel_path(application_choice, interview),
-             params: { provider_interface_cancel_interview_wizard: { location: 'here' } }
+             params: { provider_interface_cancel_interview_wizard: { cancellation_reason: nil } }
       }.to change(ValidationError, :count).by(1)
     end
   end


### PR DESCRIPTION
## Context

`params.expect` is a much safer and cleaner way to define what params a controller should receive. This is a feature of rails 8. The old way is still supported but we want to upgrade the way we handle params in our controllers.

Vendor API controllers have not change because the new `params.expect` syntax changes the error message if you inputted the wrong params. So we don't want to change anything in our API responses with this change

Also other controllers have been skipped because they rely on allowing other params to be passed in.

## Changes proposed in this pull request

All controllers

## Guidance to review

Prepare yourself to review the same change a lot of times 🙈 
Maybe go on the review app and click around? Send an application?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
