### PR TITLE
[764] Sentry fix Do not check for monthly statistics report in non-prod environments

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -13,6 +13,8 @@ class DetectInvariantsDailyCheck
   end
 
   def detect_if_the_monthly_statistics_has_not_run
+    return unless HostingEnvironment.production?
+
     latest_monthly_report = Publications::MonthlyStatistics::MonthlyStatisticsReport.last
 
     return if latest_monthly_report.nil? || latest_monthly_report.generation_date >= MonthlyStatisticsTimetable.current_generation_date

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -191,6 +191,7 @@ RSpec.describe DetectInvariantsDailyCheck do
       let(:exception) { described_class::MonthlyStatisticsReportHasNotRun.new(message) }
 
       before do
+        allow(HostingEnvironment).to receive(:production?).and_return true
         allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::MonthlyStatisticsReportHasNotRun))
       end
 


### PR DESCRIPTION

## Context

One of our invariant checks is to see if the monthly statistics report has generated. This check is run on all environments, so creates a lot of noise since the report can only be run in production. 

## Changes proposed in this pull request

Just an early return on the invariant check to make sure it only runs in production.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
