### PR TITLE
[720] Remove reliance on CycleTimetable class in test suite

### DIFF
--- a/spec/components/candidate_interface/carry_over_mid_cycle_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_mid_cycle_component_spec.rb
@@ -9,14 +9,11 @@ RSpec.describe CandidateInterface::CarryOverMidCycleComponent do
   end
 
   context 'after the new recruitment cycle begins year' do
-    let(:timetable) { RecruitmentCycleTimetable.current_timetable }
-
     before do
-      TestSuiteTimeMachine.travel_permanently_to(timetable.apply_opens_at)
+      TestSuiteTimeMachine.travel_permanently_to(current_timetable.apply_opens_at)
     end
 
     it 'renders the correct academic years' do
-      current_year = timetable.recruitment_cycle_year
       application_year = current_year - 1
       application_form = build(:completed_application_form, recruitment_cycle_year: application_year)
       result = render_inline(described_class.new(application_form:))
@@ -27,7 +24,6 @@ RSpec.describe CandidateInterface::CarryOverMidCycleComponent do
 
     context 'the application was started two years ago' do
       it 'renders the correct academic years' do
-        current_year = timetable.recruitment_cycle_year
         application_year = current_year - 2
 
         application_form = build(:completed_application_form, recruitment_cycle_year: application_year)

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
   describe '#render' do
     let(:application_form) { build(:application_form) }
-    let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
 
-    it 'does not render when flash is not empty', seed_timetables do
+    it 'does not render when flash is not empty' do
       travel_temporarily_to(current_timetable.apply_deadline_at - 1.minute) do
         result = render_inline(described_class.new(application_form:, flash_empty: false))
         expect(result.text).to eq('')

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
     context 'before find reopens', time: after_apply_deadline do
       it 'renders the banner for an app with the correct details' do
         result = render_inline(described_class.new(flash_empty: true))
-        timetable = RecruitmentCycleTimetable.current_timetable
 
-        apply_opens_date = timetable.apply_reopens_at.to_fs(:govuk_date)
-        academic_year = timetable.academic_year_range_name
-        next_academic_year = timetable.relative_next_timetable.academic_year_range_name
+        apply_opens_date = current_timetable.apply_reopens_at.to_fs(:govuk_date)
+        academic_year = current_timetable.academic_year_range_name
+        next_academic_year = next_timetable.academic_year_range_name
 
         expect(result).to have_content 'The application deadline has passed'
         expect(result).to have_content(
@@ -32,19 +31,17 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       it 'renders the banner for with the correct details' do
         result = render_inline(described_class.new(flash_empty: true))
 
-        timetable = RecruitmentCycleTimetable.current_timetable
-
-        apply_opens_date = timetable.apply_opens_at.to_fs(:govuk_date)
-        academic_year = timetable.cycle_range_name
-        next_academic_year = timetable.academic_year_range_name
+        apply_opens_date = current_timetable.apply_opens_at.to_fs(:govuk_date)
+        previous_academic_year = previous_timetable.academic_year_range_name
+        current_academic_year = current_timetable.academic_year_range_name
 
         expect(result).to have_content 'The application deadline has passed'
         expect(result).to have_content(
-          "The application deadline has passed for courses starting in the #{academic_year} academic year.",
+          "The application deadline has passed for courses starting in the #{previous_academic_year} academic year.",
         )
         expect(result)
           .to have_content(
-            "From #{apply_opens_date} you will be able to apply for courses starting in the #{next_academic_year} academic year.",
+            "From #{apply_opens_date} you will be able to apply for courses starting in the #{current_academic_year} academic year.",
           )
       end
     end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     it 'renders the recruitment cycle' do
-      current_year = RecruitmentCycle.current_year
-      expect(card).to include("#{current_year - 1} to #{current_year}")
+      expect(card).to include current_timetable.cycle_range_name
     end
 
     it 'renders the location of the course' do
@@ -184,8 +183,6 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
   end
 
   describe '#recruitment_cycle_text' do
-    let(:current_year) { RecruitmentCycle.current_year }
-
     let(:course_option) { create(:course_option) }
 
     let(:application_choice) do
@@ -212,7 +209,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     context 'for any other year' do
       let(:course_option) do
-        course = create(:course, :open, recruitment_cycle_year: RecruitmentCycle.previous_year - 1)
+        course = create(:course, :open, recruitment_cycle_year: previous_year - 1)
         create(:course_option, course:)
       end
 

--- a/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
     context 'when the deferred offer is from the previous cycle and the provider user can respond' do
       it 'renders Confirm deferred offer content' do
         application_choice = build_stubbed(:application_choice, :offer_deferred)
-        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
         result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
 
         expect(result.css('h2').text.strip).to eq('Confirm deferred offer')
@@ -17,7 +17,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
     context 'when the deferred offer is in the current cycle' do
       it 'explains the deferred offer will need to be confirmed at the start of the next cycle' do
         application_choice = build_stubbed(:application_choice, :offer_deferred)
-        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.current_year)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(current_year)
         result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
 
         expect(result.text.strip).to eq('Your offer will need to be confirmed at the start of the next recruitment cycle.')
@@ -27,7 +27,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
     context 'when the provider user cannot respond' do
       it 'explains that the deferred offer needs to be confirmed' do
         application_choice = build_stubbed(:application_choice, :offer_deferred)
-        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
         result = render_inline(described_class.new(application_choice:))
 
         expect(result.text.strip).to eq('The deferred offer needs to be confirmed.')
@@ -38,28 +38,28 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
   describe '#deferred_offer_wizard_applicable?' do
     it 'is true for a deferred offer belonging to the previous recruitment cycle' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
 
       expect(described_class.new(application_choice:, provider_can_respond: true).deferred_offer_wizard_applicable?).to be true
     end
 
     it 'is false if the provider cannot respond to the application' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
 
       expect(described_class.new(application_choice:, provider_can_respond: false).deferred_offer_wizard_applicable?).to be false
     end
 
     it 'is false when the application status is not deferred' do
       application_choice = instance_double(ApplicationChoice, status: 'withdrawn')
-      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
 
       expect(described_class.new(application_choice:, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
     end
 
     it 'is false when the application recruitment cycle is current' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.current_year)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(current_year)
 
       expect(described_class.new(application_choice:, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
     end
@@ -68,7 +68,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
   describe '#deferred_offer_but_cannot_respond?' do
     it 'is true if the provider cannot respond to the application' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
-      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+      allow(application_choice).to receive(:recruitment_cycle).and_return(previous_year)
 
       expect(described_class.new(application_choice:, provider_can_respond: false).deferred_offer_but_cannot_respond?).to be true
     end
@@ -77,7 +77,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
   describe '#deferred_offer_in_current_cycle?' do
     it 'is true for a deferred offer without an open offered option' do
       course_option = instance_double(CourseOption, course: instance_double(Course))
-      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: current_year)
       allow(course_option).to receive(:in_next_cycle).and_return(false)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)
 
@@ -86,7 +86,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
 
     it 'is false for a deferred offer with an open offered option' do
       course_option = instance_double(CourseOption, course: instance_double(Course))
-      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: current_year)
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)
 
@@ -95,7 +95,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
 
     it 'is false for a deferred offer from the previous cycle' do
       course_option = instance_double(CourseOption, course: instance_double(Course))
-      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.previous_year)
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: previous_year)
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)
 

--- a/spec/components/support_interface/applications_table_component_spec.rb
+++ b/spec/components/support_interface/applications_table_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupportInterface::ApplicationsTableComponent do
   let(:application_forms) { [application_form_apply_again] + create_list(:application_form, 3, updated_at: 1.day.ago) }
 
   it 'renders the apply again text for the first application' do
-    expect(render_result.text).to include("(#{RecruitmentCycleTimetable.current_year}, apply again)")
+    expect(render_result.text).to include("(#{current_year}, apply again)")
   end
 
   def render_result

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       end
 
       context 'course is next recruitment cycle' do
-        let(:course) { create(:course, :open, recruitment_cycle_year: RecruitmentCycleTimetable.next_year) }
+        let(:course) { create(:course, :open, recruitment_cycle_year: next_year) }
 
         it { is_expected.to match(/Unpublished/) }
       end

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
     let(:rendered_component) { render_inline(component) }
 
     it 'renders table headings' do
-      travel_temporarily_to(RecruitmentCycleTimetable.current_year, 9, 1) do
+      travel_temporarily_to(current_year, 9, 1) do
         header_row = rendered_component.css('.govuk-table__row').first
         header_row_text = header_row.text.split("\n").compact_blank.map(&:strip)
         expect(header_row_text[0]).to eq('Reason')
@@ -104,15 +104,13 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
 
   describe '.recruitment_cycle_context' do
     it 'formats a string for the current recruitment cycle' do
-      timetable = RecruitmentCycleTimetable.current_timetable
-      expected = "#{timetable.cycle_range_name_with_current_indicator} (starts #{timetable.recruitment_cycle_year})"
-      expect(described_class.recruitment_cycle_context(timetable.recruitment_cycle_year)).to eq(expected)
+      expected = "#{current_timetable.cycle_range_name_with_current_indicator} (starts #{current_timetable.recruitment_cycle_year})"
+      expect(described_class.recruitment_cycle_context(current_timetable.recruitment_cycle_year)).to eq(expected)
     end
 
     it 'formats a string for a previous recruitment cycle' do
-      timetable = RecruitmentCycleTimetable.previous_timetable
-      expected = "#{timetable.cycle_range_name} (starts #{timetable.recruitment_cycle_year})"
-      expect(described_class.recruitment_cycle_context(timetable.recruitment_cycle_year)).to eq(expected)
+      expected = "#{previous_timetable.cycle_range_name} (starts #{previous_timetable.recruitment_cycle_year})"
+      expect(described_class.recruitment_cycle_context(previous_timetable.recruitment_cycle_year)).to eq(expected)
     end
   end
 end

--- a/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
@@ -5,14 +5,13 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
 
   def render_result(
     search_attribute = :id,
-    search_value = 'qualifications',
-    recruitment_cycle_year = RecruitmentCycleTimetable.current_year
+    search_value = 'qualifications'
   )
     @rendered_result ||= render_inline(
       described_class.new(
         search_attribute:,
         search_value:,
-        recruitment_cycle_year:,
+        recruitment_cycle_year: current_year,
       ),
     )
   end
@@ -37,7 +36,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
     end
 
     it 'renders the link back to the dashboard' do
-      dashboard_path = support_interface_reasons_for_rejection_dashboard_path(year: RecruitmentCycleTimetable.current_year)
+      dashboard_path = support_interface_reasons_for_rejection_dashboard_path(year: current_year)
 
       expect(@rendered_result.css("a[href='#{dashboard_path}']")).to be_present
     end
@@ -45,7 +44,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
     it 'renders the link back to communication' do
       reason_path = support_interface_reasons_for_rejection_application_choices_path(
         'structured_rejection_reasons[id]' => 'communication_and_scheduling',
-        'recruitment_cycle_year' => RecruitmentCycleTimetable.current_year,
+        'recruitment_cycle_year' => current_year,
       )
 
       expect(@rendered_result.css("a[href='#{reason_path}']")).to be_present

--- a/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
+++ b/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
     end
 
     it 'shows all time and current month percentages and totals' do
-      travel_temporarily_to(RecruitmentCycleTimetable.current_year, 9, 1) do
+      travel_temporarily_to(current_year, 9, 1) do
         table_headings = rendered_component.css('thead th')
         expect(table_headings.size).to eq(5)
         expect(table_headings[0].text.strip).to eq('Reason')
@@ -87,7 +87,7 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
           total_this_month: 20,
           total_for_reason_all_time: 25,
           total_for_reason_this_month: 15,
-          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          recruitment_cycle_year: previous_year,
         ),
       )
     end

--- a/spec/factory_specs/application_choice_factory_spec.rb
+++ b/spec/factory_specs/application_choice_factory_spec.rb
@@ -164,11 +164,11 @@ RSpec.describe 'ApplicationChoice factory' do
     it { is_expected.to be_valid }
 
     it 'associates a course option from the previous recruitment cycle' do
