### PR TITLE
[653] Ensure `Have you completed this section?` questions are not pre-selected

### DIFF
--- a/app/controllers/candidate_interface/degrees/university_degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/university_degree_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
         return render :new unless @university_degree_form.valid?
 
         if @university_degree_form.degree?
-          current_application.update!(university_degree: true, degrees_completed: false)
+          current_application.update!(university_degree: true)
           redirect_to candidate_interface_degree_country_path
         else
           current_application.update!(university_degree: false, degrees_completed: true)

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -110,7 +110,7 @@ module CandidateInterface
       attributes[:postcode] = nil if international?
 
       unless valid_for_submission?
-        attributes = attributes.merge(contact_details_completed: false)
+        attributes = attributes.merge(contact_details_completed: nil)
       end
       application_form.update(attributes)
     end

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       contact_details = described_class.new(form_data)
 
       expect(contact_details.save_address_type(application_form)).to be(true)
-      expect(application_form.reload.contact_details_completed).to be(false)
+      expect(application_form.reload.contact_details_completed).to be_nil
     end
 
     it 'preserves the `contact_details_completed` flag if data is complete' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'Entering their contact information' do
     when_i_fill_in_an_international_address
     and_i_submit_my_address
     then_i_can_check_my_revised_address
+    and_the_completed_section_radios_are_not_selected
 
     when_i_mark_the_section_as_completed
     and_i_submit_my_details
@@ -53,6 +54,15 @@ RSpec.describe 'Entering their contact information' do
 
     when_i_click_on_contact_information
     then_i_can_check_my_revised_answers
+  end
+
+  def and_the_completed_section_radios_are_not_selected
+    %w[
+      candidate-interface-section-complete-form-completed-true-field
+      candidate-interface-section-complete-form-completed-field
+    ].each do |radio_id|
+      expect(page).to have_no_checked_field(radio_id)
+    end
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Entering a degree' do
 
     # Review
     then_i_can_check_my_undergraduate_degree
+    and_the_completed_section_radios_are_not_selected
 
     # Mark section as complete
     when_i_mark_this_section_as_completed
@@ -196,5 +197,14 @@ RSpec.describe 'Entering a degree' do
     expect(page).to have_content 'First-class honours'
     expect(page).to have_content '2006'
     expect(page).to have_content '2009'
+  end
+
+  def and_the_completed_section_radios_are_not_selected
+    %w[
+      candidate-interface-section-complete-form-completed-true-field
+      candidate-interface-section-complete-form-completed-field
+    ].each do |radio_id|
+      expect(page).to have_no_checked_field(radio_id)
+    end
   end
 end


### PR DESCRIPTION
## Context

There are a couple of sections on the candidate where the `Have you completed this section?` has a pre-selected answer.

## Changes proposed in this pull request

Ensure that the question is not pre-selected. The user should have to explicitly choose themselves.

The fix is for the following sections:

- Contact details
- Degrees

## Guidance to review

Go and complete the following sections and when you get to the review page ensure that the  `Have you completed this section?` is **not** pre-selected:

- Contact details
- Degrees


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
