### PR TITLE
[xxxx] Ensure confidential is set to true when auto approved in test environments

### DIFF
--- a/app/services/request_reference.rb
+++ b/app/services/request_reference.rb
@@ -40,6 +40,7 @@ private
       relationship_correction: '',
       safeguarding_concerns: '',
       safeguarding_concerns_status: :no_safeguarding_concerns_to_declare,
+      confidential: true,
       feedback: 'Automatically approved.',
     )
 


### PR DESCRIPTION
## Context

We have an auto approving reference functionality in test environments, we need to ensure that the `confidential` value is set correctly for these references.

## Changes proposed in this pull request

Set `confidential` to true on auto approved references.

## Guidance to review

🚢 