-      expect(record.course_option.course.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
+      expect(record.course_option.course.recruitment_cycle_year).to eq(previous_year)
     end
 
     it 'associates a form from the previous recruitment cycle' do
-      expect(record.application_form.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
+      expect(record.application_form.recruitment_cycle_year).to eq(previous_year)
     end
   end
 
@@ -179,13 +179,13 @@ RSpec.describe 'ApplicationChoice factory' do
       expect { record }.to change { CourseOption.count }.by(2)
       expect(CourseOption.count).to eq(2)
 
-      previous_year = CourseOption.first
-      expect(previous_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
-      expect(record.course_option).to eq(previous_year)
+      previous_year_option = CourseOption.first
+      expect(previous_year_option.course.recruitment_cycle_year).to eq(previous_year)
+      expect(record.course_option).to eq(previous_year_option)
 
-      current_year = CourseOption.last
-      expect(current_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
-      expect(current_year.site.code).to eq(previous_year.site.code)
+      current_year_option = CourseOption.last
+      expect(current_year_option.course.recruitment_cycle_year).to eq(current_year)
+      expect(current_year_option.site.code).to eq(previous_year_option.site.code)
     end
   end
 

--- a/spec/factory_specs/application_form_factory_spec.rb
+++ b/spec/factory_specs/application_form_factory_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe 'ApplicationForm factory' do
     field :work_history_explanation, type: String
     field :volunteering_experience, one_of: [true, false, nil]
     field :phase, value: phase || 'apply_1'
-    field :recruitment_cycle_year, value: RecruitmentCycle.current_year
 
     context "if `first_nationality` is 'British'" do
       let(:attributes) { { first_nationality: 'British' } }
@@ -327,26 +326,24 @@ RSpec.describe 'ApplicationForm factory' do
   trait :carry_over do
     it_behaves_like 'trait :completed'
 
-    field :recruitment_cycle_year, value: RecruitmentCycle.current_year
     field :created_at, value: CycleTimetableHelper.mid_cycle
     field :updated_at, value: CycleTimetableHelper.mid_cycle
 
     it 'associates a previous application form in the previous year' do
       expect(record.previous_application_form).to be_present
-      expect(record.previous_application_form.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
+      expect(record.previous_application_form.recruitment_cycle_year).to eq(previous_year)
     end
   end
 
   trait :apply_again do
     it_behaves_like 'trait :completed', phase: 'apply_2'
 
-    field :recruitment_cycle_year, value: RecruitmentCycle.current_year
     field :created_at, value: CycleTimetableHelper.before_apply_deadline
     field :updated_at, value: CycleTimetableHelper.before_apply_deadline
 
     it 'associates a previous application form in the current year' do
       expect(record.previous_application_form).to be_present
-      expect(record.previous_application_form.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+      expect(record.previous_application_form.recruitment_cycle_year).to eq(current_year)
     end
   end
 

--- a/spec/factory_specs/course_factory_spec.rb
+++ b/spec/factory_specs/course_factory_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Course factory' do
     end
 
     field :age_range, type: String
-    field :applications_open_from, value: CycleTimetable.apply_opens
+    field :applications_open_from, value: current_timetable.apply_opens_at
     field :code, type: String
     field :course_length, value: 'OneYear'
     field :description, type: String
@@ -29,7 +29,6 @@ RSpec.describe 'Course factory' do
     field :name, type: String
     field :program_type, value: 'scitt_programme'
     field :qualifications, value: %w[qts pgce]
-    field :recruitment_cycle_year, value: RecruitmentCycle.current_year
     field :start_date, presence: true
     field :withdrawn, value: false
 
@@ -82,7 +81,7 @@ RSpec.describe 'Course factory' do
     end
 
     trait :previous_year do
-      field :recruitment_cycle_year, value: RecruitmentCycle.previous_year
+      field :recruitment_cycle_year, value: previous_year
     end
 
     trait :available_the_year_after do
@@ -102,7 +101,7 @@ RSpec.describe 'Course factory' do
     end
 
     trait :available_in_current_and_next_year do
-      field :recruitment_cycle_year, value: RecruitmentCycle.current_year
+      field :recruitment_cycle_year, value: current_year
       it_behaves_like 'trait :available_the_year_after'
     end
 

--- a/spec/factory_specs/course_option_factory_spec.rb
+++ b/spec/factory_specs/course_option_factory_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'CourseOption factory' do
 
     trait :previous_year do
       it 'associates a course from the previous year' do
-        expect(record.course.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
+        expect(record.course.recruitment_cycle_year).to eq(previous_year)
       end
     end
 
@@ -61,32 +61,32 @@ RSpec.describe 'CourseOption factory' do
         expect { record }.to change { CourseOption.count }.by(2)
         expect(CourseOption.count).to eq(2)
 
-        previous_year = CourseOption.first
-        expect(previous_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.previous_year)
-        expect(record).to eq(previous_year)
+        previous_year_option = CourseOption.first
+        expect(previous_year_option.course.recruitment_cycle_year).to eq(previous_year)
+        expect(record).to eq(previous_year_option)
 
-        current_year = CourseOption.last
-        expect(current_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
-        expect(current_year.site.code).to eq(previous_year.site.code)
+        current_year_option = CourseOption.last
+        expect(current_year_option.course.recruitment_cycle_year).to eq(current_year)
+        expect(current_year_option.site.code).to eq(previous_year_option.site.code)
       end
     end
 
     trait :available_in_current_and_next_year do
       it 'associates a course from the current year' do
-        expect(record.course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+        expect(record.course.recruitment_cycle_year).to eq(current_year)
       end
 
       it 'creates a new next-year course option for the same course as this year' do
         expect { record }.to change { CourseOption.count }.by(2)
         expect(CourseOption.count).to eq(2)
 
-        current_year = CourseOption.first
-        expect(current_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
-        expect(record).to eq(current_year)
+        current_year_option = CourseOption.first
+        expect(current_year_option.course.recruitment_cycle_year).to eq(current_year)
+        expect(record).to eq(current_year_option)
 
-        next_year = CourseOption.last
-        expect(next_year.course.recruitment_cycle_year).to eq(RecruitmentCycle.next_year)
-        expect(next_year.site.code).to eq(current_year.site.code)
+        next_year_option = CourseOption.last
+        expect(next_year_option.course.recruitment_cycle_year).to eq(next_year)
+        expect(next_year_option.site.code).to eq(current_year_option.site.code)
       end
     end
   end

--- a/spec/forms/candidate_interface/course_choices/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/course_choices/which_course_are_you_applying_to_step_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe CandidateInterface::CourseChoices::WhichCourseAreYouApplyingToSte
         create_list(:application_choice, 2, :rejected,
                     course_option:,
                     application_form: current_application,
-                    current_recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+                    current_recruitment_cycle_year: previous_year)
       end
 
       it 'validates true' do

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe CandidateInterface::DegreeWizard do
 
   let(:store) { instance_double(WizardStateStores::RedisStore) }
   let(:application_form) { create(:application_form) }
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
-  let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-  let(:next_year) { RecruitmentCycleTimetable.next_year }
 
   before do
     allow(store).to receive(:read)

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -106,8 +106,6 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
     describe 'award year' do
       context 'year validations' do
-        let(:next_year) { RecruitmentCycleTimetable.next_year }
-
         it 'allows award year to be valid for the next recruitment_cycle_year' do
           valid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: next_year.to_s)
           invalid_award_year = described_class.new(nil, nil, qualification_type: 'A level', award_year: (next_year + 1).to_s)

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::PickProviderForm do
       create(:course, :open, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
       create(:course, :open, exposed_in_find: true, applications_open_from: Time.zone.today, provider: create(:provider, name: 'School with courses'))
       create(:course, :open, exposed_in_find: true, applications_open_from: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
-      create(:course, :open, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      create(:course, :open, exposed_in_find: true, recruitment_cycle_year: previous_year)
 
       form = described_class.new({})
 

--- a/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
     end
 
     it 'updates the provided ApplicationForm from a previous cycle' do
-      application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      application_form = create(:application_form, recruitment_cycle_year: previous_year)
       create(:application_choice, :awaiting_provider_decision, application_form:)
       details_form = described_class.new(data)
       data[:postcode] = 'BN1 1AA'
@@ -94,7 +94,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
     end
 
     it 'updates the provided ApplicationForm from a previous cycle' do
-      application_form = create(:application_form, address_type: 'Other', recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      application_form = create(:application_form, address_type: 'Other', recruitment_cycle_year: previous_year)
       create(:application_choice, :awaiting_provider_decision, application_form:)
       details_form = described_class.new(data)
 

--- a/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
         create(
           :application_form,
           :with_accepted_offer,
-          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          recruitment_cycle_year: previous_year,
         )
       end
       let(:reference) do

--- a/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
         create(
           :application_form,
           :with_accepted_offer,
-          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          recruitment_cycle_year: previous_year,
         )
       end
       let(:reference) do

--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
 
     it 'returns only course options from current cycle' do
       course = create(:course, :open, code: 'ABC', provider:)
-      same_course_from_another_cycle = create(:course, :open, code: course.code, provider:, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, accredited_provider_id: provider.id)
+      same_course_from_another_cycle = create(:course, :open, code: course.code, provider:, recruitment_cycle_year: previous_year, accredited_provider_id: provider.id)
       course_option_current_cycle = create(:course_option, site: first_site, course:)
       create(:course_option, :previous_year, site: second_site, course: same_course_from_another_cycle)
       application_form = create(:application_form)

--- a/spec/helpers/navigation_items_spec.rb
+++ b/spec/helpers/navigation_items_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe NavigationItems do
         let(:current_candidate) do
           create(
             :candidate,
-            application_forms: [create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)],
+            application_forms: [create(:application_form, recruitment_cycle_year: previous_year)],
           )
         end
 
@@ -116,7 +116,7 @@ RSpec.describe NavigationItems do
         let(:current_candidate) do
           create(
             :candidate,
-            application_forms: [create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)],
+            application_forms: [create(:application_form, recruitment_cycle_year: previous_year)],
           )
         end
 

--- a/spec/lib/equality_and_diversity/values_checker_spec.rb
+++ b/spec/lib/equality_and_diversity/values_checker_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
           }
           application_form = create(
             :application_form,
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
+            recruitment_cycle_year: previous_year,
             equality_and_diversity:,
           )
 
-          check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+          check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
           expect(check).to be true
         end
       end
@@ -46,11 +46,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
           }
           application_form = create(
             :application_form,
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
+            recruitment_cycle_year: previous_year,
             equality_and_diversity:,
           )
 
-          check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+          check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
           expect(check).to be true
         end
       end
@@ -65,11 +65,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
           }
           application_form = create(
             :application_form,
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
+            recruitment_cycle_year: previous_year,
             equality_and_diversity:,
           )
 
-          check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+          check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
           expect(check).to be true
         end
       end
@@ -84,11 +84,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
           }
           application_form = create(
             :application_form,
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
+            recruitment_cycle_year: previous_year,
             equality_and_diversity:,
           )
 
-          check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+          check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
           expect(check).to be true
         end
       end
@@ -104,11 +104,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
         }
         application_form = create(
           :application_form,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          recruitment_cycle_year: previous_year,
           equality_and_diversity:,
         )
 
-        check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+        check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
         expect(check).to be true
       end
     end
@@ -124,11 +124,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
 
         application_form = create(
           :application_form,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          recruitment_cycle_year: previous_year,
           equality_and_diversity:,
         )
 
-        check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+        check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
         expect(check).to be true
       end
     end
@@ -141,11 +141,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
         }
         application_form = create(
           :application_form,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          recruitment_cycle_year: previous_year,
           equality_and_diversity:,
         )
 
-        check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+        check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
         expect(check).to be false
       end
     end
@@ -160,11 +160,11 @@ RSpec.describe EqualityAndDiversity::ValuesChecker do
         }
         application_form = create(
           :application_form,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          recruitment_cycle_year: previous_year,
           equality_and_diversity:,
         )
 
-        check = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year).check_values
+        check = described_class.new(application_form:, recruitment_cycle_year: current_year).check_values
         expect(check).to be false
       end
     end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TimeLimitConfig do
     end
 
     it ':reject_by_default returns a limit of 20 days date is after June in the current cycle' do
-      TestSuiteTimeMachine.travel_permanently_to(Date.new(RecruitmentCycle.current_year, 7, 1)) do
+      TestSuiteTimeMachine.travel_permanently_to(Date.new(current_year, 7, 1)) do
         expect(described_class.limits_for(:reject_by_default).first.limit).to eq(20)
       end
     end

--- a/spec/mailers/candidate_mailer/candidate_mailer_deferred_offer_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_deferred_offer_reminder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CandidateMailer do
                      :offer_deferred,
                      course_option:,
                      current_course_option: course_option,
-                     offer_deferred_at: Time.zone.local(RecruitmentCycleTimetable.current_year, 4, 15))]
+                     offer_deferred_at: Time.zone.local(current_year, 4, 15))]
     end
 
     before { application_form }
@@ -19,7 +19,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Reminder of your deferred offer',
       'heading' => 'Dear Fred',
-      'when offer deferred' => "On 15 April #{RecruitmentCycleTimetable.current_year}",
+      'when offer deferred' => "On 15 April #{current_year}",
       'provider and course name' => 'Arithmetic College deferred your offer to study Mathematics (M101)',
     )
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_deferred_offer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_deferred_offer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateMailer do
       'heading' => 'Dear Fred',
       'name and code for course' => 'Mathematics (M101)',
       'name of provider' => 'Arithmetic College',
-      'year of new course' => "until the next academic year (#{RecruitmentCycleTimetable.next_timetable.academic_year_range_name})",
+      'year of new course' => "until the next academic year (#{next_timetable.academic_year_range_name})",
     )
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe CandidateMailer do
       it_behaves_like 'an email with unsubscribe option'
 
       it 'renders the correct dates' do
-        expect(email.body).to include("as soon as you can to get on a course starting in the #{RecruitmentCycleTimetable.current_academic_year_range_name} academic year.")
-        expect(email.body).to include("The deadline to submit your application is 6pm on #{RecruitmentCycleTimetable.current_timetable.apply_deadline_at.to_fs(:govuk_date)}")
+        expect(email.body).to include("as soon as you can to get on a course starting in the #{current_timetable.academic_year_range_name} academic year.")
+        expect(email.body).to include("The deadline to submit your application is 6pm on #{current_timetable.apply_deadline_at.to_fs(:govuk_date)}")
       end
     end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      "Submit your teacher training application before #{I18n.l(RecruitmentCycleTimetable.current_timetable.apply_deadline_at.to_date, format: :no_year)}",
+      "Submit your teacher training application before #{I18n.l(current_timetable.apply_deadline_at.to_date, format: :no_year)}",
       'heading' => 'Dear Fred',
-      'cycle_details' => "you’ll be able to apply for courses starting in the #{RecruitmentCycleTimetable.current_academic_year_range_name} academic year.",
-      'details' => "You must submit your application by #{I18n.l(RecruitmentCycleTimetable.current_timetable.apply_deadline_at.to_date, format: :no_year)} if you want to start teacher training this year.",
+      'cycle_details' => "you’ll be able to apply for courses starting in the #{current_timetable.academic_year_range_name} academic year.",
+      'details' => "You must submit your application by #{I18n.l(current_timetable.apply_deadline_at.to_date, format: :no_year)} if you want to start teacher training this year.",
       'realistic job preview heading' => 'Gain insights into life as a teacher',
       'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,

--- a/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Find your teacher training course now',
       'greeting' => 'Dear Fred',
-      'academic_year' => RecruitmentCycleTimetable.current_academic_year_range_name.to_s,
+      'academic_year' => current_timetable.academic_year_range_name.to_s,
       'details' => 'Find your courses',
       'realistic job preview heading' => 'Gain insights into life as a teacher',
       'realistic job preview' => 'Try the realistic job preview tool',

