### PR TITLE
Fixes to error summary implementation

### DIFF
--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.degree_review', count: @application_form.application_qualifications.degrees.size) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.degree_review', count: @application_form.application_qualifications.degrees.size), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_degree_complete_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Check your answers to equality and diversity questions' %>
+<% content_for :title, title_with_error_prefix('Check your answers to equality and diversity questions', @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("gcse_summary.page_titles.review.#{@subject}") %>
+<% content_for :title, title_with_error_prefix(t("gcse_summary.page_titles.review.#{@subject}"), @section_complete_form.errors.any?) %>
 <% content_for(:before_content, govuk_back_link_to(application_form_path)) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_gcse_complete_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/gcse/statement_comparability/_form.html.erb
+++ b/app/views/candidate_interface/gcse/statement_comparability/_form.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <% scope = 'application_form.gcse.comparable_uk_qualification' %>
 
 <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.enter_enic', subject: @subject), size: 'l' } do %>

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.interview_preferences.review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences.review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_interview_preferences_complete_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, other_qualifications_title(@application_form) %>
+<% content_for :title, title_with_error_prefix(other_qualifications_title(@application_form), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_other_qualifications_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -5,9 +5,9 @@
 </h1>
 
 <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
-  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>
+  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::AS_LEVEL_TYPE, label: { text: 'AS level' } %>
-  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
+  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' } %>
 
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::OTHER_TYPE, label: { text: 'Other UK qualification' } do %>
     <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name', size: 's' } %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.personal_statement_review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.personal_statement_review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_becoming_a_teacher_complete_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @application_form.application_work_experiences.blank? ? t('page_titles.work_history') : t('page_titles.restructured_work_history_review') %>
+<% content_for :title, title_with_error_prefix(@application_form.application_work_experiences.blank? ? t('page_titles.work_history') : t('page_titles.restructured_work_history_review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_restructured_work_history_complete_path(@return_to[:params]), method: :patch do |f| %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.suitability_to_work_with_children_review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children_review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_safeguarding_path, method: :post do |f| %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.training_with_a_disability_review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.training_with_a_disability_review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_training_with_a_disability_complete_path, method: :patch do |f| %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.volunteering.review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.volunteering.review'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_volunteering_path, method: :patch do |f| %>

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -113,6 +113,8 @@ en:
               invalid: Enter a real other English subject grade
             other_english_gcse_name:
               blank: Enter an English GCSE
+            other_grade:
+              blank: Enter your grade
         candidate_interface/gcse_year_form:
           attributes:
             award_year:

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -18,4 +18,4 @@ en:
               too_many_words:
                 one: Your answer must be %{maximum} words or less. You have %{count} word too many.
                 other: Your answer must be %{maximum} words or less. You have %{count} words too many.
-              blank: Write your personal statement
+              blank: Enter your personal statement

--- a/spec/requests/candidate_interface/personal_statement_spec.rb
+++ b/spec/requests/candidate_interface/personal_statement_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
       it 'redirects to application form page' do
         patch candidate_interface_new_becoming_a_teacher_path, params: params
 
-        expect(response.body).to match(/Write your personal statement/)
+        expect(response.body).to match(/Enter your personal statement/)
         expect(response).not_to have_http_status(:redirect)
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
       it 'does not redirect' do
         patch candidate_interface_new_becoming_a_teacher_path, params: params
 
-        expect(response.body).to match(/Write your personal statement/)
+        expect(response.body).to match(/Enter your personal statement/)
         expect(response).not_to have_http_status(:redirect)
       end
     end

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -123,6 +123,6 @@ RSpec.describe 'Entering "Personal statement"' do
   end
 
   def then_i_am_told_to_write_my_personal_statement
-    expect(page).to have_content('Write your personal statement')
+    expect(page).to have_content('Enter your personal statement')
   end
 end


### PR DESCRIPTION
## Context

Following an internal accessibility audit, bugs with the implementation of the error summary component were identified.

## Changes proposed in this pull request

- Add missing error summary to "Enter your ENIC number" page
- Add missing custom error summary messages to "What grade is your English qualification" page
- Correct focus of error link on "Enter A Levels" page to first checkbox item as per accessibility guidelines
- Add `title_with_error_prefix` to all review pages during entering details stage

## Guidance to review

Please review the affected pages to make sure the error summary and messages appear as expected. Please also click the error summary links to make sure the page focuses to the relevant item on the page.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card