### PR TITLE
[609] Reimplement cycle switcher

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include RecruitmentCycleTimetables
   include RequestQueryParams
   include DfE::Analytics::Requests
   include ApplicationHelper

--- a/app/controllers/concerns/recruitment_cycle_timetables.rb
+++ b/app/controllers/concerns/recruitment_cycle_timetables.rb
@@ -1,0 +1,14 @@
+module RecruitmentCycleTimetables
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.cycle_timetable = RecruitmentCycleTimetable.current_timetable
+      Current.next_cycle_timetable = Current.cycle_timetable.relative_next_timetable
+      Current.cycle_week = RecruitmentCycleTimetable.current_cycle_week
+      Current.cycle_year = Current.cycle_timetable.recruitment_cycle_year
+      Current.previous_cycle_year = Current.cycle_year - 1
+      Current.next_cycle_year = Current.cycle_year + 1
+    end
+  end
+end

--- a/app/controllers/support_interface/recruitment_cycle_timetables_controller.rb
+++ b/app/controllers/support_interface/recruitment_cycle_timetables_controller.rb
@@ -1,0 +1,57 @@
+module SupportInterface
+  class RecruitmentCycleTimetablesController < SupportInterfaceController
+    def index
+      @timetable_presenter = SupportInterface::RecruitmentCycleTimetablePresenter.new(Current.cycle_timetable)
+    end
+
+    def edit
+      @cycle_switcher_form = SupportInterface::CycleSwitcherForm.build_from_timetable(timetable)
+    end
+
+    def update
+      @cycle_switcher_form = SupportInterface::CycleSwitcherForm.build_from_form(
+        recruitment_cycle_timetable_form_params, timetable:
+      )
+
+      if @cycle_switcher_form.persist
+        flash[:success] = I18n.t(
+          'support_interface.recruitment_cycle_timetables.update.success_message',
+        )
+
+        redirect_to support_interface_recruitment_cycle_timetables_path
+      else
+        render :edit
+      end
+    end
+
+    def reset
+      # Reseeding is temporary. Will sync using the json endpoint in future PR, trello card: https://trello.com/c/MMmEL3HE
+      DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase.new.change
+      flash[:success] = I18n.t('support_interface.recruitment_cycle_timetables.reset.success_message')
+      redirect_to support_interface_recruitment_cycle_timetables_path
+    end
+
+  private
+
+    def recruitment_cycle_year_params
+      params.expect(:recruitment_cycle_year)
+    end
+
+    def timetable
+      RecruitmentCycleTimetable.find_by!(recruitment_cycle_year: recruitment_cycle_year_params)
+    end
+
+    def recruitment_cycle_timetable_form_params
+      params.expect(
+        support_interface_cycle_switcher_form: %i[
+          find_opens_at
+          apply_opens_at
+          apply_deadline_at
+          reject_by_default_at
+          decline_by_default_at
+          find_closes_at
+        ],
+      )
+    end
+  end
+end

--- a/app/forms/support_interface/cycle_switcher_form.rb
+++ b/app/forms/support_interface/cycle_switcher_form.rb
@@ -1,0 +1,90 @@
+module SupportInterface
+  class CycleSwitcherForm
+    include ActiveModel::Model
+
+    attr_reader :timetable
+    attr_accessor :find_opens_at,
+                  :apply_opens_at,
+                  :apply_deadline_at,
+                  :reject_by_default_at,
+                  :decline_by_default_at,
+                  :find_closes_at
+
+    validates :find_opens_at,
+              :apply_opens_at,
+              :apply_deadline_at,
+              :reject_by_default_at,
+              :decline_by_default_at,
+              :find_closes_at,
+              presence: true
+
+    validates_with RecruitmentCycleTimetableDateSequenceValidator
+
+    delegate :recruitment_cycle_year, to: :timetable
+    delegate :cycle_state, to: :presenter
+
+    def self.build_from_timetable(timetable)
+      attrs =
+        {
+          find_opens_at: timetable.find_opens_at.to_date,
+          apply_opens_at: timetable.apply_opens_at.to_date,
+          apply_deadline_at: timetable.apply_deadline_at.to_date,
+          reject_by_default_at: timetable.reject_by_default_at.to_date,
+          decline_by_default_at: timetable.decline_by_default_at.to_date,
+          find_closes_at: timetable.find_closes_at.to_date,
+        }
+
+      new(attrs, timetable:)
+    end
+
+    def self.build_from_form(attrs, timetable:)
+      form_attributes = {}
+      %i[find_opens_at
+         apply_opens_at
+         apply_deadline_at
+         reject_by_default_at
+         decline_by_default_at
+         find_closes_at].each do |date_time_attribute|
+        year = attrs["#{date_time_attribute}(1i)"]
+        month = attrs["#{date_time_attribute}(2i)"]
+        day = attrs["#{date_time_attribute}(3i)"]
+
+        form_attributes[date_time_attribute] = Time.zone.local(
+          year,
+          month,
+          day,
+          timetable.send(date_time_attribute).hour,
+          timetable.send(date_time_attribute).min,
+        )
+      rescue ArgumentError, RangeError
+        form_attributes[date_time_attribute] = Struct.new(:year, :month, :day).new(year, month, day)
+      end
+
+      new(form_attributes, timetable:)
+    end
+
+    def initialize(attributes = {}, timetable: RecruitmentCycleTimetable.current_timetable)
+      @timetable = timetable
+      super(attributes)
+    end
+
+    def persist
+      if valid?
+        timetable.update(
+          find_opens_at:,
+          apply_opens_at:,
+          apply_deadline_at:,
+          reject_by_default_at:,
+          decline_by_default_at:,
+          find_closes_at:,
+        )
+      end
+    end
+
+  private
+
+    def presenter
+      @presenter ||= SupportInterface::RecruitmentCycleTimetablePresenter.new(timetable)
+    end
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :session
+  attribute :session, :cycle_timetable, :next_cycle_timetable, :cycle_year, :previous_cycle_year, :next_cycle_year, :cycle_week
   delegate :candidate, to: :session, allow_nil: true
 end