--- a/spec/mailers/candidate_mailer/candidate_mailer_interview_cancelled_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_interview_cancelled_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateMailer do
     let(:application_choice_with_interview) { build_stubbed(:application_choice, course_option:, application_form:) }
     let(:interview) do
       build_stubbed(:interview,
-                    date_and_time: Time.zone.local(RecruitmentCycleTimetable.current_year, 1, 15, 9, 30),
+                    date_and_time: Time.zone.local(current_year, 1, 15, 9, 30),
                     location: 'Hogwarts Castle',
                     additional_details: 'Bring your magic wand for the spells test',
                     provider: course_option.provider,
@@ -20,7 +20,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Interview cancelled - Arithmetic College',
       'greeting' => 'Dear Fred',
-      'details' => "Arithmetic College has cancelled your interview on 15 January #{RecruitmentCycleTimetable.current_year} at 9:30am",
+      'details' => "Arithmetic College has cancelled your interview on 15 January #{current_year} at 9:30am",
       'cancellation reason' => 'We recruited someone else',
     )
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_interview_updated_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_interview_updated_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateMailer do
     let(:application_choice_with_interview) { build_stubbed(:application_choice, course_option:, application_form:) }
     let(:interview) do
       build_stubbed(:interview,
-                    date_and_time: Time.zone.local(RecruitmentCycleTimetable.current_year, 1, 15, 9, 30),
+                    date_and_time: Time.zone.local(current_year, 1, 15, 9, 30),
                     location: 'Hogwarts Castle',
                     additional_details: 'Bring your magic wand for the spells test',
                     provider: course_option.provider,
@@ -25,7 +25,7 @@ RSpec.describe CandidateMailer do
         'details' => 'The details of your interview for Geography (G100) have been updated.',
         'interview with new course details' => 'The interview is with Arithmetic College.',
         'new course' => 'It is now for Mathematics (M101).',
-        'interview date' => "15 January #{RecruitmentCycleTimetable.current_year}",
+        'interview date' => "15 January #{current_year}",
         'interview time' => '9:30am',
         'interview location' => 'Hogwarts Castle',
         'additional interview details' => 'Bring your magic wand for the spells test',

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_cycle_has_started_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_cycle_has_started_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      "Apply for teacher training starting in the #{RecruitmentCycleTimetable.current_academic_year_range_name} academic year",
+      "Apply for teacher training starting in the #{current_timetable.academic_year_range_name} academic year",
       'greeting' => 'Dear Fred',
-      'academic_year' => "You can now apply for teacher training courses that start in the #{RecruitmentCycleTimetable.current_academic_year_range_name} academic year.",
+      'academic_year' => "You can now apply for teacher training courses that start in the #{current_timetable.academic_year_range_name} academic year.",
       'details' => 'Courses can fill up quickly, so apply as soon as you are ready.',
     )
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_interview_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_interview_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateMailer do
     let(:application_choice_with_interview) { build_stubbed(:application_choice, course_option:, application_form:) }
     let(:interview) do
       build_stubbed(:interview,
-                    date_and_time: Time.zone.local(RecruitmentCycleTimetable.current_year, 1, 15, 9, 30),
+                    date_and_time: Time.zone.local(current_year, 1, 15, 9, 30),
                     location: 'Hogwarts Castle',
                     additional_details: 'Bring your magic wand for the spells test',
                     provider: course_option.provider,
@@ -20,7 +20,7 @@ RSpec.describe CandidateMailer do
       'Interview arranged for Mathematics (M101)',
       'greeting' => 'Dear Fred',
       'details' => 'Arithmetic College has arranged an interview with you for Mathematics (M101).',
-      'interview date' => "15 January #{RecruitmentCycleTimetable.current_year}",
+      'interview date' => "15 January #{current_year}",
       'interview time' => '9:30am',
       'interview location' => 'Hogwarts Castle',
       'additional interview details' => 'Bring your magic wand for the spells test',

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.new_offer_made well in advance of the decline by default date' do
-    let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
     let(:application_choices) do
       [build_stubbed(
         :application_choice,
@@ -34,7 +33,6 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.new_offer_made within 4 weeks of decline by default date' do
-    let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
     let(:email) { described_class.new_offer_made(application_form.application_choices.first) }
     let(:application_choices) do
       [build_stubbed(

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_accepted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_accepted_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.offer_accepted' do
-    let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+    let(:recruitment_cycle_year) { current_year }
     let(:candidate) { create(:candidate) }
     let(:application_form) do
       build_stubbed(:application_form, first_name: 'Fred',

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CandidateMailer do
     end
 
     context 'mid cycle', time: mid_cycle do
-      let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+      let(:recruitment_cycle_year) { current_year }
 
       it_behaves_like(
         'a mail with subject and content',

--- a/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.withdraw_last_application_choice' do
-    let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+    let(:recruitment_cycle_year) { current_year }
     let(:application_form_with_references) do
       create(:application_form, first_name: 'Fred',
                                 recruitment_cycle_year: recruitment_cycle_year,
@@ -52,7 +52,7 @@ RSpec.describe CandidateMailer do
     end
 
     context 'when new reference flow is active' do
-      let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+      let(:recruitment_cycle_year) { current_year }
       let(:application_choices) { [create(:application_choice, status: 'withdrawn')] }
 
       it_behaves_like(

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -365,7 +365,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       :course_option,
       course: FactoryBot.build_stubbed(
         :course,
-        recruitment_cycle_year: RecruitmentCycle.previous_year,
+        recruitment_cycle_year: CycleTimetableHelper.previous_year,
       ),
     )
 

--- a/spec/mailers/provider_mailer/provider_mailer_apply_service_is_now_open_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_apply_service_is_now_open_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProviderMailer do
       'a mail with subject and content',
       'Candidates can now apply - manage teacher training applications',
       'salutation' => 'Dear Johny English',
-      'main paragraph' => "The #{RecruitmentCycleTimetable.current_cycle_range_name} recruitment cycle has started. Candidates can now apply to your courses.",
+      'main paragraph' => "The #{current_timetable.cycle_range_name} recruitment cycle has started. Candidates can now apply to your courses.",
       'link to applications' => 'http://localhost:3000/provider/applications',
       'footer' => 'Get help, report a problem or give feedback',
     )

--- a/spec/mailers/provider_mailer/provider_mailer_find_service_is_now_open_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_find_service_is_now_open_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ProviderMailer do
       'a mail with subject and content',
       'Candidates can now find courses - manage teacher training applications',
       'salutation' => 'Dear Johny English',
-      'main paragraph' => "Candidates can now find your courses for the #{RecruitmentCycleTimetable.current_cycle_range_name} recruitment cycle.",
-      'Opening date paragraph' => "They’ll be able to apply on #{RecruitmentCycleTimetable.current_timetable.apply_opens_at.to_fs(:govuk_date)} at 9am.",
+      'main paragraph' => "Candidates can now find your courses for the #{current_timetable.cycle_range_name} recruitment cycle.",
+      'Opening date paragraph' => "They’ll be able to apply on #{current_timetable.apply_opens_at.to_fs(:govuk_date)} at 9am.",
     )
   end
 end

--- a/spec/models/application_dates_spec.rb
+++ b/spec/models/application_dates_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationDates do
-  let(:submitted_at) { Time.zone.local(RecruitmentCycleTimetable.current_year, 5, 1, 12, 0, 0).end_of_day }
+  let(:submitted_at) { Time.zone.local(current_year, 5, 1, 12, 0, 0).end_of_day }
 
   let(:application_form) do
     create(:application_form, submitted_at:, application_choices: [application_choice])
@@ -59,7 +59,7 @@ RSpec.describe ApplicationDates do
     end
 
     it 'returns date that providers will respond by when reject_by_default_at is set' do
-      reject_by_default_at = Time.zone.local(RecruitmentCycleTimetable.current_year, 6, 28, 23, 59, 59)
+      reject_by_default_at = Time.zone.local(current_year, 6, 28, 23, 59, 59)
       application_form.application_choices.each do |application_choice|
         application_choice.update(reject_by_default_at:)
       end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApplicationReference do
   end
 
   describe '#order_in_application_references' do
-    let(:last_cycle_application_form) { create(:completed_application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
+    let(:last_cycle_application_form) { create(:completed_application_form, recruitment_cycle_year: previous_year) }
     let(:application_form) { create(:application_form, previous_application_form: last_cycle_application_form) }
 
     context 'with a selection of references' do

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Candidate do
 
       it 'does not touch the application choice when its in a previous recruitment cycle' do
         candidate = create(:candidate)
-        previous_year = RecruitmentCycleTimetable.previous_year
         application_choice = create(:application_choice, current_recruitment_cycle_year: previous_year)
         application_form = ApplicationForm.with_unsafe_application_choice_touches do
           create(:completed_application_form, application_choices: [application_choice], candidate:, recruitment_cycle_year: previous_year)
@@ -84,7 +83,7 @@ RSpec.describe Candidate do
       it 'does not touch the application form when its in a previous recruitment cycle' do
         candidate = create(:candidate)
         application_form = ApplicationForm.with_unsafe_application_choice_touches do
-          create(:completed_application_form, application_choices_count: 1, candidate:, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+          create(:completed_application_form, application_choices_count: 1, candidate:, recruitment_cycle_year: previous_year)
         end
 
         expect { candidate.update(email_address: 'new.email@example.com') }
@@ -167,7 +166,7 @@ RSpec.describe Candidate do
 
       it 'creates an application_form with the current cycle if there are none' do
         expect { candidate.current_application }.to change { candidate.application_forms.count }.from(0).to(1)
-        expect(candidate.current_application.recruitment_cycle_year).to eq RecruitmentCycleTimetable.current_year
+        expect(candidate.current_application.recruitment_cycle_year).to eq current_year
       end
 
       it 'returns the most recent application' do
@@ -187,7 +186,7 @@ RSpec.describe Candidate do
 
       it 'creates an application_form in the next cycle if there are none' do
         expect { candidate.current_application }.to change { candidate.application_forms.count }.from(0).to(1)
-        expect(candidate.current_application.recruitment_cycle_year).to eq RecruitmentCycleTimetable.next_year
+        expect(candidate.current_application.recruitment_cycle_year).to eq next_year
       end
     end
   end
@@ -262,7 +261,7 @@ RSpec.describe Candidate do
     end
 
     context 'when the candidate has applications in apply again in previous cycle' do
-      let!(:application_form_previous_year) { create(:application_form, candidate:, phase: 'apply_2', recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
+      let!(:application_form_previous_year) { create(:application_form, candidate:, phase: 'apply_2', recruitment_cycle_year: previous_year) }
       let!(:application_form) { create(:application_form, candidate:) }
 
       it 'returns true' do
@@ -434,7 +433,7 @@ RSpec.describe Candidate do
       _last_cycle_form = create(
         :application_form,
         :completed,
-        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        recruitment_cycle_year: previous_year,
         candidate:,
         first_name: 'last',
         last_name: 'cycle',

--- a/spec/models/chaser_sent_spec.rb
+++ b/spec/models/chaser_sent_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ChaserSent do
       it 'returns records created this cycle' do
         this_year = create(:chaser_sent)
 
-        previous_timetable = RecruitmentCycleTimetable.previous_timetable
         travel_temporarily_to(previous_timetable.find_opens_at) do
           create(:chaser_sent)
         end
@@ -21,7 +20,6 @@ RSpec.describe ChaserSent do
       it 'returns records created this cycle' do
         this_year = create(:chaser_sent)
 
-        previous_timetable = RecruitmentCycleTimetable.previous_timetable
         travel_temporarily_to(previous_timetable.find_opens_at) do
           create(:chaser_sent)
         end

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -123,7 +123,6 @@ RSpec.describe CourseOption do
     let(:site_current_cycle) { create(:site) }
     let(:course_current_cycle) { create(:course, provider: site_current_cycle.provider) }
     let!(:course_option_current_cycle) { create(:course_option, site: site_current_cycle, course: course_current_cycle) }
-    let(:previous_year) { RecruitmentCycleTimetable.previous_year }
 
     it 'returns the correct course option in the previous cycle' do
       site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
@@ -158,7 +157,6 @@ RSpec.describe CourseOption do
     let(:site_current_cycle) { create(:site) }
     let(:course_current_cycle) { create(:course, provider: site_current_cycle.provider) }
     let!(:course_option_current_cycle) { create(:course_option, site: site_current_cycle, course: course_current_cycle) }
-    let(:next_year) { RecruitmentCycleTimetable.next_year }
 
     it 'returns the correct course option in the next cycle' do
       site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe PerformanceStatistics do
 
   describe '#candidate_count' do
     it 'returns the total number of candidates that were created during a given cycle' do
-      timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2023)
+      timetable = get_timetable(2023)
       travel_temporarily_to(timetable.find_opens_at + 1.day) do
         create_list(:candidate, 2)
       end

--- a/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReportGenerator do
   let(:provider_id) { create(:provider).id }
   let(:generation_date) { Time.zone.today }
 
-  describe 'when a normal response is received', seed_timetables do
+  describe 'when a normal response is received' do
     before do
       stub_bigquery_application_metrics_by_provider_request(
         rows: [[

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   let(:application_choice) { create(:application_choice, status: 'awaiting_provider_decision', course_option:, sent_to_provider_at: Time.zone.today - 1.week) }
   let(:provider) { course_option.course.provider }
 
-  let(:cycle_week) { RecruitmentCycleTimetable.current_cycle_week.pred }
-  let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+  let(:cycle_week) { current_cycle_week.pred }
+  let(:recruitment_cycle_year) { current_year }
 
   context 'provider report is generated for appropriate providers' do
     before do
@@ -32,7 +32,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
     end
 
     it 'creates a report if one has been generated for that cycle week in the previous year' do
-      create(:provider_recruitment_performance_report, provider:, cycle_week:, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      create(:provider_recruitment_performance_report, provider:, cycle_week:, recruitment_cycle_year: previous_year)
 
       described_class.new.call
 
@@ -74,7 +74,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         statistics: {},
         publication_date: Time.zone.today,
         cycle_week:,
-        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        recruitment_cycle_year: previous_year,
       )
 
       described_class.new.call
@@ -87,7 +87,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         statistics: {},
         publication_date: Time.zone.today,
         cycle_week:,
-        recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+        recruitment_cycle_year: current_year,
       )
 
       described_class.new.call

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.describe Site do
   subject { create(:site) }
 
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
-  let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-
   describe 'a valid site' do
     it { is_expected.to validate_presence_of :code }
     it { is_expected.to validate_presence_of :name }

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SupportInterface::ApplicationsFilter do
       verify_filtered_applications_for_params(
         [expected_form],
         params: {
-          year: [RecruitmentCycleTimetable.previous_year],
+          year: [previous_year],
         },
       )
     end

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe SupportInterface::ProvidersFilter do
       training_provider2 = create(:provider, :unsigned)
       create(:course, provider: training_provider1, accredited_provider:)
       create(:course, provider: training_provider2, accredited_provider:)
-      course_from_previous_cycle = create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, accredited_provider:)
+      course_from_previous_cycle = create(:course, recruitment_cycle_year: previous_year, accredited_provider:)
 
       filter = described_class.new(params: { accredited_provider: 'accredited prov' })
       expect(filter.filter_records(Provider.all)).to contain_exactly(training_provider1, training_provider2)

--- a/spec/presenters/publications/v1/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v1/monthly_statistics_presenter_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe Publications::V1::MonthlyStatisticsPresenter do
 
   describe '#first_published_cycle?' do
     context 'when current cycle' do
-      let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
-
       before do
         allow(report).to receive(:generation_date).and_return(
           current_timetable.apply_opens_at.to_date,

--- a/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'ApplicationPresenter' do
 
   describe 'Equality and diversity data' do
     context 'when it is a current cycle application' do
-      let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+      let(:recruitment_cycle_year) { current_year }
 
       it 'returns the 2023 HESA codes associated with that application' do
         equality_and_diversity_data = application_form[:equality_and_diversity]

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -198,13 +198,13 @@ RSpec.describe GetApplicationChoicesForProviders do
     course_option_for_current_cycle = course_option_for_provider(provider: current_provider)
     course_option_for_previous_cycle = course_option_for_provider(
       provider: current_provider,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: current_timetable.relative_previous_year,
     )
 
     ratified_course_option_for_previous_cycle = course_option_for_accredited_provider(
       provider: provider_we_ratify,
       accredited_provider: current_provider,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: current_timetable.relative_previous_year,
     )
 
     choice_for_current_cycle = create(
@@ -225,7 +225,7 @@ RSpec.describe GetApplicationChoicesForProviders do
       course_option: ratified_course_option_for_previous_cycle,
     )
 
-    returned_applications = described_class.call(providers: [current_provider], recruitment_cycle_year: RecruitmentCycle.current_year)
+    returned_applications = described_class.call(providers: [current_provider], recruitment_cycle_year: current_timetable.recruitment_cycle_year)
 
     expect(returned_applications.map(&:id)).to include(choice_for_current_cycle.id)
     expect(returned_applications.map(&:id)).not_to include(choice_for_previous_cycle.id)

--- a/spec/queries/get_application_progress_data_by_course_spec.rb
+++ b/spec/queries/get_application_progress_data_by_course_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe GetApplicationProgressDataByCourse do
     end
 
     it 'only shows results for the current recuitment cycle year' do
-      previous_year_course = create(:course, name: 'Alpha Plus Physics', code: '2AIC', provider: report_provider, accredited_provider: nil, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      previous_year_course = create(:course, name: 'Alpha Plus Physics', code: '2AIC', provider: report_provider, accredited_provider: nil, recruitment_cycle_year: previous_year)
       previous_year_course_option = create(:course_option, course: previous_year_course)
       create_list(:application_choice, 5, status: :pending_conditions, course_option: previous_year_course_option)
       expect(progress_data).not_to include(previous_year_course)
@@ -66,7 +66,7 @@ RSpec.describe GetApplicationProgressDataByCourse do
     end
 
     it 'only shows results for the current recuitment cycle year for when we are the accredited provider' do
-      previous_year_course = create(:course, name: 'Alpha Plus Physics', code: '2AIC', provider: accredited_provider, accredited_provider: report_provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      previous_year_course = create(:course, name: 'Alpha Plus Physics', code: '2AIC', provider: accredited_provider, accredited_provider: report_provider, recruitment_cycle_year: previous_year)
       previous_year_course_option = create(:course_option, course: previous_year_course)
       create_list(:application_choice, 5, status: :pending_conditions, course_option: previous_year_course_option)
       expect(progress_data).not_to include(previous_year_course)

--- a/spec/queries/get_incomplete_course_choice_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_course_choice_applications_ready_to_nudge_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       course_choices_completed: false,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: previous_year,
     )
     application_form.update_columns(
       updated_at: 10.days.ago,

--- a/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :unsubmitted,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: previous_year,
       references_count: 0,
     )
     create(:application_choice, application_form:)
@@ -262,7 +262,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       :completed_application_form,
       :unsubmitted,
       references_completed: false,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: previous_year,
     )
     application_form1.update_columns(
       updated_at: 10.days.ago,

--- a/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       :unsubmitted,
-      recruitment_cycle_year: RecruitmentCycle.previous_year,
+      recruitment_cycle_year: previous_year,
     )
     application_form.update_columns(
       updated_at: 10.days.ago,

--- a/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
+++ b/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
       candidate_with_account_locked = create(:candidate, account_locked: true)
       candidate_unsubscribed_from_emails = create(:candidate, unsubscribed_from_emails: true)
 
-      accepted_application_form_from_previous_cycle = create(:application_form, :submitted, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      accepted_application_form_from_previous_cycle = create(:application_form, :submitted, recruitment_cycle_year: current_timetable.relative_previous_year)
       create(:application_choice, :accepted, application_form: accepted_application_form_from_previous_cycle)
 
-      create(:application_form, candidate: candidate_with_submission_blocked, recruitment_cycle_year: RecruitmentCycle.previous_year)
-      create(:application_form, candidate: candidate_with_account_locked, recruitment_cycle_year: RecruitmentCycle.previous_year)
-      create(:application_form, candidate: candidate_unsubscribed_from_emails, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_form, candidate: candidate_with_submission_blocked, recruitment_cycle_year: current_timetable.relative_previous_year)
+      create(:application_form, candidate: candidate_with_account_locked, recruitment_cycle_year: current_timetable.relative_previous_year)
+      create(:application_form, candidate: candidate_unsubscribed_from_emails, recruitment_cycle_year: current_timetable.relative_previous_year)
 
       rejected_application_form_from_previous_cycle = create(
         :application_form,
         :minimum_info,
-        recruitment_cycle_year: RecruitmentCycle.previous_year,
+        recruitment_cycle_year: current_timetable.relative_previous_year,
       )
 
       create(:application_choice, :rejected, application_form: rejected_application_form_from_previous_cycle)
@@ -25,21 +25,21 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
       carried_over_application_form = create(
         :application_form,
         :minimum_info,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
+        recruitment_cycle_year: current_timetable.recruitment_cycle_year,
         candidate: rejected_application_form_from_previous_cycle.candidate,
       )
 
-      application_form_current_year = create(:application_form, :minimum_info, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.current_year)
+      application_form_current_year = create(:application_form, :minimum_info, submitted_at: nil, recruitment_cycle_year: current_timetable.recruitment_cycle_year)
 
-      application_form_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      application_form_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: current_timetable.relative_previous_year)
 
       create(:application_choice, :rejected, application_form: application_form_previous_year)
 
-      another_application_form_from_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      another_application_form_from_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: current_timetable.relative_previous_year)
       create(:application_choice, :recruited, application_form: another_application_form_from_previous_year)
 
       rejected_application_choice_from_previous_cycle = create(:application_choice, :rejected, :previous_year, application_form: application_form_previous_year)
-      unsubmitted_application_from_previous_cycle = create(:application_form, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      unsubmitted_application_from_previous_cycle = create(:application_form, submitted_at: nil, recruitment_cycle_year: current_timetable.relative_previous_year)
 
       unsuccessful_and_unsubmitted_applications = described_class.call
 

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe OffersToChaseQuery do
   let(:application_choice_without_offer) { create(:application_choice, :awaiting_provider_decision) }
   let(:application_choice_with_offer_not_in_offer_status) { create(:application_choice, :recruited, offered_at: Time.zone.now) }
-  let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: CycleTimetable.previous_year, offered_at: inside_range) }
+
+  let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: current_timetable.relative_previous_year, offered_at: inside_range) }
 
   let(:application_choice_with_chaser) { create(:application_choice, :offer, chasers_sent: [create(:chaser_sent, chaser_type: "offer_#{days}_day")]) }
 
   let(:application_choice_without_chaser) { create(:application_choice, :offer, current_recruitment_cycle_year:) }
-  let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
   let(:current_recruitment_cycle_year) { current_timetable.recruitment_cycle_year }
 
   # We have to make sure our offset doesn't mean we are straddling two recruitment cycles.
@@ -106,7 +106,7 @@ RSpec.describe OffersToChaseQuery do
     context 'and the application is from the previous recruitment cycle' do
       let(:offset) { inside_range }
       let(:chaser_type) { :offer_10_day }
-      let(:current_recruitment_cycle_year) { RecruitmentCycleTimetable.previous_year }
+      let(:current_recruitment_cycle_year) { previous_year }
 
       it 'excludes applications from previous cycle' do
         expect(date_range).to cover(application_choice_without_chaser.offered_at)

--- a/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
+++ b/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
-  subject(:query) { described_class.call(cycle_week: RecruitmentCycleTimetable.current_cycle_week.pred, recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
+  subject(:query) { described_class.call(cycle_week: current_cycle_week.pred, recruitment_cycle_year: current_year) }
 
   let(:application_choice_offer_from_last_cycle) { create(:application_choice, :awaiting_provider_decision).provider }
   let(:application_this_week) { create(:application_choice, :awaiting_provider_decision).provider }
@@ -10,8 +10,8 @@ RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
   let(:application_with_existing_report) do
     create(:application_choice, :awaiting_provider_decision).provider.tap do |provider|
       Publications::ProviderRecruitmentPerformanceReport.create(
-        cycle_week: RecruitmentCycleTimetable.current_cycle_week,
-        recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+        cycle_week: current_cycle_week,
+        recruitment_cycle_year: current_year,
         provider_id: provider.id,
         publication_date: Time.zone.today,
       )

--- a/spec/queries/reasons_for_rejection_applications_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_applications_query_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ReasonsForRejectionApplicationsQuery do
     end
     let!(:application_choice_without_sr4r) { create(:application_choice) }
     let!(:application_choice_from_previous_year) do
-      create(:application_choice, :with_old_structured_rejection_reasons, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_choice, :with_old_structured_rejection_reasons, current_recruitment_cycle_year: previous_year)
     end
 
     subject(:query) { described_class.new(filter_params) }
@@ -43,7 +43,7 @@ RSpec.describe ReasonsForRejectionApplicationsQuery do
       let(:filter_params) do
         {
           structured_rejection_reasons: { 'id' => 'visa_sponsorship' },
-          recruitment_cycle_year: RecruitmentCycle.current_year,
+          recruitment_cycle_year: current_year,
           page: 1,
         }
       end
@@ -57,7 +57,7 @@ RSpec.describe ReasonsForRejectionApplicationsQuery do
       let(:filter_params) do
         {
           structured_rejection_reasons: { 'personal_statement' => 'quality_of_writing' },
-          recruitment_cycle_year: RecruitmentCycle.current_year,
+          recruitment_cycle_year: current_year,
           page: 1,
         }
       end

--- a/spec/queries/reasons_for_rejection_count_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_count_query_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ReasonsForRejectionCountQuery do
 
     it 'defaults to counts for current recruitment cycle' do
       reject_application(
-        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
+        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: previous_year),
         [qualifications, visa_sponsorship],
       )
       counts = described_class.new.grouped_reasons
@@ -85,10 +85,10 @@ RSpec.describe ReasonsForRejectionCountQuery do
 
     it 'can be initialized for a specific recruitment cycle year' do
       reject_application(
-        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
+        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: previous_year),
         [visa_sponsorship, qualifications],
       )
-      counts = described_class.new(RecruitmentCycle.previous_year).grouped_reasons
+      counts = described_class.new(previous_year).grouped_reasons
       expect(counts[:visa_sponsorship]).to eq(described_class::Result.new(1, 1, {}))
       expect(counts[:qualifications]).to eq(described_class::Result.new(1, 1, {}))
     end
@@ -105,7 +105,7 @@ RSpec.describe ReasonsForRejectionCountQuery do
 
     it 'only returns counts for current recruitment cycle' do
       reject_application(
-        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
+        create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: previous_year),
         [visa_sponsorship, qualifications],
       )
       counts = described_class.new.subgrouped_reasons

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,10 +23,25 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'dotenv/rails'
 
+CYCLE_DATES.each do |recruitment_cycle_year, dates|
+  RecruitmentCycleTimetable.find_or_create_by(recruitment_cycle_year:).tap do |timetable|
+    timetable.update(
+      find_opens_at: dates[:find_opens],
+      apply_opens_at: dates[:apply_opens],
+      apply_deadline_at: dates[:apply_deadline],
+      reject_by_default_at: dates[:reject_by_default],
+      decline_by_default_at: dates[:find_closes] - 1.day,
+      find_closes_at: dates[:find_closes],
+      christmas_holiday_range: dates.dig(:holidays, :christmas),
+      easter_holiday_range: dates.dig(:holidays, :easter),
+    )
+  end
+end
+
 STANDARD_TEST_DATES = {
-  'after_apply_deadline' => (CycleTimetable.apply_deadline + 1.hour).to_fs,
-  'before_apply_reopens' => (CycleTimetable.apply_reopens - 1.day).to_fs,
-  'after_apply_reopens' => (CycleTimetable.apply_reopens + 1.day).to_fs,
+  'after_apply_deadline' => (RecruitmentCycleTimetable.current_timetable.apply_deadline_at + 1.hour).to_fs,
+  'before_apply_reopens' => (RecruitmentCycleTimetable.current_timetable.apply_reopens_at - 1.day).to_fs,
+  'after_apply_reopens' => (RecruitmentCycleTimetable.current_timetable.apply_reopens_at + 1.day).to_fs,
 }.freeze
 
 test_date_time_var = ENV.fetch('TEST_DATE_AND_TIME', 'real_world')

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Submit to continuous apps' do
 
   context 'when old cycles trying to cheat and submit into the new cycle' do
     let(:application_form) do
-      create(:application_form, :completed, :with_degree, submitted_at: nil, recruitment_cycle_year: CycleTimetable.previous_year)
+      create(:application_form, :completed, :with_degree, submitted_at: nil, recruitment_cycle_year: previous_year)
     end
 
     it 'be successful' do

--- a/spec/requests/publications/recruitment_cycle_timetables_spec.rb
+++ b/spec/requests/publications/recruitment_cycle_timetables_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'RecruitmentCycleTimetables' do
   let(:response_body) { response.parsed_body }
 
-  describe '#index', seed_timetables do
+  describe '#index' do
     let(:data) { response_body['data'] }
 
     it 'returns all recruitment cycle timetables in descending order' do
@@ -21,7 +21,7 @@ RSpec.describe 'RecruitmentCycleTimetables' do
     end
   end
 
-  describe '#show', seed_timetables do
+  describe '#show' do
     let(:data) { response_body['data'].first }
 
     context 'valid year' do
@@ -29,7 +29,7 @@ RSpec.describe 'RecruitmentCycleTimetables' do
         year = RecruitmentCycleTimetable.pluck(:recruitment_cycle_year).sample
         get("/publications/recruitment-cycle-timetables/#{year}", params: { format: 'json' })
         expect(response).to have_http_status(:ok)
-        recruitment_cycle_timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: year)
+        recruitment_cycle_timetable = get_timetable(year)
         expect(data['recruitment_cycle_year']).to eq recruitment_cycle_timetable.recruitment_cycle_year
       end
     end
@@ -38,19 +38,18 @@ RSpec.describe 'RecruitmentCycleTimetables' do
       it 'returns the current recruitment cycle timetable' do
         get('/publications/recruitment-cycle-timetables/current', params: { format: 'json' })
         expect(response).to have_http_status(:ok)
-        recruitment_cycle_timetable = RecruitmentCycleTimetable.current_timetable
-        expect(data['recruitment_cycle_year']).to eq recruitment_cycle_timetable.recruitment_cycle_year
+        expect(data['recruitment_cycle_year']).to eq current_year
       end
 
       it 'returns ranges as array of start and end dates' do
         get('/publications/recruitment-cycle-timetables/current', params: { format: 'json' })
         expect(response).to have_http_status(:ok)
 
-        christmas_holiday_range = RecruitmentCycleTimetable.current_timetable.christmas_holiday_range
+        christmas_holiday_range = current_timetable.christmas_holiday_range
         expect(data['christmas_holiday_range'])
           .to eq([christmas_holiday_range.first.to_s, christmas_holiday_range.last.to_s])
 
-        easter_holiday_range = RecruitmentCycleTimetable.current_timetable.easter_holiday_range
+        easter_holiday_range = current_timetable.easter_holiday_range
         expect(data['easter_holiday_range'])
           .to eq([easter_holiday_range.first.to_s, easter_holiday_range.last.to_s])
       end

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe 'GET /register-api/applications' do
   include RegisterAPISpecHelper
 
   it 'returns unauthorised when passing a non existent API token' do
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: 'this-token-does-not-exist'
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: 'this-token-does-not-exist'
     expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'does not allow access to the API from other data users' do
     api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: api_token
     expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
   end
 
   it 'allows access to the API for Register users' do
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(response).to have_http_status(:success)
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
@@ -31,7 +31,7 @@ RSpec.describe 'GET /register-api/applications' do
       application_form: create(:completed_application_form, :with_equality_and_diversity_data),
     )
 
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
@@ -47,7 +47,7 @@ RSpec.describe 'GET /register-api/applications' do
       application_form: application_form,
     )
 
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
@@ -61,7 +61,7 @@ RSpec.describe 'GET /register-api/applications' do
       application_form: create(:completed_application_form),
     )
 
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}&per_page=2", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}&per_page=2", token: register_api_token
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
     expect(parsed_response['data'].count).to be(2)
@@ -94,7 +94,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'returns HTTP status 422 if the per_page param is too big' do
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}&per_page=#{RegisterAPI::ApplicationsController::MAX_PER_PAGE + 1}", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}&per_page=#{RegisterAPI::ApplicationsController::MAX_PER_PAGE + 1}", token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql("the 'per_page' parameter cannot exceed #{RegisterAPI::ApplicationsController::MAX_PER_PAGE} results per page")
@@ -102,7 +102,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'returns HTTP status 422 if the page param is too big' do
-    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}&page=2", token: register_api_token
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}&page=2", token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql("expected 'page' parameter to be between 1 and 1, got 2")
@@ -110,7 +110,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'returns HTTP status 422 given an unparseable `changed_since` date value' do
-    get_api_request "/register-api/applications?changed_since=17/07/2020T12:00:42Z&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?changed_since=17/07/2020T12:00:42Z&recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
@@ -118,7 +118,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
-    get_api_request "/register-api/applications?changed_since=12936&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?changed_since=12936&recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): changed_since')
@@ -126,7 +126,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'returns HTTP status 422 given a parseable but nonsensensical `changed_since` date value' do
-    get_api_request "/register-api/applications?changed_since=-004713-03-23T11:52:19.448Z&recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: register_api_token
+    get_api_request "/register-api/applications?changed_since=-004713-03-23T11:52:19.448Z&recruitment_cycle_year=#{current_year}", token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): changed_since')

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer' 
         'data' => {
           'conditions' => [],
           'course' => {
-            'recruitment_cycle_year' => RecruitmentCycle.current_year,
+            'recruitment_cycle_year' => current_year,
             'provider_code' => 'ABC',
             'course_code' => 'X100',
             'site_code' => 'E',
@@ -452,7 +452,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer' 
   context 'making an offer to an application from a previous cycle', time: after_apply_deadline do
     it 'returns an error' do
       application_choice = create_application_choice_for_currently_authenticated_provider(status: 'rejected')
-      advance_time_to(after_find_opens(RecruitmentCycle.next_year))
+      advance_time_to(after_find_opens(next_year))
 
       request_body = { data: { conditions: ['DBS Check'] } }
 
@@ -461,7 +461,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer' 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response)
         .to contain_schema_with_error('UnprocessableEntityResponse',
-                                      "Course must be in #{RecruitmentCycle.current_year} recruitment cycle")
+                                      "Course must be in #{current_year} recruitment cycle")
     end
   end
 

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
-    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(1)
     expect(ApplicationChoice.all.map(&:status).uniq).to eq(%w[pending_conditions])
-    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: previous_year }).count).to eq(1)
   end
 
   describe 'next_cycle' do
