### PR TITLE
Candidate pool filters geolocation filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,7 @@ gem 'archive-zip'
 
 # Geocoding
 gem 'geocoder'
+gem 'geokit-rails'
 
 gem 'dfe-reference-data', require: 'dfe/reference_data', github: 'DFE-Digital/dfe-reference-data', tag: 'v3.6.8'
 gem 'dfe-autocomplete', require: 'dfe/autocomplete', github: 'DFE-Digital/dfe-autocomplete', tag: 'v0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,10 @@ GEM
     geocoder (1.8.5)
       base64 (>= 0.1.0)
       csv (>= 3.0.0)
+    geokit (1.14.0)
+    geokit-rails (2.5.0)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-apis-bigquery_v2 (0.83.0)
@@ -886,6 +890,7 @@ DEPENDENCIES
   factory_bot_rails
   faker (= 2.22.0)
   geocoder
+  geokit-rails
   get_into_teaching_api_client_faraday!
   google-cloud-bigquery
   govuk-components (~> 5.8.0)

--- a/app/components/provider_interface/location_filter_component.html.erb
+++ b/app/components/provider_interface/location_filter_component.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-form-group">
+  <div id="location-hint" class="govuk-hint"><%= filter[:hint] %></div>
+
+  <div class="govuk-input__wrapper govuk-!-padding-bottom-2">
+    <label class="govuk-label location-filter-label" for="within">Within</label>
+    <select class="govuk-select" name="within">
+      <%= select_options %>
+    </select>
+  </div>
+
+  <div class="govuk-input__wrapper"
+    data-controller="location-autocomplete"
+    data-location-autocomplete-path-value="<%= provider_interface_location_suggestions_path %>">
+
+    <label class="govuk-label location-filter-label" for="location">of</label>
+    <input class="govuk-input"
+    id="original-location"
+    name="original_location"
+    type="text"
+    value="<%= filter[:original_location] %>"
+    autocomplete="off"
+    data-location-autocomplete-target="input">
+  </div>
+</div>

--- a/app/components/provider_interface/location_filter_component.rb
+++ b/app/components/provider_interface/location_filter_component.rb
@@ -1,0 +1,22 @@
+class ProviderInterface::LocationFilterComponent < ViewComponent::Base
+  attr_reader :filter
+
+  def initialize(filter:)
+    @filter = filter
+  end
+
+  def select_options
+    options = []
+    selected_value = filter[:within].to_i.positive? ? filter[:within].to_i : 10
+
+    filter[:radius_values].map do |radius|
+      options << content_tag(
+        :option,
+        pluralize(radius, 'mile'),
+        value: radius,
+        selected: radius == selected_value,
+      )
+    end
+    options.join.html_safe
+  end
+end

--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -48,7 +48,10 @@
                   <legend id="filter-legend-<%= filter[:name] %>" class="govuk-fieldset__legend govuk-fieldset__legend--s">
                     <%= filter[:heading] %>
                   </legend>
-                  <% if filter[:type] == :search %>
+
+                  <% if filter[:type] == :location_search %>
+                    <%= render ProviderInterface::LocationFilterComponent.new(filter:) %>
+                  <% elsif filter[:type] == :search %>
                     <input class="govuk-input <%= filter[:css_classes] %>" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" autocomplete="off">
                   <% elsif filter[:type] == :checkboxes %>
                     <input value="" name="<%= filter[:name] %>[]" type="hidden">

--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -3,31 +3,37 @@ module ProviderInterface
     class CandidatesController < ProviderInterfaceController
       include Pagy::Backend
       before_action :redirect_to_applications_unless_provider_opted_in
-      before_action :set_candidate, only: :show
 
       def index
