### PR TITLE
[629] Prevent completion of safeguarding section without all the required data

### DIFF
--- a/app/components/candidate_interface/safeguarding_review_component.rb
+++ b/app/components/candidate_interface/safeguarding_review_component.rb
@@ -22,17 +22,30 @@ module CandidateInterface
     def sharing_safeguarding_issues_row
       {
         key: 'Do you want to share any safeguarding issues?',
-        value: @safeguarding.share_safeguarding_issues,
-        action: {
-          href: candidate_interface_edit_safeguarding_path(return_to_params),
-          visually_hidden_text: 'if you want to share any safeguarding issues',
-        },
-        html_attributes: {
-          data: {
-            qa: 'safeguarding-issues',
-          },
-        },
+        value: safeguarding_value_or_link_to_complete,
+      }.tap do |row|
+        if @safeguarding.share_safeguarding_issues.present?
+          row[:action] = safeguarding_action('if you want to share any safeguarding issues')
+        end
+      end
+    end
+
+    def safeguarding_value_or_link_to_complete
+      @safeguarding.share_safeguarding_issues.presence || govuk_link_to(
+        'Enter any safeguarding issues you want to share',
+        safeguarding_edit_path,
+      )
+    end
+
+    def safeguarding_action(visually_hidden_text)
+      {
+        href: safeguarding_edit_path,
+        visually_hidden_text:,
       }
+    end
+
+    def safeguarding_edit_path
+      candidate_interface_edit_safeguarding_path(return_to_params)
     end
 
     def relevant_information_row
@@ -41,10 +54,7 @@ module CandidateInterface
       {
         key: 'Relevant information',
         value: @safeguarding.safeguarding_issues || 'Not entered',
-        action: {
-          href: candidate_interface_edit_safeguarding_path(return_to_params),
-          visually_hidden_text: 'relevant information for safeguarding issues',
-        },
+        action: safeguarding_action('relevant information for safeguarding issues'),
       }
     end
 

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class SafeguardingController < SectionController
     def show
       @application_form = current_application
+      @can_complete = SafeguardingIssuesDeclarationForm.build_from_application(current_application).valid_for_submission?
       @section_complete_form = SectionCompleteForm.new(completed: current_application.safeguarding_issues_completed)
     end
 

--- a/app/forms/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/forms/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -37,5 +37,14 @@ module CandidateInterface
     def share_safeguarding_issues?
       share_safeguarding_issues == 'Yes'
     end
+
+    def all_errors
+      validate(%i[share_safeguarding_issues])
+      errors
+    end
+
+    def valid_for_submission?
+      all_errors.blank?
+    end
   end
 end

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -10,5 +10,8 @@
 
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application, editable: @section_policy.can_edit?) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
+
+  <% if @can_complete %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
+  <% end %>
 <% end %>

--- a/spec/components/candidate_interface/safeguarding_review_component_spec.rb
+++ b/spec/components/candidate_interface/safeguarding_review_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SafeguardingReviewComponent do
+  include Rails.application.routes.url_helpers
+
   context 'when safeguarding issues has a value of "Yes"' do
     it 'displays "Yes" for sharing safeguarding issues and "Not entered" for relevant information' do
       application_form = build_stubbed(
@@ -31,6 +33,23 @@ RSpec.describe CandidateInterface::SafeguardingReviewComponent do
       expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('No')
       expect(result.text).not_to include('Relevant information')
+    end
+  end
+
+  context 'when safeguarding issues has not been selected' do
+    it 'renders a link to enter safeguarding issues as a value' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+      )
+
+      result = render_inline(described_class.new(application_form:))
+
+      expect(result.text).to include('Do you want to share any safeguarding issues?')
+      expect(result).to have_link('Enter any safeguarding issues you want to share', href: candidate_interface_edit_safeguarding_path)
+      expect(result.text).to include('Relevant information')
+      expect(result.text).to include('Not entered')
+      expect(result.text).not_to include('Change if you want to share any safeguarding issues')
     end
   end
 


### PR DESCRIPTION
## Context

Users should not be able to mark the safeguarding section as complete without actually completing the section.

## Changes proposed in this pull request

- Do not render the `CompleteSectionComponent` if the user has not completed the section.
- Add missing information links as values when the information has not been completed as per the [design system guidance](https://design-system.service.gov.uk/components/summary-list/#showing-missing-information).

## Guidance to review

- Create an application form
- Navigate to `safeguarding/review`
- Ensure you cannot submit the section without filling in the details

| Before    | After |
| -------- | ------- |
|<img width="911" alt="image" src="https://github.com/user-attachments/assets/4007b626-613b-432a-869d-64fd1b85c1b9" />|<img width="1013" alt="image" src="https://github.com/user-attachments/assets/860a7ae8-9cde-410b-b33b-32b263ea9357" />|
