### PR TITLE
Renamed Adviser::TeachingSubjects to make way for a new AR model

### DIFF
--- a/app/models/adviser/sign_up.rb
+++ b/app/models/adviser/sign_up.rb
@@ -16,7 +16,7 @@ class Adviser::SignUp
   def initialize(application_form, *, **)
     @application_form = application_form
     @availability = Adviser::SignUpAvailability.new(application_form)
-    @teaching_subjects = Adviser::TeachingSubjects.new
+    @teaching_subjects = Adviser::TeachingSubjectsService.new
 
     super(*, **)
   end

--- a/app/services/adviser/teaching_subjects_service.rb
+++ b/app/services/adviser/teaching_subjects_service.rb
@@ -1,4 +1,4 @@
-class Adviser::TeachingSubjects
+class Adviser::TeachingSubjectsService
   def all
     @all ||= secondary + [primary]
   end

--- a/spec/models/adviser/sign_up_spec.rb
+++ b/spec/models/adviser/sign_up_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Adviser::SignUp do
   end
 
   describe 'validations' do
-    let(:valid_subjects) { Adviser::TeachingSubjects.new.all.map(&:id) }
+    let(:valid_subjects) { Adviser::TeachingSubjectsService.new.all.map(&:id) }
 
     it { is_expected.to validate_inclusion_of(:preferred_teaching_subject_id).in_array(valid_subjects) }
   end

--- a/spec/services/adviser/teaching_subjects_service_spec.rb
+++ b/spec/services/adviser/teaching_subjects_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Adviser::TeachingSubjects do
+RSpec.describe Adviser::TeachingSubjectsService do
   include_context 'get into teaching api stubbed endpoints'
 
   subject(:teaching_subjects) { described_class.new }


### PR DESCRIPTION
## Context

We want to introduce an Active Record model to replace this service

## Changes proposed in this pull request

- Renamed `Adviser::TeachingSubjects` to `Adviser::TeachingSubjectsService`

## Guidance to review
- No changes to behaviour

https://trello.com/c/qPnIleab