### PR TITLE
Updated text for recruitment performance reports 2025

### DIFF
--- a/app/components/provider_interface/recruitment_performance_report/candidates_rejected_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/candidates_rejected_table_component.html.erb
@@ -6,10 +6,14 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('candidates_rejected_table_component.description_one', provider_name: @provider.name) %>
+      <%= t('.number_of_rejected_candidates', provider_name: @provider.name) %>
     </p>
     <p class="govuk-body">
-      <%= t('candidates_rejected_table_component.description_two', provider_name: @provider.name) %>
+      <%= t('.you_can_compare_the_data_to') %>
+    </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
+    <p class="govuk-body">
+      <%= t('.candidates_rejected_and_awaiting_decisions', provider_name: @provider.name) %>
     </p>
   </span>
 <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/candidates_with_offers_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/candidates_with_offers_table_component.html.erb
@@ -6,15 +6,20 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('candidates_with_offers_table_component.candidates_who_have_received_offer', provider_name: @provider.name) %>
+      <%= t('.candidates_who_have_received_offer', provider_name: @provider.name) %>
     </p>
     <p class="govuk-body">
-      <%= t('candidates_with_offers_table_component.table_includes') %>
+      <%= t('.you_can_compare_the_data_to') %>
+    </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
+
+    <p class="govuk-body">
+      <%= t('.table_includes') %>
     </p>
     <%= govuk_list([
-         t('candidates_with_offers_table_component.li_one'),
-         t('candidates_with_offers_table_component.li_two'),
-         t('candidates_with_offers_table_component.li_three'),
+         t('.declined'),
+         t('.withdrawn_before_they_could_accept'),
+         t('.deferred_withdrawn_unsuccessful'),
        ], type: :bullet) %>
   </span>
 <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/deferrals_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/deferrals_table_component.html.erb
@@ -1,19 +1,19 @@
 <div class="govuk-grid-column-two-thirds">
   <h2 class="govuk-heading-m" id="candidate_deferrals">
-    <%= t('deferrals_table_component.caption') %>
+    <%= t('.caption') %>
   </h2>
-  <p class="govuk-body"><%= t('deferrals_table_component.description_one', provider_name:) %></p>
-  <p class="govuk-body"><%= t('deferrals_table_component.description_two') %></p>
+  <p class="govuk-body"><%= t('.deferred_offers_this_cycle', provider_name:) %></p>
+  <p class="govuk-body"><%= t('.deferred_to_the_next_cycle') %></p>
   <% if deferral_rows.empty? %>
     <p class="govuk-body"><%= t('shared.empty_state') %></p>
   <% else %>
     <div class="recruitment-performance-report-table__wrapper">
       <%= govuk_table do |table| %>
