### PR TITLE
[737] Block submission from applicants after visa sponsorship deadlines have passed

### DIFF
--- a/app/components/candidate_interface/application_review_and_submit_component.html.erb
+++ b/app/components/candidate_interface/application_review_and_submit_component.html.erb
@@ -1,7 +1,7 @@
 <% unless application_can_submit? %>
   <% errors.each do |error| %>
     <% error.message.split(/\n+/).each_with_index do |line, index| %>
-      <% if index.zero? && (error.type.in?(%i[course_closed course_unavailable immigration_status])) %>
+      <% if index.zero? && (error.type.in?(%i[course_closed course_unavailable immigration_status visa_sponsorship_application_deadline_passed])) %>
         <%= govuk_warning_text do %>
           <%= line.html_safe %>
         <% end %>
@@ -12,11 +12,23 @@
   <% end %>
 <% end %>
 
-<% if errors.map(&:type).intersection([:course_unavailable, :course_closed]).empty? %>
-<h2 class="govuk-heading-m">Delete draft application</h2>
+<% if errors.map(&:type).intersection([:course_unavailable, :course_closed, :visa_sponsorship_application_deadline_passed]).empty? %>
+<h2 class="govuk-heading-m"><%= t('.delete_draft_application') %></h2>
 <p class="govuk-body">
   You can <%= govuk_link_to('delete your draft application', candidate_interface_course_choices_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }) %> if you no longer want to apply for <%= @application_choice.current_course.name_and_code %> at <%= @application_choice.current_course.provider.name %>.
 </p>
+<% end %>
+
+<% if errors.map(&:type).include?(:visa_sponsorship_application_deadline_passed) %>
+  <h2 class="govuk-heading-m"><%= t('.delete_draft_application') %></h2>
+  <p class="govuk-body">
+    <%= t(
+          '.you_should_delete_html',
+          link: govuk_link_to(t('.delete_your_draft'), candidate_interface_course_choices_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }),
+          course_name: @application_choice.current_course.name_and_code,
+          provider_name: @application_choice.current_course.provider.name,
+        ) %>
+  </p>
 <% end %>
 
 <% if application_can_submit? %>

--- a/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.html.erb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.html.erb
@@ -1,0 +1,9 @@
+<%= govuk_notification_banner(title_text: t('notification_banner.important')) do %>
+  <h2 class="govuk-heading-m">
+    <%= t(
+          '.text',
+          count: count_down,
+          deadline_at:,
+        ) %>
+  </h2>
+<% end %>

--- a/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.rb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.rb
@@ -1,0 +1,37 @@
+module CandidateInterface
+  module SponsorshipApplicationDeadlines
+    class ApplicationChoiceBannerComponent < ViewComponent::Base
+      attr_reader :application_choice
+
+      def initialize(application_choice:)
+        @application_choice = application_choice
+      end
+
+      def render?
+        FeatureFlag.active?(:early_application_deadlines_for_candidates_with_visa_sponsorship) &&
+          application_choice.unsubmitted? &&
+          application_form.right_to_work_or_study == 'no' &&
+          course.visa_sponsorship_application_deadline_at.present? &&
+          course.visa_sponsorship_application_deadline_at.between?(Time.zone.now, 15.days.from_now)
+      end
+
+      def count_down
+        (course.visa_sponsorship_application_deadline_at.to_datetime - Time.zone.now.to_datetime).to_i
+      end
+
+      def deadline_at
+        course.visa_sponsorship_application_deadline_at.to_datetime.to_fs(:govuk_time)
+      end
+
+    private
+
+      def course
+        @course ||= application_choice.course
+      end
+
+      def application_form
+        @application_form ||= application_choice.application_form
+      end
+    end
+  end
+end

