### PR TITLE
Change header level sequence for more accurate hierarchy

### DIFF
--- a/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.html.erb
+++ b/app/components/candidate_interface/one_login_post_release_sign_in_banner_component.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_notification_banner(title_text: t('.title')) do |banner| %>
-  <% banner.with_heading(text: t('.heading')) %>
+<%= govuk_notification_banner(title_text: t('.title')) do %>
+  <%= tag.h3(t('.heading'), class: 'govuk-notification-banner__heading') %>
   <%= t('.text_html') %>
 <% end %>

--- a/app/views/candidate_interface/application_form/_review_unsubmitted.html.erb
+++ b/app/views/candidate_interface/application_form/_review_unsubmitted.html.erb
@@ -16,7 +16,7 @@
     application_qualification: @application_form.english_gcse,
     subject: 'english',
     editable: editable,
-    heading_level: 4,
+    heading_level: 3,
     missing_error: nil,
     submitting_application: true,
   )) %>
@@ -34,7 +34,7 @@
     application_qualification: @application_form.maths_gcse,
     subject: 'maths',
     editable: editable,
-    heading_level: 4,
+    heading_level: 3,
     missing_error: nil,
     submitting_application: true,
   )) %>
@@ -45,7 +45,7 @@
       application_qualification: @application_form.science_gcse,
       subject: 'science',
       editable: editable,
-      heading_level: 4,
+      heading_level: 3,
       missing_error: nil,
       submitting_application: true,
     )) %>
@@ -54,14 +54,14 @@
   <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(
     application_form: application_form,
     editable: editable,
-    heading_level: 4,
+    heading_level: 3,
     missing_error: nil,
     submitting_application: true,
   )) %>
 
     <%= render(CandidateInterface::DegreeReviewComponent.new(
       application_form: application_form,
-      editable: editable, heading_level: 4,
+      editable: editable, heading_level: 3,
       show_incomplete: true,
       missing_error: nil
     )) %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -25,7 +25,7 @@
       editable: @section_policy.can_edit?,
       deletable: @section_policy.can_delete?,
       references: @references,
-      heading_level: 3,
+      heading_level: 2,
     ),
   ) %>
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -109,8 +109,8 @@ private
   alias_method :click_on_references, :when_i_view_referees
 
   def then_i_can_see_the_referees_i_previously_added
-    expect(page).to have_css('h3', text: @first_reference.name)
-    expect(page).to have_css('h3', text: @second_reference.name)
+    expect(page).to have_css('h2', text: @first_reference.name)
+    expect(page).to have_css('h2', text: @second_reference.name)
   end
 
   def when_i_view_courses


### PR DESCRIPTION
## Context

As part of an internal accessibility audit, heading sequence has been reviewed. Headings communicate the organisation of the content on the page. Web browsers, plug-ins, and assistive technologies can use them to provide in-page navigation. When the order is not sequential, content is provided out of order and this can impact understanding or and ability to use the page.

## Changes proposed in this pull request

- One sign in notice on the start page now has a heading with an `h3` tag instead of `p`
- Referee names on the reference review page are now `h2` instead of `h3`
 - Qualification titles on a full application review page are now `h3` instead of `h4`

## Guidance to review

Please look at the HTML output of the affected areas in the review app.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card