@@ -31,7 +31,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
       post_api_request '/api/v1.0/test-data/generate?count=1&next_cycle=true'
 
       expect(Candidate.count).to eq(1)
-      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.next_year }).count).to eq(1)
+      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: next_year }).count).to eq(1)
     end
 
     it 'ignores the previous cycle param' do
@@ -40,8 +40,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
       post_api_request '/api/v1.0/test-data/generate?count=1&next_cycle=true&previous_cycle=false'
 
       expect(Candidate.count).to eq(1)
-      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.next_year }).count).to eq(1)
-      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(0)
+      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: next_year }).count).to eq(1)
+      expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(0)
     end
   end
 
@@ -86,8 +86,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
-    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
-    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(1)
     expect(ApplicationChoice.all.map(&:status).uniq).to eq(%w[pending_conditions])
     expect(ApplicationChoice.all.map(&:course_option).uniq).to contain_exactly(expected_option)
   end
@@ -111,8 +111,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
-    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
-    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(1)
     expect(ApplicationChoice.all.map(&:status).uniq).to eq(%w[pending_conditions])
     expect(ApplicationChoice.all.map(&:course_option).uniq).to contain_exactly(expected_option)
   end
@@ -124,8 +124,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
     post_api_request '/api/v1.0/test-data/generate?count=1&for_test_provider_courses=true&previous_cycle=true'
 
     expect(Candidate.count).to eq(1)
-    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
-    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: RecruitmentCycle.previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:course).where(course: { recruitment_cycle_year: previous_year }).count).to eq(1)
+    expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(1)
     expect(ApplicationChoice.all.map(&:status).uniq).to eq(%w[pending_conditions])
     expect(ApplicationChoice.all.map(&:course_option).map(&:provider).map(&:code).compact).to contain_exactly('TEST')
   end

--- a/spec/requests/vendor_api/v1.1/post_defer_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.1/post_defer_offer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/defer-o
     end
 
     describe 'when successful' do
-      let(:course) { build(:course, provider: currently_authenticated_provider, recruitment_cycle_year: RecruitmentCycle.current_year) }
+      let(:course) { build(:course, provider: currently_authenticated_provider, recruitment_cycle_year: current_timetable.recruitment_cycle_year) }
       let(:course_option) { build(:course_option, course:) }
       let!(:application_choice) do
         create(:application_choice, :with_completed_application_form, :accepted, course_option:)
@@ -52,7 +52,7 @@ RSpec.describe 'Vendor API - POST /api/v1.1/applications/:application_id/defer-o
         expect(parsed_response['data']['attributes']['offer'])
           .to include('status_before_deferral' => original_status,
                       'offer_deferred_at' => application_choice.reload.offer_deferred_at.iso8601,
-                      'deferred_to_recruitment_cycle_year' => RecruitmentCycle.current_year + 1)
+                      'deferred_to_recruitment_cycle_year' => current_timetable.relative_next_year)
 
         expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.1')
       end

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AcceptOffer do
   include CourseOptionHelpers
 
   before do
-    timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
+    timetable = get_timetable(ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
     TestSuiteTimeMachine.travel_permanently_to(timetable.apply_opens_at)
   end
 

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
       context 'when apply is closed and course open for applications same day' do
         it 'adds error to application choice', time: after_find_opens do
-          apply_opens_date = RecruitmentCycleTimetable.current_timetable.apply_opens_at.to_fs(:govuk_date)
+          apply_opens_date = current_timetable.apply_opens_at.to_fs(:govuk_date)
           expect(application_choice_submission).not_to be_valid
           expect(application_choice_submission.errors[:application_choice]).to include(
             "This course is not yet open to applications. You will be able to submit your application on #{apply_opens_date}.",

--- a/spec/services/candidate_interface/apply_from_find_page_spec.rb
+++ b/spec/services/candidate_interface/apply_from_find_page_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe CandidateInterface::ApplyFromFindPage do
   end
 
   describe '#candidate_has_application_in_wrong_cycle?' do
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-    let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-
     context 'when the application is not in the wrong cycle' do
       it 'is false' do
         candidate = create(:candidate)

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::HesaCodeBackfill do
   describe '#call' do
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-
     it 'populates an application form with hesa codes' do
       application_form = create(:application_form,
                                 equality_and_diversity: {

--- a/spec/services/candidate_interface/inactive_date_calculator_spec.rb
+++ b/spec/services/candidate_interface/inactive_date_calculator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::InactiveDateCalculator do
   let(:application_choice) { create(:application_choice, :unsubmitted) }
 
   before do
-    timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2024)
+    timetable = get_timetable(2024)
     BusinessTime::Config.holidays += timetable.christmas_holiday_range.to_a
     BusinessTime::Config.holidays += timetable.easter_holiday_range.to_a
   end

--- a/spec/services/candidate_interface/sign_in_candidate_spec.rb
+++ b/spec/services/candidate_interface/sign_in_candidate_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe CandidateInterface::SignInCandidate do
     )
   end
 
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
-
   context 'course is in the current cycle' do
     let(:course) { create(:course, recruitment_cycle_year: current_year) }
 
@@ -30,7 +28,7 @@ RSpec.describe CandidateInterface::SignInCandidate do
   end
 
   context 'course is in the previous cycle' do
-    let(:course) {  create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
+    let(:course) {  create(:course, recruitment_cycle_year: previous_year) }
 
     it 'is does not set the candidates `course_from_find_id` if the course is not in the current cycle' do
       candidate = create(:candidate)

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -45,25 +45,25 @@ RSpec.describe CarryOverApplication do
   context 'when original application is from an earlier recruitment cycle' do
     before do
       TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
-      original_application_form.recruitment_cycle_year = RecruitmentCycleTimetable.previous_year
+      original_application_form.recruitment_cycle_year = previous_year
       original_application_form.save(touch: false)
     end
 
-    it_behaves_like 'duplicates application form', RecruitmentCycleTimetable.current_year
+    it_behaves_like 'duplicates application form', current_year
   end
 
   context 'when original application is from multiple cycles ago' do
     before do
       TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
-      original_application_form.recruitment_cycle_year = RecruitmentCycleTimetable.previous_year - 1
+      original_application_form.recruitment_cycle_year = previous_year - 1
       original_application_form.save(touch: false)
     end
 
-    it_behaves_like 'duplicates application form', RecruitmentCycleTimetable.current_year
+    it_behaves_like 'duplicates application form', current_year
   end
 
   context 'when original application is from the current recruitment cycle but that cycle has now closed', time: after_apply_deadline do
-    it_behaves_like 'duplicates application form', RecruitmentCycleTimetable.next_year
+    it_behaves_like 'duplicates application form', next_year
   end
 
   context 'when application form has unstructured work history', time: after_apply_deadline do

--- a/spec/services/data_api/tad_application_export_spec.rb
+++ b/spec/services/data_api/tad_application_export_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe DataAPI::TADApplicationExport, :with_audited do
   describe '#as_json' do
     it 'returns json' do
-      current_year = RecruitmentCycleTimetable.current_year
       application_choice = create(:application_choice, :offer_deferred_after_recruitment)
       application_form = application_choice.application_form
       candidate = application_choice.candidate

--- a/spec/services/data_migrations/add_all_recruitment_cycle_timetables_to_database_spec.rb
+++ b/spec/services/data_migrations/add_all_recruitment_cycle_timetables_to_database_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase do
 
   it 'handles holidays as expected' do
     described_class.new.change
-    year_without_holidays = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2020)
-    year_with_holidays = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2021)
+    year_without_holidays = get_timetable(2020)
+    year_with_holidays = get_timetable(2021)
 
     expect(year_without_holidays.easter_holiday_range).to be_nil
     expect(year_without_holidays.christmas_holiday_range).to be_nil

--- a/spec/services/data_migrations/add_recruitment_cycle_year_to_performance_reports_spec.rb
+++ b/spec/services/data_migrations/add_recruitment_cycle_year_to_performance_reports_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::AddRecruitmentCycleYearToPerformanceReports do
-  let(:start_of_2025_cycle) { RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2025).find_opens_at }
+  let(:start_of_2025_cycle) { get_timetable(2025).find_opens_at }
 
   before do
     DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase.new.change

--- a/spec/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications_spec.rb
+++ b/spec/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications do
   let(:data_migration) { described_class.new.change }
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
-  let(:previous_year) { RecruitmentCycleTimetable.previous_year }
 
   before do
     # This test ony relevant for 2024. We were backfilling data that was missed when carrying over previous applications

--- a/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
+++ b/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DataMigrations::BackfillSandboxCourseUuids do
 
     stub_teacher_training_api_courses(
       provider_code: provider.code,
-      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+      recruitment_cycle_year: current_year,
       specified_attributes: [
         { code: up_to_date_course.code, uuid: up_to_date_course_uuid },
         { code: out_of_date_course.code, uuid: new_course_uuid },

--- a/spec/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete_spec.rb
+++ b/spec/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficie
   end
 
   context 'when english proficiency record does not exists' do
-    let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-
     describe 'application is in an earlier cycle' do
       it 'does not change record' do
         application_form = create(

--- a/spec/services/data_migrations/remove_courses_not_on_publish_spec.rb
+++ b/spec/services/data_migrations/remove_courses_not_on_publish_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe DataMigrations::RemoveCoursesNotOnPublish do
   let!(:course_existing_in_apply_but_not_publish_with_choices) { create(:application_choice, course_option: create(:course_option, course: create(:course, :uuid, provider:))).current_course }
 
   before do
-    current_year = RecruitmentCycleTimetable.current_year
     stub_teacher_training_api_courses(
       provider_code: provider.code,
       recruitment_cycle_year: current_year,

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DuplicateApplication do
     described_class.new(@original_application_form).duplicate
   end
 
-  let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+  let(:recruitment_cycle_year) { current_year }
 
   it 'marks reference as incomplete' do
     expect(duplicate_application_form).not_to be_references_completed

--- a/spec/services/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/generate_test_applications_for_provider_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
         # The generator does something weird leading to a withdrawn application
         # despite it not being in the states list of `GenerateTestApplicationsForCourses`.
         expect(choices.map(&:status).uniq).to include('pending_conditions', 'withdrawn')
-        expect(choices.pluck(:current_recruitment_cycle_year).uniq).to eq([RecruitmentCycleTimetable.previous_year])
+        expect(choices.pluck(:current_recruitment_cycle_year).uniq).to eq([previous_year])
       end
     end
 

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe GetRefereesToChase do
     end
 
     context 'when between apply 1 deadline and find has opened', time: (after_apply_deadline(2023) + 1.day) do
-      let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
-
       it 'returns requested references for candidates on apply 2 only for the current cycle' do
         application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
         create(:reference, :feedback_requested, application_form: application_form, requested_at: current_timetable.apply_deadline_at - 7.days)
@@ -63,8 +61,6 @@ RSpec.describe GetRefereesToChase do
     end
 
     context 'when between apply has opened and the apply 1 deadline', time: (after_find_opens(2024) + 7.days) do
-      let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
-
       it 'returns requested references in last days of current recruitment cycle' do
         old_application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
         create(:reference, :feedback_requested, application_form: old_application_form, requested_at: current_timetable.find_opens_at - 7.days)

--- a/spec/services/hesa_converter_spec.rb
+++ b/spec/services/hesa_converter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HesaConverter do
         ),
       )
 
-      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
+      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: current_year)
       expect(hesa_converter.hesa_sex).to eq(
         data[:expected_hesa_sex],
       )
@@ -55,7 +55,7 @@ RSpec.describe HesaConverter do
           disabilities: data[:disabilities],
         ),
       )