-        <%= table.with_caption(text: t('deferrals_table_component.caption'),
+        <%= table.with_caption(text: t('.caption'),
                                html_attributes: { class: 'govuk-visually-hidden' }) %>
         <%= table.with_head do |head| %>
           <%= head.with_row do |row| %>
-            <%= row.with_cell(text: t('deferrals_table_component.deferrals'),
+            <%= row.with_cell(text: t('.deferrals'),
                               html_attributes: { class: 'recruitment-performance-report-table__subheading' }) %>
             <%= row.with_cell(text: provider_name, numeric: true,
                               html_attributes: { class: 'recruitment-performance-report-table__subheading' }) %>
@@ -24,7 +24,7 @@
         <% table.with_body do |body| %>
           <% deferral_rows.each do |deferral_row| %>
             <% body.with_row do |row| %>
-              <%= row.with_cell(header: true, text: t("deferrals_table_component.#{deferral_row.title}")) %>
+              <%= row.with_cell(header: true, text: t(".#{deferral_row.title}")) %>
               <%= row.with_cell(text: format_number(deferral_row, :provider_deferrals_count), numeric: true) %>
               <%= row.with_cell(text: format_number(deferral_row, :national_deferrals_count), numeric: true) %>
             <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/offers_accepted_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/offers_accepted_table_component.html.erb
@@ -6,18 +6,19 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('offers_accepted_table_component.description_one', provider_name: @provider.name) %>
-    </p>
-        <p class="govuk-body">
-      <%= t('offers_accepted_table_component.description_two') %>
+      <%= t('.candidates_who_have_accepted_offers') %>
     </p>
     <p class="govuk-body">
-      <%= t('offers_accepted_table_component.table_does_not_include') %>
+      <%= t('.you_can_compare_the_data_to') %>
+    </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
+    <p class="govuk-body">
+      <%= t('.table_does_not_include') %>
     </p>
     <%= govuk_list([
-                     t('offers_accepted_table_component.li_one'),
-                     t('offers_accepted_table_component.li_two'),
-                     t('offers_accepted_table_component.li_three'),
+                     t('.withdrawn_by_provider'),
+                     t('.withdrawn_by_candidate'),
+                     t('.deferred'),
                    ], type: :bullet) %>
   </span>
 <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/proportion_candidates_with_offers_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/proportion_candidates_with_offers_table_component.html.erb
@@ -6,15 +6,17 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('proportion_candidates_with_offers_table_component.proportion_of_all_candidates', provider_name: @provider.name) %>
+      <%= t('.proportion_of_all_candidates', provider_name: @provider.name) %>
     </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
     <p class="govuk-body">
-      <%= t('proportion_candidates_with_offers_table_component.table_includes') %>
+      <%= t('.table_includes') %>
     </p>
-    <%= govuk_list([
-                     t('proportion_candidates_with_offers_table_component.li_one'),
-                     t('proportion_candidates_with_offers_table_component.li_two'),
-                     t('proportion_candidates_with_offers_table_component.li_three'),
-         ], type: :bullet) %>
+    <%= govuk_list(
+          [t('.candidates_with_offers_received'),
+           t('.offers_withdrawn_or_deferred_by_providers'),
+           t('.candidates_deferred_or_declined_after_accepting'),
+           t('.candidates_failed_to_meet_conditions')], type: :bullet
+        ) %>
   </span>
 <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.html.erb
@@ -6,9 +6,19 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('proportion_with_inactive_applications_table_component.description_one', provider_name:) %>
+      <%= t('.proportion_of_candidates_waiting_more_than_30_days', provider_name: @provider.name) %>
     </p>
-    <p class="govuk-body"><%= t('proportion_with_inactive_applications_table_component.description_two') %></p>
-    <p class="govuk-body"><%= t('proportion_with_inactive_applications_table_component.description_three') %></p>
+    <p class="govuk-body">
+      <%= t('.you_can_compare_the_data_to') %>
+    </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
+
+    <p class="govuk-body"><%= t('.responding_to_applications_include') %></p>
+    <%= govuk_list(
+          [t('.making_an_offer'),
+           t('.interviewing'),
+           t('.rejecting_application'),
+           t('.withdrawing')], type: :bullet
+        ) %>
   </span>
 <% end %>

--- a/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.rb
+++ b/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.rb
@@ -14,10 +14,6 @@ module ProviderInterface
           national_statistics:,
         )
       end
-
-      def provider_name
-        @provider.name
-      end
     end
   end
 end

--- a/app/components/provider_interface/recruitment_performance_report/submitted_applications_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/submitted_applications_table_component.html.erb
@@ -6,10 +6,11 @@
 ) do %>
   <span>
     <p class="govuk-body">
-      <%= t('submitted_applications_table_component.description_one', provider_name: @provider.name) %>
+      <%= t('.number_of_candidates_submitted', provider_name: @provider.name) %>
     </p>
+    <%= govuk_list([t('.last_cycle'), t('.national_data')], type: :bullet) %>
     <p class="govuk-body">
-      <%= t('submitted_applications_table_component.description_two') %>
+      <%= t('.candidates_who_withdrew') %>
     </p>
   </span>
 <% end %>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
@@ -1,69 +1,37 @@
 <div class="govuk-grid-column-two-thirds">
-
   <h2 class="govuk-heading-m" id='about_this_data'>
-    <%= t('about_this_data_section.section_heading') %>
+    <%= t('.section_heading') %>
   </h2>
+  <% if @provider_report.show_changes_section? %>
+    <h3 class="govuk-heading-s">
+      <%= t('.subsection_heading_one', cycle_range: @provider_report.cycle_range_name) %>
+    </h3>
+    <%= t('.whats_new_in_2024_html') %>
+  <% end %>
 
   <h3 class="govuk-heading-s">
-    <% if @provider_report.show_changes_section? %>
-      <%= t('about_this_data_section.subsection_heading_one', cycle_range: @provider_report.cycle_range_name) %>
-      <p class="govuk-body">
-        <%= t('about_this_data_section.whats_new_in_2024_paragraph_one') %>
-      </p>
-      <p class="govuk-body">
-        <%= t('about_this_data_section.whats_new_in_2024_paragraph_two') %>
-      </p>
-      <p class="govuk-body">
-        <%= t('about_this_data_section.whats_new_in_2024_paragraph_three') %>
-      </p>
-    <% end %>
-  </h3>
-
-  <h3 class="govuk-heading-s">
-    <%= t('about_this_data_section.subsection_heading_two') %>
+    <%= t('.subsection_heading_two') %>
   </h3>
   <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_two_paragraph_one') %>
+    <%= t('.these_applications_are_not_included') %>
   </p>
   <%= govuk_list([
-                   t('about_this_data_section.subsection_two_list_item_one'),
-                   t('about_this_data_section.subsection_two_list_item_two'),
-                   t('about_this_data_section.subsection_two_list_item_three'),
+                   t('.applications_made_directly_to_providers'),
+                   t('.undergraduate_except_tda'),
+                   t('.further_education_applications'),
                  ], type: :bullet) %>
 
   <h3 class="govuk-heading-s">
-    <%= t('about_this_data_section.subsection_heading_three') %>
+    <%= t('.understanding_the_figures_in_the_table_heading') %>
   </h3>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_three_paragraph_one') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_three_paragraph_two') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_three_paragraph_three') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_three_paragraph_four') %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_three_paragraph_five') %>