--- a/app/models/recruitment_cycle_timetable.rb
+++ b/app/models/recruitment_cycle_timetable.rb
@@ -8,7 +8,7 @@ class RecruitmentCycleTimetable < ApplicationRecord
             :find_closes_at,
             presence: true
   validates :recruitment_cycle_year, uniqueness: { allow_nil: false }
-  validate :sequential_dates
+  validates_with RecruitmentCycleTimetableDateSequenceValidator
   validate :christmas_holiday_validation
   validate :easter_holiday_validation
 
@@ -45,6 +45,10 @@ class RecruitmentCycleTimetable < ApplicationRecord
     (weeks % 53).succ
   end
 
+  def self.last_timetable
+    order(:recruitment_cycle_year).last
+  end
+
   def cycle_range_name
     "#{recruitment_cycle_year - 1} to #{recruitment_cycle_year}"
   end
@@ -69,6 +73,18 @@ class RecruitmentCycleTimetable < ApplicationRecord
     start_of_week.all_week
   end
 
+  def after_find_closes?
+    Time.zone.now.after? find_closes_at
+  end
+
+  def after_decline_by_default?
+    Time.zone.now.after? decline_by_default_at
+  end
+
+  def after_reject_by_default?
+    Time.zone.now.after? reject_by_default_at
+  end
+
   def after_apply_deadline?
     Time.zone.now.after? apply_deadline_at
   end
@@ -79,6 +95,18 @@ class RecruitmentCycleTimetable < ApplicationRecord
 
   def before_apply_opens?
     Time.zone.now.before? apply_opens_at
+  end
+
+  def after_find_opens?
+    Time.zone.now.after? find_opens_at
+  end
+
+  def approaching_apply_deadline?
+    Time.zone.now.after? show_banners_at
+  end
+
+  def show_banners_at
+    12.weeks.before apply_deadline_at
   end
 
 private
@@ -120,28 +148,5 @@ private
 
   def cycle_range
     find_opens_at..find_closes_at
-  end
-
-  def sequential_dates
-    return if [
-      find_opens_at,
-      apply_opens_at,
-      apply_deadline_at,
-      reject_by_default_at,
-      decline_by_default_at,
-      find_closes_at,
-    ].any?(&:blank?)
-
-    if find_opens_at.after? apply_opens_at
-      errors.add(:apply_opens_at, :apply_opens_after_find_opens)
-    elsif apply_opens_at.after? apply_deadline_at
-      errors.add(:apply_deadline_at, :apply_deadline_after_apply_opens)
-    elsif apply_deadline_at.after? reject_by_default_at
-      errors.add(:reject_by_default_at, :reject_by_default_after_apply_deadline)
-    elsif reject_by_default_at.after? decline_by_default_at
-      errors.add(:decline_by_default_at, :decline_by_default_after_reject_by_default)
-    elsif decline_by_default_at.after? find_closes_at
-      errors.add(:find_closes_at, :find_closes_after_decline_by_default)
-    end
   end
 end

--- a/app/presenters/support_interface/recruitment_cycle_timetable_presenter.rb
+++ b/app/presenters/support_interface/recruitment_cycle_timetable_presenter.rb
@@ -1,0 +1,31 @@
+module SupportInterface
+  class RecruitmentCycleTimetablePresenter
+    delegate_missing_to :timetable
+    attr_reader :timetable, :next_timetable
+
+    def initialize(timetable)
+      @timetable = timetable
+      @next_timetable = timetable.relative_next_timetable
+    end
+
+    def cycle_state
+      if next_timetable.present? && next_timetable.after_find_opens?
+        :find_has_reopened
+      elsif timetable.after_find_closes?
+        :after_find_has_closed
+      elsif timetable.after_decline_by_default?
+        :after_decline_by_default
+      elsif timetable.after_reject_by_default?
+        :after_reject_by_default
+      elsif timetable.after_apply_deadline?
+        :after_apply_deadline
+      elsif timetable.approaching_apply_deadline?
+        :apply_deadline_approaching
+      elsif timetable.after_apply_opens?
+        :apply_has_opened
+      elsif timetable.after_find_opens?
+        :find_has_opened
+      end
+    end
+  end
+end

--- a/app/validators/recruitment_cycle_timetable_date_sequence_validator.rb
+++ b/app/validators/recruitment_cycle_timetable_date_sequence_validator.rb
@@ -1,0 +1,56 @@
+class RecruitmentCycleTimetableDateSequenceValidator < ActiveModel::Validator
+  delegate :find_opens_at,
+           :apply_opens_at,
+           :apply_deadline_at,
+           :reject_by_default_at,
+           :decline_by_default_at,
+           :find_closes_at,
+           :errors,
+           to: :record
+  attr_reader :record
+  def validate(record)
+    @record = record
+
+    return if blank_attributes?
+
+    check_for_invalid_dates
+
+    return if errors.any?
+
+    if find_opens_at.after? apply_opens_at
+      errors.add(:apply_opens_at, :apply_opens_after_find_opens)
+    elsif apply_opens_at.after? apply_deadline_at
+      errors.add(:apply_deadline_at, :apply_deadline_after_apply_opens)
+    elsif apply_deadline_at.after? reject_by_default_at
+      errors.add(:reject_by_default_at, :reject_by_default_after_apply_deadline)
+    elsif reject_by_default_at.after? decline_by_default_at
+      errors.add(:decline_by_default_at, :decline_by_default_after_reject_by_default)
+    elsif decline_by_default_at.after? find_closes_at
+      errors.add(:find_closes_at, :find_closes_after_decline_by_default)
+    end
+  end
+
+  def blank_attributes?
+    [
+      find_opens_at,
+      apply_opens_at,
+      apply_deadline_at,
+      reject_by_default_at,
+      decline_by_default_at,
+      find_closes_at,
+    ].any?(&:blank?)
+  end
+
+  def check_for_invalid_dates
+    %i[
+      find_opens_at
+      apply_opens_at
+      apply_deadline_at
+      reject_by_default_at
+      decline_by_default_at
+      find_closes_at
+    ].each do |attr|
+      errors.add(attr, :invalid_date) unless record.send(attr).respond_to? :to_date
+    end
+  end
+end

