### PR TITLE
Edit change action for degree type to reflect action

### DIFF
--- a/app/components/candidate_interface/degree_review_component.rb
+++ b/app/components/candidate_interface/degree_review_component.rb
@@ -102,7 +102,7 @@ module CandidateInterface
         value: degree.qualification_type,
         action: {
           href: candidate_interface_degree_edit_path(degree.id, :type),
-          visually_hidden_text: generate_action(degree:, attribute: t('application_form.degree.type_of_degree.change_action')),
+          visually_hidden_text: generate_action(degree:, attribute: t('application_form.degree.type_of_degree.change_action', degree: append_degree(degree).to_s.downcase)),
         },
         html_attributes: {
           data: {

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -30,7 +30,7 @@ en:
         review_label: Degree type
       type_of_degree:
         review_label: Type of %{degree}
-        change_action: specific type of degree
+        change_action: type of %{degree}
       international_qualification_type:
         hint_text: For example, Bachelor degree, Bachelor of Arts, Diplôme, Licenciatura
       subject:

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -21,7 +21,7 @@ en:
   application_form:
     degree:
       qualification:
-        change_action: qualification
+        change_action: degree type
       uk_degree:
         label: UK degree
       non_uk_degree:

--- a/spec/components/candidate_interface/degree_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_review_component_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
           key: 'Type of bachelor degree',
           value: 'Bachelor of Arts in Architecture',
           action: {
-            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            text: "Change #{t('application_form.degree.type_of_degree.change_action', degree: 'bachelor degree')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
             href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
           },
         )
@@ -141,7 +141,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
             key: 'Type of bachelor degree',
             value: 'Bachelor of arts in architecture',
             action: {
-              text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of arts in architecture, Woof, University of Doge, 2008",
+              text: "Change #{t('application_form.degree.type_of_degree.change_action', degree: 'bachelor degree')} for Bachelor of arts in architecture, Woof, University of Doge, 2008",
               href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
             },
           )
@@ -183,7 +183,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
           key: 'Type of bachelor degree',
           value: 'Bachelor of Arts in Architecture',
           action: {
-            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            text: "Change #{t('application_form.degree.type_of_degree.change_action', degree: 'bachelor degree')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
             href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
           },
         )
@@ -237,7 +237,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         key: 'Type of bachelor degree',
         value: 'Bachelor of Arts in Architecture',
         action: {
-          text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          text: "Change #{t('application_form.degree.type_of_degree.change_action', degree: 'bachelor degree')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
           href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
         },
       )
@@ -628,7 +628,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         key: t('application_form.degree.type_of_degree.review_label', degree: 'bachelor degree'),
         value: 'Bachelor of Arts',
         action: {
-          text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          text: "Change #{t('application_form.degree.type_of_degree.change_action', degree: 'bachelor degree')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
           href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
         },
       )
@@ -698,7 +698,7 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         key: 'Type of doctorate',
         value: 'Doctor of education',
         action: {
-          text: "Change specific type of degree for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          text: "Change type of doctorate for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
           href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
         },
       )

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Degrees' do
   end
 
   def and_i_click_to_change_my_undergraduate_degree_type
-    click_change_link('qualification')
+    click_change_link('degree type')
   end
 
   def and_i_click_the_back_link
@@ -112,7 +112,7 @@ RSpec.describe 'Degrees' do
   end
 
   def when_i_click_to_change_my_undergraduate_degree_type
-    click_change_link('qualification')
+    click_change_link('degree type')
   end
 
   def then_i_am_taken_back_to_the_degree_type_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def and_if_there_is_only_a_foundation_degree
-    click_change_link('qualification')
+    click_change_link('degree type')
     choose 'Foundation degree'
     and_i_click_on_save_and_continue
     choose 'Foundation of Arts (FdA)'

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def and_i_click_to_change_my_undergraduate_degree_type
-    click_change_link('qualification')
+    click_change_link('degree type')
   end
 
   def when_i_click_to_change_my_undergraduate_degree_start_year
@@ -258,7 +258,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def when_i_change_my_undergraduate_degree_type_to_a_diploma
-    click_change_link('qualification')
+    click_change_link('degree type')
     choose 'Level 6 Diploma'
     and_i_click_on_save_and_continue
   end
@@ -271,7 +271,7 @@ RSpec.describe 'Editing a degree' do
 
   def when_i_click_to_change_my_undergraduate_degree_type_again
     visit candidate_interface_degree_review_path
-    click_change_link('qualification')
+    click_change_link('degree type')
   end
 
   def and_i_change_my_degree_to_another_masters_degree_type

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def when_i_click_to_change_my_masters_undergraduate_degree_type
-    click_change_link('specific type of degree')
+    click_change_link('type of master’s degree')
   end
 
   def then_i_see_another_masters_degree_selected


### PR DESCRIPTION
## Context

**Bug fix on "check your degree" page:** currently the screen reader inaccurately announces "change qualification" in place of "change degree type" for the degree type change link. The link label should accurately tell the user where the link will take them.

## Changes proposed in this pull request

- The change link for "degree type" now announces "change degree type"
- The change link for "type of [bachelor's] degree" now announces "change type of [bachelor's] degree" (dynamic according to degree level, e.g. master's degree, doctorate)

## Guidance to review

- Sign in as a candidate user
- Add a degree
- On the "Check your degree" page, activate the screen reader (Press Command+F5 to turn on VoiceOver for Mac)
- Use Control+Option+Right arrow to tab through the page
- When VoiceOver reaches the degree type change link, check that it announces "change degree type"

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