-        @pagy, @candidates = pagy(
-          Pool::Candidates.for_provider(providers: current_provider_user.providers)
-            .order('application_forms.submitted_at'),
+        @filter = ProviderInterface::CandidatePoolFilter.new(
+          filter_params:,
+        )
+
+        @pagy, @application_forms = pagy(
+          Pool::Candidates.application_forms_for_provider(
+            providers: current_provider_user.providers,
+            filters: @filter.applied_filters,
+          ),
         )
       end
 
       def show
-        @application_form = @candidate.application_forms.current_cycle.last
+        @application_form = Pool::Candidates.application_forms_for_provider(
+          providers: current_provider_user.providers,
+        ).find_by(candidate_id: params.expect(:id))
+        @candidate = @application_form.candidate
       end
 
     private
-
-      def set_candidate
-        @candidate ||= Pool::Candidates.for_provider(
-          providers: current_provider_user.providers,
-        ).find_by(id: params.expect(:id))
-      end
 
       def redirect_to_applications_unless_provider_opted_in
         invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
 
         redirect_to provider_interface_applications_path if invites.blank?
+      end
+
+      def filter_params
+        params.permit(:within, :original_location, visa_sponsorship: [])
       end
     end
   end

--- a/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
@@ -53,9 +53,9 @@ module ProviderInterface
     private
 
       def set_candidate
-        @candidate ||= Pool::Candidates.for_provider(
+        @candidate ||= Pool::Candidates.application_forms_for_provider(
           providers: current_provider_user.providers,
-        ).find_by(id: params.expect(:candidate_id))
+        ).find_by(candidate_id: params.expect(:candidate_id)).candidate
       end
 
       def pool_invite_form_params

--- a/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
@@ -26,9 +26,9 @@ module ProviderInterface
     private
 
       def set_candidate
-        @candidate ||= Pool::Candidates.for_provider(
+        @candidate ||= Pool::Candidates.application_forms_for_provider(
           providers: current_provider_user.providers,
-        ).find_by(id: params.expect(:candidate_id))
+        ).find_by(candidate_id: params.expect(:candidate_id)).candidate
       end
 
       def invite

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -152,3 +152,9 @@
     vertical-align: bottom;
   }
 }
+
+.location-filter-label {
+  align-content: center;
+
+  width: 25%;
+}

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,30 +1,30 @@
 class Pool::Candidates
-  attr_reader :providers
+  attr_reader :providers, :filters
 
-  def initialize(providers:)
+  def initialize(providers:, filters: {})
     @providers = providers
+    @filters = filters
   end
 
-  def self.for_provider(providers:)
-    new(providers:).for_provider
+  def self.application_forms_for_provider(providers:, filters: {})
+    new(providers:, filters:).application_forms_for_provider
   end
 
-  def for_provider
+  def application_forms_for_provider
     dismissed_candidates = Candidate.joins(:pool_dismissals).where(pool_dismissals: { provider: providers })
 
-    Candidate
-      .where(id: rejected_candidates_this_cycle)
-      .pool_status_opt_in
-      .excluding(dismissed_candidates)
-      .joins(:application_forms)
-        .where(application_forms: { recruitment_cycle_year: RecruitmentCycleTimetable.current_year })
-      .select('candidates.*', 'application_forms.submitted_at')
+    filtered_application_forms.joins(:candidate)
+      .where(candidate: { pool_status: :opt_in })
+      .where.not(candidate_id: dismissed_candidates.ids)
+      .order(order_by)
   end
 
 private
 
-  def rejected_candidates_this_cycle
-    curated_application_forms.select(:candidate_id)
+  def filtered_application_forms
+    scope = curated_application_forms
+    scope = filter_by_right_to_work_or_study(scope)
+    filter_by_distance(scope)
   end
 
   def curated_application_forms
@@ -39,5 +39,51 @@ private
           },
         ).select(:id),
       )
+  end
+
+  def filter_by_distance(scope)
+    return scope unless active_location_filter?
+
+    origin = filters.fetch(:origin)
+
+    calculate_distance_sql = Site.distance_sql(
+      Struct.new(:latitude, :longitude).new(
+        latitude: filters.fetch(:origin).first,
+        longitude: filters.fetch(:origin).last,
+      ),
+    )
+
+    site_ids = Site.within(
+      filters.fetch(:within),
+      units: :miles,
+      origin:,
+    ).map(&:id)
+
+    scope.joins(application_choices: { course_option: :site })
+      .where('application_choices.created_at = ( select max(created_at) from application_choices where application_choices.application_form_id = application_forms.id)')
+      .where(sites: { id: site_ids })
+      .select('application_forms.*', "#{calculate_distance_sql} AS site_distance")
+  end
+
+  def filter_by_right_to_work_or_study(scope)
+    return scope if filters[:visa_sponsorship].blank?
+
+    filter_values = filters[:visa_sponsorship].flat_map do |value|
+      value == 'required' ? 'no' : nil # required means no right_to_work_or_study, nil means yes
+    end
+
+    scope.where(right_to_work_or_study: filter_values)
+  end
+
+  def active_location_filter?
+    filters[:within].present? && filters[:origin].present?
+  end
+
+  def order_by
+    if active_location_filter?
+      'site_distance ASC'
+    else
+      'application_forms.submitted_at'
+    end
   end
 end