-  </p>
+  <%= t('.understanding_the_figures_explanation_html') %>
 
   <h3 class="govuk-heading-s">
-    <%= t('about_this_data_section.subsection_heading_four') %>
+    <%= t('.data_timeframes_heading') %>
   </h3>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_four_paragraph_one') %>
-  </p>
-  <p class="govuk-body">
-    <%= t(
-          'about_this_data_section.subsection_four_paragraph_two',
-          last_cycle_start_date: @provider_report.last_cycle_start_date,
-          this_cycle_start_date: @provider_report.this_cycle_start_date,
-        ) %>
-  </p>
-  <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_four_paragraph_three') %>
-  </p>
+  <%= t(
+        '.data_timeframes_explanation_html',
+        last_cycle_start_date: @provider_report.last_cycle_start_date,
+        this_cycle_start_date: @provider_report.this_cycle_start_date,
+      ) %>
 </div>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
@@ -1,29 +1,29 @@
 <div class="govuk-grid-column-two-thirds">
-  <p class="govuk-body"><%= t('show.last_updated', date: @provider_report.generation_date.to_date.to_fs(:govuk_date)) %></p>
+  <p class="govuk-body"><%= t('.last_updated', date: @provider_report.generation_date.to_date.to_fs(:govuk_date)) %></p>
   <p class="govuk-body">
-    <%= t('show.this_report_shows',
+    <%= t('.this_report_shows',
           cycle_name: @provider_report.cycle_range_name,
           start_date: @provider_report.report_show_data_from_date,
           end_date: @provider_report.report_show_data_to_date) %>
   </p>
   <p class="govuk-body">
     <% if @provider_report.previous_cycle? %>
-      <%= t('show.next_reports_will_be_available',
+      <%= t('.next_reports_will_be_available',
             next_cycle_name: @provider_report.next_cycle_range_name,
             next_reporting_start_date: @provider_report.next_reporting_start_date) %>
     <% else %>
-      <%= t('show.this_report_will_update', date: @provider_report.report_starting_date) %>
+      <%= t('.this_report_will_update', date: @provider_report.report_starting_date) %>
     <% end %>
   </p>
-  <p class="govuk-body"><%= t('show.this_report_compares') %></p>
-  <h2 class="govuk-heading-m"><%= t('show.contents') %></h2>
-  <%= govuk_list [govuk_link_to(t('show.about_this_data'), '#about_this_data', no_visited_state: true),
-                  govuk_link_to(t('show.candidates_who_have_submitted_applications'), '#candidates_who_have_submitted_applications', no_visited_state: true),
-                  govuk_link_to(t('show.candidates_with_an_offer'), '#candidates_with_an_offer', no_visited_state: true),
-                  govuk_link_to(t('show.proportion_of_candidates_with_an_offer'), '#proportion_of_candidates_with_an_offer', no_visited_state: true),
-                  govuk_link_to(t('show.offers_accepted'), '#offers_accepted', no_visited_state: true),
-                  govuk_link_to(t('show.candidate_deferrals'), '#candidate_deferrals', no_visited_state: true),
-                  govuk_link_to(t('show.candidates_rejected'), '#candidates_rejected', no_visited_state: true),
-                  govuk_link_to(t('show.proportion_of_candidates_who_have_waited_30_days_or_more_for_a_response'), '#proportion_with_inactive_applications_table_component', no_visited_state: true)],
+  <p class="govuk-body"><%= t('.this_report_compares') %></p>
+  <h2 class="govuk-heading-m"><%= t('.contents') %></h2>
+  <%= govuk_list [govuk_link_to(t('.about_this_data'), '#about_this_data', no_visited_state: true),
+                  govuk_link_to(t('.candidates_who_have_submitted_applications'), '#candidates_who_have_submitted_applications', no_visited_state: true),
+                  govuk_link_to(t('.candidates_with_an_offer'), '#candidates_with_an_offer', no_visited_state: true),
+                  govuk_link_to(t('.proportion_of_candidates_with_an_offer'), '#proportion_of_candidates_with_an_offer', no_visited_state: true),
+                  govuk_link_to(t('.offers_accepted'), '#offers_accepted', no_visited_state: true),
+                  govuk_link_to(t('.candidate_deferrals'), '#candidate_deferrals', no_visited_state: true),
+                  govuk_link_to(t('.candidates_rejected'), '#candidates_rejected', no_visited_state: true),
+                  govuk_link_to(t('.proportion_of_candidates_who_have_waited_30_days_or_more_for_a_response'), '#proportion_with_inactive_applications_table_component', no_visited_state: true)],
                  type: :number %>
 </div>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
@@ -1,10 +1,10 @@
 <% if @national_data.present? && @provider_data.present? %>
-  <%= content_for :title, t('show.title', cycle_year_range: @provider_report.cycle_range_name) %>
+  <%= content_for :title, t('.title', cycle_year_range: @provider_report.cycle_range_name) %>
   <%= content_for :before_content,
-                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.heading', cycle_year_range: @provider_report.cycle_range_name) => nil) %>
+                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('.heading', cycle_year_range: @provider_report.cycle_range_name) => nil) %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t('show.heading', cycle_year_range: @provider_report.cycle_range_name) %></h1>
+      <h1 class="govuk-heading-l"><%= t('.heading', cycle_year_range: @provider_report.cycle_range_name) %></h1>
     </div>
 
     <%= render 'provider_interface/reports/recruitment_performance_reports/report_description' %>
@@ -18,13 +18,13 @@
     <%= render ProviderInterface::RecruitmentPerformanceReport::ProportionWithInactiveApplicationsTableComponent.new(@provider, @provider_data, @national_data) %>
   </div>
 <% else %>
-  <%= content_for :title, t('show.empty_report_title') %>
+  <%= content_for :title, t('.empty_report_title') %>
   <%= content_for :before_content,
-                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.empty_report_heading') => nil) %>
+                  breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('.empty_report_heading') => nil) %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= t('show.empty_report_heading') %></h1>
-      <p class="govuk-body"><%= t('show.not_ready_to_view') %></p>
+      <h1 class="govuk-heading-l"><%= t('.empty_report_heading') %></h1>
+      <p class="govuk-body"><%= t('.not_ready_to_view') %></p>
     </div>
   </div>
 <% end %>