--- a/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.html.erb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.html.erb
@@ -1,0 +1,30 @@
+<%= govuk_notification_banner(title_text: t('notification_banner.important')) do %>
+  <% if choices.count == 1 %>
+    <h2 class="govuk-heading-m">
+      <%= t(
+            '.one_choice_text',
+            course_name: course_name(choices.first),
+            count: count_down(choices.first),
+            deadline_at: deadline_at(choices.first),
+          ) %>
+    </h2>
+  <% else %>
+    <h2 class="govuk-heading-m">
+      <%= t('.submit_your_applications_soon') %>
+    </h2>
+    <p class="govuk-body">
+      <%= t('.deadlines_approaching') %>
+    </p>
+    <%= govuk_list(
+          choices.map do |choice|
+            t(
+              '.multiple_choice_text',
+              course_name: course_name(choice),
+              count: count_down(choice),
+              deadline_at: deadline_at(choice),
+            )
+          end,
+          type: :bullet,
+        ) %>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.rb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.rb
@@ -1,0 +1,37 @@
+module CandidateInterface
+  module SponsorshipApplicationDeadlines
+    class ApplicationsDashboardBannerComponent < ViewComponent::Base
+      attr_reader :application_form
+      def initialize(application_form:)
+        @application_form = application_form
+      end
+
+      def render?
+        FeatureFlag.active?(:early_application_deadlines_for_candidates_with_visa_sponsorship) &&
+          application_form.right_to_work_or_study_no? &&
+          choices.present?
+      end
+
+      def course_name(choice)
+        "#{choice.course.name_and_code} at #{choice.course.provider.name}"
+      end
+
+      def count_down(choice)
+        (choice.course.visa_sponsorship_application_deadline_at.to_datetime - Time.zone.now.to_datetime).to_i
+      end
+
+      def deadline_at(choice)
+        choice.course.visa_sponsorship_application_deadline_at.to_datetime.to_fs(:govuk_time)
+      end
+
+      def choices
+        @choices ||= application_form
+                       .application_choices
+                       .unsubmitted
+                       .joins(:course)
+                       .where('courses.visa_sponsorship_application_deadline_at' => Time.zone.now..15.days.from_now)
+                       .order('courses.visa_sponsorship_application_deadline_at')
+      end
+    end
+  end
+end

--- a/app/services/candidate_interface/application_choice_submission.rb
+++ b/app/services/candidate_interface/application_choice_submission.rb
@@ -14,6 +14,7 @@ module CandidateInterface
               incomplete_postgraduate_course_details: { if: :validate_choice? },
               incomplete_undergraduate_course_details: { if: :validate_choice? },
               incomplete_details: { if: :validate_choice? },
