### PR TITLE
Axe automated testing spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -193,3 +193,8 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-rails', require: false
 end
+
+gem "axe-core-capybara", "~> 4.10"
+gem "axe-core-selenium", "~> 4.10"
+
+gem "axe-core-rspec", "~> 4.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,25 @@ GEM
     audited (5.8.0)
       activerecord (>= 5.2, < 8.2)
       activesupport (>= 5.2, < 8.2)
+    axe-core-api (4.10.2)
+      dumb_delegator
+      ostruct
+      virtus
+    axe-core-capybara (4.10.2)
+      axe-core-api (= 4.10.2)
+      dumb_delegator
+    axe-core-rspec (4.10.2)
+      axe-core-api (= 4.10.2)
+      dumb_delegator
+      ostruct
+      virtus
+    axe-core-selenium (4.10.2)
+      axe-core-api (= 4.10.2)
+      dumb_delegator
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     azure-blob (0.5.7)
       rexml
     base64 (0.2.0)
@@ -210,6 +229,8 @@ GEM
       clockwork
       timecop
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (1.1.0)
     commonmarker (1.1.5)
       rb_sys (~> 0.9)
@@ -223,6 +244,8 @@ GEM
     date (3.4.1)
     declarative (0.0.20)
     deepsort (0.5.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -240,6 +263,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     dry-initializer (3.1.1)
+    dumb_delegator (1.1.0)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)
@@ -390,6 +414,7 @@ GEM
     humanize (3.1.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.8.0)
     io-like (0.3.1)
     irb (1.15.1)
@@ -779,6 +804,7 @@ GEM
     test_suite_time_machine (2.0.0)
       timecop (~> 0.9)
     thor (1.3.2)
+    thread_safe (0.3.6)
     timecop (0.9.10)
     timeliness (0.5.2)
     timeout (0.4.3)
@@ -805,6 +831,10 @@ GEM
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -871,6 +901,9 @@ DEPENDENCIES
   ar-sequence
   archive-zip
   audited
+  axe-core-capybara (~> 4.10)
+  axe-core-rspec (~> 4.10)
+  axe-core-selenium (~> 4.10)
   azure-blob
   bcrypt
   blazer

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+# require 'axe-capybara'
+# require 'axe-rspec'
+# require 'axe-selenium'
 ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path('../config/environment', __dir__)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,5 @@
 require 'capybara/rspec'
+require 'axe-rspec'
 
 # Use different Capybara ports when running tests in parallel
 if ENV['TEST_ENV_NUMBER']
@@ -24,7 +25,7 @@ end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by(:rack_test)
+    driven_by(:chrome_headless)
   end
 
   config.before(:each, :js, type: :system) do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -11,21 +11,28 @@ RSpec.describe 'Carry over application and submit new application choices', time
 
     when_i_sign_in_again
     then_i_am_redirected_to_the_carry_over_interstitial
+    and_the_page_is_accessible
 
     when_i_click_on_continue
     then_i_see_application_details_page
+    and_the_page_is_accessible
     and_i_can_navigate_to_application_choices
+    and_the_page_is_accessible
 
     when_i_view_referees
     then_i_can_see_the_referees_i_previously_added
+    and_the_page_is_accessible
 
     when_i_view_courses
     then_i_can_see_that_i_need_to_select_courses
+    and_the_page_is_accessible
 
     when_i_add_a_course
     and_i_visit_the_application_dashboard
+    and_the_page_is_accessible
     and_i_click_on_the_course_name
     then_i_see_the_course_choice_review_page
+    and_the_page_is_accessible
 
     when_i_complete_the_rest_of_my_details
     and_i_visit_the_application_dashboard
@@ -35,6 +42,10 @@ RSpec.describe 'Carry over application and submit new application choices', time
   end
 
 private
+
+  def and_the_page_is_accessible
+    expect(page).to be_axe_clean.according_to(:wcag2aaa)
+  end
 
   def when_i_have_an_unsubmitted_application
     @application_form = create(


### PR DESCRIPTION
## Context

This spike explores the changes required to add the [axe-core gem](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md) to enable automated accessibility testing

## Changes proposed in this pull request

- Added required gems
- Modified driver configuration for Capybara
- Added assertions to an existing test

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
