### PR TITLE
Update heading levels for consistent hierarchy

### DIFF
--- a/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
@@ -2,9 +2,9 @@
 <%= f.hidden_field(:provider_id) %>
 
 <% if @wizard.current_step.provider_exists? %>
-  <p class="govuk-caption-xl govuk-!-margin-top-0">
+  <span class="govuk-caption-xl govuk-!-margin-top-0">
     <%= @wizard.current_step.provider.name %>
-  </p>
+  </span>
 <% end %>
 
 <% if @wizard.current_step.available_courses.count > 20 %>

--- a/app/views/candidate_interface/personal_statement/_guidance.html.erb
+++ b/app/views/candidate_interface/personal_statement/_guidance.html.erb
@@ -1,13 +1,13 @@
 <p class="govuk-body">You can write about these 3 areas in your personal statement to show how your knowledge, qualifications and experience make you suited to teaching. Include any information that you think supports your application.</p>
 
 <ul class="govuk-list govuk-list--number">
-  <li><p class="govuk-!-font-weight-bold">Explain why you want to be a teacher.</p></li>
+  <li><h2 class="govuk-heading-s">Explain why you want to be a teacher.</h2></li>
   <p class="govuk-body">Reflect on what motivates you about a career in teaching.</p>
 
-  <li><p class="govuk-!-font-weight-bold">Describe why you want to teach this subject or specialism. For primary, describe why you want to teach this age group.</p></li>
+  <li><h2 class="govuk-heading-s">Describe why you want to teach this subject or specialism. For primary, describe why you want to teach this age group.</h2></li>
   <p class="govuk-body">Highlight your expertise in a subject gained through your qualifications or work experience.</p>
 
-  <li><p class="govuk-!-font-weight-bold">Describe your relevant experience and personal characteristics and explain how they would make you a great teacher.</p></li>
+  <li><h2 class="govuk-heading-s">Describe your relevant experience and personal characteristics and explain how they would make you a great teacher.</h2></li>
   <p class="govuk-body">Discuss any relevant experience of working or volunteering with young people and any transferable skills or strengths gained through life experience that would support you in the classroom.</p>
 </ul>
 


### PR DESCRIPTION
## Context

As part of an internal accessibility audit, heading sequence has been reviewed. Headings communicate the organisation of the content on the page. Web browsers, plug-ins, and assistive technologies can use them to provide in-page navigation. When the order is not sequential, content is provided out of order and this can impact understanding or and ability to use the page.

## Changes proposed in this pull request

- The caption above the h1 on the course choices step "which course are you applying to?" is now a `<span>` tag instead of a`<p>` tag
- The guidance questions on the personal statement entering details page are now `<h2 class="govuk-heading-s">` instead of `<p class="govuk-!-font-weight-bold">`

## Guidance to review

Please visit the affected pages in the review app and inspect the html.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card