### PR TITLE
Add H1 tags to legends and labels in candidate application where missing

### DIFF
--- a/app/components/candidate_interface/degree_grade_component.html.erb
+++ b/app/components/candidate_interface/degree_grade_component.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, title_with_error_prefix(legend_helper, @model.errors.any?) %>
 <%= form_with model: @model, url: candidate_interface_degree_grade_path do |form| %>
   <%= form.govuk_error_summary %>
-  <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' } do %>
+  <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, tag: 'h1', size: 'l' } do %>
     <% if @model.uk? && specific_grade_options? %>
       <% grades.each_with_index do |grade, index| %>
         <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: index.zero? do %>

--- a/app/components/candidate_interface/degree_type_component.html.erb
+++ b/app/components/candidate_interface/degree_type_component.html.erb
@@ -2,7 +2,7 @@
 <%= form_with model: @wizard, url: candidate_interface_degree_type_path do |form| %>
   <%= form.govuk_error_summary %>
   <% if @wizard.uk? %>
-    <%= form.govuk_radio_buttons_fieldset :type, legend: { text: "What type of #{dynamic_types} is it?", size: 'l' } do %>
+    <%= form.govuk_radio_buttons_fieldset :type, legend: { text: "What type of #{dynamic_types} is it?", tag: 'h1', size: 'l' } do %>
 
       <% find_degree_type_options.each_with_index do |type, index| %>
         <%= form.govuk_radio_button :type, type[:name], label: { text: name_and_abbr(type) }, link_errors: index.zero? %>

--- a/app/views/candidate_interface/degrees/degree/new_award_year.erb
+++ b/app/views/candidate_interface/degrees/degree/new_award_year.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.award_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_award_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), size: 'l' }, hint: { text: t('application_form.degree.award_year.hint') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), tag: 'h1', size: 'l' }, hint: { text: t('application_form.degree.award_year.hint') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/degree/new_completed.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_completed.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.reviewing_and_unchanged_country? ? @wizard.back_to_review : candidate_interface_degree_university_path) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_completed_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_radio_buttons_fieldset :completed, legend: { text: t('page_titles.degree_completion_status'), size: 'l' } do %>
+    <%= f.govuk_radio_buttons_fieldset :completed, legend: { text: t('page_titles.degree_completion_status'), tag: 'h1', size: 'l' } do %>
       <%= f.hidden_field(:completed) %>
       <%= f.govuk_radio_button :completed, 'Yes', label: { text: 'Yes' }, link_errors: true %>
       <%= f.govuk_radio_button :completed, 'No', label: { text: 'No, I am studying for my degree' } %>

--- a/app/views/candidate_interface/degrees/degree/new_country.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_country.html.erb
@@ -6,7 +6,7 @@
 
   <%= form_with model: @wizard, url: candidate_interface_degree_country_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_radio_buttons_fieldset :uk_or_non_uk, legend: { text: 'Which country was the degree from?', size: 'l' } do %>
+    <%= f.govuk_radio_buttons_fieldset :uk_or_non_uk, legend: { text: 'Which country was the degree from?', tag: 'h1', size: 'l' } do %>
       <%= f.govuk_radio_button :uk_or_non_uk, 'uk', label: { text: 'United Kingdom' }, link_errors: true %>
 
       <%= f.govuk_radio_button :uk_or_non_uk, 'non_uk', label: { text: 'Another country' } do %>

--- a/app/views/candidate_interface/degrees/degree/new_degree_level.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_degree_level.html.erb
@@ -6,7 +6,7 @@
   <%= form_with model: @wizard, url: candidate_interface_degree_degree_level_path, method: :post do |f| %>
     <%= f.govuk_error_summary %>
 
