### PR TITLE
Bug fix: contact details review page renders complete section component when rerendered

### DIFF
--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -10,6 +10,7 @@ module CandidateInterface
 
     def complete
       @application_form = current_application
+      @can_complete = ContactDetailsForm.build_from_application(current_application).valid_for_submission?
       @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
       if ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed) && !details_complete?

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(
   :title,
-  title_with_error_prefix(t('page_titles.contact_information_review'), @contact_details_form&.errors&.any?),
+  title_with_error_prefix(t('page_titles.contact_information_review'), @contact_details_form&.errors&.any? || @section_complete_form.errors.any? ),
 ) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(
   :title,
-  title_with_error_prefix(t('page_titles.contact_information_review'), @contact_details_form&.errors&.any? || @section_complete_form.errors.any? ),
+  title_with_error_prefix(t('page_titles.contact_information_review'), @contact_details_form&.errors&.any? || @section_complete_form.errors.any?),
 ) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 


### PR DESCRIPTION
## Context

We identified a bug wherein the complete section component did not render when the contact details review page was re-rendered.

## Changes proposed in this pull request

- Add missing form to complete action in the review controller.
- Add `@complete_section_form.errors.any?` to the existing `title_with_error_prefix` for consistency with other review pages.

## Guidance to review

- Log in as a candidate.
- Visit the contact details review page and press "Continue" **without selecting a radio button**.
- You should be able to see the validation error summary and the complete section should render as expected.
- You should also see the error prefix attached to the page title.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card