### PR TITLE
Remove location radius filter on find a candidate

### DIFF
--- a/app/components/provider_interface/location_filter_component.html.erb
+++ b/app/components/provider_interface/location_filter_component.html.erb
@@ -1,18 +1,8 @@
 <div class="govuk-form-group">
-  <div id="location-hint" class="govuk-hint"><%= filter[:hint] %></div>
-
-  <div class="govuk-input__wrapper govuk-!-padding-bottom-2">
-    <label class="govuk-label location-filter-label" for="within">Within</label>
-    <select class="govuk-select" name="within">
-      <%= select_options %>
-    </select>
-  </div>
-
-  <div class="govuk-input__wrapper"
+  <div class="govuk-input__wrapper location-autocomplete"
     data-controller="location-autocomplete"
     data-location-autocomplete-path-value="<%= provider_interface_location_suggestions_path %>">
 
-    <label class="govuk-label location-filter-label" for="location">of</label>
     <input class="govuk-input"
     id="original-location"
     name="original_location"

--- a/app/components/provider_interface/location_filter_component.rb
+++ b/app/components/provider_interface/location_filter_component.rb
@@ -4,19 +4,4 @@ class ProviderInterface::LocationFilterComponent < ViewComponent::Base
   def initialize(filter:)
     @filter = filter
   end
-
-  def select_options
-    options = []
-    selected_value = filter[:within].to_i.positive? ? filter[:within].to_i : 10
-
-    filter[:radius_values].map do |radius|
-      options << content_tag(
-        :option,
-        pluralize(radius, 'mile'),
-        value: radius,
-        selected: radius == selected_value,
-      )
-    end
-    options.join.html_safe
-  end
 end

--- a/app/components/utility/filter_component.rb
+++ b/app/components/utility/filter_component.rb
@@ -13,7 +13,7 @@ class FilterComponent < ViewComponent::Base
     when :location_search
       [
         {
-          title: location_filter_title(filter),
+          title: filter[:original_location],
           hint: filter[:hint],
           remove_link: location_filter_tag_link,
         },
@@ -31,7 +31,6 @@ class FilterComponent < ViewComponent::Base
 
   def location_filter_tag_link
     params = filters_to_params(filters)
-    params.delete(:within)
     params.delete(:original_location)
     params[:remove] = true # for removing last filter
     to_query(params)
@@ -85,7 +84,6 @@ class FilterComponent < ViewComponent::Base
       case filter[:type]
       when :location_search
         hash[:original_location] = filter[:original_location]
-        hash[:within] = filter[:within]
       when :search
         hash[filter[:name]] = filter[:value]
       when :checkboxes, :checkbox_filter
@@ -101,13 +99,6 @@ private
   end
 
   def active_location_filter?(filter_hash)
-    filter_hash[:within].present? && filter_hash[:original_location].present?
-  end
-
-  def location_filter_title(filter_hash)
-    miles = pluralize(filter_hash[:within], 'mile')
-    original_location = filter_hash[:original_location]
-
-    I18n.t('filter_component.location_filter_title', miles:, original_location:)
+    filter_hash[:original_location].present?
   end
 end

--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -19,3 +19,7 @@
 
   pointer-events: none;
 }
+
+.location-autocomplete {
+  display: block;
+}

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -156,12 +156,6 @@
   }
 }
 
-.location-filter-label {
-  align-content: center;
-
-  width: 25%;
-}
-
 .filter-group {
   padding-bottom: 10px;
   margin-bottom: 15px;

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,4 +1,5 @@
 class Pool::Candidates
+  LOCATION_RADIUS = 30
   attr_reader :providers, :filters
 
   def initialize(providers:, filters: {})
@@ -66,7 +67,7 @@ private
     )
 
     site_ids = Site.within(
-      filters.fetch(:within),
+      LOCATION_RADIUS,
       units: :miles,
       origin:,
     ).select(:id)
@@ -120,7 +121,7 @@ private
   end
 
   def active_location_filter?
-    filters[:within].present? && filters[:origin].present?
+    filters[:origin].present?
   end
 
   def order_by

--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -2,8 +2,7 @@ module ProviderInterface
   class CandidatePoolFilter
     include FilterParamsHelper
 
-    RADIUS_VALUES = [1, 5, 10, 15, 20, 25, 50, 100, 200].freeze
-    FILTERS = %w[within original_location subject study_mode course_type visa_sponsorship].freeze
+    FILTERS = %w[original_location subject study_mode course_type visa_sponsorship].freeze
 
     attr_reader :filter_params
 