-    <%= f.govuk_radio_buttons_fieldset :degree_level, legend: { text: 'What type of degree is it?', size: 'l' } do %>
+    <%= f.govuk_radio_buttons_fieldset :degree_level, legend: { text: 'What type of degree is it?', tag: 'h1', size: 'l' } do %>
 
       <% CandidateInterface::DegreeWizard::DEGREE_LEVEL.each_with_index do |name, index| %>
         <%= f.govuk_radio_button :degree_level, name, label: { text: name }, hint: -> { tag.span(t('application_form.degree.level.bachelor_degree')) if name == 'Bachelor degree' }, link_errors: index.zero? %>

--- a/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.start_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_start_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
+    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), tag: 'h1', size: 'l' }, hint: { text: 'For example, 1999' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/degree/new_subject.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_subject.html.erb
@@ -11,7 +11,7 @@
       form_field: f.govuk_select(
         :subject,
         options_for_select(dfe_autocomplete_options(@wizard.subjects), f.object.subject),
-        label: { text: t('application_form.degree.subject.label'), size: 'l' },
+        label: { text: t('application_form.degree.subject.label'), tag: 'h1', size: 'l' },
         hint: { text: t('application_form.degree.subject.hint') },
       ),
     ) %>

--- a/app/views/candidate_interface/degrees/degree/new_university.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.university_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_university_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_fieldset legend: { text: t('page_titles.degree_university'), size: 'l' } do %>
+    <%= f.govuk_fieldset legend: { text: t('page_titles.degree_university'), tag: 'h1', size: 'l' } do %>
       <% if @wizard.uk? %>
         <%= render DfE::Autocomplete::View.new(
           f,

--- a/app/views/candidate_interface/gcse/not_completed_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/not_completed_qualification/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { size: 'l', text: "Are you currently studying for a GCSE in #{capitalize_english(@subject)}, or equivalent?" } do %>
+        <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { tag: 'h1', size: 'l', text: "Are you currently studying for a GCSE in #{capitalize_english(@subject)}, or equivalent?" } do %>
           <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
                 <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 6, max_chars: 256, threshold: 90 do %>
                 <% end %>

--- a/app/views/candidate_interface/gcse/statement_comparability/_form.html.erb
+++ b/app/views/candidate_interface/gcse/statement_comparability/_form.html.erb
@@ -1,6 +1,6 @@
 <% scope = 'application_form.gcse.comparable_uk_qualification' %>
 
-<%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.enter_enic', subject: @subject), size: 'l' } do %>
+<%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.enter_enic', subject: @subject), tag: 'h1', size: 'l' } do %>
   <%= f.govuk_text_field :enic_reference, label: { text: "#{t('service_name.enic.short_name')} reference number", size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
 
   <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('label', scope:), size: 's' }, hint: { text: t('hint_text', scope:) } do %>

--- a/app/views/candidate_interface/gcse/type/_form.html.erb
+++ b/app/views/candidate_interface/gcse/type/_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :qualification_type,
-  legend: { text: t("gcse_edit_type.page_titles.#{@subject}"), size: 'l' },
+  legend: { text: t("gcse_edit_type.page_titles.#{@subject}"), tag: 'h1', size: 'l' },
   hint: { text: @subject == 'english' ? 'This should not be a qualification showing you speak English as a foreign language.' : '' } do %>
 
   <% select_gcse_qualification_type_standard_options.each_with_index do |option, i| %>


### PR DESCRIPTION
## Context

Following an internal accessibility audit, we have been making changes to comprehensively align header sequencing with WCAG guidelines.

## Changes proposed in this pull request

- Add `<h1>` tags to labels and legends where identified as missing. 

## Guidance to review

- Please review the affected application pages and check that the fieldset legend or label used to render the question is rendered with the relevant `<h1>` tag.
- Note that in the html the `<legend>` tag encapsulates the `<h1>` tag, whereas `<label>` is wrapped within the `<h1>`. This is automatically rendered correctly when a tag parameter is included in the selector. See the [fieldset legends and labels page on the design system](https://govuk-form-builder.netlify.app/introduction/labels-captions-hints-and-legends/#output-html-radio-buttons-with-a-fully-customised-legend) for more information.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card