--- a/app/views/support_interface/recruitment_cycle_timetables/_navigation.html.erb
+++ b/app/views/support_interface/recruitment_cycle_timetables/_navigation.html.erb
@@ -3,7 +3,7 @@
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Feature flags', url: support_interface_feature_flags_path },
-  { name: 'Recruitment cycles', url: support_interface_recruitment_cycle_timetables_path },
+  { name: 'Recruitment cycles', url: support_interface_recruitment_cycle_timetables_path, current: true },
   { name: 'Tasks', url: support_interface_tasks_path },
   { name: 'Support users', url: support_interface_support_users_path },
   { name: 'Send notify template', url: support_interface_notify_template_path },

--- a/app/views/support_interface/recruitment_cycle_timetables/edit.html.erb
+++ b/app/views/support_interface/recruitment_cycle_timetables/edit.html.erb
@@ -1,0 +1,19 @@
+<%= render 'navigation', title: t('.page_title', year: @cycle_switcher_form.recruitment_cycle_year) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with model: @cycle_switcher_form, url: support_interface_update_recruitment_cycle_timetable_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_date_field :find_opens_at, legend: { text: t('.find_opens_at.label') }, hint: { text: t('.find_opens_at.hint') } %>
+      <%= f.govuk_date_field :apply_opens_at, legend: { text: t('.apply_opens_at.label') }, hint: { text: t('.apply_opens_at.hint') } %>
+      <%= f.govuk_date_field :apply_deadline_at, legend: { text: t('.apply_deadline_at.label') }, hint: { text: t('.apply_deadline_at.hint') } %>
+      <%= f.govuk_date_field :reject_by_default_at, legend: { text: t('.reject_by_default_at.label') }, hint: { text: t('.reject_by_default_at.hint') } %>
+      <%= f.govuk_date_field :decline_by_default_at, legend: { text: t('.decline_by_default_at.label') }, hint: { text: t('.decline_by_default_at.hint') } %>
+      <%= f.govuk_date_field :find_closes_at, legend: { text: t('.find_closes_at.label') }, hint: { text: t('.find_closes_at.hint') } %>
+
+      <%= f.govuk_submit t('update') %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/recruitment_cycle_timetables/index.html.erb
+++ b/app/views/support_interface/recruitment_cycle_timetables/index.html.erb
@@ -1,0 +1,57 @@
+<%= render 'navigation', title: t('.page_title') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl">
+      <%= t('.today_is', date: Time.zone.now.to_fs(:govuk_date)) %>
+    </span>
+    <h1 class="govuk-heading-l">
+      <%= t(".#{@timetable_presenter.cycle_state}", year: Current.cycle_year) %>
+    </h1>
+
+    <p class="govuk-body">
+      <%= t(".current_state_description.#{@timetable_presenter.cycle_state}") %>
+    </p>
+
+    <% unless HostingEnvironment.production? %>
+      <h2 class='govuk-heading-m'>
+        <%= t('.you_can_edit') %>
+      </h2>
+
+      <%= govuk_list(
+            [
+              govuk_link_to(Current.cycle_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: Current.cycle_year)),
+              govuk_link_to(Current.next_cycle_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: Current.next_cycle_year)),
+            ],
+          ) %>
+
+      <%= form_for :resetting_timetables, url: support_interface_sync_cycle_with_production_path, method: :post do |form| %>
+        <%= form.govuk_submit t('.sync_with_production') %>
+      <% end %>
+
+    <% end %>
+
+    <h2 class="govuk-heading-m">
+      <%= t('.cycle_years') %>
+    </h2>
+
+    <%= render SummaryListComponent.new(rows: {
+      'Previous cycle year' => Current.previous_cycle_year,
+      'Current cycle year' => Current.cycle_year,
+      'Next cycle year' => Current.next_cycle_year,
+      'Years visible to providers' => [Current.cycle_year, Current.next_cycle_year].to_sentence,
+      'Current cycle week' => Current.cycle_week,
+    }) %>
+
+    <h2 class="govuk-heading-m">
+      <%= t('.deadlines') %>
+    </h2>
+
+    <%= render Publications::RecruitmentCycleTimetableCard.new(Current.cycle_timetable) %>
+
+    <% if Current.next_cycle_timetable.present? %>
+      <%= render Publications::RecruitmentCycleTimetableCard.new(Current.next_cycle_timetable) %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">End-of-cycle: Cancel unsubmitted applications</h2>
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_deadline).to_fs(:govuk_date) %>.</p>
+      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= Current.cycle_timteable.apply_deadline_at.to_fs(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_button_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, warning: true %>
@@ -44,7 +44,7 @@
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Generate test applications for the <%= RecruitmentCycle.current_year %> recruitment cycle</h2>
+        <h2 class="govuk-heading-m">Generate test applications for the <%= Current.cycle_year %> recruitment cycle</h2>
         <p class="govuk-body">This task generates ~10 mostly-random test applications in all of the states.</p>
       </div>
       <div class="govuk-grid-column-one-third">
@@ -53,19 +53,17 @@
     </div>
   </section>
 
-  <% if CycleTimetable.current_year == CycleTimetable.real_current_year %>
-    <section class="app-section app-section--with-top-border">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-m">Generate test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle</h2>
-          <p class="govuk-body">This task generates mostly-random test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle.</p>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <%= govuk_button_to "Generate #{RecruitmentCycle.next_year} recruitment cycle test applications", support_interface_run_task_path('generate_next_cycle_test_applications'), secondary: true %>
-        </div>
+  <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Generate test applications for the <%= Current.next_cycle_year %> recruitment cycle</h2>
+        <p class="govuk-body">This task generates mostly-random test applications for the <%= Current.next_cycle_year %> recruitment cycle.</p>
       </div>
-    </section>
-  <% end %>
+      <div class="govuk-grid-column-one-third">
+        <%= govuk_button_to "Generate #{Current.next_cycle_year} recruitment cycle test applications", support_interface_run_task_path('generate_next_cycle_test_applications'), secondary: true %>
+      </div>
+    </div>
+  </section>
 
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">

--- a/config/locales/cycle_switcher_form.yml
+++ b/config/locales/cycle_switcher_form.yml
@@ -1,0 +1,23 @@
+en:
+  activemodel:
+    errors:
+      models:
+        support_interface/cycle_switcher_form:
+          attributes:
+            find_opens_at:
+              invalid_date: Enter a valid Find open date
+            apply_opens_at:
+              invalid_date: Enter a valid Apply open date
+              apply_opens_after_find_opens: Enter an Apply open date that is after Find has opened
+            apply_deadline_at:
+              invalid_date: Enter a valid Apply deadline date
+              apply_deadline_after_apply_opens: Enter an Apply deadline that is after Apply has opened
+            reject_by_default_at:
+              invalid_date: Enter a valid reject by default date
+              reject_by_default_after_apply_deadline: Enter a reject by default date that is after the Apply deadline
+            decline_by_default_at:
+              invalid_date: Enter a valid decline by default date
+              decline_by_default_after_reject_by_default: Enter a decline by default date that is after the reject by default date
+            find_closes_at:
+              invalid_date: Enter a valid Find closes date
+              find_closes_after_decline_by_default: Enter a Find close date that is after the decline by default date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -564,21 +564,21 @@ en:
         recruitment_cycle_timetable:
           attributes:
             apply_opens_at:
-              apply_opens_after_find_opens: Apply opens after find opens
+              apply_opens_after_find_opens: Enter an Apply open date that is after Find has opened
             apply_deadline_at:
-              apply_deadline_after_apply_opens: Apply deadline must be after apply opens
+              apply_deadline_after_apply_opens: Enter an Apply deadline that is after Apply has opened
             reject_by_default_at:
-              reject_by_default_after_apply_deadline: Reject by default must be after the apply deadline
+              reject_by_default_after_apply_deadline: Enter a reject by default date that is after the Apply deadline
             decline_by_default_at:
-              decline_by_default_after_reject_by_default: Decline by default must be after reject by default
+              decline_by_default_after_reject_by_default: Enter a decline by default date that is after the reject by default date
             find_closes_at:
-              find_closes_after_decline_by_default: Find closes after decline by default
+              find_closes_after_decline_by_default: Enter a Find close date that is after the decline by default date
             easter_holiday_range:
-              easter_holiday_range_should_be_within_cycle: Easter holiday range should be within cycle
-              easter_holiday_range_should_include_easter: Easter holiday range should include easter
+              easter_holiday_range_should_be_within_cycle: Enter an Easter holiday range within cycle
+              easter_holiday_range_should_include_easter: Enter an Easter holiday range that includes Easter
             christmas_holiday_range:
-              christmas_holiday_range_should_be_in_cycle: Christmas holiday range should be within cycle
-              christmas_holiday_range_should_include_christmas: Christmas holiday range should include Christmas day
+              christmas_holiday_range_should_be_in_cycle: Enter a Christmas holiday within cycle
+              christmas_holiday_range_should_include_christmas: Enter a Christmas holiday range that includes Christmas day
         candidate:
           attributes:
             email_address:

--- a/config/locales/support_interface/recruitment_cycle_timetables.yml
+++ b/config/locales/support_interface/recruitment_cycle_timetables.yml
@@ -1,0 +1,75 @@
+en:
+  support_interface:
+    recruitment_cycle_timetables:
+      edit:
+        page_title: Recruitment cycle %{year}
+        find_opens_at:
+          label: Find opens
+          hint: The date Find opens and candidates can start choosing courses
+        apply_opens_at:
+          label: Apply opens
+          hint: The date Apply opens for submissions
+        apply_deadline_at:
+          label: Apply deadline
+          hint: The deadline for candidates to submit applications
+        reject_by_default_at:
+          label: Reject by default
+          hint: The deadline for providers to make offers
+        decline_by_default_at:
+          label: Decline by default
+          hint: The deadline for candidates to accept offers
+        find_closes_at:
+          label: Find closes
+          hint: The end of the cycle.
+        christmas_holiday_range_start_at:
+          label: The beginning of the Christmas holiday period
+          hint: The Christmas holiday is not included in 'inactive' calculations
+        christmas_holiday_range_end_at:
+          label: The end of the Christmas holiday period
+          hint: The Christmas holiday is not included in 'inactive' calculations
+        easter_holiday_range_start_at:
+          label: The beginning of the Easter holiday period
+          hint: The Easter holiday is not included in 'inactive' calculations
+        easter_holiday_range_end_at:
+          label: The end of the Easter holiday period
+          hint: The Easter holiday is not included in 'inactive' calculations
+      index:
+        page_title: Recruitment cycles
+        form_title: Move forward in the recruitment cycle
+        deadlines: Deadlines
+        cycle_years: Cycle years
+        you_can_edit: You can edit the following timetables
+        today_is: Today is %{date}
+        the_next_cycle_is_not_defined: The next cycle is not defined
+        sync_with_production: Sync cycle timetables with production
+        find_has_opened: Find has opened (%{year})
+        apply_has_opened: Apply has opened  (%{year})
+        apply_deadline_approaching: Apply deadline approaching (%{year})
+        after_apply_deadline: Apply deadline has passed (%{year})
+        after_reject_by_default: Reject by default deadline has passed (%{year})
+        after_decline_by_default: Decline by default deadline has passed (%{year})
+        after_find_has_closed: Find has closed (%{year})
+        current_state_description:
+          find_has_opened: >
+            Candidate can make choices, but they cannot submit applications.
+          apply_has_opened: >
+            Candidates can make choices and submit applications, providers can act on applications.
+          apply_deadline_approaching: >
+            Candidates can make choices and submit applications, providers can act on applications.
+            The deadline is within 12 weeks and candidates will see banners reminding them of the approaching deadlines,
+          after_apply_deadline: >
+            The deadline for submitting applications has passed.
+            Candidates without active applications can start preparing applications for next year.
+            Providers can still act on submitted applications.
+          after_reject_by_default:
+            This is the deadline for providers to make offers to candidates has passed.
+            Candidates can still act on offers.
+          after_decline_by_default:
+            The deadline for candidates to accept offers has passed.
+          after_find_has_closed:
+            The service is down before reopening. Candidates cannot select courses.
+      reset:
+        success_message: Recruitment cycles are synced with production.
+      update:
+        success_message: The cycle has been updated.
+

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -237,7 +237,12 @@ namespace :support_interface, path: '/support' do
     post '/feature-flags/:feature_name/activate' => 'settings#activate_feature_flag', as: :activate_feature_flag
     post '/feature-flags/:feature_name/deactivate' => 'settings#deactivate_feature_flag', as: :deactivate_feature_flag
 
-    get '/cycles', to: 'settings#cycles', as: :cycles
+    get 'recruitment-cycle-timetable', to: 'recruitment_cycle_timetables#index', as: :recruitment_cycle_timetables
+    unless HostingEnvironment.production?
+      post '/recruitment-cycle-timetables/reset', to: 'recruitment_cycle_timetables#reset', as: :sync_cycle_with_production
+      get '/recruitment-cycle-timetable/:recruitment_cycle_year', to: 'recruitment_cycle_timetables#edit', as: :edit_recruitment_cycle_timetable
+      post '/recruitment-cycle-timetable/:recruitment_cycle_year', to: 'recruitment_cycle_timetables#update', as: :update_recruitment_cycle_timetable
+    end
 
     get '/notify-template', to: 'settings#notify_template', as: :notify_template
     post '/send-notify-template', to: 'settings#send_notify_template', as: :send_notify_template

--- a/spec/factories/recruitment_cycle_timetable.rb
+++ b/spec/factories/recruitment_cycle_timetable.rb
@@ -1,14 +1,13 @@
 FactoryBot.define do
   factory :recruitment_cycle_timetable do
-    recruitment_cycle_year { CycleTimetable.current_year }
+    current_timetable = RecruitmentCycleTimetable.last_timetable
+    recruitment_cycle_year { current_timetable.recruitment_cycle_year + 1 }
 
-    find_opens_at { CycleTimetable.find_opens }
-    apply_opens_at { CycleTimetable.apply_opens }
-    apply_deadline_at { CycleTimetable.apply_deadline }
-    reject_by_default_at { CycleTimetable.reject_by_default }
-    decline_by_default_at { CycleTimetable.decline_by_default_date }
-    find_closes_at { CycleTimetable.find_closes }
-    christmas_holiday_range { CycleTimetable.holidays[:christmas] }
-    easter_holiday_range { CycleTimetable.holidays[:easter] }
+    find_opens_at { current_timetable.find_opens_at + 1.year }
+    apply_opens_at { current_timetable.apply_opens_at + 1.year }
+    apply_deadline_at { current_timetable.apply_deadline_at + 1.year }
+    reject_by_default_at { current_timetable.reject_by_default_at + 1.year }
+    decline_by_default_at { current_timetable.decline_by_default_at + 1.year }
+    find_closes_at { current_timetable.find_closes_at + 1.year }
   end
 end

--- a/spec/models/recruitment_cycle_timetable_spec.rb
+++ b/spec/models/recruitment_cycle_timetable_spec.rb
@@ -14,39 +14,41 @@ RSpec.describe RecruitmentCycleTimetable do
     describe 'validates christmas range' do
       it 'validates christmas range is within cycle' do
         timetable = build(:recruitment_cycle_timetable)
-        timetable.christmas_holiday_range = timetable.find_opens_at - 3.days..timetable.christmas_holiday_range.last
+        year = timetable.recruitment_cycle_year
+        timetable.christmas_holiday_range = timetable.find_opens_at - 3.days..Time.zone.local(year, 1, 2)
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:christmas_holiday_range]).to eq ['Christmas holiday range should be within cycle']
+        expect(timetable.errors[:christmas_holiday_range]).to eq ['Enter a Christmas holiday within cycle']
       end
 
       it 'validates christmas range includes christmas day' do
         timetable = build(:recruitment_cycle_timetable)
