### PR TITLE
Add safeguarding component to find candidates show page

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.html.erb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l"><%= t('.title') %></h2>
+<h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
 <% application_form.application_choices.each_with_index do |choice, index| %>
   <h2 class="govuk-heading-m"><%= t('.subtitle', counter: index + 1) %></h3>

--- a/app/components/provider_interface/find_candidates/safeguarding_component.html.erb
+++ b/app/components/provider_interface/find_candidates/safeguarding_component.html.erb
@@ -1,0 +1,5 @@
+<section class="app-section govuk-!-width-two-thirds govuk-!-padding-top-4">
+  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
+
+  <%= render SummaryListComponent.new(rows: rows) %>
+</section>

--- a/app/components/provider_interface/find_candidates/safeguarding_component.rb
+++ b/app/components/provider_interface/find_candidates/safeguarding_component.rb
@@ -1,0 +1,44 @@
+class ProviderInterface::FindCandidates::SafeguardingComponent < ViewComponent::Base
+  attr_reader :application_form, :provider_user
+
+  def initialize(application_form:, provider_user:)
+    @application_form = application_form
+    @provider_user = provider_user
+  end
+
+  def rows
+    rows = [{ key: I18n.t('provider_interface.safeguarding_declaration_component.declare_safeguarding_issues'), value: declare_safeguarding_issues }]
+
+    if safeguarding_issues_declared?
+      rows << { key: I18n.t('provider_interface.safeguarding_declaration_component.safeguarding_information'), value: safeguarding_information }
+    end
+
+    rows
+  end
+
+private
+
+  def declare_safeguarding_issues
+    if safeguarding_issues_declared?
+      I18n.t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare')
+    else
+      I18n.t('provider_interface.safeguarding_declaration_component.no_safeguarding_issues_to_declare')
+    end
+  end
+
+  def safeguarding_information
+    if provider_user_can_view_safeguarding?
+      application_form.safeguarding_issues
+    else
+      I18n.t('provider_interface.safeguarding_declaration_component.cannot_see_safeguarding_information')
+    end
+  end
+
+  def provider_user_can_view_safeguarding?
+    provider_user.provider_permissions.any?(&:view_safeguarding_information)
+  end
+
+  def safeguarding_issues_declared?
+    application_form.has_safeguarding_issues_to_declare?
+  end
+end

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -9,6 +9,7 @@
 
     <%= render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form: @application_form) %>
     <%= render ProviderInterface::FindCandidates::ApplicationChoicesComponent.new(application_form: @application_form) %>
+    <%= render ProviderInterface::FindCandidates::SafeguardingComponent.new(application_form: @application_form, provider_user: current_provider_user) %>
     <%= render WorkHistoryAndUnpaidExperienceComponent.new(application_form: @application_form, details: false) %>
   </div>
 

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -1,6 +1,8 @@
 en:
   provider_interface:
     find_candidates:
+      safeguarding_component:
+        title: Criminal record and professional misconduct
       right_to_work_component:
         title: Right to work or study in the UK
         visa_sponsorhip: Visa sponsorhip

--- a/spec/components/provider_interface/find_candidates/safeguarding_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/safeguarding_component_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::SafeguardingComponent, type: :component do
+  context 'when provider user does not have safeguarding persmissions' do
+    it 'when the candidate has declared no safeguarding issues' do
+      application_form = create(:application_form, :with_accepted_offer)
+      provider_user = create(:provider_user, :with_view_safeguarding_information)
+
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
+      expect(page).to have_css(
+        'dt.govuk-summary-list__key',
+        text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
+      )
+      expect(page).to have_css('dd.govuk-summary-list__value', text: 'No')
+    end
+
+    it 'when the candidate has declared safeguarding issues' do
+      application_form = create(
+        :application_form,
+        :with_accepted_offer,
+        safeguarding_issues: 'I have a criminal conviction.',
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
+      provider_user = create(:provider_user, :with_view_safeguarding_information)
+
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Yes, I want to declare something',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Give any relevant information',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'You cannot view this because you do not have permission to view criminal record and professional misconduct information.',
+      )
+    end
+  end
+
+  context 'when provider user has safeguarding persmissions' do
+    it 'when the candidate has declared no safeguarding issues' do
+      application_form = create(:application_form, :with_accepted_offer)
+      provider_user = create(:provider_user, :with_view_safeguarding_information)
+
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
+      expect(page).to have_css(
+        'dt.govuk-summary-list__key',
+        text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
+      )
+      expect(page).to have_css('dd.govuk-summary-list__value', text: 'No')
+    end
+
+    it 'when the candidate has declared safeguarding issues' do
+      application_form = create(
+        :application_form,
+        :with_accepted_offer,
+        safeguarding_issues: 'I have a criminal conviction.',
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
+      provider_user = create(:provider_user)
+      create(
+        :provider_permissions,
+        view_safeguarding_information: true,
+        provider_user:,
+      )
+
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Yes, I want to declare something',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'Give any relevant information',
+      )
+
+      expect(page).to have_css(
+        'dl.govuk-summary-list',
+        text: 'I have a criminal conviction.',
+      )
+    end
+  end
+end

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Providers views candidate pool list' do
     expect(page).to have_content('Right to work or study in the UK')
     expect(page).to have_content('Applications made')
     expect(page).to have_content('Personal statement')
+    expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).to have_content('Work history and unpaid experience')
     expect(page).to have_content('Qualifications')
     expect(page).to have_content('A levels and other qualifications')


### PR DESCRIPTION
## Context

We need to include the safeguarding information and if the provider user has permission to view the safeguarding information within any provider the provider user is associated with we will allow them to see it.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![Screenshot from 2025-03-07 15-37-07](https://github.com/user-attachments/assets/e07a5de4-50e8-4d84-8cdd-5bf75b66bb23)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