--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -1,0 +1,68 @@
+module ProviderInterface
+  class CandidatePoolFilter
+    include FilterParamsHelper
+
+    RADIUS_VALUES = [1, 5, 10, 15, 20, 25, 50, 100, 200].freeze
+
+    attr_reader :filter_params
+
+    def initialize(filter_params:)
+      @filter_params = compact_params(filter_params)
+    end
+
+    def filters
+      [
+        {
+          type: :location_search,
+          heading: 'Search radius',
+          name: 'location_search',
+          hint: "Candidate's last course location",
+          radius_values: RADIUS_VALUES,
+          within: filter_params[:within],
+          original_location: filter_params[:original_location],
+        },
+        {
+          type: :checkboxes,
+          heading: 'Visa sponsorship',
+          name: 'visa_sponsorship',
+          options: visa_sponsorship_options,
+        },
+      ]
+    end
+
+    def applied_filters
+      if applied_location_search?
+        geocoder_location = Geocoder.search(filter_params[:original_location], components: 'country:UK').first
+
+        return filter_params unless geocoder_location
+
+        filter_params.merge!(
+          {
+            origin: [
+              geocoder_location.latitude,
+              geocoder_location.longitude,
+            ],
+          },
+        )
+      end
+
+      filter_params
+    end
+
+    def applied_location_search?
+      filter_params[:within].present? && filter_params[:original_location].present?
+    end
+
+  private
+
+    def visa_sponsorship_options
+      ['required', 'not required'].map do |value|
+        {
+          value: value,
+          label: value.capitalize,
+          checked: applied_filters[:visa_sponsorship]&.include?(value),
+        }
+      end
+    end
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,6 +3,8 @@ class Site < ApplicationRecord
   has_many :course_options
   has_many :courses, through: :course_options
 
+  acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
+
   validates :code, presence: true
   validates :name, presence: true
   validates :uuid, presence: true

--- a/app/services/location_suggestions.rb
+++ b/app/services/location_suggestions.rb
@@ -1,9 +1,8 @@
 class LocationSuggestions
-  attr_reader :query, :cache, :cache_expiration
+  attr_reader :query, :cache_expiration
 
   def initialize(query, cache_expiration: 7.days)
     @query = query
-    @cache = cache
     @cache_expiration = cache_expiration
   end
 
@@ -23,13 +22,7 @@ class LocationSuggestions
     suggestions = fetch_suggestions
     return [] if suggestions.blank?
 
-    cache_suggestions(suggestions)
-
     suggestions
-  end
-
-  def cache_suggestions(response)
-    cache.write(cache_key, response, expires_in: cache_expiration)
   end
 
   def fetch_suggestions

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -1,42 +1,41 @@
 <% content_for :browser_title, t('.title') %>
+<%= render ServiceInformationBanner.new(namespace: :provider) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render ServiceInformationBanner.new(namespace: :provider) %>
+<h1 class="govuk-heading-l"><%= t('.title') %></h1>
+<p class="govuk-body"><%= t('.candidate_information_agreement') %></p>
+<p class="govuk-body"><%= t('.review_candidates') %></p>
 
-    <% if @candidates.present? %>
-      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-
-      <p class="govuk-body"><%= t('.candidate_information_agreement') %></p>
-      <p class="govuk-body"><%= t('.review_candidates') %></p>
-    <% else %>
-      <h1 class="govuk-heading-l"><%= t('.no_candidates') %></h1>
-    <% end %>
-  </div>
-
-  <div class="govuk-grid-column-full">
-    <% if @candidates.present? %>
-      <%= govuk_table do |table| %>
-        <%= table.with_head do |head| %>
-          <%= head.with_row do |row| %>
-            <%= row.with_cell(text: t('.name')) %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>
+  <% if @application_forms.present? %>
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t('.name')) %>
+          <% if @filter.applied_location_search? %>
+            <%= row.with_cell(text: t('.distance_from', origin: @filter.applied_filters[:original_location])) %>
           <% end %>
         <% end %>