-      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
+      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: current_year)
       expect(hesa_converter.hesa_disabilities).to eq(data[:expected_hesa_disabilities])
       expect(hesa_converter.disabilities).to eq(data[:expected_disabilities])
     end
@@ -158,7 +158,7 @@ RSpec.describe HesaConverter do
           ethnic_background: data[:ethnic_background],
         ),
       )
-      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
+      hesa_converter = described_class.new(application_form:, recruitment_cycle_year: current_year)
       expect(hesa_converter.hesa_ethnicity).to eq(data[:expected_hesa_ethnicity])
     end
   end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe MonthlyStatisticsTimetable do
   describe '#generate_monthly_statistics?' do
-    let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
     let(:current_year) { current_timetable.recruitment_cycle_year }
     let(:find_opens_month) { current_timetable.find_opens_at.to_date.month }
     let(:report_months) { (1..12).to_a - [find_opens_month] }

--- a/spec/services/provider_interface/diversity_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/diversity_data_by_provider_spec.rb
@@ -4,7 +4,6 @@ module ProviderInterface
   RSpec.describe DiversityDataByProvider do
     let(:provider) { create(:provider) }
     let(:diversity_data_by_provider) { described_class.new(provider: [provider.id]) }
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
 
     describe '#total_submitted_applications' do
       it 'returns the number of application forms that have been submitted' do

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -176,13 +176,13 @@ RSpec.describe ProviderInterface::HesaDataExport do
   end
 
   describe '#export_data' do
-    let(:exporter) { described_class.new(actor: provider_user, recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
+    let(:exporter) { described_class.new(actor: provider_user, recruitment_cycle_year: current_year) }
     let(:exported_data) { exporter.export_data }
     let(:export_row) { exporter.export_row(exported_data.first) }
 
     context 'when provider has courses in multiple recruitment cycles' do
       it 'only exports current recruitment cycle data' do
-        previous_cycle_course = create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, provider: training_provider, accredited_provider:)
+        previous_cycle_course = create(:course, recruitment_cycle_year: previous_year, provider: training_provider, accredited_provider:)
         course_option = create(:course_option, course: previous_cycle_course)
         create(:application_choice, :accepted, course_option:)
 

--- a/spec/services/provider_interface/provider_options_service_spec.rb
+++ b/spec/services/provider_interface/provider_options_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
 
     it 'does not return accredited providers with courses from recruitment cycles 2 years ago' do
       accredited_provider = create(:provider)
-      create(:course, provider: @providers[0], accredited_provider:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year - 2)
+      create(:course, provider: @providers[0], accredited_provider:, recruitment_cycle_year: current_year - 2)
       expect(described_class.new(@provider_user).accredited_providers).not_to include(accredited_provider)
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
 
     it 'does not return providers with courses from recruitment cycles 2 years ago' do
       provider = create(:provider)
-      create(:course, provider:, accredited_provider: @providers[0], recruitment_cycle_year: RecruitmentCycleTimetable.current_year - 2)
+      create(:course, provider:, accredited_provider: @providers[0], recruitment_cycle_year: current_year - 2)
       expect(described_class.new(@provider_user).providers).not_to include(provider)
     end
 

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StatsSummary do
     create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
     create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
 
-    travel_temporarily_to(RecruitmentCycleTimetable.this_day_last_cycle) do
+    travel_temporarily_to(this_day_last_cycle) do
       last_cycle_international_form = create(:application_form, :submitted, first_nationality: 'Vatican citizen')
       last_cycle_domestic_form = create(:application_form, :submitted)
       create(:application_choice, :recruited, application_form: last_cycle_domestic_form)

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, :with_audited do
   end
 
   describe '#application_choices' do
-    let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-
     def expect_form(actual, form, choice:)
       expect(actual[:candidate_id]).to eq(form.candidate.id)
       expect(actual[:recruitment_cycle_year]).to eq(form.recruitment_cycle_year)

--- a/spec/services/support_interface/applications_export_spec.rb
+++ b/spec/services/support_interface/applications_export_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SupportInterface::ApplicationsExport, :with_audited do
 
     it 'only returns application data from the current cycle when current_cycle is set to true' do
       create(:application_form, :minimum_info)
-      create(:application_form, :minimum_info, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      create(:application_form, :minimum_info, recruitment_cycle_year: previous_year)
 
       expect(described_class.new.applications('current_cycle' => true).size).to eq(1)
     end

--- a/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe SupportInterface::MinisterialReportCandidatesExport do
           :offered,
           course_option:,
           candidate:,
-          current_recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          current_recruitment_cycle_year: current_year,
         )
 
         create(
@@ -467,7 +467,7 @@ RSpec.describe SupportInterface::MinisterialReportCandidatesExport do
           candidate:,
           phase: 'apply_2',
           application_choices: [application_choice],
-          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          recruitment_cycle_year: previous_year,
         )
 
         data = described_class.new.call

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
     it 'correctly reports course metadata' do
       provider_one = create(:provider, code: 'ABC1', name: 'Tehanu')
       provider_two = create(:provider, code: 'DEF2', name: 'Anarres')
-      previous_year = RecruitmentCycleTimetable.previous_year
 
       course_option_for_provider(provider: provider_one, course: create(:course, :open, name: 'History', provider: provider_one, code: 'XYZ'))
       course_option_for_provider(provider: provider_one, course: create(:course, :open, name: 'Biology', provider: provider_one))

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, :sidekiq do
     end
 
     context 'a previous year recruitment cycle' do
-      let(:recruitment_cycle_year) { RecruitmentCycleTimetable.previous_year }
+      let(:recruitment_cycle_year) { previous_year }
       let(:sync_provider) { instance_double(TeacherTrainingPublicAPI::SyncProvider) }
 
       before do
@@ -38,7 +38,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, :sidekiq do
     end
 
     context 'incremental sync' do
-      let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+      let(:recruitment_cycle_year) { current_year }
       let(:sync_provider) { instance_double(TeacherTrainingPublicAPI::SyncProvider) }
       let(:updated_since) { 2.hours.ago }
 

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
     let!(:provider) { create(:provider) }
     let(:perform_job) do
       described_class.new.perform(provider.id,
-                                  RecruitmentCycleTimetable.current_year)
+                                  current_year)
     end
     let(:stubbed_attributes) { [{ accredited_body_code: nil, state: stubbed_api_course_state, visa_sponsorship_application_deadline_at: stubbed_sponsorship_application_deadline_at }] }
     let(:stubbed_sponsorship_application_deadline_at) { nil }

--- a/spec/services/teacher_training_public_api/sync_sites_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_sites_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncSites, :sidekiq do
     let(:incremental_sync) { false }
     let(:perform_job) do
       described_class.new.perform(provider.id,
-                                  RecruitmentCycleTimetable.current_year,
+                                  current_year,
                                   course.id,
                                   'open',
                                   incremental_sync)
@@ -153,7 +153,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncSites, :sidekiq do
       it 'updates corresponding course options to no vacancies' do
         described_class.new.perform(
           provider.id,
-          RecruitmentCycleTimetable.current_year,
+          current_year,
           course.id,
           'closed',
           true,
@@ -227,7 +227,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncSites, :sidekiq do
       original_site_b_address_line3 = site_b.address_line3
 
       described_class.new.perform(provider.id,
-                                  RecruitmentCycleTimetable.current_year,
+                                  current_year,
                                   course.id,
                                   'open',
                                   incremental_sync)

--- a/spec/services/teacher_training_public_api/trigger_full_sync_if_find_closed_spec.rb
+++ b/spec/services/teacher_training_public_api/trigger_full_sync_if_find_closed_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed do
 
   context 'when find closed within the last day' do
     it 'triggers a full sync for the next year ignoring update errors' do
-      timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2024)
+      timetable = get_timetable(2024)
 
       travel_temporarily_to(timetable.find_closes_at + 5.minutes) do
         described_class.call
@@ -16,8 +16,7 @@ RSpec.describe TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed do
 
   context 'when find is yet to close' do
     before do
-      timetable = RecruitmentCycleTimetable.current_timetable
-      TestSuiteTimeMachine.travel_permanently_to(2.hours.before(timetable.find_closes_at))
+      TestSuiteTimeMachine.travel_permanently_to(2.hours.before(current_timetable.find_closes_at))
     end
 
     it 'does not trigger a sync' do
@@ -28,8 +27,7 @@ RSpec.describe TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed do
 
   context 'when find closed over a day ago' do
     before do
-      timetable = RecruitmentCycleTimetable.current_timetable
-      TestSuiteTimeMachine.travel_permanently_to(timetable.find_closes_at + (1.day + 1.hour))
+      TestSuiteTimeMachine.travel_permanently_to(current_timetable.find_closes_at + (1.day + 1.hour))
     end
 
     it 'does not trigger a sync' do

--- a/spec/services/test_provider_spec.rb
+++ b/spec/services/test_provider_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe TestProvider do
         courses = described_class.training_courses(previous_cycle)
 
         expect(courses.count).to be >= 3
-        expect(courses.pluck(:recruitment_cycle_year).uniq).to eq([RecruitmentCycleTimetable.previous_year])
+        expect(courses.pluck(:recruitment_cycle_year).uniq).to eq([previous_year])
         expect(courses.current_cycle).to be_empty
       end
     end

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -85,8 +85,6 @@ RSpec.describe TimeLimitCalculator do
   end
 
   describe 'configured reject_by_default limits', time: mid_cycle(2023) do
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-
     it 'applies the 20 day rule' do
       calculator = described_class.new(
         rule: :reject_by_default,

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe UpdateDuplicateMatches, :sidekiq do
   let(:candidate1) { create(:candidate, email_address: 'exemplar1@example.com') }
   let(:candidate2) { create(:candidate, email_address: 'exemplar2@example.com') }
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
 
   let(:expected_slack_message) do
     <<~MSG

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WeeklyStatsSummary do
     create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
     create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
 
-    travel_temporarily_to(RecruitmentCycleTimetable.this_day_last_cycle) do
+    travel_temporarily_to(this_day_last_cycle) do
       last_cycle_international_form = create(:application_form, :submitted, first_nationality: 'Vatican citizen')
       last_cycle_domestic_form = create(:application_form, :submitted)
       create(:application_choice, :recruited, application_form: last_cycle_domestic_form)

--- a/spec/support/cycle_timetable_helper.rb
+++ b/spec/support/cycle_timetable_helper.rb
@@ -7,6 +7,45 @@ module_function
     SeedRecruitmentCycleTimetables.call
   end
 
+  def current_year
+    current_timetable.recruitment_cycle_year
+  end
+
+  def previous_timetable
+    current_timetable.relative_previous_timetable
+  end
+
+  def previous_year
+    previous_timetable.recruitment_cycle_year
+  end
+
+  def current_timetable
+    get_timetable
+  end
+
+  def current_cycle_week
+    seed_timetables if RecruitmentCycleTimetable.all.empty?
+    RecruitmentCycleTimetable.current_cycle_week
+  end
+
+  def next_timetable
+    current_timetable.relative_next_timetable
+  end
+
+  def next_year
+    next_timetable.recruitment_cycle_year
+  end
+
+  def years_visible_to_providers
+    seed_timetables if RecruitmentCycleTimetable.all.empty?
+    RecruitmentCycleTimetable.years_visible_to_providers
+  end
+
+  def this_day_last_cycle
+    seed_timetables if RecruitmentCycleTimetable.all.empty?
+    RecruitmentCycleTimetable.this_day_last_cycle
+  end
+
   def after_find_opens(year = nil)
     timetable = get_timetable(year)
     timetable.find_opens_at + 1.day
@@ -18,8 +57,8 @@ module_function
   end
 
   def after_find_reopens(year = nil)
-    timetable = get_timetable(year + 1)
-    timetable.find_opens_at + 1.day
+    timetable = get_timetable(year)
+    timetable.relative_next_timetable.find_opens_at + 1.day
   end
 
   def mid_cycle(year = nil)
@@ -52,7 +91,7 @@ module_function
 
   def after_reject_by_default(year = nil)
     timetable = get_timetable(year)
-    timetable.reject_by_default_at(year) + 1.day
+    timetable.reject_by_default_at + 1.day
   end
 
   def reject_by_default_run_date(year = nil)

--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -108,7 +108,8 @@ module StatisticsTestHelper
   def recruitment_cycle_year(year)
     return if year.blank?
 
-    RecruitmentCycle.public_send("#{year}_year")
+    # year is either current, previous or next, not an integer value
+    RecruitmentCycleTimetable.public_send("#{year}_year")
   end
 
   def primary_subjects
@@ -131,6 +132,6 @@ module StatisticsTestHelper
   def date_of_birth(years_ago:)
     return if years_ago.blank?
 
-    Date.new(RecruitmentCycle.current_year - years_ago, 1, 1)
+    Date.new(RecruitmentCycleTimetable.current_year - years_ago, 1, 1)
   end
 end

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,5 +1,5 @@
 module CourseOptionHelpers
-  def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time', recruitment_cycle_year: RecruitmentCycle.current_year)
+  def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time', recruitment_cycle_year: CycleTimetable.current_year)
     course ||= build(:course, :open, provider:, recruitment_cycle_year:)
     site ||= build(:site, provider:)
     create(:course_option, course:, site:, study_mode:)
@@ -12,7 +12,7 @@ module CourseOptionHelpers
     create(:course_option, course:, site:)
   end
 
-  def course_option_for_accredited_provider(provider:, accredited_provider:, recruitment_cycle_year: RecruitmentCycle.current_year, permissions_required: true)
+  def course_option_for_accredited_provider(provider:, accredited_provider:, recruitment_cycle_year: CycleTimetable.current_year, permissions_required: true)
     course = if permissions_required
                build(:course, :open, :with_provider_relationship_permissions, provider:, accredited_provider:, recruitment_cycle_year:)
              else

--- a/spec/support/test_helpers/teacher_training_public_api_helper.rb
+++ b/spec/support/test_helpers/teacher_training_public_api_helper.rb
@@ -5,7 +5,7 @@ module TeacherTrainingPublicAPIHelper
     both_full_time_and_part_time_vacancies: 'site_list_response_with_full_time_and_part_time_vacancies.json',
   }.stringify_keys.freeze
 
-  def stub_teacher_training_api_providers(recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_providers(recruitment_cycle_year: CycleTimetable.current_year, specified_attributes: [], filter_option: nil)
     scope = stub_request(
       :get,
       "#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers",
@@ -22,13 +22,13 @@ module TeacherTrainingPublicAPIHelper
     )
   end
 
-  def stub_teacher_training_api_providers_with_multiple_pages(recruitment_cycle_year: RecruitmentCycle.current_year)
+  def stub_teacher_training_api_providers_with_multiple_pages(recruitment_cycle_year: CycleTimetable.current_year)
     [1, 2, 3].each do |page_number|
       stub_pagination_request(recruitment_cycle_year, page_number, paginated_response(page_number))
     end
   end
 
-  def stub_teacher_training_api_provider(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [], filter_option: nil)
+  def stub_teacher_training_api_provider(provider_code:, recruitment_cycle_year: CycleTimetable.current_year, specified_attributes: [], filter_option: nil)
     response_body = build_response_body('single_provider_response.json', specified_attributes)
 
     stub_teacher_training_single_api_request(
@@ -38,24 +38,24 @@ module TeacherTrainingPublicAPIHelper
     )
   end
 
-  def stub_teacher_training_api_course_with_site(provider_code:, course_code:, site_code:, recruitment_cycle_year: RecruitmentCycle.current_year, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
+  def stub_teacher_training_api_course_with_site(provider_code:, course_code:, site_code:, recruitment_cycle_year: CycleTimetable.current_year, vacancy_status: 'full_time_vacancies', course_attributes: [], site_attributes: [])
     course_attributes = course_attributes.any? ? [course_attributes.first.merge(code: course_code)] : [{ code: course_code }]
     site_attributes = site_attributes.any? ? [site_attributes.first.merge(code: site_code)] : [{ code: site_code }]
     stub_teacher_training_api_courses(recruitment_cycle_year:, provider_code:, specified_attributes: course_attributes)
     stub_teacher_training_api_sites(recruitment_cycle_year:, provider_code:, course_code:, specified_attributes: site_attributes, vacancy_status:)
   end
 
-  def stub_teacher_training_api_course(provider_code:, course_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: {})
+  def stub_teacher_training_api_course(provider_code:, course_code:, recruitment_cycle_year: CycleTimetable.current_year, specified_attributes: {})
     response_body = build_response_body('course_single_response.json', specified_attributes.merge(code: course_code))
     stub_teacher_training_single_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}", response_body)
   end
 
-  def stub_teacher_training_api_courses(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [])
+  def stub_teacher_training_api_courses(provider_code:, recruitment_cycle_year: CycleTimetable.current_year, specified_attributes: [])
     response_body = build_response_body('course_list_response.json', specified_attributes)
     stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses", response_body)
   end
 
-  def stub_teacher_training_api_sites(provider_code:, course_code:, recruitment_cycle_year: RecruitmentCycle.current_year, specified_attributes: [], vacancy_status: 'full_time_vacancies')
+  def stub_teacher_training_api_sites(provider_code:, course_code:, recruitment_cycle_year: CycleTimetable.current_year, specified_attributes: [], vacancy_status: 'full_time_vacancies')
     fixture_file = site_fixture(vacancy_status)
     response_body = build_response_body(fixture_file, specified_attributes)
     stub_teacher_training_list_api_request("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}/locations", response_body)
@@ -68,15 +68,15 @@ module TeacherTrainingPublicAPIHelper
     stub_teacher_training_list_api_request(url, response)
   end
 
-  def stub_teacher_training_api_provider_404(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year)
+  def stub_teacher_training_api_provider_404(provider_code:, recruitment_cycle_year: CycleTimetable.current_year)
     stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}")
   end
 
