### PR TITLE
Resolve WAVE missing legend error

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/jobs/_form.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/jobs/_form.html.erb
@@ -7,14 +7,11 @@
 <% end %>
 
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_fieldset(legend: { text: t('application_form.restructured_work_history.start_date.label') }, size: 'm') do %>
-    <%= tag.p(t('application_form.restructured_work_history.start_date.hint_text'), class: 'govuk-hint') %>
-    <%= f.govuk_date_field :start_date, omit_day: true, legend: nil %>
-    <div class="govuk-form-group">
-      <%= f.hidden_field :start_date_unknown, value: false %>
-      <%= f.govuk_check_box :start_date_unknown, true, multiple: false, label: { text: t('application_form.restructured_work_history.start_date_unknown_checkbox') } %>
-    </div>
-  <% end %>
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.restructured_work_history.start_date.label'), size: 'm' }, hint: { text: t('application_form.restructured_work_history.start_date.hint_text') } %>
+  <div class="govuk-form-group">
+    <%= f.hidden_field :start_date_unknown, value: false %>
+    <%= f.govuk_check_box :start_date_unknown, true, multiple: false, label: { text: t('application_form.restructured_work_history.start_date_unknown_checkbox') } %>
+  </div>
 </div>
 
 <div class="app-work-experience__currently_working" data-qa="currently-working">


### PR DESCRIPTION
## Context

Following an internal accessibility audit and use of the WAVE accessibility tool, we have identified a missing fieldset legend. We have decided to remove the encompassing fieldset for "employment start date" to remove the need for the nested date fieldset to carry a legend `nil` value.

## Changes proposed in this pull request

- Remove the encompassing fieldset and make use of the parameters available on the date fieldset for the label and hint text.

## Guidance to review

- Please visit the affected page and inspect the html.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card