### PR TITLE
[635] Prevent users from completing the personal details section without selecting a visa or immigration status

### DIFF
--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module PersonalDetails
     class ReviewController < SectionController
+      before_action :finish_immigration_status, if: -> { ImmigrationStatus.new(current_application: current_application).incomplete? }, only: :show
       def show
         @application_form = current_application
         @section_complete_form = SectionCompleteForm.new(
@@ -51,6 +52,10 @@ module CandidateInterface
 
       def application_form_params
         strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+      end
+
+      def finish_immigration_status
+        redirect_to candidate_interface_immigration_status_path
       end
     end
   end

--- a/app/services/candidate_interface/immigration_status.rb
+++ b/app/services/candidate_interface/immigration_status.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  class ImmigrationStatus
+    delegate :immigration_status, :right_to_work_or_study, to: :current_application
+
+    attr_reader :current_application
+
+    def initialize(current_application:)
+      @current_application = current_application
+    end
+
+    def incomplete?
+      right_to_work_or_study? && !british_or_irish? && immigration_status.blank?
+    end
+
+    def british_or_irish?
+      UK_AND_IRISH_NATIONALITIES.intersect?(current_application.nationalities)
+    end
+
+    def right_to_work_or_study?
+      right_to_work_or_study == 'yes'
+    end
+  end
+end

--- a/spec/services/candidate_interface/immigration_status_spec.rb
+++ b/spec/services/candidate_interface/immigration_status_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ImmigrationStatus do
+  subject(:immigration_status_service) { described_class.new(current_application:) }
+
+  let(:current_application) { create(:application_form, first_nationality:, second_nationality:, right_to_work_or_study:, immigration_status:) }
+
+  let(:immigration_status) { nil }
+  let(:right_to_work_or_study) { 'no' }
+  let(:first_nationality) { 'Canadian' }
+  let(:second_nationality) { nil }
+
+  describe '#incomplete?' do
+    context 'when the candidate has the right to work or study and is not British or Irish' do
+      let(:right_to_work_or_study) { 'yes' }
+      let(:first_nationality) { 'Canadian' }
+      let(:second_nationality) { 'Australian' }
+
+      it 'returns true if immigration status is blank' do
+        expect(immigration_status_service.incomplete?).to be true
+      end
+
+      it 'returns false if immigration status is present' do
+        current_application.update!(immigration_status: 'eu_settled')
+        expect(immigration_status_service.incomplete?).to be false
+      end
+    end
+
+    context 'when the candidate has the right to work or study' do
+      let(:right_to_work_or_study) { 'yes' }
+
+      context 'and they are British or Irish' do
+        it 'returns false regardless of immigration status' do
+          %w[British Irish].each do |nationality|
+            current_application.update!(first_nationality: nationality)
+            expect(immigration_status_service.incomplete?).to be false
+          end
+        end
+      end
+    end
+
+    context 'when the candidate does not have the right to work or study' do
+      let(:right_to_work_or_study) { 'no' }
+      let(:first_nationality) { 'Canadian' }
+      let(:second_nationality) { nil }
+
+      it 'returns false regardless of immigration status' do
+        expect(immigration_status_service.incomplete?).to be false
+      end
+    end
+  end
+
+  describe '#british_or_irish?' do
+    let(:right_to_work_or_study) { 'no' }
+
+    context 'when the candidate is British or Irish' do
+      it 'returns true if nationality is British or Irish' do
+        %w[British Irish].each do |nationality|
+          current_application.update!(first_nationality: nationality)
+          expect(immigration_status_service.british_or_irish?).to be true
+        end
+      end
+    end
+
+    context 'when the candidate is not British or Irish' do
+      it 'returns false' do
+        current_application.update!(first_nationality: 'Canadian')
+        expect(immigration_status_service.british_or_irish?).to be false
+      end
+    end
+  end
+
+  describe '#right_to_work_or_study?' do
+    context 'when the candidate has the right to work or study' do
+      let(:right_to_work_or_study) { 'yes' }
+
+      it 'returns true' do
+        expect(immigration_status_service.right_to_work_or_study?).to be true
+      end
+    end
+
+    context 'when the candidate does not have the right to work or study' do
+      let(:right_to_work_or_study) { 'no' }
+
+      it 'returns false' do
+        expect(immigration_status_service.right_to_work_or_study?).to be false
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -40,6 +40,33 @@ RSpec.describe 'Entering their personal details' do
     then_i_can_check_my_revised_answers
   end
 
+  scenario 'International candidate does not complete all their personal details' do
+    given_i_am_signed_in_with_one_login
+    and_i_visit_the_site
+    when_i_click_on_personal_information
+    and_i_fill_in_all_my_details
+    and_i_submit_the_form
+    and_i_choose_american
+    and_i_submit_the_form
+    and_i_choose_yes_to_having_the_right_to_work_in_the_uk
+    and_i_submit_the_form
+    and_i_click_on_your_details
+    and_i_click_on_personal_information
+    then_i_do_not_see_the_complete_section_component
+  end
+
+  def then_i_do_not_see_the_complete_section_component
+    expect(page).to have_no_content('Have you completed this section?')
+  end
+
+  def and_i_click_on_personal_information
+    click_link_or_button 'Personal information'
+  end
+
+  def and_i_click_on_your_details
+    click_link_or_button 'Your details'
+  end
+
   def and_i_visit_the_site
     visit candidate_interface_details_path
   end
@@ -74,6 +101,15 @@ RSpec.describe 'Entering their personal details' do
     fill_in 'Year', with: '1937'
   end
 
+  def and_i_fill_in_all_my_details
+    @scope = 'application_form.personal_details'
+    fill_in t('first_name.label', scope: @scope), with: 'Lando'
+    fill_in t('last_name.label', scope: @scope), with: 'Calrissian'
+    fill_in 'Day', with: '10'
+    fill_in 'Month', with: '11'
+    fill_in 'Year', with: '1975'
+  end
+
   def and_i_submit_the_form
     click_link_or_button t('save_and_continue')
   end
@@ -84,6 +120,13 @@ RSpec.describe 'Entering their personal details' do
 
   def when_i_input_my_nationalities
     check 'British'
+    check 'Citizen of a different country'
+    within('#candidate-interface-nationalities-form-other-nationality1-field') do
+      select 'American'
+    end
+  end
+
+  def and_i_choose_american
     check 'Citizen of a different country'
     within('#candidate-interface-nationalities-form-other-nationality1-field') do
       select 'American'
@@ -140,5 +183,9 @@ RSpec.describe 'Entering their personal details' do
 
   def and_that_the_section_is_completed
     expect(page).to have_css('#personal-information-badge-id', text: 'Completed')
+  end
+
+  def and_i_choose_yes_to_having_the_right_to_work_in_the_uk
+    choose('Yes')
   end
 end


### PR DESCRIPTION
## Context

This fixes a bug that allowed users to submit incomplete application forms.

## Changes proposed in this pull request

- Redirect to the immigration status edit page if it is required and has not been completed.

## Guidance to review

To replicate the issue, follow these steps:

1. Set the nationality to a non-UK nationality.
2. Click the **Save & Continue** button.
3. Set the "Has the right to work or study in the UK?" field to **Yes**.
4. Click the **Save & Continue** button.
5. On the **Visa or Immigration Status** page, navigate away without selecting a value (using the browser back button, the application "Back" link, or by selecting "Your Details" or "Your Applications").
6. Go back to the **Personal Information** section and mark it as complete.
7. Complete all other required sections.
8. Attempt to submit the application.


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