-  def stub_teacher_training_api_courses_404(provider_code:, recruitment_cycle_year: RecruitmentCycle.current_year)
+  def stub_teacher_training_api_courses_404(provider_code:, recruitment_cycle_year: CycleTimetable.current_year)
     stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/")
   end
 
-  def stub_teacher_training_api_course_404(provider_code:, course_code:, recruitment_cycle_year: RecruitmentCycle.current_year)
+  def stub_teacher_training_api_course_404(provider_code:, course_code:, recruitment_cycle_year: CycleTimetable.current_year)
     stub_404("#{ENV.fetch('TEACHER_TRAINING_API_BASE_URL')}/recruitment_cycles/#{recruitment_cycle_year}/providers/#{provider_code}/courses/#{course_code}")
   end
 
@@ -92,7 +92,7 @@ module TeacherTrainingPublicAPIHelper
   end
 
   def stubbed_recruitment_cycle_year
-    @stubbed_recruitment_cycle_year || RecruitmentCycle.current_year
+    @stubbed_recruitment_cycle_year || CycleTimetable.current_year
   end
 
 private

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -82,11 +82,7 @@ RSpec.describe Clockwork, :clockwork do
     end
   end
 
-  context 'when the performance report is out season' do
-    before do
-      allow(RecruitmentPerformanceReportTimetable).to receive(:report_season?).and_return(false)
-    end
-
+  context 'when the performance report is out season', time: after_find_opens + 2.weeks do
     it 'does not run the report scheduler every Monday' do
       start_time = Time.zone.now.beginning_of_week.change(hour: 5)
       end_time = Time.zone.now.beginning_of_week.change(hour: 6)

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -3,30 +3,66 @@ require 'rails_helper'
 RSpec.describe 'Carry over next cycle with cycle switcher' do
   include CandidateHelper
 
-  it 'Candidate can submit in next cycle with cycle switcher after apply opens', time: mid_cycle do
-    given_i_am_signed_in_with_one_login
-    when_i_have_an_unsubmitted_application_without_a_course
-    and_the_cycle_switcher_set_to_apply_opens
+  context 'candidate preferences feature flag is activated' do
+    before do
+      FeatureFlag.activate(:candidate_preferences)
+    end
 
-    when_i_sign_in_again
-    and_i_visit_the_application_dashboard
-    then_i_cannot_submit_my_application
-    and_i_am_redirected_to_the_carry_over_interstitial
+    it 'candidate can submit in next cycle after dismissing candidate preferences' do
+      given_i_am_signed_in_with_one_login
+      when_i_have_an_unsubmitted_application_without_a_course
+      and_the_cycle_switcher_set_to_apply_opens
 
-    when_i_click_on_continue
-    then_i_see_my_details
+      when_i_sign_in_again
+      and_i_visit_the_application_dashboard
+      then_i_cannot_submit_my_application
+      and_i_am_redirected_to_the_carry_over_interstitial
 
-    when_i_view_referees
-    then_i_can_see_the_referees_i_previously_added
-    and_i_can_complete_the_references_section
-    and_i_can_complete_the_equality_and_diversity_section
+      when_i_click_on_continue
+      then_i_see_my_details
 
-    when_i_view_courses
-    then_i_can_see_that_i_need_to_select_courses
-    then_i_can_see_that_i_need_to_select_courses
+      when_i_view_referees
+      then_i_can_see_the_referees_i_previously_added
+      and_i_can_complete_the_references_section
+      and_i_can_complete_the_equality_and_diversity_section
 
-    and_i_select_a_course
-    and_my_application_is_awaiting_provider_decision
+      when_i_view_courses
+      then_i_can_see_that_i_need_to_select_courses
+
+      and_i_select_a_course_and_dismiss_candidate_preferences
+      and_my_application_is_awaiting_provider_decision
+    end
+  end
+
+  context 'candidate preferences feature flag is deactivated' do
+    before do
+      FeatureFlag.deactivate(:candidate_preferences)
+    end
+
+    it 'Candidate can submit in next cycle with cycle switcher after apply opens', time: mid_cycle do
+      given_i_am_signed_in_with_one_login
+      when_i_have_an_unsubmitted_application_without_a_course
+      and_the_cycle_switcher_set_to_apply_opens
+
+      when_i_sign_in_again
+      and_i_visit_the_application_dashboard
+      then_i_cannot_submit_my_application
+      and_i_am_redirected_to_the_carry_over_interstitial
+
+      when_i_click_on_continue
+      then_i_see_my_details
+
+      when_i_view_referees
+      then_i_can_see_the_referees_i_previously_added
+      and_i_can_complete_the_references_section
+      and_i_can_complete_the_equality_and_diversity_section
+
+      when_i_view_courses
+      then_i_can_see_that_i_need_to_select_courses
+
+      and_i_select_a_course
+      and_my_application_is_awaiting_provider_decision
+    end
   end
 
   def when_i_have_an_unsubmitted_application_without_a_course
@@ -132,6 +168,29 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
 
     click_on 'Review application'
     click_on 'Confirm and submit application'
+
+    expect(page).to have_content('You can add 3 more applications')
+  end
+
+  def and_i_select_a_course_and_dismiss_candidate_preferences
+    given_courses_exist
+    and_those_courses_are_for_this_year
+    click_link_or_button 'Add application'
+
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button 'Continue'
+
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button 'Continue'
+
+    choose 'Primary (2XT2)'
+    click_link_or_button 'Continue'
+
+    click_on 'Review application'
+    click_on 'Confirm and submit application'
+    click_on 'Continue'
+    choose 'No'
+    click_on 'Continue'
 
     expect(page).to have_content('You can add 3 more applications')
   end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
@@ -23,7 +23,7 @@ private
   end
 
   def and_find_has_opened_but_apply_has_not
-    advance_time_to(after_find_opens(RecruitmentCycle.next_year))
+    advance_time_to(after_find_reopens)
   end
 
   def and_a_course_exists

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
 
   before do
     @candidate = create(:candidate)
-    @application_form = create(:application_form, :completed, recruitment_cycle_year: CycleTimetable.current_year - 1, candidate: @candidate)
+    @current_year = current_year
+    @previous_year = previous_year
+    @next_year = next_year
+    @application_form = create(:application_form, :completed, recruitment_cycle_year: @previous_year, candidate: @candidate)
   end
 
   scenario 'Candidate sees complete page when submitted at has value but courses choices does not have submission' do
@@ -166,8 +169,8 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   end
 
   def then_i_am_ask_to_apply_for_courses_into_the_new_recruitment_cycle
-    expect(page).to have_content("courses starting in the #{CycleTimetable.current_year - 1} to #{CycleTimetable.current_year} academic year, which have now closed.")
-    expect(page).to have_content("apply for courses starting in the #{CycleTimetable.current_year} to #{CycleTimetable.current_year + 1} academic year instead.")
+    expect(page).to have_content("courses starting in the #{@previous_year} to #{@current_year} academic year, which have now closed.")
+    expect(page).to have_content("apply for courses starting in the #{@current_year} to #{@next_year} academic year instead.")
     then_i_am_on_the_pages_that_is_possible_to_carry_over_an_application
   end
 
@@ -182,8 +185,8 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   end
 
   def then_my_application_is_into_the_new_cycle
-    expect(@candidate.application_forms.pluck(:recruitment_cycle_year)).to contain_exactly(CycleTimetable.current_year - 1, CycleTimetable.current_year)
-    expect(@candidate.current_application.recruitment_cycle_year).to be(CycleTimetable.current_year)
+    expect(@candidate.application_forms.pluck(:recruitment_cycle_year)).to contain_exactly(@previous_year, @current_year)
+    expect(@candidate.current_application.recruitment_cycle_year).to be(@current_year)
   end
 
   def and_i_am_in_your_details_page

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe 'Carry over application and submit new application choices', time: CycleTimetableHelper.mid_cycle do
+RSpec.describe 'Carry over application and submit new application choices' do
   include CandidateHelper
 
   before do
     FeatureFlag.activate(:candidate_preferences)
   end
 
-  it 'Candidate carries over unsubmitted application with a course to new cycle' do
+  it 'Candidate carries over unsubmitted application with a course to new cycle', time: mid_cycle do
     given_i_am_signed_in_with_one_login
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -119,8 +119,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_see_the_carry_over_inset_text
-    next_recruitment_year_range = CycleTimetable.cycle_year_range(CycleTimetable.next_year)
-    expect(page).to have_content "You can apply for courses starting in the #{next_recruitment_year_range} academic year instead."
+    expect(page).to have_content "You can apply for courses starting in the #{current_timetable.academic_year_range_name} academic year instead."
   end
 
   def then_i_am_on_the_carry_over_page_mid_cycle

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -136,7 +136,7 @@ private
   alias_method :and_the_decline_by_default_date_has_passed, :when_the_decline_by_default_date_has_passed
 
   def when_then_new_cycle_start
-    advance_time_to(after_find_opens(RecruitmentCycle.next_year))
+    advance_time_to(after_find_opens(next_year))
   end
 
   def then_i_see_my_declined_application_on_the_carry_over_page
@@ -154,7 +154,6 @@ private
     expect(page).to have_current_path candidate_interface_application_choices_path
     relative_next_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
     apply_reopens_date = relative_next_timetable.apply_opens_at.to_fs(:day_and_month)
-    # apply_reopens_date = I18n.l(CycleTimetable.apply_reopens.to_date, format: :no_year).strip
     expect(page).to have_content(
       "If your application(s) are not successful, or you do not accept any offers, you will be able to apply for courses starting in the #{relative_next_timetable.academic_year_range_name} academic year from #{apply_reopens_date}.",
     )

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate has an application where provider does not make a deci
 
   before do
     TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
+    @timetable = current_timetable
     @candidate = create(:candidate)
   end
 
@@ -114,10 +115,10 @@ private
   end
 
   def then_i_cannot_carry_over_my_application
-    apply_reopens_date = I18n.l(CycleTimetable.apply_reopens.to_date, format: :no_year).strip
+    apply_reopens_date = I18n.l(@timetable.apply_reopens_at.to_date, format: :no_year).strip
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content(
-      "If your application(s) are not successful, or you do not accept any offers, you will be able to apply for courses starting in the #{CycleTimetable.cycle_year_range(RecruitmentCycle.next_year)} academic year from #{apply_reopens_date}.",
+      "If your application(s) are not successful, or you do not accept any offers, you will be able to apply for courses starting in the #{@timetable.next_available_academic_year_range} academic year from #{apply_reopens_date}.",
     )
   end
   alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application

--- a/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Candidate attempts to add course via Find to application from pr
 
   def then_i_see_that_my_application_must_be_carried_over
     expect(page).to have_content('You started an application for courses starting in the 2020 to 2021 academic year, which have now closed.')
-    expect(page).to have_content("Continue your application to apply for courses starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year instead.")
+    expect(page).to have_content("Continue your application to apply for courses starting in the #{current_year} to #{next_year} academic year instead.")
 
     # Normally we'd avoid a trip directly to the db in a system spec,
     # this is here to prove a particular bug has been solved.

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Entering personal details', time: Time.zone.local(RecruitmentCycle.current_year, 7, 6, 12) do
+RSpec.describe 'Entering personal details' do
   include CandidateHelper
 
-  scenario 'I can specify that I need to apply for right to work or study in the UK' do
+  scenario 'I can specify that I need to apply for right to work or study in the UK', time: mid_cycle do
     and_i_am_signed_in
     and_i_can_complete_personal_information_with_non_british_or_irish_nationality
     and_i_can_mark_the_section_complete

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def when_i_change_my_undergraduate_degree_award_year_again
-    graduation_year = RecruitmentCycle.current_year.to_s
+    graduation_year = current_year.to_s
     fill_in t('page_titles.what_year_will_you_graduate'), with: graduation_year
   end
 
@@ -236,7 +236,7 @@ RSpec.describe 'Editing a degree' do
     completion_status_row = page.all('.govuk-summary-list__row').find { |row| row.has_link? 'Change completion status' }
     expect(completion_status_row).to have_content 'No'
 
-    expect(page).to have_content RecruitmentCycle.current_year.to_s
+    expect(page).to have_content current_year.to_s
   end
 
   def then_i_can_check_my_undergraduate_degree_type_has_been_cleared

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
@@ -159,13 +159,13 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
 
   def and_today_is_the_last_day_of_the_cycle
     TestSuiteTimeMachine.travel_permanently_to(
-      CycleTimetable.reject_by_default - 1.day,
+      after_find_closes - 1.day,
     )
   end
 
   def and_today_is_after_apply_deadline
     TestSuiteTimeMachine.travel_permanently_to(
-      CycleTimetable.apply_deadline + 1.day,
+      after_apply_deadline,
     )
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
@@ -67,7 +67,7 @@ private
       candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
-      recruitment_cycle_year: RecruitmentCycle.current_year,
+      recruitment_cycle_year: current_year,
     )
 
     @application_form.application_references.each do |ref|

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def when_a_new_cycle_starts
-    advance_time_to(mid_cycle(RecruitmentCycle.next_year))
+    advance_time_to(mid_cycle(next_year))
   end
 
   def and_i_visit_my_application_complete_page
@@ -43,7 +43,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_see_carry_over_page
-    expect(page).to have_content "You started an application for courses starting in the #{RecruitmentCycle.previous_year} to #{RecruitmentCycle.current_year} academic year, which have now closed"
+    timetable = previous_timetable
+    expect(page).to have_content "You started an application for courses starting in the #{timetable.academic_year_range_name} academic year, which have now closed"
   end
 
   def when_i_click_continue

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_from_previous_cycle_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetable.apply_opens(2024) do
+RSpec.describe 'Post-offer references', :with_audited do
   include CandidateHelper
 
-  scenario 'Candidate views their references on the post offer dashboard' do
+  scenario 'Candidate views their references on the post offer dashboard', time: mid_cycle(2024) do
     given_i_am_signed_in_with_one_login
     and_i_have_an_accepted_offer_from_previous_cycle
 

--- a/spec/system/candidate_interface/rejections/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/rejections/candidate_receives_rejection_email_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe 'Receives rejection email' do
   end
 
   def and_it_includes_text_for_between_cycle
-    expect(current_email.text).to include("You can apply again from#{I18n.l(CycleTimetable.apply_reopens.to_date, format: :long)}")
+    apply_reopens = current_timetable.apply_reopens_at
+    expect(current_email.text).to include("You can apply again from#{I18n.l(apply_reopens.to_date, format: :long)}")
     expect(current_email.text).to include('Lots of people are successful when they apply again.')
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
   end
 
   def and_a_course_is_available
-    @course_option = create(:course_option, course: create(:course, :open, recruitment_cycle_year: RecruitmentCycle.current_year))
+    @course_option = create(:course_option, course: create(:course, :open, recruitment_cycle_year: current_year))
   end
 
   def and_i_am_a_candidate_with_a_blank_application

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
@@ -3,19 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Candidate visits the sign-in page and views guidance' do
   include SignInHelper
 
-  scenario 'User can open the guidance page with dates for the current recruitment cycle year' do
-    given_the_recruitment_cycle_year_is_2024
-    and_i_visit_the_sign_in_page
+  scenario 'User can open the guidance page with dates for the current recruitment cycle year', time: after_find_opens(2024) do
+    given_i_visit_the_sign_in_page
     and_i_click_on_the_guidance_link
     then_i_am_taken_to_the_guidance_page
     and_i_can_see_the_correct_dates
   end
 
-  def given_the_recruitment_cycle_year_is_2024
-    allow(CycleTimetable).to receive(:current_year).and_return(2024)
-  end
-
-  def and_i_visit_the_sign_in_page
+  def given_i_visit_the_sign_in_page
     visit candidate_interface_create_account_or_sign_in_path
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_a_course_with_closed_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_a_course_with_closed_application_spec.rb
@@ -9,25 +9,25 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
     and_i_have_one_application_in_draft
   end
 
-  scenario 'Apply is open but course not open for applications', time: CycleTimetableHelper.mid_cycle(CycleTimetable.current_year) do
+  scenario 'Apply is open but course not open for applications', time: mid_cycle do
     and_my_course_choice_is_not_open_for_applications
     when_i_continue_my_draft_application
     then_i_see_the_course_closed_error_message
   end
 
-  scenario 'Apply is closed and course open for applications before apply opens', time: CycleTimetableHelper.after_find_opens do
+  scenario 'Apply is closed and course open for applications before apply opens', time: after_find_opens do
     and_my_course_choice_is_not_open_for_applications
     when_i_continue_my_draft_application
     then_i_see_the_course_closed_error_message_until_apply_opens
   end
 
-  scenario 'Apply is closed and course open for applications same day', time: CycleTimetableHelper.after_find_opens do
+  scenario 'Apply is closed and course open for applications same day', time: after_find_opens do
     and_my_course_choice_is_open_at_the_same_time_apply_opens
     when_i_continue_my_draft_application
     then_i_see_the_course_closed_error_message_until_apply_opens
   end
 
-  scenario 'Apply is open and course is open', time: mid_cycle(CycleTimetable.current_year) do
+  scenario 'Apply is open and course is open', time: mid_cycle do
     and_my_course_choice_is_open_at_the_same_time_apply_opens
     when_i_continue_my_draft_application
     then_i_do_not_see_any_error_message