+      <% end %>
 
-        <%= table.with_body do |body| %>
-          <% @candidates.each do |candidate| %>
-            <%= body.with_row do |row| %>
-              <%= row.with_cell do %>
-                <%= govuk_link_to candidate.redacted_full_name_current_cycle, provider_interface_candidate_pool_candidate_path(candidate) %>
+      <%= table.with_body do |body| %>
+        <% @application_forms.each do |application_form| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell do %>
+              <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
+            <% end %>
+
+            <%= row.with_cell do %>
+              <% if @filter.applied_location_search? %>
+                <%= pluralize(application_form.site_distance.round(2), t('.miles')) %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
-
-      <div class="govuk-grid-row govuk-!-margin-top-4">
-        <%= govuk_pagination(pagy: @pagy) %>
-      </div>
     <% end %>
-  </div>
-</div>
+
+    <%= govuk_pagination(pagy: @pagy) %>
+  <% else %>
+    <p class="govuk-body"><%= t('.no_candidates') %></p>
+  <% end %>
+<% end %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -10,4 +10,8 @@ Geocoder.configure(
   always_raise: [Geocoder::InvalidApiKey, Geocoder::OverQueryLimitError],
 
   units: :mi, # :km for kilometers or :mi for miles
+  cache: Rails.cache,
+  cache_options: {
+    expiration: 1.day,
+  },
 )

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,5 @@
+Geokit.default_units = :miles # others :kms, :nms, :meters
+Geokit.default_formula = :sphere
+Geokit::Geocoders.request_timeout = 3
+Geokit::Geocoders::GoogleGeocoder.api_key = ENV['GOOGLE_MAPS_API_KEY']
+Geokit::Geocoders.provider_order = [:google]

--- a/config/locales/components/shared.yml
+++ b/config/locales/components/shared.yml
@@ -1,4 +1,6 @@
 en:
+  filter_component:
+    location_filter_title: Within %{miles} of %{original_location}
   personal_statement:
     title: Personal statement
     vocation: Why do you want to be a teacher?

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -8,6 +8,8 @@ en:
           candidate_information_agreement: These candidates have agreed to share their application details.
           review_candidates: You can review their applications and decide whether to invite them to apply.
           name: Name
+          miles: miles
+          distance_from: Distance from %{origin}
         show:
           title: Candidate details
           invite: Invite to apply

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -1,91 +1,158 @@
 require 'rails_helper'
 
 RSpec.describe Pool::Candidates do
-  describe '.for_provider' do
-    it 'returns candidates that should be on candidate pool list' do
-      providers = [create(:provider)]
+  describe '.application_forms_for_provider' do
+    context 'tests base query without filters' do
+      it 'returns application_forms that should be on candidate pool list' do
+        providers = [create(:provider)]
 
-      rejected_candidate = create(:candidate, pool_status: 'opt_in')
-      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
-      create(:application_choice, :rejected, application_form: rejected_candidate_form)
+        rejected_candidate = create(:candidate, pool_status: 'opt_in')
+        rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
+        create(:application_choice, :rejected, application_form: rejected_candidate_form)
 
-      declined_candidate = create(:candidate, pool_status: 'opt_in')
-      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
-      create(:application_choice, :declined, application_form: declined_candidate_form)
+        declined_candidate = create(:candidate, pool_status: 'opt_in')
+        declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+        create(:application_choice, :declined, application_form: declined_candidate_form)
 
-      withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
-      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
-      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+        withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+        create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
-      conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
-      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
-      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+        conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+        conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+        create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
 
-      offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
-      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
-      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+        offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+        create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
 
-      inactive_candidate = create(:candidate, pool_status: 'opt_in')
-      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
-      create(:application_choice, :inactive, application_form: inactive_candidate_form)
+        inactive_candidate = create(:candidate, pool_status: 'opt_in')
+        inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+        create(:application_choice, :inactive, application_form: inactive_candidate_form)
 
