### PR TITLE
[464] Remove `unlock_application_for_editing` Feature Flag from the Database

### DIFF
--- a/app/services/data_migrations/remove_unlock_application_for_editing_feature_flag.rb
+++ b/app/services/data_migrations/remove_unlock_application_for_editing_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveUnlockApplicationForEditingFeatureFlag
+    TIMESTAMP = 20250217153711
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :unlock_application_for_editing)&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveUnlockApplicationForEditingFeatureFlag',
   'DataMigrations::RemoveShowReferenceConfidentialityStatusFeatureFlag',
   'DataMigrations::AddRecruitmentCycleYearToPerformanceReports',
   'DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase',

--- a/spec/services/data_migrations/remove_unlock_application_for_editing_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_unlock_application_for_editing_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveUnlockApplicationForEditingFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'unlock_application_for_editing')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'unlock_application_for_editing')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Usages were removed in #10388. 

## Changes proposed in this pull request

Remove the feature flag from the database.