### PR TITLE
Enable strict_args in Sidekiq ahead of 7.0 upgrade

### DIFF
--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -22,9 +22,9 @@ private
 
   def chaser_type
     if email_timetabler.send_first_end_of_cycle_reminder?
-      :eoc_first_deadline_reminder
+      'eoc_first_deadline_reminder'
     elsif email_timetabler.send_second_end_of_cycle_reminder?
-      :eoc_second_deadline_reminder
+      'eoc_second_deadline_reminder'
     end
   end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,9 @@
 require 'workers/audit_trail_attribution_middleware'
 
+# strict_args required for Sidekiq 7.0 upgrade
+# https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#strict-arguments
+Sidekiq.strict_args!
+
 Sidekiq.configure_server do |config|
   # https://github.com/redis-rb/redis-client#configuration
   config.redis = {

--- a/spec/services/send_eoc_deadline_reminder_email_to_candidate_spec.rb
+++ b/spec/services/send_eoc_deadline_reminder_email_to_candidate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidate do
     let(:application_form) { create(:application_form) }
 
     it 'sends a reminder email to the candidate and creates and EOC chaser' do
-      %i[eoc_first_deadline_reminder eoc_second_deadline_reminder].each do |chaser_type|
+      %w[eoc_first_deadline_reminder eoc_second_deadline_reminder].each do |chaser_type|
         allow(CandidateMailer).to receive(chaser_type).and_return(mail)
         described_class.new(application_form:, chaser_type:).call
 


### PR DESCRIPTION
## Context

Sidekiq 7.x enables `strict_args` by default, meaning that the only arguments that can be sent to a worker are "simple" JSON serialisable values.

## Changes proposed in this pull request

- Enables strict_args in Sidekiq setup
- Fixed call to `SendEocDeadlineReminderEmailToCandidatesBatchWorker` to avoid using unserializable args - symbols are not accepted.


## Guidance to review

- Test suite only
- [Upgrade docs](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#strict-arguments)
- [Best practice docs](https://github.com/sidekiq/sidekiq/wiki/Best-Practices)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
