### PR TITLE
Find candidates additional filters

### DIFF
--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -67,7 +67,7 @@
                     <% end %>
                      <% elsif filter[:type] == :checkbox_filter %>
                     <div id="<%= filter[:name] %>" class="app-checkbox-filter app-checkbox-filter--enhanced">
-                      <% if active_filters&.find { |f| f[:name] == filter[:name] } %>
+                      <% if active_filters&.find { |f| f[:name] == filter[:name] } && filter[:hide_tags].blank? %>
                         <div class="app-checkbox-filter__selected">
                           <ul class="app-checkbox-filter__tags">
                             <% tags_for_active_filter(filter).each do |tag| %>

--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -33,7 +33,14 @@ module ProviderInterface
       end
 
       def filter_params
-        params.permit(:within, :original_location, visa_sponsorship: [])
+        params.permit(
+          :within,
+          :original_location,
+          subject: [],
+          study_mode: [],
+          course_type: [],
+          visa_sponsorship: [],
+        )
       end
     end
   end

--- a/app/frontend/packs/components/checkbox_search_filter.js
+++ b/app/frontend/packs/components/checkbox_search_filter.js
@@ -28,7 +28,7 @@ class CheckboxSearchFilter {
       if (labelValue.search(textValue) === -1) {
         allCheckboxes[i].style.display = 'none'
       } else {
-        allCheckboxes[i].style.display = 'block'
+        allCheckboxes[i].style.display = 'flex'
       }
     }
 

--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -109,7 +109,7 @@ module ProviderInterface
 
     def course_type_options
       %w[undergraduate postgraduate].map do |value|
-        filter_value = if value == 'undergraduate'
+        filter_value = if value == 'postgraduate'
                          Course.program_types.except('teacher_degree_apprenticeship').values.join(',')
                        else
                          Course.program_types['teacher_degree_apprenticeship']

--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -22,6 +22,26 @@ module ProviderInterface
           original_location: filter_params[:original_location],
         },
         {
+          type: :checkbox_filter,
+          heading: 'Subject',
+          name: 'subject',
+          options: subject_options,
+          hide_tags: true,
+
+        },
+        {
+          type: :checkboxes,
+          heading: 'Study type',
+          name: 'study_mode',
+          options: study_mode_options,
+        },
+        {
+          type: :checkboxes,
+          heading: 'Course type',
+          name: 'course_type',
+          options: course_type_options,
+        },
+        {
           type: :checkboxes,
           heading: 'Visa sponsorship',
           name: 'visa_sponsorship',
@@ -61,6 +81,44 @@ module ProviderInterface
           value: value,
           label: value.capitalize,
           checked: applied_filters[:visa_sponsorship]&.include?(value),
+        }
+      end
+    end
+
+    def subject_options
+      subjects = Subject.select("name, string_agg(id::text, ',') as ids").group(:name)
+
+      subjects.map do |subject|
+        {
+          value: subject.ids,
+          label: subject.name.capitalize,
+          checked: applied_filters[:subject]&.include?(subject.ids),
+        }
+      end
+    end
+
+    def study_mode_options
+      CourseOption.study_modes.map do |_, value|
+        {
+          value: value,
+          label: value.split('_').join(' ').capitalize,
+          checked: applied_filters[:study_mode]&.include?(value),
+        }
+      end
+    end
+
+    def course_type_options
+      %w[undergraduate postgraduate].map do |value|
+        filter_value = if value == 'undergraduate'
+                         Course.program_types.except('teacher_degree_apprenticeship').values.join(',')
+                       else
+                         Course.program_types['teacher_degree_apprenticeship']
+                       end
+
+        {
+          value: filter_value,
+          label: value.capitalize,
+          checked: applied_filters[:course_type]&.include?(filter_value),
         }
       end
     end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -92,67 +92,175 @@ RSpec.describe Pool::Candidates do
 
     context 'with filters' do
       it 'returns application_forms based on filters' do
-        providers = [create(:provider)]
-
-        manchester_candidate = create(:candidate, pool_status: 'opt_in')
-        manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
+        provider = create(:provider)
         aa_teamworks = create(
           :site,
           latitude: 51.4524877,
           longitude: -0.1204749,
-          provider: providers.first,
+          provider:,
+        )
+        course = create(:course, provider:)
+        tda_course = create(
+          :course,
+          provider:,
+          program_type: :teacher_degree_apprenticeship,
         )
         course_option = create(
           :course_option,
           site: aa_teamworks,
-          course: create(:course, provider: providers.first),
+          course: course,
         )
