### PR TITLE
Don't show candidates with over MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS in candidate pool

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -17,6 +17,7 @@ class Pool::Candidates
       .where(candidate: { pool_status: :opt_in, submission_blocked: false, account_locked: false })
       .where.not(candidate_id: dismissed_candidates.ids)
       .order(order_by)
+      .distinct
   end
 
 private
@@ -41,6 +42,13 @@ private
             status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited offer_deferred],
           },
         ).select(:id),
+      )
+      .where(
+        id: ApplicationForm.joins(:application_choices)
+            .where(application_choices: { status: ApplicationStateChange::UNSUCCESSFUL_STATES })
+            .group(:id)
+            .having("count(application_choices) < #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
+            .select(:id),
       )
   end
 

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -47,7 +47,8 @@ private
         id: ApplicationForm.joins(:application_choices)
             .where(application_choices: { status: ApplicationStateChange::UNSUCCESSFUL_STATES })
             .group(:id)
-            .having("count(application_choices) < #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
+            # Inactive doesn't count as an unsuccessful state, so need to exclude it when counting
+            .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
             .select(:id),
       )
   end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe Pool::Candidates do
         inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
         create(:application_choice, :inactive, application_form: inactive_candidate_form)
         create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
+
+        candidate_with_too_many_choices = create(:candidate, pool_status: 'opt_in')
+        candidate_with_too_many_choices_form = create(:application_form, :completed, candidate: candidate_with_too_many_choices)
+        create_list(:application_choice, 15, :offer_withdrawn, application_form: candidate_with_too_many_choices_form)
+
         application_forms = described_class.application_forms_for_provider(providers:, filters: {})
 
         expect(application_forms).to be_empty


### PR DESCRIPTION
## Context

We should not show candidates in the candidate pool that have more unsuccessful application choices than `MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS`

Also, since changing the find_candidates query to return application forms we need to make sure we only return 1 application form per candidate.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
