### PR TITLE
Stop sending errors to sentry when candidate inputs wrong email

### DIFF
--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -26,10 +26,6 @@ class OneLoginController < ApplicationController
     if e.is_a?(OneLoginUser::Error)
       session_error.wrong_email_address!
       session[:session_error_id] = session_error.id
-      Sentry.capture_message(
-        "One login session error, check session_error record #{session_error.id}",
-        level: :error,
-      )
 
       redirect_to auth_one_login_sign_out_path
     else

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'OneLoginController' do
       it 'redirects to auth_one_login_sign_out_path' do
         candidate = create(:candidate, email_address: 'test@email.com')
         create(:one_login_auth, candidate:, token: '456')
-        allow(Sentry).to receive(:capture_message)
 
         expect {
           get auth_one_login_callback_path
@@ -54,11 +53,6 @@ RSpec.describe 'OneLoginController' do
 
         expect(response).to redirect_to(auth_one_login_sign_out_path)
         expect(session[:session_error_id]).to eq(SessionError.last.id)
-
-        expect(Sentry).to have_received(:capture_message).with(
-          "One login session error, check session_error record #{SessionError.last.id}",
-          level: :error,
-        )
       end
     end
   end
@@ -137,18 +131,12 @@ RSpec.describe 'OneLoginController' do
       it 'redirects to one_login logout url and persists the session error message' do
         candidate = create(:candidate, email_address: 'test@email.com')
         create(:one_login_auth, candidate:, token: '456')
-        allow(Sentry).to receive(:capture_message)
 
         expect {
           get auth_one_login_callback_path # set the session variables
         }.to change(SessionError, :count).by(1)
 
         get auth_one_login_sign_out_path
-
-        expect(Sentry).to have_received(:capture_message).with(
-          "One login session error, check session_error record #{SessionError.last.id}",
-          level: :error,
-        )
 
         expect(session[:session_error_id]).to eq(SessionError.last.id)
 
@@ -187,7 +175,6 @@ RSpec.describe 'OneLoginController' do
       it 'redirects to logout_one_login_path and persists the session error message' do
         candidate = create(:candidate, email_address: 'test@email.com')
         create(:one_login_auth, candidate:, token: '456')
-        allow(Sentry).to receive(:capture_message)
 
         expect {
           get auth_one_login_callback_path # set the session variables
@@ -195,10 +182,6 @@ RSpec.describe 'OneLoginController' do
 
         get auth_one_login_sign_out_complete_path
 
-        expect(Sentry).to have_received(:capture_message).with(
-          "One login session error, check session_error record #{SessionError.last.id}",
-          level: :error,
-        )
         expect(response).to redirect_to(candidate_interface_wrong_email_address_path)
       end
     end
@@ -216,8 +199,6 @@ RSpec.describe 'OneLoginController' do
 
   describe 'GET /auth/one-login/failure' do
     it 'redirects to the root_path' do
-      allow(Sentry).to receive(:capture_message)
-
       get auth_failure_path(params: { message: 'error_message', strategy: 'one_login' })
 
       expect(response).to redirect_to(root_path)


### PR DESCRIPTION
## Context

This was more to monitor the release of one login but we don't need it anymore

We still record this event in the SessionError table for debuging

Related to https://dfe-teacher-services.sentry.io/issues/6210404884/events/68829506b0054f9189213d2edefd5856/

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