@@ -18,11 +17,8 @@ module ProviderInterface
       [
         {
           type: :location_search,
-          heading: 'Search radius',
+          heading: 'Candidates near town, city or postcode:',
           name: 'location_search',
-          hint: "Candidate's last course location",
-          radius_values: RADIUS_VALUES,
-          within: filter_params[:within],
           original_location: filter_params[:original_location],
         },
         {
@@ -74,7 +70,7 @@ module ProviderInterface
     end
 
     def applied_location_search?
-      filter_params[:within].present? && filter_params[:original_location].present?
+      filter_params[:original_location].present?
     end
 
   private

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Pool::Candidates do
         withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
         create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
-        filters = { origin: [51.4524877, -0.1204749], within: 10 }
+        filters = { origin: [51.4524877, -0.1204749] }
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
@@ -153,11 +153,7 @@ RSpec.describe Pool::Candidates do
           visa_sponsorship_candidate_form.id,
         )
 
-        filters = {
-          origin: [51.4524877, -0.1204749],
-          within: 10,
-          subject: [subject.id.to_s],
-        }
+        filters = { origin: [51.4524877, -0.1204749], subject: [subject.id.to_s] }
 
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
@@ -170,7 +166,6 @@ RSpec.describe Pool::Candidates do
 
         filters = {
           origin: [51.4524877, -0.1204749],
-          within: 10,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
         }
@@ -185,7 +180,6 @@ RSpec.describe Pool::Candidates do
 
         filters = {
           origin: [51.4524877, -0.1204749],
-          within: 10,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
           course_type: ['TDA'],
@@ -200,7 +194,6 @@ RSpec.describe Pool::Candidates do
 
         filters = {
           origin: [51.4524877, -0.1204749],
-          within: 10,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
           course_type: ['TDA'],

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
       expect(filter.filters).to eq([
         {
           type: :location_search,
-          heading: 'Search radius',
+          heading: 'Candidates near town, city or postcode:',
           name: 'location_search',
-          hint: "Candidate's last course location",
-          radius_values: [1, 5, 10, 15, 20, 25, 50, 100, 200],
-          within: nil,
           original_location: nil,
         },
         {
@@ -82,7 +79,6 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
   describe 'set_filters' do
     it 'saves the filters on the provider user' do
       filter_params = {
-        'within' => 10,
         'original_location' => 'Manchester',
         'visa_sponsorship' => ['required'],
       }
@@ -96,10 +92,10 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
     context 'when clearing the filters' do
       it 'removes the filters from DB' do
         filter_params = { remove: 'true' }
-        current_provider_user = create(:provider_user, find_a_candidate_filters: { 'within' => 10 })
+        current_provider_user = create(:provider_user, find_a_candidate_filters: { 'original_location' => 'Manchester' })
 
         expect { described_class.new(filter_params:, current_provider_user:) }.to(
-          change { current_provider_user.find_a_candidate_filters }.from({ 'within' => 10 }).to({}),
+          change { current_provider_user.find_a_candidate_filters }.from({ 'original_location' => 'Manchester' }).to({}),
         )
       end
     end
@@ -107,7 +103,6 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
     context 'when filters already exist in DB' do
       it 'stores updated filters' do
         filter_params = {
-          'within' => 10,
           'original_location' => 'Manchester',
         }
         current_provider_user = create(
@@ -127,7 +122,6 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
   describe '#applied_filters' do
     it 'returns the applied filters' do
       filter_params = {
-        'within' => 10,
         'original_location' => 'Manchester',
         'visa_sponsorship' => ['required'],
       }
@@ -136,7 +130,6 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
 
       expect(filter.applied_filters).to eq(
         {
-          within: 10,
           original_location: 'Manchester',
           visa_sponsorship: ['required'],
           origin: [51.4524877, -0.1204749],
@@ -147,10 +140,7 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
 
   describe '#applied_location_search?' do
     it 'returns true if location search is applied' do
-      filter_params = {
-        'within' => 10,
-        'original_location' => 'Manchester',
-      }
+      filter_params = { 'original_location' => 'Manchester' }
       current_provider_user = create(:provider_user)
       filter = described_class.new(filter_params:, current_provider_user:)
 


### PR DESCRIPTION
## Context

This filter is being removed after some UR. We will only search within a 30 miles radius for now.

Further changes will follow, making the location filter search within candidate preferences.

For now we will just default to 30 miles radius of the candidate's last course choice.

The provider can still input a location

We don't need to update any filters that we save on the Provider User. The `within` filter will just be ignored and the records will update themselves.

WE still need a radius in the backend, 30 miles for now

## Changes proposed in this pull request

This is based on the figma designs here https://www.figma.com/design/9kqQyBl6XzBIGsBKubwUVI/Candidate-pool?node-id=887-5322&t=LDyl6LCDuAMWa2No-4

## Guidance to review

You can go on review app to view the changes


https://github.com/user-attachments/assets/801eb261-af06-44a0-bb59-280021a27ce9




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
