### PR TITLE
Remove rejection reasons from find candidates show page

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.html.erb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.html.erb
@@ -22,16 +22,6 @@
     <% end %>
 
     <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.status') } %>
-      <% row.with_value { render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: choice)) } %>
-    <% end %>
-
-    <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.rejection_reason') } %>
-      <% row.with_value { rejection_reason_value(choice) } %>
-    <% end %>
-
-    <% summary_list.with_row do |row| %>
       <% row.with_key { t('.qualification') } %>
       <% row.with_value { choice.course.qualifications_to_s } %>
     <% end %>

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -11,8 +11,6 @@ en:
         subtitle: Application %{counter}
         subject: Subject
         location: Location
-        status: Status
-        rejection_reason: Rejection reason
         qualification: Qualification
         funding_type: Funding type
         personal_statement: Personal statement


### PR DESCRIPTION
## Context

We don't want to show the rejection reason or the status of each application choice to providers during UR.


## Changes proposed in this pull request


## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