-        create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
+        part_time_course_option = create(
+          :course_option,
+          site: aa_teamworks,
+          course: course,
+          study_mode: :part_time,
+        )
+        part_time_tda_course_option = create(
+          :course_option,
+          site: aa_teamworks,
+          course: tda_course,
+          study_mode: :part_time,
+        )
 
-        visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
-        visa_sponsorship_candidate_form = create(
-          :application_form,
-          :completed,
-          candidate: visa_sponsorship_candidate,
-          right_to_work_or_study: :no,
-        )
-        aa_teamworks = create(
-          :site,
-          latitude: 51.4524893,
-          longitude: -0.1204768,
-          provider: providers.first,
-        )
-        course_option = create(
-          :course_option,
-          site: aa_teamworks,
-          course: create(:course, provider: providers.first),
-        )
-        create(:application_choice, :declined, application_form: visa_sponsorship_candidate_form, course_option:)
+        subject = create(:subject)
+        create(:course_subject, subject:, course:)
+        create(:course_subject, subject:, course: tda_course)
+
+        manchester_candidate_form = create_manchester_candidate_form(provider, aa_teamworks)
+        subject_candidate_form = create_subject_candidate_form(course_option)
+        part_time_candidate_form = create_part_time_candidate_form(part_time_course_option)
+        undergraduate_candidate_form = create_undergraduate_candidate_form(part_time_tda_course_option)
+        visa_sponsorship_candidate_form = create_visa_sponsorship_candidate_form(part_time_tda_course_option)
 
         withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
         withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
         create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
         filters = { origin: [51.4524877, -0.1204749], within: 10 }
