### PR TITLE
Candidate pool find candidates

### DIFF
--- a/app/controllers/provider_interface/find_candidates_controller.rb
+++ b/app/controllers/provider_interface/find_candidates_controller.rb
@@ -1,21 +1,18 @@
 module ProviderInterface
   class FindCandidatesController < ProviderInterfaceController
     include Pagy::Backend
-    before_action :redirect_to_applications_if_no_candidate_pool_invitation
+    before_action :redirect_to_applications_unless_provider_opted_in
 
     def index
       @pagy, @candidates = pagy(
-        Pool::Candidates.for_provider(
-          providers: current_provider_user.providers,
-        ).includes(:application_forms).where(
-          application_forms: { recruitment_cycle_year: RecruitmentCycleTimetable.current_year },
-        ).order('application_forms.submitted_at'),
+        Pool::Candidates.for_provider(providers: current_provider_user.providers)
+          .order('application_forms.submitted_at'),
       )
     end
 
   private
 
-    def redirect_to_applications_if_no_candidate_pool_invitation
+    def redirect_to_applications_unless_provider_opted_in
       invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
 
       redirect_to provider_interface_applications_path if invites.blank?

--- a/app/controllers/provider_interface/find_candidates_controller.rb
+++ b/app/controllers/provider_interface/find_candidates_controller.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class FindCandidatesController < ProviderInterfaceController
+    include Pagy::Backend
+    before_action :redirect_to_applications_if_no_candidate_pool_invitation
+
+    def index
+      @pagy, @candidates = pagy(
+        Pool::Candidates.for_provider(
+          providers: current_provider_user.providers,
+        ).includes(:application_forms).where(
+          application_forms: { recruitment_cycle_year: RecruitmentCycleTimetable.current_year },
+        ).order('application_forms.submitted_at'),
+      )
+    end
+
+  private
+
+    def redirect_to_applications_if_no_candidate_pool_invitation
+      invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
+
+      redirect_to provider_interface_applications_path if invites.blank?
+    end
+  end
+end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -124,6 +124,15 @@ class NavigationItems
             ],
           ),
         }
+
+        if CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids).present?
+          items << {
+            text: 'Find candidates',
+            href: provider_interface_find_candidates_index_path,
+            active: active?(current_controller, %w[find_candidates]),
+          }
+        end
+
         items << {
           text: 'Interview schedule',
           href: provider_interface_interview_schedule_path,

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -308,7 +308,7 @@ class ApplicationForm < ApplicationRecord
       first_letter = name.first
 
       name.delete!(first_letter)
-      redacted = '*' * name.size
+      redacted = '*' * 5
 
       "#{first_letter}#{redacted}"
     end.join(' ')

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -303,6 +303,17 @@ class ApplicationForm < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def redacted_full_name
+    full_name.split.map do |name|
+      first_letter = name.first
+
+      name.delete!(first_letter)
+      redacted = '*' * name.size
+
+      "#{first_letter}#{redacted}"
+    end.join(' ')
+  end
+
   def blank_application?
     updated_at == created_at
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -36,6 +36,12 @@ class Candidate < ApplicationRecord
     dismissed: 'dismissed',
   }, prefix: true
 
+  enum :pool_status, {
+    not_set: 'not_set',
+    opt_in: 'opt_in',
+    opt_out: 'opt_out',
+  }, prefix: true
+
   after_create do
     update!(candidate_api_updated_at: Time.zone.now)
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -54,6 +54,10 @@ class Candidate < ApplicationRecord
 
   delegate :previous_account_email_address, to: :account_recovery_request, allow_nil: true
 
+  def redacted_full_name_current_cycle
+    application_forms.current_cycle.last.redacted_full_name
+  end
+
   def touch_application_choices_and_forms
     return unless application_choices.any?
 

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,0 +1,37 @@
+class Pool::Candidates
+  attr_reader :providers
+
+  def initialize(providers:)
+    @providers = providers
+  end
+
+  def self.for_provider(providers:)
+    new(providers:).for_provider
+  end
+
+  def for_provider
+    dismissed_candidates = Candidate.joins(:pool_dismissals).where(pool_dismissals: { provider: providers })
+    rejected_candidate_ids = curated_application_forms.pluck(:candidate_id).uniq
+
+    Candidate
+      .where(id: rejected_candidate_ids)
+      .pool_status_opt_in
+      .excluding(dismissed_candidates)
+  end
+
+private
+
+  def curated_application_forms
+    ApplicationForm.current_cycle.joins(:application_choices)
+      .where(application_choices: {
+        status: %i[rejected declined withdrawn conditions_not_met offer_withdrawn inactive],
+      })
+      .where.not(
+        id: ApplicationForm.joins(:application_choices).where(
+          application_choices: {
+            status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited offer_deferred],
+          },
+        ).select(:id),
+      )
+  end
+end

