### PR TITLE
Handle and reduce errors form GIT API

### DIFF
--- a/app/workers/adviser/fetch_teaching_subjects_worker.rb
+++ b/app/workers/adviser/fetch_teaching_subjects_worker.rb
@@ -4,6 +4,8 @@ class Adviser::FetchTeachingSubjectsWorker
   sidekiq_options retry: 0, queue: :low_priority
 
   def perform
+    return unless FeatureFlag.active?(:adviser_sign_up)
+
     # Get the subjects from the API
     # Find or Create TeachingSubject using the ID/external_identifier
     teaching_subject_from_api = api_teaching_subjects.map do |api_teaching_subject|

--- a/app/workers/adviser/refresh_adviser_status_worker.rb
+++ b/app/workers/adviser/refresh_adviser_status_worker.rb
@@ -6,14 +6,14 @@ class Adviser::RefreshAdviserStatusWorker
 
     application_form = ApplicationForm.find(application_form_id)
 
-    candidate_matchback_adviser_status = candidate_matchback_adviser_status(application_form)
+    adviser_status = candidate_matchback_adviser_status(application_form)
 
     # The Application Form is in this state by default,
     # We may have only just sent the sign-up to the GIT API and manually updated the Application Form's adviser_status to 'waiting_to_be_assigned'
     # We don't want to go back a step
-    return if candidate_matchback_adviser_status == 'unassigned'
+    return if adviser_status == 'unassigned'
 
-    application_form.update!(adviser_status: candidate_matchback_adviser_status)
+    application_form.update!(adviser_status:)
   end
 
 private

--- a/app/workers/adviser/refresh_adviser_status_worker.rb
+++ b/app/workers/adviser/refresh_adviser_status_worker.rb
@@ -6,8 +6,7 @@ class Adviser::RefreshAdviserStatusWorker
 
     application_form = ApplicationForm.find(application_form_id)
 
-    candidate_matchback = Adviser::CandidateMatchback.new(application_form)
-    candidate_matchback_adviser_status = candidate_matchback.teacher_training_adviser_sign_up.adviser_status
+    candidate_matchback_adviser_status = candidate_matchback_adviser_status(application_form)
 
     # The Application Form is in this state by default,
     # We may have only just sent the sign-up to the GIT API and manually updated the Application Form's adviser_status to 'waiting_to_be_assigned'
@@ -15,5 +14,15 @@ class Adviser::RefreshAdviserStatusWorker
     return if candidate_matchback_adviser_status == 'unassigned'
 
     application_form.update!(adviser_status: candidate_matchback_adviser_status)
+  end
+
+private
+
+  def candidate_matchback_adviser_status(application_form)
+    candidate_matchback = Adviser::CandidateMatchback.new(application_form)
+    candidate_matchback.teacher_training_adviser_sign_up.adviser_status
+  rescue GetIntoTeachingApiClient::ApiError
+    # This API often falls over - return `unassigned` we can try again later
+    'unassigned'
   end
 end


### PR DESCRIPTION
## Context

When the GIT API errors we can ignore the error when it's in the Refresh status worker. We will retry syncing the status in 30mins time. Resolve [Sentry error](https://dfe-teacher-services.sentry.io/issues/6333746708/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=385002e2-c0f6-45ce-902e-ea62124b180d&project=1765973)

The Fetch Teaching Subjects worker is currently running on all environments which is causing issues in Review Apps as the GIT API connection is not configured. We will use the feature flag to turn this sync off in review apps. Resolves [Sentry error](https://dfe-teacher-services.sentry.io/issues/6350042061/?project=1765973&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D&sort=date&stream_index=0)

## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
