### PR TITLE
[464] Remove `unlock_application_for_editing` feature flag`

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -142,16 +142,14 @@ module SupportInterface
     end
 
     def editable_extension_row
-      if FeatureFlag.active?(:unlock_application_for_editing)
-        {
-          key: 'Is this application editable',
-          value: application_form.editable_extension? ? "Yes, editable until #{application_form.editable_until.to_fs(:govuk_date_and_time)}" : 'No',
-          action: {
-            href: support_interface_editable_extension_path(application_form),
-            visually_hidden_text: 'editable until',
-          },
-        }
-      end
+      {
+        key: 'Is this application editable',
+        value: application_form.editable_extension? ? "Yes, editable until #{application_form.editable_until.to_fs(:govuk_date_and_time)}" : 'No',
+        action: {
+          href: support_interface_editable_extension_path(application_form),
+          visually_hidden_text: 'editable until',
+        },
+      }
     end
 
     def formatted_status

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,7 +19,6 @@ class FeatureFlag
     [:service_unavailable_page, 'Displays a maintenance page on the whole application', 'Apply team'],
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
-    [:unlock_application_for_editing, 'Allow the candidate to make edits to their application form post submission', 'Find and Apply team'],
     [:draft_vendor_api_specification, 'The specification for upcoming vendor API releases', 'Abeer Salameh'],
     [:adviser_sign_up, 'Allow candidates to sign up for a teacher training adviser', 'Ross Oliver'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -24,28 +24,10 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
       expect(result.css('.govuk-summary-list__value').text).to include('Over 5 days ago')
     end
 
-    context 'when the unlock editing feature flag is active' do
-      before do
-        FeatureFlag.activate(:unlock_application_for_editing)
-      end
+    it 'renders the editable row' do
+      result = render_inline(described_class.new(application_form: create(:completed_application_form)))
 
-      it 'renders the editable row' do
-        result = render_inline(described_class.new(application_form: create(:completed_application_form)))
-
-        expect(result.css('.govuk-summary-list__key').text).to include('Is this application editable')
-      end
-    end
-
-    context 'when the unlock editing feature flag is inactive' do
-      before do
-        FeatureFlag.deactivate(:unlock_application_for_editing)
-      end
-
-      it 'does not render the editable row' do
-        result = render_inline(described_class.new(application_form: create(:completed_application_form)))
-
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Is this application editable')
-      end
+      expect(result.css('.govuk-summary-list__key').text).to include('Is this application editable')
     end
 
     context 'when the candidate has a OneLogin account' do

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
   scenario 'Unlocking some sections via support', :with_audited do
     given_i_am_a_support_user
     and_there_is_a_submitted_application
-    and_the_feature_flag_is_active
-
     when_i_visit_the_application_page
     and_i_click_to_change_the_editable_sections
     then_i_do_not_see_references_or_safeguarding
@@ -35,10 +33,6 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
-  end
-
-  def and_the_feature_flag_is_active
-    FeatureFlag.activate(:unlock_application_for_editing)
   end
 
   def and_there_is_a_submitted_application


### PR DESCRIPTION
## Context

We are removing the ability to globally control whether application forms can be editable or not. Control is still possible on a more granular level.

This has been active in production since: `4 December 2023 at 14:56`

## Changes proposed in this pull request

- Remove usages
- Remove feature flag

## Guidance to review

- The feature flag will be removed from the database in a following PR.
- Have all other instances of the feature flag been removed? 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