--- a/config/locales/components/provider_interface/recruitment_performance_report/en.yml
+++ b/config/locales/components/provider_interface/recruitment_performance_report/en.yml
@@ -1,41 +1,90 @@
 en:
+  provider_interface:
+    recruitment_performance_report:
+      submitted_applications_table_component:
+        number_of_candidates_submitted: >
+          This table shows the number of candidates who have submitted one or more applications to %{provider_name} so
+          far this recruitment cycle. You can compare the data to:
+        last_cycle: last cycle,
+        national_data: national data.
+        candidates_who_withdrew: Candidates who withdrew or deferred their applications after they submitted them are included.
+      candidates_with_offers_table_component:
+        candidates_who_have_received_offer: >
+          This table shows candidates who have received one or more offers from %{provider_name} so far this recruitment cycle.
+        you_can_compare_the_data_to: "You can compare the data to:"
+        last_cycle: last cycle,
+        national_data: national data.
+        table_includes: "This table includes candidates who have received at least one offer on at least one of their applications in this cycle. They are included whether or not the offer was:"
+        declined: declined
+        withdrawn_before_they_could_accept: withdrawn before they could accept it
+        deferred_withdrawn_unsuccessful: deferred, withdrawn or unsuccessful after acceptance
+      proportion_candidates_with_offers_table_component:
+        proportion_of_all_candidates: >
+          This table shows the proportion of all candidates who submitted one or more applications to %{provider_name} who
+          have received an offer so far this recruitment cycle. You can compare the data to:
+        last_cycle: last cycle,
+        national_data: national data.
+        table_includes: "The offered candidates in this table include:"
+        candidates_with_offers_received: candidates who have received one or more offers this cycle
+        offers_withdrawn_or_deferred_by_providers: offers which were then withdrawn or deferred by the provider
+        candidates_deferred_or_declined_after_accepting: candidates who deferred or declined their offers, or withdrew after accepting an offer
+        candidates_failed_to_meet_conditions: candidates that failed to meet the conditions of their offer
+      offers_accepted_table_component:
+        candidates_who_have_accepted_offers: >
+          The table includes candidates who accepted and then deferred an offer from the provider in a previous cycle,
+          which has been confirmed this cycle. It also includes candidates who accepted offers, but then did not meet
+          the conditions of that offer.
+        you_can_compare_the_data_to: "You can compare the data to:"
+        last_cycle: last cycle,
+        national_data: national data.
+        candidates_who_deferred: >
+          The table includes candidates who accepted and then deferred an offer from the provider in a previous cycle,
+          which has been confirmed this cycle.
+        table_does_not_include: "The table does not include applications with offers that have been:"
+        withdrawn_by_provider: withdrawn by the provider
+        withdrawn_by_candidate: withdrawn by candidates
+        deferred: deferred until the next cycle
+      deferrals_table_component:
+        caption: 6. Deferrals
+        deferrals: Deferrals
+        deferrals_last_cycle_to_this_cycle: Deferrals from last cycle to this cycle
+        deferrals_this_cycle_to_next: Deferrals this cycle (so far) to next cycle
+        deferred_offers_this_cycle: >
+          This table shows the number of deferred offers from %{provider_name} so far this recruitment cycle, compared
+          to national data.
+        deferred_to_the_next_cycle: >
+          This table includes candidates who have received an offer this cycle but deferred it to the next cycle,
+          excluding offers for withdrawn applications. Offers that were deferred and then withdrawn are not included.
+          Candidates who deferred again to the next cycle after that, are included in the cycle they first deferred in.
+      candidates_rejected_table_component:
+        number_of_rejected_candidates:  >
+          This table shows the number of candidates who have had all their applications to %{provider_name} rejected so
+          far this recruitment cycle.
+        you_can_compare_the_data_to: "You can compare the data to:"
+        last_cycle: last cycle,
+        national_data: national data.
+        candidates_rejected_and_awaiting_decisions: >
+          If a candidate has had all their applications rejected by %{provider_name} but still have applications
+          waiting for a decision with other providers, they will appear as rejected in your data but not the national
+          data.
+      proportion_with_inactive_applications_table_component:
+        proportion_of_candidates_waiting_more_than_30_days: >
+          This table shows the proportion of candidates who have waited for 30 working days or more for %{provider_name} to
+          respond to their application.
+        you_can_compare_the_data_to: "You can compare the data to:"
+        last_cycle: last cycle,
+        national_data: national data.
+        responding_to_applications_include: "Responding to an application includes actions such as:"
+        making_an_offer: making an offer
+        interviewing: interviewing
+        rejecting_application: rejecting the candidate's application
+        withdrawing: withdrawing an offer
   shared:
     empty_state: There is no data available to display.
     all_providers: All providers
     subject: Subject
     all_subjects: All subjects
     not_available: Not available
