### PR TITLE
[709] Fix heading structure in manage application review pages

### DIFF
--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="course-details">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
+  <h3 class="govuk-heading-m" id="course-details">Course</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/choice_personal_statement_component.html.erb
+++ b/app/components/provider_interface/choice_personal_statement_component.html.erb
@@ -1,5 +1,5 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
+  <h3 class="govuk-heading-m" id="personal-statement"><%= t('personal_statement.title') %></h3>
 
   <%= govuk_details(summary_text: 'Guidance given to candidates', classes: 'govuk-!-margin-bottom-4') do %>
     <%= render 'candidate_interface/personal_statement/guidance' %>

--- a/app/components/provider_interface/contact_information_component.html.erb
+++ b/app/components/provider_interface/contact_information_component.html.erb
@@ -1,4 +1,4 @@
 <section id="contact-information-section" class="app-section govuk-!-width-two-thirds" data-qa="contact-information">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="contact-information">Contact information</h2>
+  <h3 class="govuk-heading-m" id="contact-information">Contact information</h3>
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="course-details">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
+  <h3 class="govuk-heading-m" id="course-details">Course</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,5 +1,5 @@
 <section id="diversity-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="diversity-information">Sex, disability and ethnicity</h2>
+  <h3 class="govuk-heading-m" id="diversity-information">Sex, disability and ethnicity</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/personal_information_component.html.erb
+++ b/app/components/provider_interface/personal_information_component.html.erb
@@ -1,4 +1,4 @@
 <section id="personal-information-section" class="app-section govuk-!-width-two-thirds" data-qa="personal-information">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-information">Personal information</h2>
+  <h3 class="govuk-heading-m" id="personal-information">Personal information</h3>
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/qualifications_component.html.erb
+++ b/app/components/provider_interface/qualifications_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="qualifications">Qualifications</h2>
+  <h3 class="govuk-heading-m" id="qualifications">Qualifications</h3>
 
   <% if render_degrees? %>
     <%= render DegreeQualificationCardsComponent.new(
@@ -9,7 +9,7 @@
       editable: false,
     ) %>
   <% else %>
-    <h3 class="govuk-heading-m" id="degrees"><%= I18n.t('provider_interface.degree.heading') %></h3>
+    <h4 class="govuk-heading-s" id="degrees"><%= I18n.t('provider_interface.degree.heading') %></h4>
 
     <p class="govuk-body"><%= I18n.t('provider_interface.degree.teacher_degree_apprenticeship_message') %></p>
   <% end %>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -2,7 +2,7 @@
 
 <% unless hiding_safeguarding_issues? %>
   <section class="app-section govuk-!-width-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal record and professional misconduct</h2>
+    <h3 class="govuk-heading-m" id="criminal-convictions-and-professional-misconduct">Criminal record and professional misconduct</h3>
 
     <%= render SummaryListComponent.new(rows: rows) %>
   </section>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,5 +1,5 @@
 <section id="disability-disclosure-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Disability support</h2>
+  <h3 class="govuk-heading-m">Disability support</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/shared/degree_qualification_cards_component.html.erb
+++ b/app/components/shared/degree_qualification_cards_component.html.erb
@@ -5,9 +5,9 @@
     <% degrees.each do |degree| %>
       <div class="govuk-grid-column-one-third">
         <div class="app-card app-card--outline" data-qa="degree-qualification">
-          <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <h5 class="govuk-heading-s govuk-!-margin-bottom-1">
             <%= degree_type_and_subject(degree) %>
-          </h4>
+          </h5>
           <dl class="app-qualification">
             <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
             <dd class="app-qualification__value app-qualification__value--caption">

--- a/app/components/shared/efl_qualification_card_component.html.erb
+++ b/app/components/shared/efl_qualification_card_component.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m govuk-!-margin-top-6" id="english-as-a-foreign-language">English as a foreign language</h3>
+<h4 class="govuk-heading-s govuk-!-margin-top-6" id="english-as-a-foreign-language">English as a foreign language</h4>
 
 <p class="govuk-body"><%= qualification_status %></p>
 
@@ -7,7 +7,7 @@
     <div class="govuk-grid-row app-grid-row--flex">
       <div class="govuk-grid-column-one-third">
         <div class="app-card app-card--outline" data-qa="english-proficiency-qualification">
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= name %></h3>
+          <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= name %></h5>
           <dl class="app-qualification">
             <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
             <dd class="app-qualification__value app-qualification__value--caption"><%= award_year %></dd>