-        application_forms = described_class.application_forms_for_provider(providers:, filters:)
+        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
-        expect(application_forms).to contain_exactly(
-          manchester_candidate_form,
-          visa_sponsorship_candidate_form,
+        expect(application_forms.map(&:id)).to contain_exactly(
+          manchester_candidate_form.id,
+          subject_candidate_form.id,
+          part_time_candidate_form.id,
+          undergraduate_candidate_form.id,
+          visa_sponsorship_candidate_form.id,
         )
 
         filters = {
           origin: [51.4524877, -0.1204749],
           within: 10,
+          subject: [subject.id.to_s],
+        }
+
+        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+
+        expect(application_forms.map(&:id)).to contain_exactly(
+          visa_sponsorship_candidate_form.id,
+          part_time_candidate_form.id,
+          subject_candidate_form.id,
+          undergraduate_candidate_form.id,
+        )
+
+        filters = {
+          origin: [51.4524877, -0.1204749],
+          within: 10,
+          subject: [subject.id.to_s],
+          study_mode: ['part_time'],
+        }
+
+        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+
+        expect(application_forms.map(&:id)).to contain_exactly(
+          visa_sponsorship_candidate_form.id,
+          part_time_candidate_form.id,
+          undergraduate_candidate_form.id,
+        )
+
+        filters = {
+          origin: [51.4524877, -0.1204749],
+          within: 10,
+          subject: [subject.id.to_s],
+          study_mode: ['part_time'],
+          course_type: ['TDA'],
+        }
+
+        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+
+        expect(application_forms.map(&:id)).to contain_exactly(
+          visa_sponsorship_candidate_form.id,
+          undergraduate_candidate_form.id,
+        )
+
+        filters = {
+          origin: [51.4524877, -0.1204749],
+          within: 10,
+          subject: [subject.id.to_s],
+          study_mode: ['part_time'],
+          course_type: ['TDA'],
           visa_sponsorship: ['required'],
         }
 
-        application_forms = described_class.application_forms_for_provider(providers:, filters:)
+        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
-        expect(application_forms).to contain_exactly(
-          visa_sponsorship_candidate_form,
+        expect(application_forms.map(&:id)).to contain_exactly(
+          visa_sponsorship_candidate_form.id,
         )
       end
+    end
+
+    def create_manchester_candidate_form(provider, aa_teamworks)
+      manchester_candidate = create(:candidate, pool_status: 'opt_in')
+      manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
+      course = create(:course, provider:)
+      course_option = create(
+        :course_option,
+        site: aa_teamworks,
+        course: course,
+      )
+      create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
+
+      manchester_candidate_form
+    end
+
+    def create_subject_candidate_form(course_option)
+      subject_candidate = create(:candidate, pool_status: 'opt_in')
+      subject_candidate_form = create(:application_form, :completed, candidate: subject_candidate)
+      create(:application_choice, :rejected, application_form: subject_candidate_form, course_option:)
+
+      subject_candidate_form
+    end
+
+    def create_part_time_candidate_form(course_option)
+      part_time_candidate = create(:candidate, pool_status: 'opt_in')
+      part_time_candidate_form = create(:application_form, :completed, candidate: part_time_candidate)
+      create(:application_choice, :rejected, application_form: part_time_candidate_form, course_option:)
+      part_time_candidate_form
+    end
+
+    def create_undergraduate_candidate_form(course_option)
+      undergraduate_candidate = create(:candidate, pool_status: 'opt_in')
+      undergraduate_candidate_form = create(
+        :application_form,
+        :completed,
+        candidate: undergraduate_candidate,
+      )
+      create(:application_choice, :declined, application_form: undergraduate_candidate_form, course_option:)
+      undergraduate_candidate_form
+    end
+
+    def create_visa_sponsorship_candidate_form(course_option)
+      visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
+      visa_sponsorship_candidate_form = create(
+        :application_form,
+        :completed,
+        candidate: visa_sponsorship_candidate,
+        right_to_work_or_study: :no,
+      )
+      create(:application_choice, :declined, application_form: visa_sponsorship_candidate_form, course_option:)
+
+      visa_sponsorship_candidate_form
     end
   end
 end

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -16,6 +16,47 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
           original_location: nil,
         },
         {
+          type: :checkbox_filter,
+          heading: 'Subject',
+          name: 'subject',
+          options: [],
+          hide_tags: true,
+        },
+        {
+          type: :checkboxes,
+          heading: 'Study type',
+          name: 'study_mode',
+          options: [
+            {
+              value: 'full_time',
+              label: 'Full time',
+              checked: nil,
+            },
+            {
+              value: 'part_time',
+              label: 'Part time',
+              checked: nil,
+            },
+          ],
+        },
+        {
+          type: :checkboxes,
+          heading: 'Course type',
+          name: 'course_type',
+          options: [
+            {
+              value: 'HE,HES,SD,SS,SC,SSC,TA',
+              label: 'Undergraduate',
+              checked: nil,
+            },
+            {
+              value: 'TDA',
+              label: 'Postgraduate',
+              checked: nil,
+            },
+          ],
+        },
+        {
           type: :checkboxes,
           heading: 'Visa sponsorship',
           name: 'visa_sponsorship',

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -45,12 +45,12 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
           name: 'course_type',
           options: [
             {
-              value: 'HE,HES,SD,SS,SC,SSC,TA',
+              value: 'TDA',
               label: 'Undergraduate',
               checked: nil,
             },
             {
-              value: 'TDA',
+              value: 'HE,HES,SD,SS,SC,SSC,TA',
               label: 'Postgraduate',
               checked: nil,
             },


### PR DESCRIPTION
## Context

This adds more filters to the find candidates index page.
- Subjects
- Study type (full time, part time)
- Course type (undergraduate, postgraduate). We treat this as tda or not :) 

With the subjects filters and course type, we need to pass multiple values to the backend from 1 checkbox. This is because 1 checkbox can mean multiple ids, Like we have multiple subjects with the same name, so instead of showing multiple subjects with the same name we group the ids behind one checkbox.

This is now how checkboxes should be used so I have to do some string splitting, watch the video to show how we pass the ids from a checkbox

Same happens for course_types, if they user filters by postgradute, we need to pass all the program types of a course, excluding TDA.

The second commit of this PR includes a fix to the checkbox search filter, changing the display to flex fixes this issues
![Screenshot from 2025-03-06 10-04-43](https://github.com/user-attachments/assets/33483b00-9e40-4052-9c02-abb1e4ecf837)



## Guidance to review

Go onto review and play with the filters. Log on as a provider with `dev-provider`



https://github.com/user-attachments/assets/dba2ae65-4ffc-42ed-80bf-34b8dc90b638






## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