-  deferrals_table_component:
-    caption: 6. Deferrals
-    deferrals: Deferrals
-    deferrals_last_cycle_to_this_cycle: Deferrals from last cycle to this cycle
-    deferrals_this_cycle_to_next: Deferrals this cycle (so far) to next cycle
-    description_one: >
-      The number of deferred offers from %{provider_name} so far this recruitment cycle, compared to national level
-      data.
-    description_two: >
-      This table includes candidates who have received an offer this cycle but deferred it to the next cycle, excluding
-      offers for withdrawn applications. Candidates who deferred again to the next cycle after that, are included in the
-      cycle they first deferred in.
-  proportion_with_inactive_applications_table_component:
-    caption: 8. Proportion of candidates who have waited more than 30 days for a response
-    description_one: >
-      The proportion of candidates who have waited for 30 days or more for %{provider_name} to respond to their
-      application, compared with national level data.
-    description_two: >
-      Responding to an offer includes actions such as making an offer, interviewing or rejecting the candidate's
-      application.
-    description_three: >
-      This is the first recruitment cycle in which we have collected this data, so it is not possible to show a
-      comparison with last cycle.
-  proportion_candidates_with_offers_table_component:
-    proportion_of_all_candidates: >
-      The proportion of all candidates who submitted one or more applications to %{provider_name} who have received an
-      offer so far this recruitment cycle, compared to national level data.
-    table_includes: "This table includes:"
-    li_one: candidates who have received one or more offers this cycle
-    li_two: applications which were then withdrawn or deferred by the provider
-    li_three: candidates who withdrew or deferred their applications
   subject_table_component:
     this_cycle: This cycle
     last_cycle: Last cycle
@@ -44,36 +93,8 @@ en:
     national_last_cycle: Last cycle
     national_percentage_change: Percentage change
     candidates_who_have_submitted_applications: 2. Candidates who have submitted applications
-    candidates_with_an_offer: 3. Candidates with an offer
+    candidates_with_an_offer: 3. Candidates that received an offer
     proportion_of_candidates_with_an_offer: 4. Proportion of candidates with an offer
     offers_accepted: 5. Offers accepted
     candidates_rejected: 7. Candidates rejected
-    proportion_with_inactive_applications_table_component: 8. Proportion of candidates who have waited more than 30 days for a response
-  submitted_applications_table_component:
-    description_one: >
-      The number of candidates who have submitted one or more applications to %{provider_name} so far this recruitment
-      cycle, compared to national level data.
-    description_two: Candidates who withdrew or deferred their applications are included.
-  candidates_with_offers_table_component:
-    candidates_who_have_received_offer: >
-      Candidates who have received one or more offers from %{provider_name} so far this recruitment cycle, compared to
-      national level.
-    table_includes: "This table includes:"
-    li_one: candidates who have received one or more offers this cycle
-    li_two: applications which were then withdrawn or deferred by the provider
-    li_three: candidates who withdrew or deferred their applications
-  offers_accepted_table_component:
-    description_one: >
-      The number of candidates who have accepted an offer from %{provider_name} so far this recruitment cycle, compared
-      to national level data.
-    description_two: >
-      The table includes candidates who accepted and then deferred an offer from the provider in a previous cycle, which
-      has been reconfirmed this cycle.
-    table_does_not_include: "The table does not include applications:"
-    li_one: with offers withdrawn by the provider
-    li_two: with offers withdrawn by candidates
-    li_three: with offers deferred until the next cycle
-  candidates_rejected_table_component:
-    description_one: The number of candidates who have had all their applications to %{provider_name} rejected so far this recruitment cycle.
-    description_two: If a candidate has had all their applications rejected by %{provider_name}  but still have applications waiting for a decision with other providers, they will appear as rejected in your data but not the national data.
-
+    proportion_with_inactive_applications_table_component: 8. Proportion of candidates who have waited more than 30 working days for a response