+              visa_sponsorship_application_deadline_passed: { if: :validate_choice? },
               can_add_more_choices: true
 
   private

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,6 +27,7 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
+    [:early_application_deadlines_for_candidates_with_visa_sponsorship, 'Implement alternative deadlines for candidates requiring visa sponsorships', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/validators/visa_sponsorship_application_deadline_passed_validator.rb
+++ b/app/validators/visa_sponsorship_application_deadline_passed_validator.rb
@@ -1,0 +1,25 @@
+class VisaSponsorshipApplicationDeadlinePassedValidator < ActiveModel::EachValidator
+  include ActionView::Helpers::UrlHelper
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+  def validate_each(record, attribute, application_choice)
+    return unless FeatureFlag.active?(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+    return unless application_choice.application_form.right_to_work_or_study == 'no'
+
+    deadline = application_choice.course.visa_sponsorship_application_deadline_at
+    return if deadline.nil? || deadline.after?(Time.zone.now)
+
+    record.errors.add(
+      attribute,
+      :visa_sponsorship_application_deadline_passed,
+      link_to_find:,
+    )
+  end
+
+  def link_to_find
+    govuk_link_to(
+      'Find a different course to apply to',
+      I18n.t('find_teacher_training.production_url'),
+    )
+  end
+end

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -24,6 +24,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+  <%= render CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent.new(application_form: current_application) %>
   <% if current_application.after_apply_deadline? %>
 <!--      It is after the deadline, but candidate has inflight applications (eg, awaiting decision) -->
     <%= render CandidateInterface::AfterDeadlineContentComponent.new(application_form: current_application) %>

--- a/app/views/candidate_interface/course_choices/review/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review/show.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
+    <%= render CandidateInterface::SponsorshipApplicationDeadlines::ApplicationChoiceBannerComponent.new(application_choice: @application_choice) %>
+
     <h1 class="govuk-heading-l">
       <%= t('page_titles.application_review', provider_name: @application_choice.current_course.provider.name) %>
     </h1>

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -52,6 +52,12 @@ en:
                 %{link_to_degree} and complete the rest of your details. You can then submit your application.
 
                 Your application will be saved as a draft while you finish adding your details.
+              visa_sponsorship_application_deadline_passed: |-
+                This course is closed to candidates who need visa sponsorship now.
+
+                You cannot apply to this course. You should choose another course or subject at another training provider who is still accepting applications.
+
+                %{link_to_find}.
   application_form:
     submit_application:
       title: Send application to training providers

--- a/config/locales/components/candidate_interface/application_review_and_submit_component.yml
+++ b/config/locales/components/candidate_interface/application_review_and_submit_component.yml
@@ -1,0 +1,7 @@
+en:
+  candidate_interface:
+    application_review_and_submit_component:
+      delete_draft_application: Delete draft application
+      you_should_delete_html:
+        You should %{link} to apply for %{course_name} at %{provider_name} because they cannot accept your application this year.
+      delete_your_draft: delete your draft application

--- a/config/locales/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.yml
+++ b/config/locales/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.yml
@@ -1,0 +1,14 @@
+en:
+  candidate_interface:
+    sponsorship_application_deadlines:
+      application_choice_banner_component:
+        text:
+          zero: >
+            Submit this application soon. The deadline for applications that need visa sponsorship is
+            at %{deadline_at} today.
+          one: >
+            Submit this application soon. The deadline for applications that need visa sponsorship is
+            in 1 day.
+          other: >
+            Submit this application soon. The deadline for applications that need visa sponsorship is
+            in %{count} days.

--- a/config/locales/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.yml
+++ b/config/locales/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.yml
@@ -1,0 +1,20 @@
+en:
+  candidate_interface:
+    sponsorship_application_deadlines:
+      applications_dashboard_banner_component:
+        one_choice_text:
+          zero: >
+            Submit your application for %{course_name} soon. The deadline for applications that need visa sponsorship is
+            at %{deadline_at} today.
+          one: >
+            Submit your application for %{course_name} soon. The deadline for applications that need visa sponsorship is
+            in 1 day.
+          other: >
+            Submit your application for %{course_name} soon. The deadline for applications that need visa sponsorship is
+            in %{count} days.
+        submit_your_applications_soon: Submit your applications soon
+        deadlines_approaching: The deadlines for these courses that need visa sponsorship are approaching
+        multiple_choice_text:
+          zero: "%{course_name} - deadline at %{deadline_at} today"
+          one: "%{course_name} - deadline in %{count} day"
+          other: "%{course_name} - deadline in %{count} days"

--- a/spec/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_spec.rb
+++ b/spec/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::ApplicationChoiceBannerComponent do
+  before do
+    FeatureFlag.activate(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+  end
+
+  context 'unsubmitted choice requires sponsorship and course has deadlines' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at:)) }
+
+    context 'deadline less than 1 day from now' do
+      let(:visa_sponsorship_application_deadline_at) { 4.hours.from_now }
+
+      it 'renders text for less than one day' do
+        application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+        rendered = render_inline(described_class.new(application_choice:))
+
+        expect(rendered).to have_text("Submit this application soon. The deadline for applications that need visa sponsorship is at #{visa_sponsorship_application_deadline_at.to_fs(:govuk_time)} today.")
+      end
+    end
+
+    context 'deadline 1 day from now' do
+      let(:visa_sponsorship_application_deadline_at) { 1.day.from_now + 1.second }
+
+      it 'renders text for one day' do
+        application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+        rendered = render_inline(described_class.new(application_choice:))
+
+        expect(rendered).to have_text('Submit this application soon. The deadline for applications that need visa sponsorship is in 1 day')
+      end
+    end
+
+    context 'deadline 14 days from now' do
+      let(:visa_sponsorship_application_deadline_at) { 14.days.from_now + 1.second }
+
+      it 'renders text for 14 days from now' do
+        application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+        rendered = render_inline(described_class.new(application_choice:))
+
+        expect(rendered).to have_text('Submit this application soon. The deadline for applications that need visa sponsorship is in 14 days')
+      end
+    end
+
+    context 'deadline 15 days from now' do
+      let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+      let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 15.days.from_now + 1.second)) }
+
+      it 'does not render component' do
+        application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+        rendered = render_inline(described_class.new(application_choice:))
+
+        expect(rendered.text).to eq ''
+      end
+    end
+
+    context 'deadline has passed' do
+      let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+      let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 1.second.ago)) }
+
+      it 'does not render component' do
+        application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+        rendered = render_inline(described_class.new(application_choice:))
+
+        expect(rendered.text).to eq ''
+      end
+    end
+  end
+
+  context 'application form does not require sponsorship' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: nil) }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 4.days.from_now)) }
+
+    it 'does not render component' do
+      application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+      rendered = render_inline(described_class.new(application_choice:))
+
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'course does not have a visa sponsorship application deadline' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: nil) }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: nil)) }
+
+    it 'does not render component' do
+      application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+      rendered = render_inline(described_class.new(application_choice:))
+
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'choice has been submitted' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 4.days.from_now)) }
+
+    it 'does not render component' do
+      application_choice = create(:application_choice, :awaiting_provider_decision, course_option:, application_form:)
+      rendered = render_inline(described_class.new(application_choice:))
+
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'feature flag is off' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 4.days.from_now)) }
+
+    it 'does not render component' do
+      FeatureFlag.deactivate(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+      application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+
+      rendered = render_inline(described_class.new(application_choice:))
+
+      expect(rendered.text).to eq ''
+    end
+  end
+end

--- a/spec/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_spec.rb
+++ b/spec/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent do
+  before do
+    FeatureFlag.activate(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+  end
+
+  context 'with a single relevant application choice' do
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at:)) }
+    let(:course_option_without_deadline) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: nil)) }
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+
+    before do
+      create(:application_choice, :unsubmitted, course_option: course_option, application_form:)
+      create(:application_choice, :unsubmitted, course_option: course_option_without_deadline, application_form:)
+    end
+
+    context 'when the deadline for one course is today' do
+      let(:visa_sponsorship_application_deadline_at) { 5.hours.from_now }
+
+      it 'renders the the deadline at time' do
+        rendered = render_inline(described_class.new(application_form:))
+
+        expect(rendered).to have_text("Submit your application for #{course_option.course.name_and_code} at #{course_option.course.provider.name} soon")
+        expect(rendered).to have_text("The deadline for applications that need visa sponsorship is at #{visa_sponsorship_application_deadline_at.to_fs(:govuk_time)} today")
+        expect(rendered).to have_no_text(course_option_without_deadline.course.name_and_code)
+      end
+    end
+
+    context 'when the deadline is one day away' do
+      let(:visa_sponsorship_application_deadline_at) { 1.day.from_now + 1.second }
+
+      it 'renders the text for one day' do
+        rendered = render_inline(described_class.new(application_form:))
+
+        expect(rendered).to have_text("Submit your application for #{course_option.course.name_and_code} at #{course_option.course.provider.name} soon")
+        expect(rendered).to have_text('The deadline for applications that need visa sponsorship is in 1 day')
+        expect(rendered).to have_no_text(course_option_without_deadline.course.name_and_code)
+      end
+    end
+
+    context 'when the deadline is between 2-14 days away' do
+      let(:visa_sponsorship_application_deadline_at) { 14.days.from_now + 1.second }
+
+      it 'renders the text for one day' do
+        rendered = render_inline(described_class.new(application_form:))
+
+        expect(rendered).to have_text("Submit your application for #{course_option.course.name_and_code} at #{course_option.course.provider.name} soon")
+        expect(rendered).to have_text('The deadline for applications that need visa sponsorship is in 14 days')
+        expect(rendered).to have_no_text(course_option_without_deadline.course.name_and_code)
+      end
+    end
+
+    context 'when the deadline is more than 14 days away' do
+      let(:visa_sponsorship_application_deadline_at) { 15.days.from_now + 1.second }
+
+      it 'does not render the component' do
+        rendered = render_inline(described_class.new(application_form:))
+
+        expect(rendered.text).to eq ''
+      end
+    end
+
+    context 'when the deadline has passed' do
+      let(:visa_sponsorship_application_deadline_at) { 1.second.ago }
+
+      it 'does not render the component' do
+        rendered = render_inline(described_class.new(application_form:))
+
+        expect(rendered.text).to eq ''
+      end
+    end
+  end
+
+  context 'with multiple relevant applications' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+
+    context 'with deadlines of today, 1 day from now, and between 2-14 days' do
+      let(:today) { 3.hours.from_now }
+      let(:course_option_with_today) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: today)) }
+      let(:course_option_with_14_days_from_now) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 14.days.from_now + 1.second)) }
+      let(:course_option_with_one_day_from_now) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 1.day.from_now + 1.second)) }
+
+      before do
+        [course_option_with_today, course_option_with_14_days_from_now, course_option_with_one_day_from_now].each do |course_option|
+          create(:application_choice, :unsubmitted, course_option:, application_form:)
+        end
+      end
+
+      it 'renders all three deadlines as expected' do
+        rendered = render_inline(described_class.new(application_form:))
+        expect(rendered).to have_text 'Submit your applications soon'
+        expect(rendered).to have_text 'The deadlines for these courses that need visa sponsorship are approaching'
+        expect(rendered).to have_text(
+          "#{course_option_with_today.course.name_and_code} at #{course_option_with_today.course.provider.name} - deadline at #{today.to_fs(:govuk_time)}",
+        )
+        expect(rendered).to have_text(
+          "#{course_option_with_one_day_from_now.course.name_and_code} at #{course_option_with_one_day_from_now.course.provider.name} - deadline in 1 day",
+        )
+        expect(rendered).to have_text(
+          "#{course_option_with_14_days_from_now.course.name_and_code} at #{course_option_with_14_days_from_now.course.provider.name} - deadline in 14 day",
+        )
+      end
+    end
+  end
+
+  context 'Feature flag is off' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 2.days.from_now)) }
+
+    before do
+      FeatureFlag.deactivate(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+      create(:application_choice, :unsubmitted, course_option:, application_form:)
+    end
+
+    it 'does not render component' do
+      rendered = render_inline(described_class.new(application_form:))
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'when application form does not require visa sponsorship' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: nil) }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 2.days.from_now)) }
+
+    before do
+      create(:application_choice, :unsubmitted, course_option:, application_form:)
+    end
+
+    it 'does not render component' do
+      rendered = render_inline(described_class.new(application_form:))
+      expect(rendered.text).to eq ''
+    end
+  end
+
+  context 'when application choice is submitted' do
+    let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
+    let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 2.days.from_now)) }
+
+    before do
+      create(:application_choice, :awaiting_provider_decision, course_option:, application_form:)
+    end
+
+    it 'does not render component' do
+      rendered = render_inline(described_class.new(application_form:))
+      expect(rendered.text).to eq ''
+    end
+  end
+end

