### PR TITLE
[653] Handle `prefer not to say` in ethnic background form

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -13,11 +13,13 @@ module CandidateInterface
       return new if background.nil?
 
       if listed_ethnic_background?(group, background)
-        new(ethnic_background: application_form.equality_and_diversity['ethnic_background'])
+        new(ethnic_background: background)
+      elsif prefer_not_to_say?(background)
+        new(ethnic_background: background, other_background: nil)
       else
         new(
           ethnic_background: OTHER_ETHNIC_BACKGROUNDS[group],
-          other_background: application_form.equality_and_diversity['ethnic_background'],
+          other_background: background,
         )
       end
     end
@@ -47,6 +49,10 @@ module CandidateInterface
 
     def self.listed_ethnic_background?(group, background)
       ETHNIC_BACKGROUNDS[group]&.include?(background) || OTHER_ETHNIC_BACKGROUNDS[group] == background
+    end
+
+    def self.prefer_not_to_say?(background)
+      background == I18n.t('equality_and_diversity.ethnic_background.opt_out.label')
     end
 
   private

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
         expect(form.other_background).to be_nil
       end
     end
+
+    context 'when ethnic background is "Prefer not to say"' do
+      it 'creates an object with ethnic background set to "Prefer not to say" and other_background as nil' do
+        application_form = build_stubbed(:application_form,
+                                         equality_and_diversity: { 'ethnic_group' => 'Black, African, Caribbean or Black British',
+                                                                   'ethnic_background' => 'Prefer not to say' })
+
+        form = described_class.build_from_application(application_form)
+
+        expect(form.ethnic_background).to eq('Prefer not to say')
+        expect(form.other_background).to be_nil
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
## Context

This fixes a bug where the prefer not to say radio is not correctly pre-selected.

## Changes proposed in this pull request

- Ensure that "Prefer not to say" is correctly stored as `ethnic_background` with `other_background` set to `nil`.

## Before/After Video

https://github.com/user-attachments/assets/4e0d9956-1ec1-4c1e-ae0b-96fd83295e26

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