--- a/config/locales/provider_interface/recruitment_performance_reports.yml
+++ b/config/locales/provider_interface/recruitment_performance_reports.yml
@@ -1,80 +1,89 @@
 en:
-  show:
-    title: Recruitment performance weekly report %{cycle_year_range} - Apply for teacher training - GOV.UK
-    empty_report_title: Recruitment performance weekly report - Apply for teacher training - GOV.UK
-    contents: Contents
-    heading: Recruitment performance weekly report %{cycle_year_range}
-    empty_report_heading: Recruitment performance weekly report
-    last_updated: 'Last updated: %{date}'
-    not_ready_to_view: This report is not ready to view.
-    this_report_shows: >
-      This report shows your organisation’s initial teacher training (ITT) recruitment performance for the %{cycle_name}
-      recruitment cycle, starting on %{start_date}, ending on %{end_date}.
-    this_report_will_update: >
-      This report will update weekly on a Monday, starting from %{date}. You will only be able to view
-      data from the most recent week.
-    next_reports_will_be_available: >
-      The weekly reports for the %{next_cycle_name} recruitment cycle will be available from %{next_reporting_start_date}.
-    this_report_compares: >
-      The report compares your organisation’s recruitment data this cycle, to the same time last recruitment cycle.
-      It also includes national level data.
-    about_this_data: About this data
-    candidates_who_have_submitted_applications: Candidates who have submitted applications
-    candidates_with_an_offer: Candidates with an offer
-    proportion_of_candidates_with_an_offer: Proportion of candidates with an offer
-    offers_accepted: Offers accepted
-    candidate_deferrals: Deferrals
-    candidates_rejected: Candidates rejected
-    proportion_of_candidates_who_have_waited_30_days_or_more_for_a_response: >
-      Proportion of candidates who have waited more than 30 days for a response
-  about_this_data_section:
-    section_heading: 1. About this data
-    subsection_heading_one: Changes for the %{cycle_range} recruitment cycle
-    whats_new_in_2024_paragraph_one: >
-      These statistics cover applications in the 2023 to 2024 recruitment cycle for courses in England starting in the
-      2024 to 2025 academic year. To allow for comparison, statistics covering the 2022 to 2023 recruitment cycle 2023
-      to 2024 academic year are also included.
-    whats_new_in_2024_paragraph_two: >
-      New definitions and methodology have been introduced for the 2023 to 2024 recruitment cycle  to 2025 academic year
-      because candidates can now submit applications to courses individually up to a maximum of 4 open applications at
-      a time. Previously, candidates submitted one application form with up to 4 course choices at the same time. All 4
-      course choices had to receive a decision before the candidate could submit another application form in the same
-      recruitment cycle.
-    whats_new_in_2024_paragraph_three: >
-      Improvements have also been made for clarity.
-    subsection_heading_two: Data which is excluded from these reports
-    subsection_two_paragraph_one: "The following types of applications are not included in these reports:"
-    subsection_two_list_item_one: teacher training applications made directly to providers
-    subsection_two_list_item_two: undergraduate teacher training
-    subsection_two_list_item_three: applications to train to teach in Further Education
-    subsection_heading_three: Understanding the figures in the tables
-    subsection_three_paragraph_one: >
-      All figures in this table are counts of candidates. A candidate is a person who has submitted at least one
-      application to an initial teacher training (ITT) course in England.
-    subsection_three_paragraph_two: >
-      Candidates can apply for different courses. On later dates they may then apply for further courses. Any of their
-      applications may change status throughout their lifecycle. This means that over time, some statistics may go up
-      or down.
-    subsection_three_paragraph_three: >
-      For example, if a candidate’s initial application to a provider had been rejected, they may have submitted a
-      second application. Before this date, they would have been included in the count of candidates with rejected
-      applications. After this date, they would not be included in this count. If that second application were also
-      rejected, they would then be included in the count of rejected applications again.
-    subsection_three_paragraph_four: >
-      Candidates may submit applications for more than one subject. These candidates are counted under all subjects
-      that apply. This means that the ‘All subjects’ row does not equal the total of the preceding rows.
-    subsection_three_paragraph_five: >
-      Subjects where no candidates have been counted are omitted from the tables. This means that some subjects may
-      appear in some tables and not others.
-    subsection_heading_four: Data timeframes
-    subsection_four_paragraph_one: >
-      Each recruitment cycle does not start on the same date each calendar year. The figures for 'last cycle' include
-      data up to and including the date which was the same number of days from the first day of the previous cycle as
-      the publication date is from the first day of the current cycle.
-    subsection_four_paragraph_two: >
-      This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of
-      last cycle was on %{last_cycle_start_date}, but day one of the current cycle was %{this_cycle_start_date}.
-    subsection_four_paragraph_three: >
-      These statistics collect data up to and including the day before they were published. The report is published
-      weekly on a Monday.
+  provider_interface:
+    reports:
+      recruitment_performance_reports:
+        report_description:
+          last_updated: 'Last updated: %{date}'
+          this_report_shows: >
+            This report shows your organisation’s initial teacher training (ITT) recruitment performance for the %{cycle_name}
+            recruitment cycle, starting on %{start_date}, ending on %{end_date}.
+          this_report_will_update: >
+            This report will update weekly on a Monday, starting from %{date}. You will only be able to view
+            data from the most recent week.
+          next_reports_will_be_available: >
+            The weekly reports for the %{next_cycle_name} recruitment cycle will be available from %{next_reporting_start_date}.
+          this_report_compares: >
+            The report compares your organisation’s recruitment data this cycle to the same time last recruitment cycle.
+            It also includes national level data.
+          contents: Contents
+          about_this_data: About this data
+          candidates_who_have_submitted_applications: Candidates who have submitted applications
+          candidates_with_an_offer: Candidates that received an offer
+          proportion_of_candidates_with_an_offer: Proportion of candidates with an offer
+          offers_accepted: Offers accepted
+          candidate_deferrals: Deferrals
+          candidates_rejected: Candidates rejected
+          proportion_of_candidates_who_have_waited_30_days_or_more_for_a_response: >
+            Proportion of candidates who have waited more than 30 working days for a response
+        show:
+          title: Recruitment performance weekly report %{cycle_year_range} - Apply for teacher training - GOV.UK
+          empty_report_title: Recruitment performance weekly report - Apply for teacher training - GOV.UK
+          heading: Recruitment performance weekly report %{cycle_year_range}
+          empty_report_heading: Recruitment performance weekly report
+          not_ready_to_view: This report is not ready to view.
+        about_this_data_section:
+          section_heading: 1. About this data
+          subsection_heading_one: Changes for the %{cycle_range} recruitment cycle
+          whats_new_in_2024_html: >
+            <p class="govuk-body">These statistics cover applications in the 2023 to 2024 recruitment cycle for courses in
+            England starting in the 2024 to 2025 academic year. To allow for comparison, statistics covering the 2022 to
+            2023 recruitment cycle 2023 to 2024 academic year are also included.</p>
+
+            <p class="govuk-body">New definitions and methodology have been introduced for the 2023 to 2024 recruitment
+            cycle to 2025 academic year because candidates can now submit applications to courses individually up to a
+            maximum of 4 open applications at a time. Previously, candidates submitted one application form with up to
+            4 course choices at the same time. All 4 course choices had to receive a decision before the candidate could
+            submit another application form in the same recruitment cycle.</p>
+
+            <p class="govuk-body">Improvements have also been made for clarity.</p>
+          subsection_heading_two: Data which is not included in these reports
+          these_applications_are_not_included: "These applications are not included in the reports:"
+          applications_made_directly_to_providers: teacher training applications made directly to providers
+          undergraduate_except_tda: undergraduate teacher training (except teacher degree apprenticeship (TDA) courses)
+          further_education_applications: applications to train to teach in Further Education
+          understanding_the_figures_in_the_table_heading: Understanding the figures in the tables
+          understanding_the_figures_explanation_html: >
+            <p class="govuk-body">All figures in this table are counts of candidates. A candidate is a person who has
+            submitted at least one application to an initial teacher training (ITT) course in England.</p>
+
+            <p class="govuk-body">Because candidates can apply for multiple courses throughout the recruitment cycle,
+            their application statuses change over time. This means that over time, some numbers in this report can go
+            up or down.</p>
+
+            <p class="govuk-body">For example, if a candidate’s first application to a provider is rejected, they might
+            submit a second application.</p>
+
+            <p class="govuk-body">After their first application is rejected, but before they submit their second
+            application, they are included in the count of candidates with rejected applications.</p>
+
+            <p class="govuk-body"> If their second application is also rejected, they would be included in the count of
+            rejected applications again.</p>
+
+            <p class="govuk-body">Candidates can submit applications for more than one subject. These candidates are
+            counted under all subjects that they have applied to. This means that the ‘All subjects’ row does not equal
+            the total of the rows above it.</p>
+
+            <p class="govuk-body">Subjects with no applications are not included in the tables. This means that some
+            subjects may appear in some tables and not others.</p>
+          data_timeframes_heading: Data timeframes
+          data_timeframes_explanation_html:
+            <p class="govuk-body">The recruitment cycle does not start on the same date each year. Where a table
+            compares data from last cycle to this cycle, the data will not be for the same dates, but it will be for the
+            same number of days.</p>
+
+            <p class="govuk-body">The time period that is used for comparison is the same number of days from the start
+            of the last cycle, as the report date is from the start of this cycle.</p>
+
+            <p class="govuk-body">These statistics are updated up to and including the day before they are published.
+            The report is published weekly on a Monday.</p>
 