-        timetable.christmas_holiday_range =
-          timetable.christmas_holiday_range.last..timetable.christmas_holiday_range.last + 10.days
+        year = timetable.recruitment_cycle_year - 1
+        timetable.christmas_holiday_range = (Time.zone.local(year, 12, 26)...Time.zone.local(year, 12, 29))
 
         expect(timetable.valid?).to be false
         expect(timetable.errors[:christmas_holiday_range])
-          .to eq ['Christmas holiday range should include Christmas day']
+          .to eq ['Enter a Christmas holiday range that includes Christmas day']
       end
     end
 
     describe 'validates easter range' do
       it 'validates easter range is within cycle' do
-        timetable = build(:recruitment_cycle_timetable)
+        # We need one where we know where Easter is
+        timetable = described_class.find_by(recruitment_cycle_year: 2024)
         timetable.easter_holiday_range = timetable.easter_holiday_range.last..timetable.find_closes_at + 2.days
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:easter_holiday_range]).to eq ['Easter holiday range should be within cycle']
+        expect(timetable.errors[:easter_holiday_range]).to eq ['Enter an Easter holiday range within cycle']
       end
 
       it 'validates easter range includes Easter Day' do
-        timetable = build(:recruitment_cycle_timetable)
+        timetable = described_class.find_by(recruitment_cycle_year: 2024)
         timetable.easter_holiday_range =
           timetable.easter_holiday_range.last..timetable.easter_holiday_range.last + 10.days
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:easter_holiday_range]).to eq ['Easter holiday range should include easter']
+        expect(timetable.errors[:easter_holiday_range]).to eq ['Enter an Easter holiday range that includes Easter']
       end
     end
 
