### PR TITLE
Fix flaky candidate pool test

### DIFF
--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'Providers views candidate pool list' do
     )
     aa_teamworks = create(
       :site,
-      latitude: 51.4524880,
+      latitude: 51.5249377,
       longitude: -0.1204752,
       provider: current_provider,
     )


### PR DESCRIPTION
## Context

We were sorting by distance but both candidates were 0.0 miles from the filtered location so it was a bit of a toss up if your spec would pass or not. This changes the spec to have 1 candidate 5 miles from the filtered location

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
