### PR TITLE
[653] Ensure user continues to incomplete GCSE question

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -92,7 +92,7 @@ module CandidateInterface
     def grade_row
       {
         key: 'Grade',
-        value: present_grades || govuk_link_to('Enter your grade', grade_edit_path),
+        value: present_grades || govuk_link_to('Enter your grade', grade_new_path),
       }.tap do |row|
         if application_qualification.grade || application_qualification.constituent_grades
           row[:action] = {
@@ -345,6 +345,17 @@ module CandidateInterface
         candidate_interface_edit_gcse_science_grade_path(return_to_params)
       when 'english'
         candidate_interface_edit_gcse_english_grade_path(return_to_params)
+      end
+    end
+
+    def grade_new_path
+      case subject
+      when 'maths'
+        candidate_interface_new_gcse_maths_grade_path(from: 'review_page')
+      when 'science'
+        candidate_interface_new_gcse_science_grade_path(from: 'review_page')
+      when 'english'
+        candidate_interface_new_gcse_english_grade_path(from: 'review_page')
       end
     end
 

--- a/app/views/candidate_interface/gcse/english/grade/multiple_gcse_new.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/multiple_gcse_new.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, title_with_error_prefix(t('multiple_gcse_edit_grade.page_title', subject: @subject), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@previous_path) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(params[:from] == 'review_page' ? candidate_interface_gcse_review_path(@subject) : govuk_back_link_to(@previous_path)) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/gcse/maths/grade/new.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/new.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@previous_path) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(params[:from] == 'review_page' ? candidate_interface_gcse_review_path(@subject) : govuk_back_link_to(@previous_path)) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/gcse/science/grade/awards_new.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/awards_new.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@previous_path) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(params[:from] == 'review_page' ? candidate_interface_gcse_review_path(@subject) : govuk_back_link_to(@previous_path)) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
@@ -21,7 +21,11 @@ RSpec.describe 'Candidate entering GCSE English details' do
     and_i_click_save_and_continue
     then_i_see_the_gcses_blank_error
 
-    when_i_click_english_single_award
+    when_i_visit_the_review_page
+    and_i_click_enter_your_grade
+    and_i_click_back
+    and_i_click_enter_your_grade
+    and_i_click_english_single_award
     and_i_click_save_and_continue
     then_i_see_the_enter_your_english_single_award_grade_error
 
@@ -51,6 +55,18 @@ RSpec.describe 'Candidate entering GCSE English details' do
 
     when_i_enter_a_new_grade
     then_i_see_my_new_grade_on_the_review_page
+  end
+
+  def when_i_visit_the_review_page
+    visit candidate_interface_gcse_review_path(subject: 'english')
+  end
+
+  def and_i_click_enter_your_grade
+    click_link_or_button 'Enter your grade'
+  end
+
+  def and_i_click_back
+    click_link_or_button 'Back'
   end
 
   def and_i_wish_to_apply_to_a_course_that_requires_gcse_english
@@ -91,6 +107,8 @@ RSpec.describe 'Candidate entering GCSE English details' do
   def when_i_click_english_single_award
     check 'English (Single award)'
   end
+
+  alias_method :and_i_click_english_single_award, :when_i_click_english_single_award
 
   def then_i_see_the_enter_your_english_single_award_grade_error
     expect(page).to have_content 'Enter your English (Single award) grade'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
@@ -15,8 +15,13 @@ RSpec.describe 'Candidate entering GCSE Science details' do
     and_i_click_save_and_continue
     then_i_see_the_multiple_science_gcses_grade_page
 
+    when_i_visit_the_review_page
+    and_i_click_enter_your_grade
+    and_i_click_back
+    and_i_click_enter_your_grade
+
     # enter single award
-    then_i_select_single_award
+    and_i_select_single_award
     and_i_click_save_and_continue
     then_i_see_the_grade_blank_error
 
@@ -27,6 +32,18 @@ RSpec.describe 'Candidate entering GCSE Science details' do
     then_i_enter_a_valid_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_year_page
+  end
+
+  def when_i_visit_the_review_page
+    visit candidate_interface_gcse_review_path(subject: 'science')
+  end
+
+  def and_i_click_enter_your_grade
+    click_link_or_button 'Enter your grade'
+  end
+
+  def and_i_click_back
+    click_link_or_button 'Back'
   end
 
   def and_i_wish_to_apply_to_a_course_that_requires_gcse_science
@@ -60,7 +77,7 @@ RSpec.describe 'Candidate entering GCSE Science details' do
     expect(page).to have_content 'Select the GCSE you did and include your grade'
   end
 
-  def then_i_select_single_award
+  def and_i_select_single_award
     choose('Single award')
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe 'Candidate entering GCSE details' do
     and_i_click_save_and_continue
     then_i_see_add_grade_page
 
-    when_i_fill_in_the_grade
+    when_i_visit_the_review_page
+    and_i_click_enter_your_grade
+    and_i_click_back
+    and_i_click_enter_your_grade
+    and_i_fill_in_the_grade
     and_i_click_save_and_continue
     then_i_see_add_year_page
 
@@ -63,6 +67,18 @@ RSpec.describe 'Candidate entering GCSE details' do
     then_i_am_returned_to_the_application_form_details
   end
 
+  def when_i_visit_the_review_page
+    visit candidate_interface_gcse_review_path(subject: 'maths')
+  end
+
+  def and_i_click_enter_your_grade
+    click_link_or_button 'Enter your grade'
+  end
+
+  def and_i_click_back
+    click_link_or_button 'Back'
+  end
+
   def and_i_click_on_the_maths_gcse_link
     click_link_or_button 'Maths GCSE or equivalent'
   end
@@ -105,7 +121,7 @@ RSpec.describe 'Candidate entering GCSE details' do
     expect(page).to have_content t('gcse_edit_year.page_title', subject: 'english', qualification_type: 'GCSE')
   end
 
-  def when_i_fill_in_the_grade
+  def and_i_fill_in_the_grade
     fill_in 'Grade', with: 'A'
   end
 


### PR DESCRIPTION
## Context

If the user comes from the review page and has not completed the next section, instead of taking them back to the review page, we are now taking them to the next incomplete question.


## Changes proposed in this pull request

- Redirect the user to the new page if they come from the review page but haven't answered the question
- Ensure the back link takes them back to the review page

## Guidance to review

1) Add a GCSE qualification type
2) Click away
3) Click back on to the GCSE section
4) You should be on the review page
5) Click "Enter your grade"
6) Enter a grade
7) Click "Save and continue"
8) Notice you are now asked for the year (previously, this would have taken you to the review page)


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