@@ -56,7 +58,7 @@ RSpec.describe RecruitmentCycleTimetable do
         timetable.find_opens_at = timetable.apply_opens_at + 1.day
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:apply_opens_at]).to eq ['Apply opens after find opens']
+        expect(timetable.errors[:apply_opens_at]).to eq ['Enter an Apply open date that is after Find has opened']
       end
 
       it 'validates apply deadline is after apply opens' do
@@ -64,7 +66,7 @@ RSpec.describe RecruitmentCycleTimetable do
         timetable.apply_opens_at = timetable.apply_deadline_at + 1.day
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:apply_deadline_at]).to eq ['Apply deadline must be after apply opens']
+        expect(timetable.errors[:apply_deadline_at]).to eq ['Enter an Apply deadline that is after Apply has opened']
       end
 
       it 'validates reject by default is after apply deadline' do
@@ -72,7 +74,7 @@ RSpec.describe RecruitmentCycleTimetable do
         timetable.apply_deadline_at = timetable.reject_by_default_at + 1.day
 
         expect(timetable.valid?).to be false
-        expect(timetable.errors[:reject_by_default_at]).to eq ['Reject by default must be after the apply deadline']
+        expect(timetable.errors[:reject_by_default_at]).to eq ['Enter a reject by default date that is after the Apply deadline']
       end
     end
   end