@@ -23,6 +23,6 @@
     </div>
   </div>
 <% elsif english_proficiency.no_qualification? %>
-  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Reason given</h4>
+  <h5 class="govuk-heading-s govuk-!-margin-bottom-2">Reason given</h5>
   <p class="govuk-body govuk-!-margin-bottom-0"><%= no_qualification_details %></p>
 <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m govuk-!-margin-top-6" id="gcses">GCSEs or equivalent</h3>
+<h4 class="govuk-heading-s govuk-!-margin-top-6" id="gcses">GCSEs or equivalent</h4>
 
 <div class="govuk-grid">
   <div class="govuk-grid-row app-grid-row--flex">
@@ -8,7 +8,7 @@
 
           <%# Missing qualification %>
           <% if qualification.missing_qualification? %>
-            <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h4>
+            <h5 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h5>
             <dl class="app-qualification">
               <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
               <% if qualification.not_completed_explanation.present? %>
@@ -22,9 +22,9 @@
 
           <%# International qualification %>
           <% elsif qualification.non_uk_qualification_type.present? %>
-            <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <h5 class="govuk-heading-s govuk-!-margin-bottom-1">
               <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
-            </h4>
+            </h5>
             <dl class="app-qualification">
               <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
               <dd class="app-qualification__value app-qualification__value--caption">
@@ -39,9 +39,9 @@
             </dl>
           <%# UK or UK Other qualification %>
           <% else %>
-            <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <h5 class="govuk-heading-s govuk-!-margin-bottom-1">
               <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
-            </h4>
+            </h5>
             <dl class="app-qualification">
               <dt class="app-qualification__key">Awarded</dt>
               <dd class="app-qualification__value">

--- a/app/components/shared/interview_preferences_component.html.erb
+++ b/app/components/shared/interview_preferences_component.html.erb
@@ -1,5 +1,5 @@
 <section id="interview-preferences-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="interview"><%= t('page_titles.interview_preferences.heading') %></h2>
+  <h3 class="govuk-heading-m" id="interview"><%= t('page_titles.interview_preferences.heading') %></h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/shared/language_skills_component.html.erb
+++ b/app/components/shared/language_skills_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="language-skills">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="language-skills">Language skills</h2>
+  <h3 class="govuk-heading-m" id="language-skills">Language skills</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,5 +1,5 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
+  <h3 class="govuk-heading-m" id="personal-statement"><%= t('personal_statement.title') %></h3>
 
     <% if @editable %>
       <%= govuk_link_to support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' do %>
@@ -14,6 +14,6 @@
 
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-  <h2 class="govuk-heading-m"><%= t('personal_statement.further_information') %></h2>
+  <h4 class="govuk-heading-s"><%= t('personal_statement.further_information') %></h4>
   <%= simple_format further_information, class: 'govuk-body' %>
 </section>

--- a/app/components/shared/qualifications_table_component.html.erb
+++ b/app/components/shared/qualifications_table_component.html.erb
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= header %></h3>
+<h4 class="govuk-heading-s govuk-!-margin-top-6" id="other-qualifications"><%= header %></h4>
 <% if qualifications.any? %>
-  <h4 class="govuk-heading-s govuk-!-margin-top-6" id="other-qualifications"><%= subheader %></h4>
+  <h5 class="govuk-heading-s govuk-!-margin-top-6" id="other-qualifications"><%= subheader %></h5>
   <table class="govuk-table govuk-!-width-full" data-qa="qualifications-table-<%= header.parameterize %>">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/components/shared/work_history_and_unpaid_experience_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_component.html.erb
@@ -1,10 +1,10 @@
 <section class="app-section govuk-!-width-two-thirds" data-qa="work-history-and-unpaid-experience">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="work-history">Work history and unpaid experience</h2>
+  <h3 class="govuk-heading-m" id="work-history">Work history and unpaid experience</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 
   <% if @details && subtitle %>
-      <h3 class="govuk-heading-m" id="work-history-subheader"><%= subtitle %></h3>
+      <h4 class="govuk-heading-s" id="work-history-subheader"><%= subtitle %></h4>
     <% end %>
 
     <% history.each do |item| %>

--- a/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0 govuk-!-margin-bottom-0 govuk-!-margin-top-0">
     <% end %>
 
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+    <h5 class="govuk-heading-s govuk-!-margin-bottom-0">
       <%= title %>
 
       <% if @editable && edit_path %>
@@ -12,7 +12,7 @@
         <% end %>
       <% end %>
 
-    </h3>
+    </h5>
     <p class="govuk-!-margin-bottom-0 govuk-body">
       <%= organisation %>
     </p>