--- a/spec/components/provider_interface/recruitment_performance_report/candidates_rejected_table_component_spec.rb
+++ b/spec/components/provider_interface/recruitment_performance_report/candidates_rejected_table_component_spec.rb
@@ -60,6 +60,6 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::CandidatesReject
   end
 
   def description(provider_name)
-    "The number of candidates who have had all their applications to #{provider_name} rejected so far this recruitment cycle."
+    "This table shows the number of candidates who have had all their applications to #{provider_name} rejected so far this recruitment cycle."
   end
 end

--- a/spec/components/provider_interface/recruitment_performance_report/candidates_with_offers_table_component_spec.rb
+++ b/spec/components/provider_interface/recruitment_performance_report/candidates_with_offers_table_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::CandidatesWithOf
 
     render_inline described_class.new(provider, provider_report.statistics, national_statistics)
 
-    expect(page).to have_table('3. Candidates with an offer')
+    expect(page).to have_table('3. Candidates that received an offer')
     expect(page).to have_content(description(provider.name))
 
     expect(page).to have_content provider.name
@@ -56,6 +56,6 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::CandidatesWithOf
   end
 
   def description(provider_name)
-    "Candidates who have received one or more offers from #{provider_name} so far this recruitment cycle, compared to national level."
+    "This table shows candidates who have received one or more offers from #{provider_name} so far this recruitment cycle."
   end
 end

