### PR TITLE
[653] Surface ENIC reference row when user chooses yes

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -249,7 +249,7 @@ module CandidateInterface
       if application_qualification.institution_country
         COUNTRIES_AND_TERRITORIES[application_qualification.institution_country]
       else
-        govuk_link_to('Enter the country or territory where you studied for your English qualification', candidate_interface_gcse_details_edit_institution_country_path(change_path_params))
+        govuk_link_to("Enter the country or territory where you studied for your #{subject} qualification", candidate_interface_gcse_details_edit_institution_country_path(change_path_params))
       end
     end
 
@@ -258,9 +258,9 @@ module CandidateInterface
 
       {
         key: t('application_form.gcse.enic_statement.review_label'),
-        value: enic_value,
+        value: enic_statment_value,
       }.tap do |row|
-        if application_qualification.enic_reference?
+        if application_qualification.enic_reason?
           row[:action] =
             {
               href: candidate_interface_gcse_details_edit_enic_path(change_path_params),
@@ -270,31 +270,39 @@ module CandidateInterface
       end
     end
 
-    def enic_value
-      if application_qualification.enic_reference?
-        translate_enic_reason(application_qualification.enic_reason)
-      else
+    def enic_statment_value
+      if application_qualification.enic_reason.nil?
         govuk_link_to('Enter your ENIC status', candidate_interface_gcse_details_edit_enic_path(change_path_params))
+      else
+        t("gcse_edit_enic.#{application_qualification.enic_reason}")
       end
     end
 
     def enic_reference_row
       return nil unless application_qualification.qualification_type == 'non_uk' &&
-                        application_qualification.enic_reference
+                        application_qualification.enic_reason_obtained?
 
       {
         key: t('application_form.gcse.enic_reference.review_label'),
-        value: application_qualification.enic_reference,
-        action: {
-          href: x_gcse_edit_statement_comparability_path(change_path_params[:subject]),
-          visually_hidden_text: t('application_form.gcse.enic_reference.change_action'),
-        },
+        value: enic_reference_value,
         html_attributes: {
           data: {
             qa: 'gcse-enic-reference',
           },
         },
-      }
+      }.tap do |row|
+        if application_qualification.enic_reference
+          row[:action] =
+            {
+              href: x_gcse_edit_statement_comparability_path(change_path_params[:subject]),
+              visually_hidden_text: t('application_form.gcse.enic_reference.change_action'),
+            }
+        end
+      end
+    end
+
+    def enic_reference_value
+      application_qualification.enic_reference.presence || govuk_link_to('Enter your ENIC reference number', x_gcse_edit_statement_comparability_path(change_path_params[:subject]))
     end
 
     def comparable_uk_qualification_row

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -302,7 +302,7 @@ module CandidateInterface
     end
 
     def enic_reference_value
-      application_qualification.enic_reference.presence || govuk_link_to('Enter your ENIC reference number', x_gcse_edit_statement_comparability_path(change_path_params[:subject]))
+      application_qualification.enic_reference.presence || govuk_link_to('Enter your UK ENIC reference number', x_gcse_edit_statement_comparability_path(change_path_params[:subject]))
     end
 
     def comparable_uk_qualification_row

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK ENIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('Yes, I have a statement of comparability')
       expect(result.css('.govuk-summary-list__key')[3].text).to include('UK ENIC reference number')
-      expect(result.css('.govuk-summary-list__value')[3].text).to include('Enter your ENIC reference number')
+      expect(result).to have_link('Enter your UK ENIC reference number', href: candidate_interface_edit_gcse_maths_statement_comparability_path(subject: 'maths'))
     end
   end
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
+  include Rails.application.routes.url_helpers
+
   context 'a non uk qualification' do
     it 'renders a the correct links when no information' do
       application_form = build(:application_form)
@@ -25,7 +27,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.css('.govuk-summary-list__key')[0].text).to include('Qualification')
       expect(result.css('.govuk-summary-list__value')[0].text).to include('High school diploma')
       expect(result.css('.govuk-summary-list__key')[1].text).to include('Country')
-      expect(result.css('.govuk-summary-list__value')[1].text).to include('Enter the country or territory where you studied for your English qualification')
+      expect(result.css('.govuk-summary-list__value')[1].text).to include('Enter the country or territory where you studied for your maths qualification')
       expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK ENIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('Enter your ENIC status')
       expect(result.css('.govuk-summary-list__key')[3].text).to include('Grade')
@@ -80,6 +82,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         grade: 'c',
         institution_country: 'United States',
         enic_reference: nil,
+        enic_reason: nil,
         comparable_uk_qualification: nil,
       )
       result = render_inline(
@@ -87,9 +90,55 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       )
 
       expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK ENIC statement of comparability?')
-      expect(result.css('.govuk-summary-list__value')[2].text).to include('No')
+      expect(result).to have_link('Enter your ENIC status', href: candidate_interface_gcse_details_edit_enic_path(subject: 'maths'))
       expect(result.css('.govuk-summary-list__key').text).not_to include('UK ENIC reference number')
       expect(result.css('.govuk-summary-list__key').text).not_to include('Comparable UK qualification')
+    end
+
+    (ApplicationQualification.enic_reasons.keys - ['obtained']).each do |reason|
+      it "hides the enic_reference row when enic_reason is not 'obtained'" do
+        application_form = build(:application_form)
+        application_qualification = build(
+          :application_qualification,
+          application_form:,
+          qualification_type: 'non_uk',
+          non_uk_qualification_type: 'High school diploma',
+          level: 'gcse',
+          grade: 'c',
+          institution_country: 'United States',
+          enic_reference: nil,
+          enic_reason: reason,
+          comparable_uk_qualification: nil,
+        )
+
+        result = render_inline(described_class.new(application_form:, application_qualification:, subject: 'maths'))
+
+        expect(result.css('.govuk-summary-list__key').text).not_to include('UK ENIC reference number')
+      end
+    end
+
+    it 'displays the enic_statment row and shows the enic_reference when obtained' do
+      application_form = build(:application_form)
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form:,
+        qualification_type: 'non_uk',
+        non_uk_qualification_type: 'High school diploma',
+        level: 'gcse',
+        grade: 'c',
+        institution_country: 'United States',
+        enic_reference: nil,
+        enic_reason: 'obtained',
+        comparable_uk_qualification: nil,
+      )
+      result = render_inline(
+        described_class.new(application_form:, application_qualification:, subject: 'maths'),
+      )
+
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK ENIC statement of comparability?')
+      expect(result.css('.govuk-summary-list__value')[2].text).to include('Yes, I have a statement of comparability')
+      expect(result.css('.govuk-summary-list__key')[3].text).to include('UK ENIC reference number')
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('Enter your ENIC reference number')
     end
   end
 


### PR DESCRIPTION
## Context

We are displaying the ENIC reference row on the review page if the user chooses "Yes, I have a statement of comparability".

## Changes proposed in this pull request

- Surface the ENIC reference row if `enic_reason == 'obtained'`



## Screenshots

| Before | After |
---------|--------
|<img width="1082" alt="image" src="https://github.com/user-attachments/assets/84757496-88ed-40d8-860e-a822837da9e1" />|<img width="1048" alt="image" src="https://github.com/user-attachments/assets/81e7b391-f0fa-414c-9040-c00f6b0194be" />|


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
