### PR TITLE
Replaced record counts with count from `pagy`

### DIFF
--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render SupportInterface::TileComponent.new(
-      count: @api_tokens.count,
+      count: @pagy.count,
       label: 'API tokens issued',
       colour: :blue,
     ) %>

--- a/spec/system/support_interface/api_tokens/view_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens/view_tokens_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'API tokens' do
 
     create(:vendor_api_token, provider: provider_1, last_used_at: 1.month.ago)
     create(:vendor_api_token, provider: provider_2)
+    create_list(:vendor_api_token, 20)
   end
 
   def when_i_visit_the_tokens_page
@@ -37,7 +38,7 @@ RSpec.describe 'API tokens' do
   end
 
   def then_i_see_the_count_of_providers_with_api_tokens
-    expect(page).to have_content '2 API tokens issued'
+    expect(page).to have_content '22 API tokens issued'
     expect(page).to have_content '1 API tokens used in the last 3 months'
 
     within '.govuk-table' do


### PR DESCRIPTION
## Context

We were displaying the number of API tokens based on the number of records on the page rather than the total number in the collection. 

## Changes proposed in this pull request

Uses the `pagy.count` rather than `collection.count`

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
