### PR TITLE
Update inactive email prompt to 'soften' the language

### DIFF
--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -2,17 +2,14 @@ Hello <%= @application_form.first_name %>
 
 You submitted an application for <%= @course_name_and_code %> on <%= @application_choice.sent_to_provider_at.to_date.to_fs(:govuk_date) %>.
 
-Because the training provider has failed to respond, we strongly recommend you apply for other courses.
+If you have not received a response to your application yet, we recommend you apply for other courses to improve your chances of success.
 
-^Our analysis shows that if you haven't heard back from a provider after 30 working days, you are unlikely to receive an offer.
-
-Candidates who apply for 4 or more courses are more likely to receive an offer.
+^Our analysis shows that if you haven't heard back from a provider after 30 working days, it is less likely that you will receive an offer.
 
 [Sign in to your account to apply for another course](<%= application_choices_link %>).
 
-You can also contact <%= @provider_name %> to check on your application.
+You can also contact <%= @provider_name %> to check on your application. If you are already in contact with them about your application, you can ignore this email.
 
 <%= render 'understand_your_professional_strengths' %>
 
 <%= render 'get_help_teacher_training_adviser' %>
-

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -6,13 +6,13 @@ You submitted the following applications on <%= @submitted_at %>:
   * <%= application[:course_name_and_code] %> at <%= application[:provider_name] %>
 <% end %>
 
-Because the training provider has failed to respond, we strongly recommend you apply for other courses.
+If you have not received a response to your applications yet, we recommend you apply for other courses to improve your chances of success.
 
-^Our analysis shows that if you haven't heard back from a provider after 30 working days, you are unlikely to receive an offer.
+^Our analysis shows that if you haven't heard back from a provider after 30 working days, it is less likely that you will receive an offer.
 
-Candidates who apply for 4 or more courses are more likely to receive an offer.
+[Sign in to your account to apply for another course](<%= application_choices_link %>).
 
-[Sign in to your account](<%= application_choices_link %>) to apply for another course.
+You can also contact the providers to check on your applications. If you are already in contact with them about your application, you can ignore this email.
 
 <%= render 'understand_your_professional_strengths' %>
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_apply_to_another_course_after_30_working_days_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_apply_to_another_course_after_30_working_days_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
-      'content' => 'Because the training provider has failed to respond, we strongly recommend you apply for other courses.',
+      'content' => 'If you have not received a response to your application yet, we recommend you apply for other courses to improve your chances of success.',
       'realistic job preview heading' => 'Understand your professional strengths',
       'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,

--- a/spec/mailers/candidate_mailer/candidate_mailer_apply_to_multiple_courses_after_30_working_days_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_apply_to_multiple_courses_after_30_working_days_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
-      'content' => 'Because the training provider has failed to respond, we strongly recommend you apply for other courses.',
+      'content' => 'If you have not received a response to your applications yet, we recommend you apply for other courses to improve your chances of success.',
       'realistic job preview heading' => 'Understand your professional strengths',
       'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,


### PR DESCRIPTION
## Context

A user had interpreted the previous copy to mean their application is no longer progressing. 

## Changes proposed in this pull request

**For a single inactive application and multiple inactive applications:**
- Added the conditional 'if' to make it clear that this only applies if the candidate has not heard from the provider, including through other means
- Removed reference to providers 'failing' to respond
- Changed 'unlikely to receive an offer' to 'less likely' to show there's a reduction in likelihood but it's not an impossibility
- Removed 'strongly' from the recommendation to soften it. Added that this will improve chances of success to make it clearer why we are making this suggestion
- Added a note that if a candidate is in contact with the provider outside of our systems, they can ignore this email

## Guidance to review

Please see a preview of the update copy at:

Single inactive application:
- https://apply-review-10452.test.teacherservices.cloud/rails/mailers/candidate_mailer/apply_to_another_course_after_30_working_days

Multiple inactive applications:
- https://apply-review-10452.test.teacherservices.cloud/rails/mailers/candidate_mailer/apply_to_multiple_courses_after_30_working_days

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