@@ -39,7 +39,7 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
   end
 
   def and_my_course_choice_is_open_at_the_same_time_apply_opens
-    @application_choice.current_course.update!(applications_open_from: CycleTimetable.apply_opens)
+    @application_choice.current_course.update!(applications_open_from: apply_opens_at)
   end
 
   def then_i_see_the_course_closed_error_message
@@ -51,7 +51,7 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
 
   def then_i_see_the_course_closed_error_message_until_apply_opens
     expect(page).to have_content(
-      "This course is not yet open to applications. You will be able to submit your application on #{CycleTimetable.apply_opens.to_fs(:govuk_date)}.",
+      "This course is not yet open to applications. You will be able to submit your application on #{apply_opens_at.to_fs(:govuk_date)}.",
     )
     expect(page).to have_no_content('Review application')
   end
@@ -62,5 +62,9 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
 
   def and_i_can_review_my_application
     expect(page).to have_content('Review application')
+  end
+
+  def apply_opens_at
+    @apply_opens_at ||= current_timetable.apply_opens_at
   end
 end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Monthly statistics page' do
   end
 
   def and_i_see_the_monthly_statistics
-    expect(page).to have_content "Initial teacher training applications for courses starting in the #{RecruitmentCycleTimetable.current_timetable.academic_year_range_name} academic year"
+    expect(page).to have_content "Initial teacher training applications for courses starting in the #{current_timetable.academic_year_range_name} academic year"
   end
 
   def when_i_click_a_link

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Providers views candidate pool list' do
       :completed,
       first_name: 'test',
       last_name: 'test',
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Providers views candidate pool list' do
       :completed,
       first_name: 'test',
       last_name: 'test',
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe 'Export applications in HESA format' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }
-  let(:previous_timetable) { RecruitmentCycleTimetable.previous_timetable }
-
   scenario 'download CSVs of application data with translated HESA codes for the current and previous recruitment cycle year' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe 'Providers should be able to filter applications' do
   end
 
   def when_i_filter_by_recruitment_cycle
-    find(:css, "#recruitment_cycle_year-#{RecruitmentCycleTimetable.current_year}").set(true)
+    find(:css, "#recruitment_cycle_year-#{current_year}").set(true)
     click_link_or_button('Apply filters')
   end
 
@@ -274,7 +274,7 @@ RSpec.describe 'Providers should be able to filter applications' do
   end
 
   def and_i_expect_the_relevant_recruitment_cycle_tags_to_be_visible
-    tag_text = "#{RecruitmentCycleTimetable.previous_year} to #{RecruitmentCycleTimetable.current_year}"
+    tag_text = "#{previous_year} to #{current_year}"
     expect(page).to have_css('.moj-filter-tags', text: tag_text)
   end
 

--- a/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
+++ b/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
@@ -132,6 +132,6 @@ RSpec.describe 'Provider reinstates deferred offer' do
   end
 
   def and_the_course_now_offered_is_from_the_current_year
-    expect(choices[:reinstatable].reload.current_course.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
+    expect(choices[:reinstatable].reload.current_course.recruitment_cycle_year).to eq(current_year)
   end
 end

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
   end
 
   def and_i_fill_out_the_form_for_applications_this_year_of_any_status_for_the_first_provider
-    check RecruitmentCycleTimetable.current_year.to_s
+    check current_year.to_s
     choose 'All statuses'
     check @current_provider_user.providers.first.name
 
@@ -167,7 +167,7 @@ RSpec.describe 'Provider user exporting applications to a csv', mid_cycle: false
   end
 
   def and_i_fill_out_the_form_for_applications_all_years_of_deferred_and_accepted_offers_for_the_first_provider
-    RecruitmentCycleTimetable.years_visible_to_providers.each do |year|
+    years_visible_to_providers.each do |year|
       check "#{year - 1} to #{year}"
     end
     choose 'Specific statuses'

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Provider with two providers reports index' do
   def and_a_provider_has_a_recruitment_performance_report
     @report = create(
       :provider_recruitment_performance_report,
-      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+      recruitment_cycle_year: current_year,
       provider: @provider,
     )
   end

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -29,16 +29,16 @@ private
   end
 
   def and_a_provider_recruitment_performance_report_has_been_generated
-    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, cycle_week: 31, provider: @provider)
+    create(:provider_recruitment_performance_report, recruitment_cycle_year: current_year, cycle_week: 31, provider: @provider)
   end
 
   def and_national_recruitment_performance_report_has_been_generated
-    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.current_year, cycle_week: 31)
+    create(:national_recruitment_performance_report, recruitment_cycle_year: current_year, cycle_week: 31)
   end
 
   def and_reports_from_a_later_week_were_generated_for_last_year
-    create(:provider_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, cycle_week: 43, provider: @provider)
-    create(:national_recruitment_performance_report, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year, cycle_week: 43)
+    create(:provider_recruitment_performance_report, recruitment_cycle_year: previous_year, cycle_week: 43, provider: @provider)
+    create(:national_recruitment_performance_report, recruitment_cycle_year: previous_year, cycle_week: 43)
   end
 
   def and_i_visit_the_provider_recruitment_report_page
@@ -46,11 +46,11 @@ private
   end
 
   def then_i_see_the_report_for_the_current_year
-    year = RecruitmentCycleTimetable.current_year
+    year = current_year
     cycle_name = "#{year - 1} to #{year}"
     expect(page).to have_content("Recruitment performance weekly report #{cycle_name}")
-    cycle_start = RecruitmentCycleTimetable.current_timetable.find_opens_at.to_date.to_fs(:govuk_date)
-    cycle_end = RecruitmentCycleTimetable.current_timetable.find_closes_at.to_date.to_fs(:govuk_date)
+    cycle_start = current_timetable.find_opens_at.to_date.to_fs(:govuk_date)
+    cycle_end = current_timetable.find_closes_at.to_date.to_fs(:govuk_date)
     description = "This report shows your organisation’s initial teacher training (ITT) recruitment performance for the #{cycle_name} recruitment cycle, starting on #{cycle_start}, ending on #{cycle_end}."
     expect(page).to have_content(description)
   end

--- a/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
+++ b/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Visit Monthly statistics V2 page', mid_cycle: false do
   end
 
   def and_i_see_the_monthly_statistics
-    cycle_name = RecruitmentCycleTimetable.current_academic_year_range_name
+    cycle_name = current_timetable.academic_year_range_name
     expect(page).to have_content "Initial teacher training applications for courses starting in the #{cycle_name} academic year"
   end
 end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe 'Referee can submit reference', :with_audited do
   include CandidateHelper
 
   around do |example|
-    old_references = CycleTimetable.apply_opens(ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
+    old_references = RecruitmentCycleTimetable
+                       .find_by(recruitment_cycle_year: ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
+                       &.apply_opens_at
     travel_temporarily_to(old_references) { example.run }
   end
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_from_previous_cycle_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_from_previous_cycle_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Referee can submit reference', :with_audited, time: CycleTimetable.apply_opens(2024) do
+RSpec.describe 'Referee can submit reference', :with_audited do
   include CandidateHelper
 
-  it 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
+  it 'Referee submits a reference for a candidate with relationship, safeguarding and review page', mid_cycle(2024) do
     given_i_am_a_referee_of_an_application_from_old_cycle
     and_i_received_the_initial_reference_request_email
     then_i_receive_an_email_with_a_reference_request

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Referee does not respond in time' do
   end
 
   def given_there_is_an_application_with_a_reference
-    @application = create(:application_form, first_name: 'F', last_name: 'B', recruitment_cycle_year: RecruitmentCycle.current_year)
+    @application = create(:application_form, first_name: 'F', last_name: 'B', recruitment_cycle_year: current_year)
     @reference = create(:reference, :feedback_requested, email_address: 'anne.other@example.com', name: 'Anne Other', application_form: @application)
     create(:application_choice, :accepted, application_form: @application)
   end

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_from_previous_cycle_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_from_previous_cycle_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Refusing to give a reference' do
   include CandidateHelper
 
-  before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2024))
-  end
-
-  scenario 'Referee refuses to give a reference' do
+  scenario 'Referee refuses to give a reference', time: mid_cycle(2024) do
     given_i_am_a_referee_of_an_application_from_old_cycle
     and_i_received_the_initial_reference_request_email
     then_i_receive_an_email_with_a_reference_request

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Refusing to give a reference' do
   include CandidateHelper
 
-  before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2021))
-  end
-
-  scenario 'Referee refuses to give a reference' do
+  scenario 'Referee refuses to give a reference', time: after_apply_deadline do
     given_i_am_a_referee_of_an_application
     and_i_received_the_initial_reference_request_email
     then_i_receive_an_email_with_a_reference_request

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Register receives an application data', time: CycleTimetableHelper.mid_cycle(2025) do
   include CandidateHelper
 
+  before do
+    @current_year = current_year
+  end
+
   scenario 'A candidate is recruited in a postgraduate course' do
     given_a_provider_recruited_a_candidate_that_applied_to_a_postgraduate_course
     when_i_retrieve_the_application_over_the_api
@@ -54,7 +58,7 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
     api_token = ServiceAPIUser.register_user.create_magic_link_token!
     page.driver.header 'Authorization', "Bearer #{api_token}"
 
-    visit "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}&since=#{CGI.escape(1.day.ago.iso8601)}"
+    visit "/register-api/applications?recruitment_cycle_year=#{@current_year}&since=#{CGI.escape(1.day.ago.iso8601)}"
 
     @api_response = JSON.parse(page.body)
   end
@@ -108,7 +112,7 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
           ethnic_background: 'Asian or Asian British',
         },
         course: {
-          recruitment_cycle_year: RecruitmentCycle.current_year,
+          recruitment_cycle_year: @current_year,
           course_code: '2XT2',
           course_uuid: @provider.courses.first.uuid,
           training_provider_code: '1N1',

--- a/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
+++ b/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Cancel previous cycle unsubmitted applications support task', :s
   end
 
   def given_i_have_a_candidate_with_an_unsubmitted_application
-    @application_form = create(:completed_application_form, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.previous_year)
+    @application_form = create(:completed_application_form, submitted_at: nil, recruitment_cycle_year: previous_year)
     create(:application_choice, application_form: @application_form, status: :unsubmitted)
   end
 

--- a/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
+++ b/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
@@ -77,6 +77,6 @@ RSpec.describe 'Change course choice for a deferred application' do
 
   def and_i_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
-    expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
+    expect(page).to have_content("#{current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
   end
 end

--- a/spec/system/support_interface/change_course_to_different_year_spec.rb
+++ b/spec/system/support_interface/change_course_to_different_year_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Change course choice to a different year' do
   end
 
   def and_i_complete_the_form_for_a_course
-    course = create(:course, :open, provider: @application_choice.provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
+    course = create(:course, :open, provider: @application_choice.provider, recruitment_cycle_year: previous_year)
     @course_option = create(:course_option, course: course)
     course_code = @course_option.course.code
 
@@ -59,7 +59,7 @@ RSpec.describe 'Change course choice to a different year' do
     fill_in('Course code', with: course_code)
     fill_in('Site code', with: @course_option.site.code)
     choose('Full time')
-    choose(RecruitmentCycle.previous_year)
+    choose(previous_year)
   end
 
   def and_i_provide_a_valid_zendesk_ticket

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Add course to submitted application' do
 
   def and_i_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
-    expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
+    expect(page).to have_content("#{current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
   end
   alias_method :and_i_see_new_course_with_no_vacancies_has_been_offered, :and_i_see_new_course_has_been_offered
 

--- a/spec/system/support_interface/cycle_switching_errors_spec.rb
+++ b/spec/system/support_interface/cycle_switching_errors_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cycle switching errors' do
   include DfESignInHelpers
-  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
+  let(:timetable) { current_timetable }
 
   scenario 'adding invalid dates' do
     given_i_am_signed_in_as_a_support_user

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Cycle switching' do
   include DfESignInHelpers
-  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
 
   scenario 'Support user switches cycle schedule' do
     given_it_is_before_the_apply_deadline
@@ -17,7 +16,7 @@ RSpec.describe 'Cycle switching' do
 private
 
   def given_it_is_before_the_apply_deadline
-    TestSuiteTimeMachine.travel_permanently_to(timetable.apply_deadline_at - 13.weeks)
+    TestSuiteTimeMachine.travel_permanently_to(current_timetable.apply_deadline_at - 13.weeks)
   end
 
   def when_i_navigate_to_the_cycle_page
@@ -26,12 +25,12 @@ private
   end
 
   def and_i_see_a_mid_cycle_description_and_content
-    expect(page).to have_content "Apply has opened (#{timetable.recruitment_cycle_year})"
+    expect(page).to have_content "Apply has opened (#{current_timetable.recruitment_cycle_year})"
     expect(page).to have_content 'Candidates can make choices and submit applications, providers can act on applications.'
   end
 
   def when_i_update_the_current_cycle_so_the_deadline_has_passed
-    click_on timetable.recruitment_cycle_year
+    click_on current_timetable.recruitment_cycle_year
     within_fieldset 'Apply deadline' do
       new_date = 1.day.ago
       fill_in 'Day', with: new_date.day
@@ -43,7 +42,7 @@ private
 
   def then_i_see_post_deadline_description
     expect(page).to have_content 'The cycle has been updated.'
-    expect(page).to have_content "Apply deadline has passed (#{timetable.recruitment_cycle_year})"
+    expect(page).to have_content "Apply deadline has passed (#{current_timetable.recruitment_cycle_year})"
     expect(page).to have_content 'The deadline for submitting applications has passed. Candidates without active applications can start preparing applications for next year. Providers can still act on submitted applications.'
   end
 end

--- a/spec/system/support_interface/disable_generate_applications_cycle_switcher_spec.rb
+++ b/spec/system/support_interface/disable_generate_applications_cycle_switcher_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe 'Disable generate future applications cycle switching', time: Cyc
   end
 
   def then_i_do_not_see_generate_future_applications
-    expect(page).to have_no_button("Generate #{RecruitmentCycle.next_year} recruitment cycle test applications")
+    expect(page).to have_no_button("Generate #{next_year} recruitment cycle test applications")
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe 'Docs' do
     then_the_candidate_flow_diagram_is_generated
     and_i_see_the_candidate_flow_documentation
 
-    # when_i_click_on_the_end_of_cycle_documentation
-    # then_i_can_see_the_apply_reopens_date
-
     when_i_click_on_qualifications_documentation
     then_i_can_see_all_qualifications_data
   end
@@ -99,18 +96,8 @@ RSpec.describe 'Docs' do
     expect(page).to have_title 'Candidate application flow'
   end
 
-  def when_i_click_on_the_end_of_cycle_documentation
-    click_link_or_button 'Cycle timeline'
-  end
-
   def when_i_click_on_qualifications_documentation
     click_link_or_button 'Qualifications'
-  end
-
-  def then_i_can_see_the_apply_reopens_date
-    expect(page).to have_content 'Cycle timeline'
-    expect(page).to have_content 'Apply reopens'
-    expect(page).to have_content CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time)
   end
 
   def then_i_can_see_all_qualifications_data

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'Reasons for rejection dashboard', time: Time.zone.local(2023, 1,
   end
 
   def and_there_are_candidates_and_application_forms_in_the_system
-    allow(CycleTimetable).to receive(:apply_opens).and_return(60.days.ago)
     @application_choice1 = create(:application_choice, :awaiting_provider_decision)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision)
     @application_choice3 = create(:application_choice, :awaiting_provider_decision)
@@ -251,7 +250,7 @@ private
     expect(page).to have_current_path(
       support_interface_reasons_for_rejection_application_choices_path(
         structured_rejection_reasons: { id: 'qualifications' },
-        recruitment_cycle_year: RecruitmentCycle.current_year,
+        recruitment_cycle_year: current_year,
       ),
     )
     expect(page).to have_css('h1', text: 'Qualifications')
@@ -282,7 +281,7 @@ private
     expect(page).to have_current_path(
       support_interface_reasons_for_rejection_application_choices_path(
         structured_rejection_reasons: { teaching_knowledge: 'teaching_demonstration' },
-        recruitment_cycle_year: RecruitmentCycle.current_year,
+        recruitment_cycle_year: current_year,
       ),
     )
 

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Service performance' do
   include DfESignInHelpers
 
   before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2021))
+    TestSuiteTimeMachine.travel_permanently_to(current_timetable.apply_deadline_at)
   end
 
   scenario 'View service statistics' do
@@ -35,10 +35,10 @@ RSpec.describe 'Service performance' do
   end
 
   def when_there_are_candidates_that_have_never_signed_in
-    travel_temporarily_to(RecruitmentCycle.previous_year - 1, 12, 25) do
+    travel_temporarily_to(previous_year - 1, 12, 25) do
       create(:candidate)
     end
-    travel_temporarily_to(RecruitmentCycle.current_year, 1, 5) do
+    travel_temporarily_to(current_year, 1, 5) do
       create_list(:candidate, 2)
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe 'Service performance' do
   end
 
   def when_i_go_a_report_for_a_specific_year
-    click_link_or_button RecruitmentCycle.cycle_name
+    click_link_or_button current_timetable.cycle_range_name
   end
 
   def then_i_only_see_candidates_that_signed_up_that_year

--- a/spec/system/support_interface/sycing_cycles_with_production_spec.rb
+++ b/spec/system/support_interface/sycing_cycles_with_production_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Syncing cycles with production' do
   include DfESignInHelpers
-  let(:timetable) { RecruitmentCycleTimetable.current_timetable }
 
   scenario 'Undoing a change in the cycle timetable' do
     given_i_am_signed_in_as_a_support_user
@@ -17,11 +16,11 @@ private
   def and_i_navigate_to_edit_current_cycle
     click_on 'Settings'
     click_on 'Recruitment cycles'
-    click_on timetable.recruitment_cycle_year
+    click_on current_timetable.recruitment_cycle_year
   end
 
   def when_i_make_a_successful_change_to_the_cycle
-    @original_apply_deadline_at = timetable.apply_deadline_at
+    @original_apply_deadline_at = current_timetable.apply_deadline_at
     within_fieldset 'Apply deadline' do
       new_date = 1.day.ago
       fill_in 'Day', with: new_date.day
@@ -30,7 +29,7 @@ private
     end
     click_on 'Update'
 
-    expect(timetable.reload.apply_deadline_at).not_to eq @original_apply_deadline_at
+    expect(current_timetable.reload.apply_deadline_at).not_to eq @original_apply_deadline_at
   end
 
   def and_i_sync_timetables_with_production
@@ -38,6 +37,6 @@ private
   end
 
   def then_the_timetable_is_restored
-    expect(timetable.reload.apply_deadline_at).to eq @original_apply_deadline_at
+    expect(current_timetable.reload.apply_deadline_at).to eq @original_apply_deadline_at
   end
 end

--- a/spec/system/support_interface/viewing_cycle_information_spec.rb
+++ b/spec/system/support_interface/viewing_cycle_information_spec.rb
@@ -35,21 +35,21 @@ private
   def then_i_see_information_about_editing_cycle_timetables
     expect(page).to have_title 'Recruitment cycles'
     expect(page).to have_content 'You can edit the following timetables'
-    expect(page).to have_link RecruitmentCycleTimetable.current_year
-    expect(page).to have_link RecruitmentCycleTimetable.next_year
+    expect(page).to have_link current_year
+    expect(page).to have_link next_year
     expect(page).to have_button 'Sync cycle timetables with production'
   end
 
   def then_i_do_not_see_information_about_editing_cycle_timetables
     expect(page).to have_title 'Recruitment cycles'
     expect(page).to have_no_content 'You can edit the following timetables'
-    expect(page).to have_no_link RecruitmentCycleTimetable.current_year
-    expect(page).to have_no_link RecruitmentCycleTimetable.next_year
+    expect(page).to have_no_link current_year
+    expect(page).to have_no_link next_year
     expect(page).to have_no_button 'Sync cycle timetables with production'
   end
 
   def and_i_see_other_content
-    year = RecruitmentCycleTimetable.current_year
+    year = current_year
     expect(page).to have_content "Apply has opened (#{year})"
     expect(page).to have_content 'Deadlines'
     expect(page).to have_content 'Cycle years'

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Sync from Teacher Training API' do
 
     TeacherTrainingPublicAPI::SyncProvider.new(
       provider_from_api:,
-      recruitment_cycle_year: RecruitmentCycle.current_year,
+      recruitment_cycle_year: current_year,
     ).call
   end
 

--- a/spec/system/vendor_api/vendor_makes_an_offer_for_course_in_past_cycle_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_an_offer_for_course_in_past_cycle_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Vendor makes an offer for a course in the past recruitment cycle
   def given_a_candidate_has_submitted_their_application
     @application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision)
     @provider = @application_choice.provider