-      candidates = described_class.for_provider(providers:)
+        application_forms = described_class.application_forms_for_provider(providers:, filters: {})
 
-      expect(candidates).to contain_exactly(
-        rejected_candidate,
-        declined_candidate,
-        withdrawn_candidate,
-        conditions_not_met_candidate,
-        offer_withdrawn_candidate,
-        inactive_candidate,
-      )
+        expect(application_forms).to contain_exactly(
+          rejected_candidate_form,
+          declined_candidate_form,
+          withdrawn_candidate_form,
+          conditions_not_met_candidate_form,
+          offer_withdrawn_candidate_form,
+          inactive_candidate_form,
+        )
+      end
+
+      it 'does not returns application_forms that should not be on the candidate pool list' do
+        provider = create(:provider)
+        providers = [provider]
+
+        opt_out_candidate = create(:candidate, pool_status: 'opt_out')
+        opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
+        create(:application_choice, :rejected, application_form: opt_out_candidate_form)
+
+        dismissed_candidate = create(:candidate, pool_status: 'opt_in')
+        dismissed_candidate_form = create(:application_form, :completed, candidate: dismissed_candidate)
+        create(:application_choice, :rejected, application_form: dismissed_candidate_form)
+        create(:pool_dismissal, provider:, candidate: dismissed_candidate)
+
+        rejected_candidate = create(:candidate, pool_status: 'opt_in')
+        rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
+        create(:application_choice, :rejected, application_form: rejected_candidate_form)
+        create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
+
+        declined_candidate = create(:candidate, pool_status: 'opt_in')
+        declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+        create(:application_choice, :declined, application_form: declined_candidate_form)
+        create(:application_choice, :interviewing, application_form: declined_candidate_form)
+
+        withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+        create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+        create(:application_choice, :offer, application_form: withdrawn_candidate_form)
+
+        conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+        conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+        create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+        create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
+
+        offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+        create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+        create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
+
+        inactive_candidate = create(:candidate, pool_status: 'opt_in')
+        inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+        create(:application_choice, :inactive, application_form: inactive_candidate_form)
+        create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
+        application_forms = described_class.application_forms_for_provider(providers:, filters: {})
+
+        expect(application_forms).to be_empty
+      end
     end
 
-    it 'does not returns candidates that should not be on the candidate pool list' do
-      provider = create(:provider)
-      providers = [provider]
+    context 'with filters' do
+      it 'returns application_forms based on filters' do
+        providers = [create(:provider)]
 
-      opt_out_candidate = create(:candidate, pool_status: 'opt_out')
-      opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
-      create(:application_choice, :rejected, application_form: opt_out_candidate_form)
+        manchester_candidate = create(:candidate, pool_status: 'opt_in')
+        manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
+        aa_teamworks = create(
+          :site,
+          latitude: 51.4524877,
+          longitude: -0.1204749,
+          provider: providers.first,
+        )
+        course_option = create(
+          :course_option,
+          site: aa_teamworks,
+          course: create(:course, provider: providers.first),
+        )
+        create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
 
-      dismissed_candidate = create(:candidate, pool_status: 'opt_in')
-      dismissed_candidate_form = create(:application_form, :completed, candidate: dismissed_candidate)
-      create(:application_choice, :rejected, application_form: dismissed_candidate_form)
-      create(:pool_dismissal, provider:, candidate: dismissed_candidate)
+        visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
+        visa_sponsorship_candidate_form = create(
+          :application_form,
+          :completed,
+          candidate: visa_sponsorship_candidate,
+          right_to_work_or_study: :no,
+        )
+        aa_teamworks = create(
+          :site,
+          latitude: 51.4524893,
+          longitude: -0.1204768,
+          provider: providers.first,
+        )
+        course_option = create(
+          :course_option,
+          site: aa_teamworks,
+          course: create(:course, provider: providers.first),
+        )
+        create(:application_choice, :declined, application_form: visa_sponsorship_candidate_form, course_option:)
 