--- a/spec/components/provider_interface/recruitment_performance_report/deferrals_table_component_spec.rb
+++ b/spec/components/provider_interface/recruitment_performance_report/deferrals_table_component_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::DeferralsTableCo
   end
 
   def description(provider_name)
-    "The number of deferred offers from #{provider_name} so far this recruitment cycle, compared to national level data."
+    "This table shows the number of deferred offers from #{provider_name} so far this recruitment cycle, compared to national data."
   end
 end

--- a/spec/components/provider_interface/recruitment_performance_report/offers_accepted_table_component_spec.rb
+++ b/spec/components/provider_interface/recruitment_performance_report/offers_accepted_table_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::OffersAcceptedTa
     render_inline described_class.new(provider, provider_report.statistics, national_statistics)
 
     expect(page).to have_table('5. Offers accepted')
-    expect(page).to have_content(description(provider.name))
+    expect(page).to have_content(description)
 
     expect(page).to have_content provider.name
     expect(page).to have_content 'All providers'
@@ -56,7 +56,7 @@ private
      'Religious Education']
   end
 
-  def description(provider_name)
-    "The number of candidates who have accepted an offer from #{provider_name} so far this recruitment cycle, compared to national level data."
+  def description
+    'The table includes candidates who accepted and then deferred an offer from the provider in a previous cycle, which has been confirmed this cycle. It also includes candidates who accepted offers, but then did not meet the conditions of that offer.'
   end
 end

--- a/spec/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component_spec.rb
+++ b/spec/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderInterface::RecruitmentPerformanceReport::ProportionWithIn
 
     render_inline described_class.new(provider, provider_report.statistics, national_statistics)
 
-    expect(page).to have_table('8. Proportion of candidates who have waited more than 30 days for a response')
+    expect(page).to have_table('8. Proportion of candidates who have waited more than 30 working days for a response')
     expect(page).to have_content(description(provider.name))
     expect(page).to have_content('Subject')
 
@@ -46,6 +46,6 @@ private
   end
 
   def description(provider_name)
-    "The proportion of candidates who have waited for 30 days or more for #{provider_name} to respond to their application, compared with national level data."
+    "This table shows the proportion of candidates who have waited for 30 working days or more for #{provider_name} to respond to their application."
   end
 end

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -73,10 +73,10 @@ private
       id: 'candidates_who_have_submitted_applications',
     )
 
-    expect(page).to have_link('Candidates with an offer', href: '#candidates_with_an_offer')
+    expect(page).to have_link('Candidates that received an offer', href: '#candidates_with_an_offer')
     expect(page).to have_css(
       'h2',
-      text: '3. Candidates with an offer',
+      text: '3. Candidates that received an offer',
       id: 'candidates_with_an_offer',
     )
 
@@ -109,12 +109,12 @@ private
     )
 
     expect(page).to have_link(
-      'Proportion of candidates who have waited more than 30 days for a response',
+      'Proportion of candidates who have waited more than 30 working days for a response',
       href: '#proportion_with_inactive_applications_table_component',
     )
     expect(page).to have_css(
       'h2',
-      text: '8. Proportion of candidates who have waited more than 30 days for a response',
+      text: '8. Proportion of candidates who have waited more than 30 working days for a response',
       id: 'proportion_with_inactive_applications_table_component',
     )
   end


### PR DESCRIPTION
## Context

We are soon to start publishing the recruitment performance reports again for providers. We have already made changes to some data. This PR makes changes to content. 

## Changes proposed in this pull request

- Updates content in line with [document](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Find%20and%20Apply%20Team/04.%20Manage/RecruitmentPerformanceReport2024/2025%20Provider%20recruitment%20performance%20report%202025%20content.docx?d=w0fc037b76d524b35beda082117bb5b6d&csf=1&web=1&e=x7eDbH)
- clean up the related translation files

## Guidance to review

have a look at the [review app](https://apply-review-10448.test.teacherservices.cloud/provider/reports/) (logging in as cameron carrot will let you view reports) and read through the text. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
