### PR TITLE
Increase edit personal statement word count Support in interface

### DIFF
--- a/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
+++ b/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
       attr_accessor :becoming_a_teacher, :audit_comment, :application_form
 
       validates :becoming_a_teacher,
-                word_count: { maximum: 600 },
+                word_count: { maximum: 1000 },
                 presence: true
 
       validates :audit_comment, presence: true

--- a/app/views/support_interface/application_forms/personal_statement/edit_becoming_a_teacher.html.erb
+++ b/app/views/support_interface/application_forms/personal_statement/edit_becoming_a_teacher.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @becoming_a_teacher_form, url: support_interface_application_form_edit_becoming_a_teacher_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('support_interface.edit_becoming_a_teacher_form.becoming_a_teacher.label'), size: 'xl' }, rows: 20, max_words: 600 %>
+      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('support_interface.edit_becoming_a_teacher_form.becoming_a_teacher.label'), size: 'xl' }, rows: 20, max_words: 1000 %>
       <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_becoming_a_teacher_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_becoming_a_teacher_form.audit_comment.hint') } %>
       <%= f.govuk_submit 'Update' %>
     <% end %>

--- a/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, :wi
     it { is_expected.to validate_presence_of(:becoming_a_teacher) }
     it { is_expected.to validate_presence_of(:audit_comment) }
 
-    valid_text = Faker::Lorem.sentence(word_count: 600)
-    invalid_text = Faker::Lorem.sentence(word_count: 601)
+    valid_text = Faker::Lorem.sentence(word_count: 1000)
+    invalid_text = Faker::Lorem.sentence(word_count: 1001)
 
     it { is_expected.to allow_value(valid_text).for(:becoming_a_teacher) }
     it { is_expected.not_to allow_value(invalid_text).for(:becoming_a_teacher) }


### PR DESCRIPTION
## Context

This is a left over from increasing the word count in the candidate interface, we need to do the same in the support interface

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