--- a/spec/components/previews/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_preview.rb
+++ b/spec/components/previews/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_preview.rb
@@ -1,0 +1,17 @@
+class CandidateInterface::SponsorshipApplicationDeadlines::ApplicationChoiceBannerComponentPreview < ViewComponent::Preview
+  def less_than_one_day_until_deadline
+    application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'no')
+    course_option = FactoryBot.create(:course_option, course: FactoryBot.create(:course, visa_sponsorship_application_deadline_at: 2.hours.from_now))
+    application_choice = FactoryBot.create(:application_choice, :unsubmitted, course_option:, application_form:)
+
+    render(CandidateInterface::SponsorshipApplicationDeadlines::ApplicationChoiceBannerComponent.new(application_choice:))
+  end
+
+  def ten_days_until_deadline
+    application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'no')
+    course_option = FactoryBot.create(:course_option, course: FactoryBot.create(:course, visa_sponsorship_application_deadline_at: 10.days.from_now + 2.seconds))
+    application_choice = FactoryBot.create(:application_choice, :unsubmitted, course_option:, application_form:)
+
+    render(CandidateInterface::SponsorshipApplicationDeadlines::ApplicationChoiceBannerComponent.new(application_choice:))
+  end
+end

--- a/spec/components/previews/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_preview.rb
+++ b/spec/components/previews/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_preview.rb
@@ -1,0 +1,20 @@
+class CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponentPreview < ViewComponent::Preview
+  def with_one_approaching_deadline
+    application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'no')
+    course_option = FactoryBot.create(:course_option, course: FactoryBot.create(:course, visa_sponsorship_application_deadline_at: 3.days.from_now))
+    FactoryBot.create(:application_choice, :unsubmitted, course_option:, application_form:)
+
+    render(CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent.new(application_form:))
+  end
+
+  def with_multiple_approaching_deadlines
+    application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'no')
+    course_option_deadline_today = FactoryBot.create(:course_option, course: FactoryBot.create(:course, visa_sponsorship_application_deadline_at: 2.hours.from_now))
+    course_option_deadline_4_days_from_now = FactoryBot.create(:course_option, course: FactoryBot.create(:course, visa_sponsorship_application_deadline_at: 4.days.from_now))
+
+    FactoryBot.create(:application_choice, :unsubmitted, course_option: course_option_deadline_4_days_from_now, application_form:)
+    FactoryBot.create(:application_choice, :unsubmitted, course_option: course_option_deadline_today, application_form:)
+
+    render(CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent.new(application_form:))
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_application_when_visa_deadline_has_passed_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_application_when_visa_deadline_has_passed_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate review application when visa deadline has passed' do
+  before do
+    FeatureFlag.activate(:early_application_deadlines_for_candidates_with_visa_sponsorship)
+  end
+
+  scenario 'Candidate with a draft application', time: mid_cycle do
+    given_i_require_visa_sponsorship
+    given_have_a_draft_application_for_a_course_with_a_visa_sponsorship_application_deadline_in_the_past
+    and_i_am_signed_in
+
+    when_i_view_my_application_choice
+    then_i_see_the_warning_text
+    and_i_can_delete_my_application_choice
+  end
+
+private
+
+  def given_have_a_draft_application_for_a_course_with_a_visa_sponsorship_application_deadline_in_the_past
+    @course = create(:course, :open, :secondary, visa_sponsorship_application_deadline_at: 1.second.ago)
+    course_option = create(:course_option, course: @course)
+    @application_choice = create(:application_choice, :unsubmitted, course_option:, application_form: @application_form)
+  end
+
+  def given_i_require_visa_sponsorship
+    @application_form = create(:application_form, :completed, :with_degree, right_to_work_or_study: 'no')
+  end
+
+  def and_i_am_signed_in
+    @current_candidate = @application_form.candidate
+    i_am_signed_in_with_one_login
+  end
+
+  def when_i_view_my_application_choice
+    click_on 'Your applications'
+    click_on @course.provider.name
+  end
+
+  def then_i_see_the_warning_text
+    within('.govuk-warning-text') do
+      expect(page).to have_text 'This course is closed to candidates who need visa sponsorship now.'
+    end
+
+    expect(page).to have_text 'You cannot apply to this course. You should choose another course or subject at another training provider who is still accepting applications.'
+    expect(page).to have_text 'Delete draft application'
+  end
+
+  def and_i_can_delete_my_application_choice
+    click_on 'delete your draft application'
+    click_on 'Yes I’m sure - delete this application'
+    expect(page.current_url).to end_with(candidate_interface_application_choices_path)
+
+    expect(page).to have_no_text @course.provider.name
+  end
+end


