### PR TITLE
[653] Reset `grade` and `constituent_grades` when `qualification type` changes

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -50,9 +50,24 @@ module CandidateInterface
       reset_other_uk_qualification_type
       reset_non_uk_qualification_type
 
+      attributes = {
+        qualification_type:,
+        other_uk_qualification_type:,
+        non_uk_qualification_type:,
+        enic_reference:,
+        comparable_uk_qualification:,
+        currently_completing_qualification: nil,
+        not_completed_explanation: nil,
+        missing_explanation: nil,
+      }
+
+      if qualification_type_changed?(qualification)
+        attributes[:grade] = nil
+        attributes[:constituent_grades] = nil
+      end
+
       if missing_qualification?
-        qualification.update!(
-          qualification_type:,
+        attributes.merge!(
           grade: nil,
           constituent_grades: nil,
           award_year: nil,
@@ -60,24 +75,12 @@ module CandidateInterface
           institution_country: nil,
           other_uk_qualification_type: nil,
           non_uk_qualification_type: nil,
-          currently_completing_qualification: nil,
-          not_completed_explanation: nil,
-          missing_explanation: nil,
           enic_reference: nil,
           comparable_uk_qualification: nil,
         )
-      else
-        qualification.update!(
-          qualification_type:,
-          other_uk_qualification_type:,
-          non_uk_qualification_type:,
-          enic_reference:,
-          comparable_uk_qualification:,
-          currently_completing_qualification: nil,
-          not_completed_explanation: nil,
-          missing_explanation: nil,
-        )
       end
+
+      qualification.update!(attributes)
     end
 
     def missing_qualification?
@@ -85,6 +88,10 @@ module CandidateInterface
     end
 
   private
+
+    def qualification_type_changed?(qualification)
+      qualification_type != qualification.qualification_type
+    end
 
     def non_uk_qualification?
       qualification_type == NON_UK_QUALIFICATION_TYPE

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -88,6 +88,37 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
       expect(qualification.missing_explanation).to be_nil
     end
 
+    context 'when the qualification_type is changed' do
+      it 'resets grade and constituent_grades' do
+        qualification = create(:gcse_qualification, constituent_grades: { 'biology' => { grade: 'B' } })
+
+        described_class.new(
+          qualification_type: 'non_uk',
+          non_uk_qualification_type: 'BTEC',
+          subject: qualification.qualification_type,
+          level: qualification.level,
+        ).update(qualification)
+
+        expect(qualification.grade).to be_nil
+        expect(qualification.constituent_grades).to be_nil
+      end
+    end
+
+    context 'when the qualification_type is not changed' do
+      it 'does not reset grade or constituent_grades' do
+        qualification = create(:gcse_qualification, grade: 'A', constituent_grades: { 'biology' => { grade: 'B', 'public_id' => 999999 } })
+
+        described_class.new(
+          qualification_type: qualification.qualification_type,
+          subject: qualification.subject,
+          level: qualification.level,
+        ).update(qualification)
+
+        expect(qualification.grade).to eq('A')
+        expect(qualification.constituent_grades).to eq({ 'biology' => { 'grade' => 'B', 'public_id' => 999999 } })
+      end
+    end
+
     context 'when the qualification_type is updated from non_uk' do
       it 'updates the existing qualification and sets non_uk_qualification_type to nil' do
         qualification = create(:gcse_qualification, :non_uk)

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Candidate entering GCSE details' do
   end
 
   def and_i_see_the_gcse_grade_entered
-    expect(page).to have_css("input[value='A']")
+    expect(page).to have_no_css("input[value='A']")
   end
 
   def then_i_see_the_gcse_year_entered


### PR DESCRIPTION
## Context

There was a bug where UK grades appeared in the grade section on the review page when a qualification was changed to non-UK. Clicking the "Change" link did not surface any values.

It makes sense to clear the grades when changing qualification types so the user has to explicitly enter them.

## Changes proposed in this pull request

Clear `grade` and `constituent_grades` when changing `qualification_type`

## Guidance to review

- Add a UK GCSE
- Add the grade
- Click away
- Go to the review page
- Change the qualification to non UK
- Ensure you do not see the previous grade there


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
