### PR TITLE
Candidate pool clean up

### DIFF
--- a/app/components/provider_interface/find_candidates/right_to_work_component.rb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.rb
@@ -6,6 +6,10 @@ class ProviderInterface::FindCandidates::RightToWorkComponent < ViewComponent::B
   end
 
   def visa_sponsorhip_value
-    application_form.right_to_work_or_study_yes? ? 'Not required' : 'Required'
+    if application_form.right_to_work_or_study_no?
+      'Required'
+    else
+      'Not required'
+    end
   end
 end

--- a/app/forms/provider_interface/pool_invite_form.rb
+++ b/app/forms/provider_interface/pool_invite_form.rb
@@ -7,6 +7,7 @@ module ProviderInterface
 
     validates :course_id, presence: true
     validate :course_is_open if -> { course.present? }
+    validate :already_invited_to_course if -> { course.present? }
 
     def initialize(current_provider_user:, candidate: nil, pool_invite_form_params: {})
       @current_provider_user = current_provider_user
@@ -61,6 +62,11 @@ module ProviderInterface
 
     def course_is_open
       errors.add(:course_id, :invalid) unless available_courses.include?(course)
+    end
+
+    def already_invited_to_course
+      existing_invite = Pool::Invite.published.find_by(course_id:, candidate_id: candidate.id).present?
+      errors.add(:course_id, :already_invited) if existing_invite
     end
   end
 end

--- a/app/workers/provider/delete_draft_pool_invites_worker.rb
+++ b/app/workers/provider/delete_draft_pool_invites_worker.rb
@@ -1,0 +1,9 @@
+class Provider::DeleteDraftPoolInvitesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform
+    Pool::Invite.draft.where('updated_at < ?', 3.days.ago).delete_all
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -29,6 +29,7 @@ class Clock
   # Daily jobs
   every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_async }
   every(1.day, 'DeleteDraftWithdrawalReasonRecordsWorker', at: '4:01') { DeleteDraftWithdrawalReasonRecordsWorker.perform_async }
+  every(1.day, 'DeleteDraftPoolInvites', at: '4:02') { Provider::DeleteDraftPoolInvitesWorker.perform_async }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
 
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -42,3 +42,4 @@ en:
             course_id:
               blank: Select a course
               invalid: Course is not available
+              already_invited: Select a different course. You have invited this person to the selected course already

--- a/spec/forms/provider_interface/pool_invite_form_spec.rb
+++ b/spec/forms/provider_interface/pool_invite_form_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe ProviderInterface::PoolInviteForm, type: :model do
         expect(form.errors[:course_id]).to eq(['Course is not available'])
       end
     end
+
+    context 'when the candidate has been invited to the course already' do
+      it 'returns course unavilable error' do
+        _existing_invite = create(:pool_invite, candidate:, status: :published, course:)
+
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:course_id]).to eq(['Select a different course. You have invited this person to the selected course already'])
+      end
+    end
   end
 
   describe '.build_from_invite' do

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'Providers views candidate pool list' do
     @rejected_candidate_form = create(
       :application_form,
       :completed,
+      first_name: 'Rejected',
+      last_name: 'Candidate',
       candidate: @rejected_candidate,
       submitted_at: 1.day.ago,
     )
@@ -42,6 +44,8 @@ RSpec.describe 'Providers views candidate pool list' do
     @declined_candidate_form = create(
       :application_form,
       :completed,
+      first_name: 'Declined',
+      last_name: 'Candidate',
       candidate: declined_candidate,
       submitted_at: Time.zone.today,
     )

--- a/spec/workers/provider/delete_draft_pool_invites_worker_spec.rb
+++ b/spec/workers/provider/delete_draft_pool_invites_worker_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Provider::DeleteDraftPoolInvitesWorker do
+  describe '#perform' do
+    it 'deletes draft pool invites records that are over 3 days old' do
+      create(:pool_invite, :published, updated_at: 3.days.ago)
+      create(:pool_invite, :published, updated_at: 4.days.ago)
+      create(:pool_invite, :draft, updated_at: 3.days.ago)
+      create(:pool_invite, :draft)
+      deletable_record = create(:pool_invite, :draft, updated_at: 4.days.ago)
+
+      expect { described_class.new.perform }.to change { Pool::Invite.count }.by(-1)
+
+      expect { deletable_record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Minor fixes to candidate pool journey.

- Validation on multiple invites to the same course
- Fixed visa sponsorship component on candidate pool show page
- Clean up job to delete stale pool invites.

Can review by commit.

## Changes proposed in this pull request


## Guidance to review


Can go to review app if you want

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