### PR DESCRIPTION
## Context
There will be changes in Publish that will allow providers to add an alternative deadline for those students seeking visa sponsorship. We have done previous to add that column (currently always nil) to the Publish API, and to consume the data on the Apply side. 

This PR adds banners as the deadlines approach and and stops relevant applicants from applying if the deadline has passed. 

## Changes proposed in this pull request

- Adds FeatureFlag because this won't go live until the work on the publish side completed.
- Banner for the Application Dashboard
- Banner for the Application Choice view
- Warning after deadline has passed advising student to delete their application and search for another course.

## Guidance to review

It is a large PR, but not conceptually complicated. It is probably easiest to review [commit by commit](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10473/commits) (feature flag, each banner, and validation for submission)

You can test it in the review app -- sign in as support and login as [this candidate](https://apply-review-10473.test.teacherservices.cloud/support/applications/81) who requires visa sponsorship and has draft applications with deadlines, some upcoming, some in the past. 

All the courses at Durham have had visa sponsorship deadlines within the next 7 weeks. So you can sign in as any candidate who requires visa sponsorship, and make draft application choices to see the banners. 

### Previews of the banners are here

- For the application dashboard: [here](https://apply-review-10473.test.teacherservices.cloud/rails/view_components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component) 
- For the application choice page: [here](https://apply-review-10473.test.teacherservices.cloud/rails/view_components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