--- a/app/views/provider_interface/find_candidates/index.html.erb
+++ b/app/views/provider_interface/find_candidates/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :browser_title, t('.title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ServiceInformationBanner.new(namespace: :provider) %>
+
+    <% if @candidates.present? %>
+      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+      <p class="govuk-body"><%= t('.candidate_information_agreement') %></p>
+      <p class="govuk-body"><%= t('.review_candidates') %></p>
+    <% else %>
+      <h1 class="govuk-heading-l"><%= t('.no_candidates') %></h1>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <% if @candidates.present? %>
+      <%= govuk_table do |table| %>
+        <%= table.with_head do |head| %>
+          <%= head.with_row do |row| %>
+            <%= row.with_cell(text: t('.name')) %>
+          <% end %>
+        <% end %>
+
+        <%= table.with_body do |body| %>
+          <% @candidates.each do |candidate| %>
+            <%= body.with_row do |row| %>
+              <%= row.with_cell(text: candidate.application_forms.current_cycle.last.redacted_full_name) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <div class="govuk-grid-row govuk-!-margin-top-4">
+        <%= govuk_pagination(pagy: @pagy) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/find_candidates/index.html.erb
+++ b/app/views/provider_interface/find_candidates/index.html.erb
@@ -26,7 +26,7 @@
         <%= table.with_body do |body| %>
           <% @candidates.each do |candidate| %>
             <%= body.with_row do |row| %>
-              <%= row.with_cell(text: candidate.application_forms.current_cycle.last.redacted_full_name) %>
+              <%= row.with_cell(text: candidate.redacted_full_name_current_cycle) %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/provider_interface/find_candidates.yml
+++ b/config/locales/provider_interface/find_candidates.yml
@@ -1,0 +1,9 @@
+en:
+  provider_interface:
+    find_candidates:
+        index:
+          title: Find candidates
+          no_candidates: No candidates
+          candidate_information_agreement: These candidates have agreed to share their application details.
+          review_candidates: You can review their applications and decide whether to invite them to apply.
+          name: Name

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -25,6 +25,8 @@ namespace :provider_interface, path: '/provider' do
 
   get '/applications' => 'application_choices#index'
 
+  get 'find-candidates/index' => 'find_candidates#index'
+
   resources :reports, only: :index
 
   namespace :reports do

--- a/spec/factories/candidate_pool_provider_opt_in.rb
+++ b/spec/factories/candidate_pool_provider_opt_in.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :candidate_pool_provider_opt_in do
+    provider
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1319,7 +1319,7 @@ RSpec.describe ApplicationForm do
       last_name = 'Last'
       application_form = build(:application_form, first_name:, last_name:)
 
-      expect(application_form.redacted_full_name).to eq('F**** L***')
+      expect(application_form.redacted_full_name).to eq('F***** L*****')
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1312,4 +1312,14 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#redacted_full_name' do
+    it 'returs the full name redacted' do
+      first_name = 'First'
+      last_name = 'Last'
+      application_form = build(:application_form, first_name:, last_name:)
+
+      expect(application_form.redacted_full_name).to eq('F**** L***')
+    end
+  end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -424,4 +424,28 @@ RSpec.describe Candidate do
       end
     end
   end
+
+  describe '#redacted_full_name_current_cycle' do
+    it 'returns the redacted full_name from the application form in current cycle' do
+      candidate = create(:candidate)
+      _current_cycle_form = create(
+        :application_form,
+        :completed,
+        candidate:,
+        first_name: 'test',
+        last_name: 'test',
+      )
+
+      _last_cycle_form = create(
+        :application_form,
+        :completed,
+        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        candidate:,
+        first_name: 'last',
+        last_name: 'cycle',
+      )
+
+      expect(candidate.redacted_full_name_current_cycle).to eq('t***** t*****')
+    end
+  end
 end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe Pool::Candidates do
+  describe '.for_provider' do
+    it 'returns candidates that should be on candidate pool list' do
+      providers = [create(:provider)]
+
+      rejected_candidate = create(:candidate, pool_status: 'opt_in')
+      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
+      create(:application_choice, :rejected, application_form: rejected_candidate_form)
+
+      declined_candidate = create(:candidate, pool_status: 'opt_in')
+      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+      create(:application_choice, :declined, application_form: declined_candidate_form)
+
+      withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+
+      conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+
+      offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+
+      inactive_candidate = create(:candidate, pool_status: 'opt_in')
+      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+      create(:application_choice, :inactive, application_form: inactive_candidate_form)
+
+      candidates = described_class.for_provider(providers:)
+
+      expect(candidates).to contain_exactly(
+        rejected_candidate,
+        declined_candidate,
+        withdrawn_candidate,
+        conditions_not_met_candidate,
+        offer_withdrawn_candidate,
+        inactive_candidate,
+      )
+    end
+
+    it 'does not returns candidates that should not be on the candidate pool list' do
+      provider = create(:provider)
+      providers = [provider]
+
+      opt_out_candidate = create(:candidate, pool_status: 'opt_out')
+      opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
+      create(:application_choice, :rejected, application_form: opt_out_candidate_form)
+
+      dismissed_candidate = create(:candidate, pool_status: 'opt_in')
+      dismissed_candidate_form = create(:application_form, :completed, candidate: dismissed_candidate)
+      create(:application_choice, :rejected, application_form: dismissed_candidate_form)
+      create(:pool_dismissal, provider:, candidate: dismissed_candidate)
+
+      rejected_candidate = create(:candidate, pool_status: 'opt_in')
+      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
+      create(:application_choice, :rejected, application_form: rejected_candidate_form)
+      create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
+
+      declined_candidate = create(:candidate, pool_status: 'opt_in')
+      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+      create(:application_choice, :declined, application_form: declined_candidate_form)
+      create(:application_choice, :interviewing, application_form: declined_candidate_form)
+
+      withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+      create(:application_choice, :offer, application_form: withdrawn_candidate_form)
+
+      conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+      create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
+
+      offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+      create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
+
+      inactive_candidate = create(:candidate, pool_status: 'opt_in')
+      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+      create(:application_choice, :inactive, application_form: inactive_candidate_form)
+      create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
+      candidates = described_class.for_provider(providers:)
+
+      expect(candidates).to be_empty
+    end
+  end
+end

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe 'Providers views candidate pool list' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  let(:current_provider) { create(:provider) }
+
+  scenario 'View candidates' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_provider_user_exists
+    and_there_are_candidates_for_candidate_pool
+    and_provider_is_opted_in_to_candidate_pool
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_find_candidates_page
+
+    then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+  end
+
+  scenario 'Provider cannot view candidates if not invited' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_provider_user_exists
+    and_there_are_candidates_for_candidate_pool
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_find_candidates_page
+
+    then_i_am_redirected_to_the_applications_page
+    and_find_candidates_is_not_in_my_navigation
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_provider_user_exists
+    provider_user_exists_in_apply_database(provider_code: current_provider.code)
+  end
+
+  def and_there_are_candidates_for_candidate_pool
+    rejected_candidate = create(:candidate, pool_status: 'opt_in')
+    @rejected_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: rejected_candidate,
+      submitted_at: 1.day.ago,
+    )
+    create(:application_choice, :rejected, application_form: @rejected_candidate_form)
+
+    declined_candidate = create(:candidate, pool_status: 'opt_in')
+    @declined_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: declined_candidate,
+      submitted_at: Time.zone.today,
+    )
+    create(:application_choice, :declined, application_form: @declined_candidate_form)
+
+    previous_cycle_form = create(
+      :application_form,
+      :completed,
+      first_name: 'test',
+      last_name: 'test',
+      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      submitted_at: 1.year.ago,
+      candidate: declined_candidate,
+    )
+    create(:application_choice, :declined, application_form: previous_cycle_form)
+  end
+
+  def and_provider_is_opted_in_to_candidate_pool
+    create(:candidate_pool_provider_opt_in, provider: current_provider)
+  end
+
+  def when_i_visit_the_find_candidates_page
+    visit provider_interface_find_candidates_index_path
+  end
+
+  def then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
+
+    expect(candidates).to eq([
+      @rejected_candidate_form.redacted_full_name,
+      @declined_candidate_form.redacted_full_name,
+    ])
+  end
+
+  def then_i_am_redirected_to_the_applications_page
+    expect(page).to have_current_path(provider_interface_applications_path, ignore_query: true)
+  end
+
+  def and_find_candidates_is_not_in_my_navigation
+    within('#service-navigation') do
+      expect(page).to have_no_css('li', text: 'Find candidates')
+    end
+  end
+end


### PR DESCRIPTION
## Context

This commit adds a index view for providers to view candidates in the
candidate pool.

It returns every candidate in current cycle with at least one
application choice in the following status:

`[rejected, declined, withdrawn, conditions_not_met, offer_withdrawn
inactive]`

Only if they don't have any other application choice in this current
state

`[awaiting_provider_decision, interviewing, offer, pending_conditions, recruited, offer_deferred]`

And has not been dismissed by the provider.

The list is also ordered by application_form `submitted_at`

## Guidance to review

Review the code and the SQL query
Go on review app and view the candidate pool list


https://github.com/user-attachments/assets/1443d91b-8402-430d-946f-429b275a1a41



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