-      rejected_candidate = create(:candidate, pool_status: 'opt_in')
-      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
-      create(:application_choice, :rejected, application_form: rejected_candidate_form)
-      create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
+        withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+        create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
-      declined_candidate = create(:candidate, pool_status: 'opt_in')
-      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
-      create(:application_choice, :declined, application_form: declined_candidate_form)
-      create(:application_choice, :interviewing, application_form: declined_candidate_form)
+        filters = { origin: [51.4524877, -0.1204749], within: 10 }
+        application_forms = described_class.application_forms_for_provider(providers:, filters:)
 
-      withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
-      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
-      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
-      create(:application_choice, :offer, application_form: withdrawn_candidate_form)
+        expect(application_forms).to contain_exactly(
+          manchester_candidate_form,
+          visa_sponsorship_candidate_form,
+        )
 
-      conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
-      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
-      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
-      create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
+        filters = {
+          origin: [51.4524877, -0.1204749],
+          within: 10,
+          visa_sponsorship: ['required'],
+        }
 
-      offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
-      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
-      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
-      create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
+        application_forms = described_class.application_forms_for_provider(providers:, filters:)
 
-      inactive_candidate = create(:candidate, pool_status: 'opt_in')
-      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
-      create(:application_choice, :inactive, application_form: inactive_candidate_form)
-      create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
-      candidates = described_class.for_provider(providers:)
-
-      expect(candidates).to be_empty
+        expect(application_forms).to contain_exactly(
+          visa_sponsorship_candidate_form,
+        )
+      end
     end
   end
 end

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CandidatePoolFilter do
+  describe '#filters' do
+    it 'returns the filters' do
+      filter = described_class.new(filter_params: {})
+
+      expect(filter.filters).to eq([
+        {
+          type: :location_search,
+          heading: 'Search radius',
+          name: 'location_search',
+          hint: "Candidate's last course location",
+          radius_values: [1, 5, 10, 15, 20, 25, 50, 100, 200],
+          within: nil,
+          original_location: nil,
+        },
+        {
+          type: :checkboxes,
+          heading: 'Visa sponsorship',
+          name: 'visa_sponsorship',
+          options: [
+            {
+              value: 'required',
+              label: 'Required',
+              checked: nil,
+            },
+            {
+              value: 'not required',
+              label: 'Not required',
+              checked: nil,
+            },
+          ],
+        },
+      ])
+    end
+  end
+
+  describe '#applied_filters' do
+    it 'returns the applied filters' do
+      filter_params = {
+        within: 10,
+        original_location: 'Manchester',
+        visa_sponsorship: ['required'],
+      }
+      filter = described_class.new(filter_params:)
+
+      expect(filter.applied_filters).to eq(
+        {
+          within: 10,
+          original_location: 'Manchester',
+          visa_sponsorship: ['required'],
+          origin: [51.4524877, -0.1204749],
+        },
+      )
+    end
+  end
+
+  describe '#applied_location_search?' do
+    it 'returns true if location search is applied' do
+      filter_params = {
+        within: 10,
+        original_location: 'Manchester',
+      }
+      filter = described_class.new(filter_params:)
+
+      expect(filter.applied_location_search?).to be_truthy
+    end
+
+    it 'returns false if location search is applied' do
+      filter = described_class.new(filter_params: {})
+
+      expect(filter.applied_location_search?).to be_falsey
+    end
+  end
+end

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -6,22 +6,34 @@ RSpec.describe 'Providers views candidate pool list' do
 
   let(:current_provider) { create(:provider) }
 
+  before do
+    set_rejected_candidate_form
+    set_declined_candidate_form
+    set_visa_sponsorship_candidate_form
+  end
+
   scenario 'View candidates' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_there_are_candidates_for_candidate_pool
     and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
 
     then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+
+    when_i_filter_by_location
+    then_i_expect_to_see_filtered_candidates([@rejected_candidate_form, @visa_sponsorship_form])
+    when_i_filter_by_visa_sponsorship
+    then_i_expect_to_see_filtered_candidates([@visa_sponsorship_form])
+
+    when_i_click('Clear filters')
+    then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
   end
 
   scenario 'Provider cannot view candidates if not invited' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_there_are_candidates_for_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
@@ -38,16 +50,7 @@ RSpec.describe 'Providers views candidate pool list' do
     provider_user_exists_in_apply_database(provider_code: current_provider.code)
   end
 