--- a/app/components/shared/work_history_item_component.html.erb
+++ b/app/components/shared/work_history_item_component.html.erb
@@ -1,7 +1,7 @@
 <section>
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+  <h5 class="govuk-heading-s govuk-!-margin-bottom-0">
     <%= title %>
-  </h3>
+  </h5>
   <p class="govuk-!-margin-bottom-0 govuk-body">
     <%= organisation %>
   </p>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -16,7 +16,7 @@
 
 <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present || @application_choice.rejected? %>
 
-<h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
+<h2 class="govuk-heading-l govuk-!-margin-bottom">Application</h2>
 
 <p class="govuk-body govuk-!-display-none-print govuk-!-width-two-thirds"><%= @application_choice.application_form.full_name %> will be able to edit some sections of their application. You will get a notification if they add any new information.</p>
 
@@ -36,7 +36,7 @@
 </p>
 
 <section class="app-section govuk-!-margin-top-7">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Application details</h2>
+  <h3 class="govuk-heading-m">Application details</h3>
 
   <div class="govuk-!-width-two-thirds">
     <%= render ProviderInterface::ApplicationSummaryComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -6,7 +6,7 @@
   provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
   course_associated_with_user_providers: @course_associated_with_user_providers,
 ) %>
-<h1 class="govuk-heading-l">Notes</h1>
+<h2 class="govuk-heading-l">Notes</h2>
 
 <div class="govuk-inset-text">
   Candidates cannot view notes.

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -6,7 +6,7 @@
   provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
   course_associated_with_user_providers: @course_associated_with_user_providers,
 ) %>
-<h1 class="govuk-heading-l">References</h1>
+<h2 class="govuk-heading-l">References</h2>
 
 <p class="govuk-body govuk-!-display-none-print">
   <%= govuk_link_to(
@@ -33,12 +33,12 @@
   ) %>
 
   <% if @references.feedback_provided.present? %>
-    <h2 class="govuk-heading-m">Received references</h2>
+    <h3 class="govuk-heading-m">Received references</h3>
     <%= render 'references', references: @references.feedback_provided, application_choice: @application_choice %>
   <% end %>
 
   <% if @references.feedback_requested.present? %>
-    <h2 class="govuk-heading-m">Requested references</h2>
+    <h3 class="govuk-heading-m">Requested references</h3>
     <%= render 'references', references: @references.feedback_requested, application_choice: @application_choice %>
   <% end %>
 <% end %>

--- a/spec/components/shared/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/shared/work_history_and_unpaid_experience_component_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
         expect(summary).to have_text('Yes')
       end
 
-      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+      expect(page).to have_css('h4#work-history-subheader', class: 'govuk-heading-s') do |subheader|
         expect(subheader).to have_text('Details of unpaid experience')
       end
 
@@ -97,7 +97,7 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
         expect(summary).to have_no_css('dd', class: 'govuk-summary-list__value', text: 'No')
       end
 
-      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+      expect(page).to have_css('h4#work-history-subheader', class: 'govuk-heading-s') do |subheader|
         expect(subheader).to have_text('Details of work history and unpaid experience')
       end
 
@@ -138,7 +138,7 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
         expect(summary).to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
       end
 
-      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+      expect(page).to have_css('h4#work-history-subheader', class: 'govuk-heading-s') do |subheader|
         expect(subheader).to have_text('Details of work history')
       end
 


### PR DESCRIPTION
## Context

In an internal WCAG audit, the following was noted: The headings after the heading level two ‘Application’ may not be logical for screen reader users. Below the ‘Application’ heading is another heading level two that contains the text ‘Application details’, and this would convey that the ‘Application details’ section is a subsection of the main heading. This is not logically correct as visually it appears to be a subsection of ‘Application’

## Changes proposed in this pull request
| The new structure is like this |
| -------- |
| <img width="812" alt="Screenshot 2025-03-13 at 09 29 31" src="https://github.com/user-attachments/assets/8e958fec-6af7-4cdf-81b5-69edcad88449" /> |

| Knock on effect further down the page |
| -------- |
| <img width="743" alt="Screenshot 2025-03-13 at 08 52 05" src="https://github.com/user-attachments/assets/2ec311ab-5ca6-468c-a1e8-4a3c029fdb2a" /> |


## Guidance to review

You can open up the page  and inspect to see that headings are in a logical order and styled consistently. (sign in as a provider user and click on an application). Check all the tabs. (Application, references, timeline, notes)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