@@ -118,6 +120,13 @@ RSpec.describe RecruitmentCycleTimetable do
     it 'returns the timetable before the current one' do
       previous_year = described_class.current_year - 1
       expect(described_class.previous_timetable).to eq described_class.find_by(recruitment_cycle_year: previous_year)
+    end
+  end
+
+  describe '.last_timetable' do
+    it 'returns the last available timetable' do
+      last_year = described_class.pluck(:recruitment_cycle_year).max
+      expect(described_class.last_timetable.recruitment_cycle_year).to eq last_year
     end
   end
 
@@ -183,6 +192,13 @@ RSpec.describe RecruitmentCycleTimetable do
     it 'returns the timetable with the next consecutive cycle year if it exists' do
       timetable = described_class.current_timetable
       expect(timetable.relative_previous_timetable.recruitment_cycle_year).to eq timetable.recruitment_cycle_year - 1
+    end
+  end
+
+  describe '#show_banners_at' do
+    it 'returns a date 12 weeks before the application deadline' do
+      timetable = described_class.current_timetable
+      expect(timetable.show_banners_at).to eq timetable.apply_deadline_at - 12.weeks
     end
   end
 end

--- a/spec/support/cycle_timetable_helper.rb
+++ b/spec/support/cycle_timetable_helper.rb
@@ -12,6 +12,11 @@ module_function
     timetable.find_opens_at + 1.day
   end
 
+  def after_find_closes(year)
+    timetable = get_timetable(year)
+    timetable.find_closes_at + 1.second
+  end
+
   def after_find_reopens(year = nil)
     timetable = get_timetable(year + 1)
     timetable.find_opens_at + 1.day

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -29,6 +29,7 @@ module DfESignInHelpers
     support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     support_user_signs_in_using_dfe_sign_in
   end
+  alias given_i_am_signed_in_as_a_support_user sign_in_as_support_user
 
   def provider_user_exists_in_apply_database(provider_code: 'ABC', email_address: 'email@provider.ac.uk')
     provider_one = Provider.find_by(code: provider_code) if provider_code