-    @recruitment_cycle_year = RecruitmentCycle.previous_year
+    @recruitment_cycle_year = previous_year
     @course = create(:course, recruitment_cycle_year: @recruitment_cycle_year, provider: @provider)
     @course_option = create(:course_option, course: @course, site: create(:site, provider: @provider))
   end
@@ -37,11 +37,11 @@ RSpec.describe 'Vendor makes an offer for a course in the past recruitment cycle
     validation_errors = parsed_response_body['errors']
 
     expect(@api_response.status).to eq 422
-    expect(validation_errors.first['message']).to eq("Site #{@course_option.site.code} does not exist for provider #{@provider.code} in #{RecruitmentCycle.current_year}")
+    expect(validation_errors.first['message']).to eq("Site #{@course_option.site.code} does not exist for provider #{@provider.code} in #{current_year}")
   end
 
   def when_a_vendor_makes_an_offer_for_a_course_in_the_current_cycle
-    @recruitment_cycle_year = RecruitmentCycle.current_year
+    @recruitment_cycle_year = current_year
     @course = create(:course, recruitment_cycle_year: @recruitment_cycle_year, provider: @provider)
     @course_option = create(:course_option, course: @course, site: create(:site, provider: @provider))
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
           email: @current_candidate.email_address,
         },
         course: {
-          recruitment_cycle_year: RecruitmentCycle.current_year,
+          recruitment_cycle_year: current_year,
           provider_code: '1N1',
           site_code: '-',
           course_code: '2XT2',

--- a/spec/validators/safe_choice_update_validator_spec.rb
+++ b/spec/validators/safe_choice_update_validator_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe SafeChoiceUpdateValidator do
   end
 
   context 'when choices are not safe to touch' do
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-
     it 'does add an error' do
       record = Record.new
       record.application_form = create(

--- a/spec/workers/cancel_previous_cycle_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_previous_cycle_unsubmitted_applications_worker_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CancelPreviousCycleUnsubmittedApplicationsWorker do
-  let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-  let(:current_year) { RecruitmentCycleTimetable.current_year }
-
   describe '#perform' do
     it 'cancels any unsubmitted applications from the last cycle' do
       unsubmitted_application_from_last_year = create(

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -13,9 +13,6 @@ RSpec.describe DetectInvariantsDailyCheck do
   end
 
   describe '#perform' do
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-    let(:previous_year) { RecruitmentCycleTimetable.previous_year }
-
     it 'detects application choices for courses in the last cycle' do
       # Both of these are captured for this scenario
       allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::ApplicationHasCourseChoiceInPreviousCycle))
@@ -59,7 +56,7 @@ RSpec.describe DetectInvariantsDailyCheck do
       application_form_with_invalid_course = create(:application_form)
       application_form_with_valid_course = create(:application_form)
 
-      course_from_previous_cycle = create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+      course_from_previous_cycle = create(:course, recruitment_cycle_year: previous_year)
       course_from_current_cycle = create(:course, recruitment_cycle_year: current_year)
 
       old_course_option = create(:course_option, course: course_from_previous_cycle)

--- a/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
@@ -5,47 +5,47 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
     let(:unsubmitted_application_from_this_year) do
       create(:application_form,
              submitted_at: nil,
-             recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+             recruitment_cycle_year: current_year,
              application_choices: [create_an_application_choice(:unsubmitted, current_year_course_option)])
     end
 
     let(:unsubmitted_application_from_last_year) do
       create(:application_form,
              submitted_at: nil,
-             recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+             recruitment_cycle_year: previous_year,
              application_choices: [create_an_application_choice(:unsubmitted, previous_year_course_option)])
     end
 
     let(:previous_year_course_option) do
       create(:course_option,
              course: create(:course,
-                            recruitment_cycle_year: RecruitmentCycleTimetable.previous_year))
+                            recruitment_cycle_year: previous_year))
     end
 
     let(:current_year_course_option) do
       create(:course_option,
              course: create(:course,
-                            recruitment_cycle_year: RecruitmentCycleTimetable.current_year))
+                            recruitment_cycle_year: current_year))
     end
 
     let(:hidden_application_from_this_year) do
       create(:application_form,
              submitted_at: nil,
              candidate: create(:candidate, hide_in_reporting: true),
-             recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+             recruitment_cycle_year: current_year,
              application_choices: [create_an_application_choice(:unsubmitted, current_year_course_option)])
     end
 
     let(:rejected_application_from_this_year) do
       create(:application_form,
-             recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+             recruitment_cycle_year: current_year,
              application_choices: [create_an_application_choice(:rejected, current_year_course_option)])
     end
 
     let(:unsubmitted_cancelled_application_from_this_year) do
       create(:application_form,
              submitted_at: nil,
-             recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+             recruitment_cycle_year: current_year,
              application_choices: [create_an_application_choice(:application_not_sent, current_year_course_option)])
     end
 
@@ -75,7 +75,7 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
     end
 
     context 'for previous cycle, current cycle' do
-      [RecruitmentCycleTimetable.previous_year, RecruitmentCycleTimetable.current_year].each do |year|
+      [previous_year, current_year].each do |year|
         context 'on cancel application deadline', time: cancel_application_deadline(year) do
           it 'cancels applications' do
             create_test_applications

--- a/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
     end
 
     context 'for previous cycle, current cycle' do
-      [RecruitmentCycleTimetable.previous_year, RecruitmentCycleTimetable.current_year].each do |year|
+      [previous_year, current_year].each do |year|
         context 'after the decline by default date', time: decline_by_default_run_date(year) do
           it 'enqueues secondary worker for offered application choices' do
             declineable = create(:application_choice, :offer)

--- a/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
     end
 
     context 'for previous cycle, current cycle' do
-      [RecruitmentCycleTimetable.previous_year, RecruitmentCycleTimetable.current_year].each do |year|
+      [previous_year, current_year].each do |year|
         context 'after the reject by default date', time: reject_by_default_run_date(year) do
           it 'enqueues the secondary worker' do
             inactive_choice = create(:application_choice, :inactive)

--- a/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWork
 
         # These two application forms should not be included
         create(:application_form, :submitted)
-        create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
+        create(:application_form, recruitment_cycle_year: previous_year)
 
         # These two won't be sent because these candidates should not receive emails
         blocked_submission_candidate = create(:candidate, submission_blocked: true)

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe GenerateTestApplications do
   include CycleTimetableHelper
 
   it 'generates test candidates with applications in various states', :sidekiq, time: mid_cycle do
-    previous_cycle = RecruitmentCycleTimetable.previous_year
-    current_cycle = RecruitmentCycleTimetable.current_year
+    previous_cycle = previous_year
+    current_cycle = current_year
 
     # necessary to test 'cancelled' state
     create(:course_option, course: create(:course, :open, recruitment_cycle_year: 2020))
@@ -47,8 +47,8 @@ RSpec.describe GenerateTestApplications do
   end
 
   it 'generates undergraduate test applications', :sidekiq, time: mid_cycle do
-    current_cycle = RecruitmentCycleTimetable.current_year
-    previous_cycle = RecruitmentCycleTimetable.previous_year
+    current_cycle = current_year
+    previous_cycle = previous_year
     provider = create(:provider)
 
     create(:course_option, course: create(:course, :open, recruitment_cycle_year: previous_cycle))
@@ -75,7 +75,7 @@ RSpec.describe GenerateTestApplications do
   end
 
   it 'generates test applications for the next cycle', :sidekiq, time: mid_cycle do
-    current_cycle = RecruitmentCycleTimetable.current_year
+    current_cycle = current_year
     provider = create(:provider)
 
     create(:course_option, course: create(:course, :open, recruitment_cycle_year: current_cycle, provider:))

--- a/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportWorker do
     allow(Publications::NationalRecruitmentPerformanceReportGenerator).to receive(:new).and_return(@instance)
   end
 
-  let(:cycle_week) { RecruitmentCycleTimetable.current_cycle_week.pred }
+  let(:cycle_week) { current_cycle_week.pred }
   let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
 

--- a/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReportWorker do
     allow(Publications::ProviderRecruitmentPerformanceReportGenerator).to receive(:new).and_return(@instance)
   end
 
-  let(:cycle_week) { RecruitmentCycleTimetable.current_cycle_week.pred }
+  let(:cycle_week) { current_cycle_week.pred }
   let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:provider_id) { create(:provider).id }

--- a/spec/workers/send_deferred_offer_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_deferred_offer_reminder_email_to_candidates_worker_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SendDeferredOfferReminderEmailToCandidatesWorker, :sidekiq do
-  let(:course_this_year) { create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
-  let(:course_last_year) { create(:course, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
+  let(:course_this_year) { create(:course, recruitment_cycle_year: current_year) }
+  let(:course_last_year) { create(:course, recruitment_cycle_year: previous_year) }
 
   describe '#perform' do
     it 'sends reminder emails to all candidates with deferred offers from the previous cycle' do

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesBatchWorker, :sidekiq do
         :application_form,
         candidate:,
         application_choices: [create(:application_choice, :application_not_sent)],
-        recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+        recruitment_cycle_year: current_year,
       )
     end
 
@@ -27,9 +27,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesBatchWorker, :sidekiq do
           expect(candidate.current_application.chasers_sent.pluck(:chaser_type)).to eq([chaser_type.to_s])
         end
 
-        it 'does nothing if the email was already sent' do
-          allow(CycleTimetable).to receive(:apply_deadline).and_return(1.day.ago)
-
+        it 'does nothing if the email was already sent', time: after_apply_deadline do
           candidate.current_application.chasers_sent.create(chaser_type:)
 
           described_class.new.perform(candidate.id, chaser_type)

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
           :application_form,
           candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
-          recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          recruitment_cycle_year: current_year,
         )
 
         described_class.new.perform
@@ -69,7 +69,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
           :application_form,
           candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
-          recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          recruitment_cycle_year: current_year,
         )
 
         described_class.new.perform
@@ -88,7 +88,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
           :application_form,
           candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
-          recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          recruitment_cycle_year: current_year,
         )
 
         described_class.new.perform
@@ -100,14 +100,14 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application when the deadline has passed' do
-      travel_temporarily_to(RecruitmentCycleTimetable.current_timetable.apply_deadline_at + 1.day) do
+      travel_temporarily_to(current_timetable.apply_deadline_at + 1.day) do
         candidate = create(:candidate)
 
         create(
           :application_form,
           candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
-          recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          recruitment_cycle_year: current_year,
         )
 
         described_class.new.perform
@@ -126,7 +126,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
           :application_form,
           candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
-          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          recruitment_cycle_year: previous_year,
         )
 
         described_class.new.perform

--- a/spec/workers/send_find_has_opened_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_find_has_opened_email_to_candidates_worker_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe SendFindHasOpenedEmailToCandidatesWorker, :sidekiq do
       :application_form,
       candidate: candidate_1,
       application_choices: [unsubmitted_application_choice],
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
     )
 
     create(
       :application_form,
       candidate: candidate_2,
       application_choices: [rejected_application_choice],
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
     )
 
     [candidate_1, candidate_2]

--- a/spec/workers/send_new_cycle_has_started_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_new_cycle_has_started_email_to_candidates_batch_worker_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesBatchWorker, :sidekiq do
         :application_form,
         candidate: candidate_1,
         application_choices: [unsubmitted_application_choice],
-        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        recruitment_cycle_year: previous_year,
       )
       create(
         :application_form,
         candidate: candidate_2,
         application_choices: [rejected_application_choice],
-        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        recruitment_cycle_year: previous_year,
       )
 
       [candidate_1, candidate_2]
@@ -42,8 +42,7 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesBatchWorker, :sidekiq do
       expect(candidate_2.current_application.chasers_sent.pluck(:chaser_type)).to eq(['new_cycle_has_started'])
     end
 
-    it 'does nothing if the email was already sent' do
-      allow(CycleTimetable).to receive(:apply_opens).and_return(1.day.ago)
+    it 'does nothing if the email was already sent', time: mid_cycle do
       candidate_1, candidate_2 = setup_candidates
 
       candidate_1.current_application.chasers_sent.create(

--- a/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
@@ -11,32 +11,32 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesWorker, :sidekiq do
       :application_form,
       candidate: unsubmitted_candidate,
       application_choices: [build(:application_choice, :application_not_sent)],
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
     )
 
     create(
       :application_form,
       candidate: rejected_candidate,
       application_choices: [build(:application_choice, :rejected)],
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
     )
 
     create(
       :application_form,
       candidate: carried_over_candidate,
       application_choices: [build(:application_choice, :application_not_sent)],
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
     )
     create(
       :application_form,
       candidate: carried_over_candidate,
-      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+      recruitment_cycle_year: current_year,
     )
 
     create(
       :application_form,
       candidate: recruited_candidate,
-      recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      recruitment_cycle_year: previous_year,
       application_choices: [build(:application_choice, :recruited)],
     )
 

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StartOfCycleNotificationWorker do
         allow(GetProvidersToNotifyAboutFindAndApply).to receive(:call).and_return(collection)
         allow(collection).to receive(:limit).and_return([])
 
-        timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2023)
+        timetable = get_timetable(2023)
         travel_temporarily_to(timetable.find_opens_at.change(hour: start_hour)) do
           described_class.new.perform('find')
         end
@@ -77,7 +77,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'find' }
 
       before do
-        TestSuiteTimeMachine.travel_permanently_to(RecruitmentCycleTimetable.current_timetable.find_opens_at.change(hour: 5))
+        TestSuiteTimeMachine.travel_permanently_to(current_timetable.find_opens_at.change(hour: 5))
       end
 
       it 'does not send any messages' do
@@ -90,7 +90,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       let(:service) { 'find' }
 
       before do
-        TestSuiteTimeMachine.travel_permanently_to(RecruitmentCycleTimetable.current_timetable.find_opens_at.change(hour: 16))
+        TestSuiteTimeMachine.travel_permanently_to(current_timetable.find_opens_at.change(hour: 16))
       end
 
       it 'notifies all provider users that the service is open' do
@@ -181,8 +181,8 @@ RSpec.describe StartOfCycleNotificationWorker do
       end
 
       context 'when a provider user received an email last cycle' do
-        let(:timetable_2023) { RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2023) }
-        let(:timetable_2024) { RecruitmentCycleTimetable.find_by(recruitment_cycle_year: 2024) }
+        let(:timetable_2023) { get_timetable(2023) }
+        let(:timetable_2024) { get_timetable(2024) }
 
         it 'they receive another email this cycle' do
           TestSuiteTimeMachine.travel_permanently_to(timetable_2023.find_opens_at.change(hour: 16))

--- a/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
+++ b/spec/workers/teacher_training_public_api/sync_all_providers_and_courses_worker_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker, :mid_
       sync_subjects_service
     end
 
-    let(:current_year) { RecruitmentCycleTimetable.current_year }
-    let(:next_year) { RecruitmentCycleTimetable.next_year }
-
     before do
       allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCourses).to receive(:call)
     end


### PR DESCRIPTION
## Context

Part of the ongoing work to remove the CycleTimetable and RecruitmentCycle classes. This PR is focused on removing those dependancies from the test suite.

## Changes proposed in this pull request

The main this is using the `CycleTimetableHelper` for any timetable related stuff in the test suite. This ensures that timetables are seeded. It also removes a lot of the repetition -- I found myself doing `let(:current_timetable) { RecruitmentCycleTimetable.current_timetable }` on nearly every test. Now it is just `current_timetable` to be used as required. 

What this doesn't yet do is remove the `CycleTimetable` / `RecruitmentCycle` classes from the factories. This was already nearly 500 changes, so wanted to draw a line under it for now. 

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
