### PR TITLE
Handle new data type in Big query response

### DIFF
--- a/app/lib/dfe/bigquery/relation.rb
+++ b/app/lib/dfe/bigquery/relation.rb
@@ -69,6 +69,8 @@ module DfE
           ActiveModel::Type::Boolean.new.cast(raw_value)
         when 'FLOAT'
           Float(raw_value)
+        when 'RECORD'
+          nil
         else
           raise UnknownTypeError, "cannot parse this type of value: '#{type}'"
         end

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics, time: Time.zone.local(2023, 11
       { name: 'number_of_candidates_submitted_to_date', type: 'INTEGER', value: '100' },
       { name: 'first_date_in_week', type: 'DATE', value: '2024-03-18' },
       { name: 'subject_filter', type: 'INTEGER', value: nil },
+      { name: 'offset', type: 'RECORD', value: {} },
     ]])
   end
 


### PR DESCRIPTION
## Context

ITT monthly reports were not generated today as expected and we received related [Sentry errors](https://dfe-teacher-services.sentry.io/issues/6412712199/?alert_rule_id=853774&alert_type=issue&notification_uuid=b51edc11-b665-4d29-8467-0b71f3309289&project=1765973&referrer=slack)
It appears that a new data type has been added to the report for a field we do not require. We deliberately raise an error for unhandled data types.

## Changes proposed in this pull request

This PR handles the new data type -- not very thoroughly, we just ignore it because the field (offset) isn't of interest to us and not used in the reports we present to users.

We really cannot make more complex changes without risking breaking things until we are able to test the responses locally (no longer possible with the new authentication).

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