--- a/spec/system/support_interface/cycle_switching_errors_spec.rb
+++ b/spec/system/support_interface/cycle_switching_errors_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe 'Cycle switching errors' do
+  include DfESignInHelpers
+  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
+
+  scenario 'adding invalid dates' do
+    given_i_am_signed_in_as_a_support_user
+    and_i_navigate_to_edit_current_cycle
+    when_i_enter_invalid_dates_in_all_the_fields
+    then_i_see_invalid_date_errors
+  end
+
+  context 'Wrong sequence dates' do
+    before do
+      given_i_am_signed_in_as_a_support_user
+      and_i_navigate_to_edit_current_cycle
+    end
+
+    scenario 'Apply opening before find opens' do
+      when_i_enter_a_bad_apply_opens_date
+      then_i_see_apply_opens_error
+    end
+
+    scenario 'Apply deadline before find apply opens' do
+      when_i_enter_a_bad_apply_deadline
+      then_i_see_apply_deadline_error
+    end
+
+    scenario 'Reject by default before apply deadline' do
+      when_i_enter_a_bad_reject_by_default_date
+      then_i_see_reject_by_default_date_error
+    end
+
+    scenario 'Decline by default before reject by default' do
+      when_i_enter_a_bad_decline_by_default_date
+      then_i_see_decline_by_default_date_error
+    end
+
+    scenario 'Find closes before decline by default date' do
+      when_i_enter_a_bad_find_closes_date
+      then_i_see_find_closes_date_error
+    end
+  end
+
+private
+
+  def and_i_navigate_to_edit_current_cycle
+    click_on 'Settings'
+    click_on 'Recruitment cycles'
+    click_on timetable.recruitment_cycle_year
+  end
+
+  def when_i_enter_invalid_dates_in_all_the_fields
+    within_fieldset 'Find opens' do
+      fill_in 'Month', with: 13
+    end
+    within_fieldset 'Apply opens' do
+      fill_in 'Day', with: 99
+    end
+    within_fieldset 'Apply deadline' do
+      fill_in 'Year', with: 'eeee'
+    end
+    within_fieldset 'Reject by default' do
+      fill_in 'Month', with: 13
+    end
+    within_fieldset 'Decline by default' do
+      fill_in 'Day', with: -1
+    end
+    within_fieldset 'Find closes' do
+      fill_in 'Year', with: 'year'
+    end
+
+    click_on 'Update'
+  end
+
+  def then_i_see_invalid_date_errors
+    expect(page).to have_content('Enter a valid Find open date').twice
+    expect(page).to have_content('Enter a valid Apply open date').twice
+    expect(page).to have_content('Enter a valid Apply deadline date').twice
+    expect(page).to have_content('Enter a valid reject by default date').twice
+    expect(page).to have_content('Enter a valid decline by default date').twice
+    expect(page).to have_content('Enter a valid Find closes date').twice
+  end
+
+  def when_i_enter_a_bad_apply_opens_date
+    within_fieldset 'Apply opens' do
+      invalid_date = timetable.find_opens_at - 1.day
+      fill_in 'Day', with: invalid_date.day
+      fill_in 'Month', with: invalid_date.month
+      fill_in 'Year', with: invalid_date.year
+    end
+    click_on 'Update'
+  end
+
+  def then_i_see_apply_opens_error
+    expect(page).to have_content('Enter an Apply open date that is after Find has opened').twice
+  end
+
+  def when_i_enter_a_bad_apply_deadline
+    within_fieldset 'Apply deadline' do
+      invalid_date = timetable.apply_opens_at - 1.day
+      fill_in 'Day', with: invalid_date.day
+      fill_in 'Month', with: invalid_date.month
+      fill_in 'Year', with: invalid_date.year
+    end
+    click_on 'Update'
+  end
+
+  def then_i_see_apply_deadline_error
+    expect(page).to have_content('Enter an Apply deadline that is after Apply has opened').twice
+  end
+
+  def when_i_enter_a_bad_reject_by_default_date
+    within_fieldset 'Reject by default' do
+      invalid_date = timetable.apply_deadline_at - 1.day
+      fill_in 'Day', with: invalid_date.day
+      fill_in 'Month', with: invalid_date.month
+      fill_in 'Year', with: invalid_date.year
+    end
+    click_on 'Update'
+  end
+
+  def then_i_see_reject_by_default_date_error
+    expect(page).to have_content('Enter a reject by default date that is after the Apply deadline').twice
+  end
+
+  def when_i_enter_a_bad_decline_by_default_date
+    within_fieldset 'Decline by default' do
+      invalid_date = timetable.reject_by_default_at - 1.day
+      fill_in 'Day', with: invalid_date.day
+      fill_in 'Month', with: invalid_date.month
+      fill_in 'Year', with: invalid_date.year
+    end
+    click_on 'Update'
+  end
+
+  def then_i_see_decline_by_default_date_error
+    expect(page).to have_content('Enter a decline by default date that is after the reject by default date').twice
+  end
+
+  def when_i_enter_a_bad_find_closes_date
+    within_fieldset 'Find closes' do
+      invalid_date = timetable.reject_by_default_at - 1.day
+      fill_in 'Day', with: invalid_date.day
+      fill_in 'Month', with: invalid_date.month
+      fill_in 'Year', with: invalid_date.year
+    end
+    click_on 'Update'
+  end
+
+  def then_i_see_find_closes_date_error
+    expect(page).to have_content('Enter a Find close date that is after the decline by default date').twice
+  end
+end

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -2,36 +2,48 @@ require 'rails_helper'
 
 RSpec.describe 'Cycle switching' do
   include DfESignInHelpers
+  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
 
-  scenario 'Support user switches cycle schedule', skip: 'Reimplement when cycle switcher is working again' do
-    given_i_am_a_support_user
-    when_i_click_on_the_recruitment_cycle_link
-    then_i_see_the_cycle_information
+  scenario 'Support user switches cycle schedule' do
+    given_it_is_before_the_apply_deadline
+    given_i_am_signed_in_as_a_support_user
+    when_i_navigate_to_the_cycle_page
+    and_i_see_a_mid_cycle_description_and_content
 
-    when_i_click_to_choose_a_new_schedule
-    then_the_schedule_is_updated
+    when_i_update_the_current_cycle_so_the_deadline_has_passed
+    then_i_see_post_deadline_description
   end
 
-  def given_i_am_a_support_user
-    sign_in_as_support_user
+private
+
+  def given_it_is_before_the_apply_deadline
+    TestSuiteTimeMachine.travel_permanently_to(timetable.apply_deadline_at - 13.weeks)
   end
 
-  def when_i_click_on_the_recruitment_cycle_link
-    click_link_or_button 'Settings'
-    click_link_or_button 'Recruitment cycles'
+  def when_i_navigate_to_the_cycle_page
+    click_on 'Settings'
+    click_on 'Recruitment cycles'
   end
 