-  def and_there_are_candidates_for_candidate_pool
-    rejected_candidate = create(:candidate, pool_status: 'opt_in')
-    @rejected_candidate_form = create(
-      :application_form,
-      :completed,
-      candidate: rejected_candidate,
-      submitted_at: 1.day.ago,
-    )
-    create(:application_choice, :rejected, application_form: @rejected_candidate_form)
-
+  def set_declined_candidate_form
     declined_candidate = create(:candidate, pool_status: 'opt_in')
     @declined_candidate_form = create(
       :application_form,
@@ -69,6 +72,61 @@ RSpec.describe 'Providers views candidate pool list' do
     create(:application_choice, :declined, application_form: previous_cycle_form)
   end
 
+  def set_rejected_candidate_form
+    rejected_candidate = create(:candidate, pool_status: 'opt_in')
+    @rejected_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: rejected_candidate,
+      submitted_at: 1.day.ago,
+    )
+    aa_teamworks = create(
+      :site,
+      latitude: 51.4524877,
+      longitude: -0.1204749,
+      provider: current_provider,
+    )
+    course_option = create(
+      :course_option,
+      site: aa_teamworks,
+      course: create(:course, provider: current_provider),
+    )
+    create(
+      :application_choice,
+      :rejected,
+      application_form: @rejected_candidate_form,
+      course_option:,
+    )
+  end
+
+  def set_visa_sponsorship_candidate_form
+    visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
+    @visa_sponsorship_form = create(
+      :application_form,
+      :completed,
+      candidate: visa_sponsorship_candidate,
+      submitted_at: 6.hours.ago,
+      right_to_work_or_study: :no,
+    )
+    aa_teamworks = create(
+      :site,
+      latitude: 51.4524880,
+      longitude: -0.1204752,
+      provider: current_provider,
+    )
+    course_option = create(
+      :course_option,
+      site: aa_teamworks,
+      course: create(:course, provider: current_provider),
+    )
+    create(
+      :application_choice,
+      :rejected,
+      application_form: @visa_sponsorship_form,
+      course_option:,
+    )
+  end
+
   def and_provider_is_opted_in_to_candidate_pool
     create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
@@ -83,6 +141,7 @@ RSpec.describe 'Providers views candidate pool list' do
     expect(candidates).to eq([
       @rejected_candidate_form.redacted_full_name,
       @declined_candidate_form.redacted_full_name,
+      @visa_sponsorship_form.redacted_full_name,
     ])
   end
 
@@ -94,5 +153,25 @@ RSpec.describe 'Providers views candidate pool list' do
     within('#service-navigation') do
       expect(page).to have_no_css('li', text: 'Find candidates')
     end
+  end
+
+  def when_i_filter_by_location
+    fill_in('original_location', with: 'Manchester')
+    click_link_or_button('Apply filters')
+  end
+
+  def when_i_filter_by_visa_sponsorship
+    check('visa_sponsorship-required')
+    click_link_or_button('Apply filters')
+  end
+
+  def then_i_expect_to_see_filtered_candidates(application_forms)
+    candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
+
+    expect(candidates).to eq(application_forms.map(&:redacted_full_name))
+  end
+
+  def when_i_click(button)
+    click_link_or_button button
   end
 end


### PR DESCRIPTION
## Context
This PR adds 2 filters to the candidate pool index page.

Location based filter and ordering and visa sponsorship.

I've used the geokit rails gem to calculate the distance from the
filtered location to the actual site location.

The location filter also makes calls to Google maps autocomplete api to
help the user find postcodes cities, etc. Sadly this endpoint doesn't
return lat and long of each location.

So another api call will be done when you apply the filters to the
google maps places details endpoint to get the lat and long which are
used to get all the sites within a range of a location.

Once you select a location filter, we order the results based on the
proximity of the sites to that location.

These api calls are cached.

I've also changed the Pool::Candidate to return application forms. This
way is easier to query and read the queries, I think. Also all the
information for the index page is on the application form.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Log in on the review app as a provider, with dev-provider
Go to find candidates and play around with the filters


https://github.com/user-attachments/assets/d9f4c091-f0cd-46c2-b104-2be07e0d6b97



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
