### PR TITLE
[625] Part 2, Ingest new visa sponsorship field 

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -98,6 +98,7 @@ module TeacherTrainingPublicAPI
         subject = ::Subject.find_or_initialize_by(code:)
         course.subjects << subject unless course.course_subjects.exists?(subject_id: subject.id)
       end
+      course.visa_sponsorship_application_deadline_at = course_from_api.visa_sponsorship_application_deadline_at
     end
 
     def study_mode(course_from_api)

--- a/spec/examples/teacher_training_api/course_list_response.json
+++ b/spec/examples/teacher_training_api/course_list_response.json
@@ -70,7 +70,8 @@
         "state": "published",
         "study_mode": "both",
         "summary": "PGCE with QTS full time",
-        "subject_codes": ["00"]
+        "subject_codes": ["00"],
+        "visa_sponsorship_application_deadline_at": "2020-06-13T10:44:31Z"
       },
       "relationships": {
         "recruitment_cycle": {

--- a/spec/examples/teacher_training_api/course_single_response.json
+++ b/spec/examples/teacher_training_api/course_single_response.json
@@ -72,7 +72,8 @@
       "subject_codes": [
         {
         }
-      ]
+      ],
+      "visa_sponsorship_application_deadline_at": "2020-06-13T10:44:31Z"
     },
     "relationships": {
       "recruitment_cycle": {

--- a/spec/examples/teacher_training_api/provider_list_response.json
+++ b/spec/examples/teacher_training_api/provider_list_response.json
@@ -105,7 +105,8 @@
         "start_date": "2020-09-01",
         "state": "published",
         "study_mode": "both",
-        "summary": "PGCE with QTS full time"
+        "summary": "PGCE with QTS full time",
+        "visa_sponsorship_application_deadline_at": "2020-06-13T10:44:31Z"
       },
       "relationships": {
         "accredited_body": {


### PR DESCRIPTION
## Context

This is the second PR for this ticket. See the [first PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10464) for a detailed description

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