-  def then_i_see_the_cycle_information
-    expect(page).to have_title 'Recruitment cycles'
-    expect(page).to have_content("Find closes on #{CycleTimetable.find_closes.to_fs(:govuk_date)}")
+  def and_i_see_a_mid_cycle_description_and_content
+    expect(page).to have_content "Apply has opened (#{timetable.recruitment_cycle_year})"
+    expect(page).to have_content 'Candidates can make choices and submit applications, providers can act on applications.'
   end
 
-  def when_i_click_to_choose_a_new_schedule
-    choose 'Apply deadline has passed'
-    click_link_or_button 'Update point in recruitment cycle'
+  def when_i_update_the_current_cycle_so_the_deadline_has_passed
+    click_on timetable.recruitment_cycle_year
+    within_fieldset 'Apply deadline' do
+      new_date = 1.day.ago
+      fill_in 'Day', with: new_date.day
+      fill_in 'Month', with: new_date.month
+      fill_in 'Year', with: new_date.year
+    end
+    click_on 'Update'
   end
 
-  def then_the_schedule_is_updated
-    expect(page).to have_content("Apply deadline #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}")
+  def then_i_see_post_deadline_description
+    expect(page).to have_content 'The cycle has been updated.'
+    expect(page).to have_content "Apply deadline has passed (#{timetable.recruitment_cycle_year})"
+    expect(page).to have_content 'The deadline for submitting applications has passed. Candidates without active applications can start preparing applications for next year. Providers can still act on submitted applications.'
   end
 end

--- a/spec/system/support_interface/sycing_cycles_with_production_spec.rb
+++ b/spec/system/support_interface/sycing_cycles_with_production_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'Syncing cycles with production' do
+  include DfESignInHelpers
+  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
+
+  scenario 'Undoing a change in the cycle timetable' do
+    given_i_am_signed_in_as_a_support_user
+    and_i_navigate_to_edit_current_cycle
+    when_i_make_a_successful_change_to_the_cycle
+    and_i_sync_timetables_with_production
+    then_the_timetable_is_restored
+  end
+
+private
+
+  def and_i_navigate_to_edit_current_cycle
+    click_on 'Settings'
+    click_on 'Recruitment cycles'
+    click_on timetable.recruitment_cycle_year
+  end
+
+  def when_i_make_a_successful_change_to_the_cycle
+    @original_apply_deadline_at = timetable.apply_deadline_at
+    within_fieldset 'Apply deadline' do
+      new_date = 1.day.ago
+      fill_in 'Day', with: new_date.day
+      fill_in 'Month', with: new_date.month
+      fill_in 'Year', with: new_date.year
+    end
+    click_on 'Update'
+
+    expect(timetable.reload.apply_deadline_at).not_to eq @original_apply_deadline_at
+  end
+
+  def and_i_sync_timetables_with_production
+    click_on 'Sync cycle timetables with production'
+  end
+
+  def then_the_timetable_is_restored
+    expect(timetable.reload.apply_deadline_at).to eq @original_apply_deadline_at
+  end
+end

--- a/spec/system/support_interface/viewing_cycle_information_spec.rb
+++ b/spec/system/support_interface/viewing_cycle_information_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing cycle information' do
+  include DfESignInHelpers
+
+  context 'Environment is not production' do
+    scenario 'viewing cycle information when not in production', time: mid_cycle do
+      given_i_am_signed_in_as_a_support_user
+      when_i_click_on_the_recruitment_cycle_link
+      then_i_see_information_about_editing_cycle_timetables
+      and_i_see_other_content
+    end
+  end
+
+  context 'Environment is production' do
+    before do
+      allow(HostingEnvironment).to receive(:production?).and_return true
+    end
+
+    scenario 'viewing cycle information when in production', time: mid_cycle do
+      given_i_am_signed_in_as_a_support_user
+      when_i_click_on_the_recruitment_cycle_link
+      then_i_do_not_see_information_about_editing_cycle_timetables
+      and_i_see_other_content
+    end
+  end
+
+private
+
+  def when_i_click_on_the_recruitment_cycle_link
+    click_on 'Settings'
+    click_on 'Recruitment cycles'
+  end
+
+  def then_i_see_information_about_editing_cycle_timetables
+    expect(page).to have_title 'Recruitment cycles'
+    expect(page).to have_content 'You can edit the following timetables'
+    expect(page).to have_link RecruitmentCycleTimetable.current_year
+    expect(page).to have_link RecruitmentCycleTimetable.next_year
+    expect(page).to have_button 'Sync cycle timetables with production'
+  end
+
+  def then_i_do_not_see_information_about_editing_cycle_timetables
+    expect(page).to have_title 'Recruitment cycles'
+    expect(page).to have_no_content 'You can edit the following timetables'
+    expect(page).to have_no_link RecruitmentCycleTimetable.current_year
+    expect(page).to have_no_link RecruitmentCycleTimetable.next_year
+    expect(page).to have_no_button 'Sync cycle timetables with production'
+  end
+
+  def and_i_see_other_content
+    year = RecruitmentCycleTimetable.current_year
+    expect(page).to have_content "Apply has opened (#{year})"
+    expect(page).to have_content 'Deadlines'
+    expect(page).to have_content 'Cycle years'
+  end
+end


### PR DESCRIPTION
## Context

Instead of maintaining a constant for the cycle switcher, we want to use the database backed version. 

## Changes proposed in this pull request

- Use `Current` for commonly used timetable methods in controllers / views
- Implement a cycle switcher

https://github.com/user-attachments/assets/21aec1f0-0794-469c-b603-6efd1958c482

## Guidance to review

I apologise for the length of this PR! I'm afraid I couldn't think of a way to shorten it! 
Click around and check the errors etc. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
