### PR TITLE
Candidate preferences form v1

### DIFF
--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  class DraftPreferencesController < CandidateInterfaceController
+    before_action :set_preference, only: %i[show update]
+    before_action :redirect_to_root_path_if_flag_is_inactive
+
+    def show; end
+
+    def update
+      @preference_form = PreferencesForm.new(
+        preference: @preference,
+        params: request_params,
+      )
+
+      if @preference_form.save
+        redirect_to candidate_interface_draft_preference_path(@preference)
+      else
+        @location_preferences = @preference.location_preferences
+        render 'candidate_interface/location_preferences/index'
+      end
+    end
+
+  private
+
+    def request_params
+      params.fetch(:candidate_interface_preferences_form, {}).permit(
+        :dynamic_location_preferences,
+      )
+    end
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params[:id])
+    end
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -1,0 +1,85 @@
+module CandidateInterface
+  class LocationPreferencesController < CandidateInterfaceController
+    before_action :set_preference
+    before_action :set_location_preference, only: %i[edit update show destroy]
+    before_action :set_back_path, only: %i[index]
+    before_action :redirect_to_root_path_if_flag_is_inactive
+
+    def index
+      @location_preferences = @preference.location_preferences
+      @preference_form = PreferencesForm.build_from_preference(
+        preference: @preference,
+      )
+    end
+
+    def show; end
+
+    def new
+      @location_preference_form = LocationPreferencesForm.new(preference: @preference)
+    end
+
+    def edit
+      @location_preference_form = LocationPreferencesForm.build_from_location_preference(
+        preference: @preference,
+        location_preference: @location_preference,
+      )
+    end
+
+    def create
+      @location_preference_form = LocationPreferencesForm.new(
+        preference: @preference,
+        params: location_preference_params,
+      )
+
+      if @location_preference_form.save
+        redirect_to candidate_interface_draft_preference_location_preferences_path(@preference)
+      else
+        render :new
+      end
+    end
+
+    def update
+      @location_preference_form = LocationPreferencesForm.new(
+        preference: @preference,
+        location_preference: @location_preference,
+        params: location_preference_params,
+      )
+
+      if @location_preference_form.save
+        redirect_to candidate_interface_draft_preference_location_preferences_path(@preference)
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @location_preference.destroy!
+
+      redirect_to candidate_interface_draft_preference_location_preferences_path(@preference)
+    end
+
+  private
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params[:draft_preference_id])
+    end
+
+    def set_location_preference
+      @location_preference = @preference.location_preferences.find_by(id: params[:id])
+    end
+
+    def location_preference_params
+      params.expect(candidate_interface_location_preferences_form: %i[name within])
+    end
+
+    def set_back_path
+      if params[:return_to] == 'review'
+        @back_path = candidate_interface_draft_preference_path(@preference)
+      end
+    end
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/location_suggestions_controller.rb
+++ b/app/controllers/candidate_interface/location_suggestions_controller.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class LocationSuggestionsController < CandidateInterfaceController
+    def index
+      return render(json: [], status: :bad_request) if params[:query].blank?
+
+      render json: { suggestions: LocationSuggestions.new(params[:query]).call }
+    end
+  end
+end

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -1,0 +1,77 @@
+module CandidateInterface
+  class PoolOptInsController < CandidateInterfaceController
+    before_action :set_preference, only: %i[edit update]
+    before_action :set_back_path, only: %i[edit update]
+    before_action :redirect_to_root_path_if_flag_is_inactive
+
+    def new
+      @preference_form = PoolOptInsForm.new(current_candidate:)
+    end
+
+    def edit
+      @preference_form = PoolOptInsForm.build_from_preference(
+        current_candidate:,
+        preference: @preference,
+      )
+    end
+
+    def create
+      @preference_form = PoolOptInsForm.new(
+        current_candidate:,
+        params: request_params,
+      )
+
+      if @preference_form.save
+        if @preference_form.preference.opt_in?
+          redirect_to candidate_interface_draft_preference_location_preferences_path(
+            @preference_form.preference,
+          )
+        else
+          redirect_to candidate_interface_application_choices_path
+        end
+      else
+        render :new
+      end
+    end
+
+    def update
+      @preference_form = PoolOptInsForm.new(
+        current_candidate:,
+        preference: @preference,
+        params: request_params,
+      )
+
+      if @preference_form.save
+        if @preference.reload.opt_in?
+          redirect_to @back_path || candidate_interface_draft_preference_location_preferences_path(@preference)
+        else
+          redirect_to candidate_interface_application_choices_path
+        end
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def request_params
+      params.fetch(:candidate_interface_pool_opt_ins_form, {}).permit(
+        :pool_status,
+      )
+    end
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params[:id])
+    end
+
+    def set_back_path
+      if params[:return_to] == 'review'
+        @back_path = candidate_interface_draft_preference_path(@preference)
+      end
+    end
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class PublishPreferencesController < CandidateInterfaceController
+    before_action :set_preference
+    before_action :redirect_to_root_path_if_flag_is_inactive
+
+    def create
+      ActiveRecord::Base.transaction do
+        @preference.published!
+        @preference.location_preferences.update_all(status: 'published')
+      end
+
+      flash[:success] = t('.success')
+      redirect_to candidate_interface_application_choices_path
+    end
+
+  private
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params[:draft_preference_id])
+    end
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+  end
+end

--- a/app/forms/candidate_interface/location_preferences_form.rb
+++ b/app/forms/candidate_interface/location_preferences_form.rb
@@ -1,0 +1,62 @@
+class CandidateInterface::LocationPreferencesForm
+  include ActiveModel::Model
+
+  attr_accessor :within, :name
+  attr_reader :preference, :location_preference
+
+  validates :within, presence: true
+  validates :name, presence: true
+  validate :location, if: -> { name.present? }
+
+  def initialize(preference:, location_preference: nil, params: {})
+    @preference = preference
+    @location_preference = location_preference
+    super(params)
+  end
+
+  def self.build_from_location_preference(preference:, location_preference:)
+    new(
+      preference:,
+      location_preference: location_preference,
+      params: {
+        within: location_preference.within,
+        name: location_preference.name,
+      },
+    )
+  end
+
+  def save
+    return if invalid?
+
+    if location_preference.present?
+      location_preference.update(
+        within:,
+        name:,
+        latitude: location_coordinates.latitude,
+        longitude: location_coordinates.longitude,
+      )
+    else
+      preference.location_preferences.create(
+        within:,
+        name:,
+        latitude: location_coordinates.latitude,
+        longitude: location_coordinates.longitude,
+      )
+    end
+  end
+
+private
+
+  def location_coordinates
+    Geocoder.search(
+      name,
+      components: 'country:UK',
+    ).first
+  end
+
+  def location
+    if location_coordinates.nil?
+      errors.add(:base, :invalid_location)
+    end
+  end
+end

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -1,0 +1,82 @@
+class CandidateInterface::PoolOptInsForm
+  include ActiveModel::Model
+
+  attr_accessor :pool_status
+  attr_reader :current_candidate, :preference
+
+  validates :pool_status, presence: true
+
+  def initialize(current_candidate:, preference: nil, params: {})
+    @current_candidate = current_candidate
+    @preference = preference
+    super(params)
+  end
+
+  def self.build_from_preference(current_candidate:, preference:)
+    new(
+      current_candidate:,
+      preference:,
+      params: {
+        pool_status: preference.pool_status,
+      },
+    )
+  end
+
+  def save
+    return if invalid?
+
+    if preference.present?
+      ActiveRecord::Base.transaction do
+        preference.update!(pool_status: pool_status)
+        preference.published! if preference.opt_out?
+        true
+      end
+    else
+      ActiveRecord::Base.transaction do
+        @preference = current_candidate.preferences.create(pool_status:)
+
+        if @preference.opt_out?
+          # We publish the preference because if they opt out it's the end of the journey
+          @preference.published!
+        else
+          add_default_location_preferences(preference)
+        end
+
+        true
+      end
+    end
+  end
+
+private
+
+  def add_default_location_preferences(preference)
+    application_form = current_candidate.current_cycle_application_form
+
+    return if application_form.application_choices.blank?
+
+    sites = application_form.application_choices
+      .joins(course_option: :site)
+      .select('sites.postcode, sites.latitude, sites.longitude')
+    attributes = []
+
+    attributes << {
+      name: application_form.postcode,
+      within: 10,
+      latitude: application_form.geocode.first,
+      longitude: application_form.geocode.last,
+      candidate_preference_id: preference.id,
+    }
+
+    sites.each do |site|
+      attributes << {
+        name: site.postcode,
+        within: 10,
+        latitude: site.latitude,
+        longitude: site.longitude,
+        candidate_preference_id: preference.id,
+      }
+    end
+
+    preference.location_preferences.insert_all!(attributes)
+  end
+end

--- a/app/forms/candidate_interface/preferences_form.rb
+++ b/app/forms/candidate_interface/preferences_form.rb
@@ -1,0 +1,36 @@
+class CandidateInterface::PreferencesForm
+  include ActiveModel::Model
+
+  attr_accessor :dynamic_location_preferences
+  attr_reader :preference
+
+  validate :location_preferences_presence
+
+  def initialize(preference:, params: {})
+    @preference = preference
+    super(params)
+  end
+
+  def self.build_from_preference(preference:)
+    new(
+      preference:,
+      params: {
+        dynamic_location_preferences: preference.dynamic_location_preferences,
+      },
+    )
+  end
+
+  def save
+    return if invalid?
+
+    preference.update!(dynamic_location_preferences:)
+  end
+
+private
+
+  def location_preferences_presence
+    if preference.location_preferences.blank?
+      errors.add(:base, :location_preferences_blank)
+    end
+  end
+end

--- a/app/frontend/packs/application-candidate.js
+++ b/app/frontend/packs/application-candidate.js
@@ -10,7 +10,14 @@ import '../styles/application-candidate.scss'
 import cookieBanners from './cookies/cookie-banners'
 import showMoreShowLess from './components/show-more-show-less'
 
+// stimulus
+import { Application } from '@hotwired/stimulus'
+import LocationAutocompleteController from './controllers/location_autocomplete_controller'
+
 require.context('govuk-frontend/dist/govuk/assets')
+
+window.Stimulus = Application.start()
+window.Stimulus.register('location-autocomplete', LocationAutocompleteController)
 
 govUKFrontendInitAll()
 

--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -23,3 +23,7 @@
 .location-autocomplete {
   display: block;
 }
+
+.location-autocomplete-input .autocomplete__wrapper {
+  width: 25%;
+}

--- a/app/frontend/styles/_input.scss
+++ b/app/frontend/styles/_input.scss
@@ -1,3 +1,9 @@
 .govuk-input[autocomplete="postal-code"] {
   text-transform: uppercase;
 }
+
+.radio-buttons-fieldset-hint {
+  // stylelint-disable declaration-no-important
+  color: govuk-colour("black") !important;
+  // stylelint-enable declaration-no-important
+}

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,6 +28,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:early_application_deadlines_for_candidates_with_visa_sponsorship, 'Implement alternative deadlines for candidates requiring visa sponsorships', 'Apply team'],
+    [:candidate_preferences, 'Allow candidates to add their preferences for providers to find them', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, t('.title') %>
+<% content_for :before_content, govuk_back_link(href: candidate_interface_draft_preference_location_preferences_path(@preference)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.share_information') } %>
+        <% row.with_value { @preference.pool_status == 'opt_in' ? 'Yes' : 'No' } %>
+        <% row.with_action(text: t('.change'), href: edit_candidate_interface_pool_opt_in_path(@preference, return_to: 'review')) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.preferred_locations') } %>
+        <% row.with_value do %>
+          <%= govuk_list do %>
+            <% @preference.location_preferences.each do |location| %>
+              <%= tag.li t('.location', radius: location.within, location: location.name) %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% row.with_action(
+          text: t('.change'),
+          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+        ) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.dynamic_locations') } %>
+        <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
+        <% row.with_action(
+          text: t('.change'),
+          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+        ) %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_button_to(
+      t('.submit'),
+      candidate_interface_draft_preference_publish_preferences_path(@preference),
+    ) %>
+
+  </div>
+</div>

--- a/app/views/candidate_interface/location_preferences/_form.html.erb
+++ b/app/views/candidate_interface/location_preferences/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: location_preference_form, url:, method: do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l"><%= title %></h1>
+
+  <%= f.govuk_text_field :within, suffix_text: t('.miles'), class: 'govuk-!-width-one-quarter', label: { text: t('.within'), size: 'm' } %>
+
+  <div class="location-autocomplete-input">
+    <%= f.govuk_text_field(
+      :name,
+      label: { text: t('.name'), size: 'm' },
+      data: {
+        controller: 'location-autocomplete',
+        location_autocomplete_path_value: candidate_interface_location_suggestions_path,
+        location_autocomplete_target: 'input',
+      },
+    ) %>
+  </div>
+
+  <%= f.govuk_submit submit_text %>
+<% end %>

--- a/app/views/candidate_interface/location_preferences/edit.html.erb
+++ b/app/views/candidate_interface/location_preferences/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, t('.title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @location_preference_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_draft_preference_location_preferences_path(@preference)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/location_preferences/edit.html.erb
+++ b/app/views/candidate_interface/location_preferences/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_draft_preference_location_preferences_path(@preference)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      'form',
+      location_preference_form: @location_preference_form,
+      url: candidate_interface_draft_preference_location_preference_path(@preference),
+      method: :patch,
+      title: t('.title'),
+      submit_text: t('.submit_text'),
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('.title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @preference_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@back_path || edit_candidate_interface_pool_opt_in_path(@preference)) %>
 
 <div class="govuk-grid-row">
@@ -57,9 +57,7 @@
         label: { text: t('.update_location_preferences') },
       ) %>
 
-      <br>
-      <br>
-      <%= f.govuk_submit %>
+      <%= f.govuk_submit class: 'govuk-!-margin-top-5' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for :title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(@back_path || edit_candidate_interface_pool_opt_in_path(@preference)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+    <p class="govuk-body"><%= t('.body') %></p>
+
+    <h2 class="govuk-heading-m"><%= t('.select_locations') %></h1>
+
+    <%= form_with(
+      model: @preference_form,
+      url: candidate_interface_draft_preference_path(@preference.id),
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border' }) do |table| %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <%= row.with_cell(text: t('.location')) %>
+            <%= row.with_cell(text: t('.distance_from_location')) %>
+          <% end %>
+        <% end %>
+
+        <% table.with_body do |body| %>
+          <% @location_preferences.each_with_index do |location, index| %>
+            <% body.with_row do |row| %>
+              <%= row.with_cell(text: location.name) %>
+
+              <%= row.with_cell(text: location.within) %>
+              <%= row.with_cell do %>
+                <%= govuk_link_to t('.change'), edit_candidate_interface_draft_preference_location_preference_path(@preference, location) %>
+              <% end %>
+              <%= row.with_cell do %>
+                <%= govuk_link_to t('.remove'), candidate_interface_draft_preference_location_preference_path(@preference, location) %>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <% body.with_row do |row| %>
+            <%= row.with_cell do %>
+              <%= govuk_button_link_to(
+                t('.add_another_location'),
+                new_candidate_interface_draft_preference_location_preference_path(@preference),
+                secondary: true,
+              ) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_check_box(
+        :dynamic_location_preferences,
+        true,
+        multiple: false,
+        label: { text: t('.update_location_preferences') },
+      ) %>
+
+      <br>
+      <br>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/location_preferences/new.html.erb
+++ b/app/views/candidate_interface/location_preferences/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, t('.title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @location_preference_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_draft_preference_location_preferences_path(@preference)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/location_preferences/new.html.erb
+++ b/app/views/candidate_interface/location_preferences/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_draft_preference_location_preferences_path(@preference)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      'form',
+      location_preference_form: @location_preference_form,
+      url: candidate_interface_draft_preference_location_preferences_path(@preference),
+      method: :post,
+      title: t('.title'),
+      submit_text: t('.submit_text'),
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate_interface/location_preferences/show.html.erb
+++ b/app/views/candidate_interface/location_preferences/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_draft_preference_location_preferences_path(@preference)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+    <%= govuk_summary_list(actions: false) do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key { t('.location') } %>
+        <%= row.with_value { @location_preference.name } %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_button_to(
+      t('.remove'),
+      candidate_interface_draft_preference_location_preference_path(@preference, @location_preference),
+      method: :delete,
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: preference_form, url:, method: do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' } do %>
+    <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
+    <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/candidate_interface/pool_opt_ins/edit.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, t('.title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @preference_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@back_path || candidate_interface_application_choices_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/pool_opt_ins/edit.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(@back_path || candidate_interface_application_choices_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      'form',
+      preference_form: @preference_form,
+      url: candidate_interface_pool_opt_in_path(@preference, return_to: @back_path.present? ? 'review' : nil),
+      method: :patch,
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate_interface/pool_opt_ins/new.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_choices_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'form', preference_form: @preference_form, url: candidate_interface_pool_opt_ins_path, method: :post %>
+  </div>
+</div>

--- a/app/views/candidate_interface/pool_opt_ins/new.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, t('.title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @preference_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_choices_path) %>
 
 <div class="govuk-grid-row">

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -18,3 +18,5 @@ shared:
   one_login_auths:
     - candidate_id
     - email_address
+  candidate_preferences:
+    - candidate_id

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -1,0 +1,80 @@
+en:
+  candidate_interface:
+    publish_preferences:
+      create:
+        success: You are sharing your application details with providers you have not applied to
+    preferences:
+      show: Check your application sharing preferences
+      share_question: Do you want to share your application details with other training providers?
+      preferred_locations: Preferred locations
+      update_my_locations: Add new locations to my preferences when I apply to new courses
+      change: Change
+      submit: Submit preferences
+    draft_preferences:
+      show:
+        title: Check your application sharing preferences
+        share_information: Do you want to share your application details with other training providers?
+        preferred_locations: Preferred locations
+        dynamic_locations: Update my location preferences when I apply to a new course
+        change: Change
+        submit: Submit preferences
+        location: Within %{radius} miles of %{location}
+    pool_opt_ins:
+      new:
+        title: Do you want to make your application details visible to other training providers?
+      edit:
+        title: Do you want to make your application details visible to other training providers?
+      show:
+        title: Check your application sharing preferences
+        share_information: Do you want to share your application details with other training providers?
+        preferred_locations: Preferred locations
+        dynamic_locations: Update my location preferences when I apply to a new course
+        change: Change
+        submit: Submit preferences
+      form:
+        title: Do you want to make your application details visible to other training providers?
+        body: When you have no applications that are waiting for a decision from a provider, other providers will be able to see your application details and invite you to apply to their courses.
+    location_preferences:
+      index:
+        title: Location Preferences
+        body: Training providers will use the locations you enter here to search for candidates near their courses
+        select_locations: Add, change or add preferred locations
+        location: Location
+        distance_from_location: Distance from location
+        change: Change
+        update_location_preferences: Add new locations to my preferences when I apply to new courses
+        remove: Remove
+        add_another_location: Add another location
+      new:
+        title: Add a location
+        submit_text: Add location
+      edit:
+        title: Change location preferences
+        submit_text: Update location
+      form:
+        within: Within
+        name: of city, town or postcode
+        miles: miles
+      show:
+        title: Do you want to remove this location?
+        location: Location
+        remove: Yes, remove location
+  activemodel:
+    errors:
+      models:
+        candidate_interface/preferences_form:
+          attributes:
+            base:
+              location_preferences_blank: Add location preferences
+        candidate_interface/pool_opt_ins_form:
+          attributes:
+            pool_status:
+              blank: Select weather to make your application details visible to other training providers
+        candidate_interface/location_preferences_form:
+          attributes:
+            within:
+              blank: Add a location radius
+            name:
+              blank: Add a location name
+            base:
+              invalid_location: Enter a real city, town or postcode

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -16,6 +16,14 @@ namespace :candidate_interface, path: '/candidate' do
 
   resources :account_recovery_requests, only: %i[new create], path: 'account-recovery-requests'
 
+  resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in'
+  resources :draft_preferences, only: %i[show update], path: 'preferences' do
+    resources :publish_preferences, only: %i[create], path: 'publish-preferences'
+    resources :location_preferences, path: 'location-preferences'
+  end
+
+  resources :location_suggestions, only: :index, path: 'location-suggestions'
+
   get 'account-recovery/new'
   post 'account-recovery/create'
   post 'dismiss-account-recovery/create'

--- a/spec/forms/candidate_interface/location_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/location_preferences_form_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::LocationPreferencesForm, type: :model do
+  subject(:form) do
+    described_class.new(preference:, location_preference:, params:)
+  end
+
+  let(:preference) { create(:candidate_preference) }
+  let(:location_preference) { nil }
+  let(:params) { { name: 'BN1 1AA', within: 20 } }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:within) }
+    it { is_expected.to validate_presence_of(:name) }
+
+    context 'when location name is invalid' do
+      it 'adds location preferences blank error' do
+        allow(Geocoder).to receive(:search).and_return([])
+
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:base]).to eq(['Enter a real city, town or postcode'])
+      end
+    end
+  end
+
+  describe '.build_from_preferences' do
+    let(:location_preference) { create(:candidate_location_preference) }
+
+    it 'builds the form from a preference' do
+      form_object = described_class.build_from_location_preference(
+        preference:,
+        location_preference:,
+      )
+
+      expect(form_object).to have_attributes(
+        preference:,
+        location_preference:,
+        name: location_preference.name,
+        within: location_preference.within,
+      )
+    end
+  end
+
+  describe '#save' do
+    context 'when creating a location preference' do
+      it 'creates a preference and adds location preferences' do
+        expect { form.save }.to change(preference.location_preferences, :count).by(1)
+
+        expect(preference.location_preferences.last).to have_attributes(
+          name: 'BN1 1AA',
+          within: 20,
+          latitude: 51.4524877,
+          longitude: -0.1204749,
+        )
+      end
+    end
+
+    context 'when updating a location_preference' do
+      let(:location_preference) { create(:candidate_location_preference) }
+
+      it 'updates a preference to opt out and publishes the preference' do
+        expect { form.save }.to change(location_preference, :name).from(location_preference.name).to('BN1 1AA')
+          .and change(location_preference, :within).from(location_preference.within).to(20)
+          .and change(location_preference, :latitude).from(location_preference.latitude).to(51.4524877)
+          .and change(location_preference, :longitude).from(location_preference.longitude).to(-0.1204749)
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PoolOptInsForm, type: :model do
+  subject(:form) do
+    described_class.new(current_candidate:, preference:, params:)
+  end
+
+  let(:current_candidate) { create(:candidate) }
+  let(:preference) { nil }
+  let(:params) { { pool_status: 'opt_in' } }
+  let(:application_form) do
+    create(:application_form, :completed, candidate: current_candidate)
+  end
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:pool_status) }
+  end
+
+  describe '.build_from_preferences' do
+    let(:preference) { create(:candidate_preference) }
+
+    it 'builds the form from a preference' do
+      form_object = described_class.build_from_preference(
+        current_candidate:,
+        preference:,
+      )
+
+      expect(form_object).to have_attributes(
+        current_candidate:,
+        preference:,
+        pool_status: 'opt_in',
+      )
+    end
+  end
+
+  describe '#save' do
+    context 'when creating a preference' do
+      it 'creates a preference and adds location preferences' do
+        expect { form.save }.to change(CandidatePreference, :count).by(1)
+          .and change { CandidateLocationPreference.count }.by(2)
+
+        preference_record = CandidatePreference.last
+        expect(preference_record.pool_status).to eq('opt_in')
+        expect(preference_record.location_preferences.count).to eq(2)
+      end
+    end
+
+    context 'when updating a preference to opt out' do
+      let(:preference) { create(:candidate_preference) }
+      let(:params) { { pool_status: 'opt_out' } }
+
+      it 'updates a preference to opt out and publishes the preference' do
+        expect { form.save }.to change(preference, :pool_status).from('opt_in').to('opt_out')
+          .and change(preference, :status).from('draft').to('published')
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/preferences_form_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PreferencesForm, type: :model do
+  subject(:form) do
+    described_class.new(preference:, params:)
+  end
+
+  let(:preference) do
+    create(:candidate_preference, dynamic_location_preferences: false)
+  end
+  let(:params) { { dynamic_location_preferences: true } }
+
+  describe 'validations' do
+    context 'when there are no location preferences' do
+      it 'adds location preferences blank error' do
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:base]).to eq(['Add location preferences'])
+      end
+    end
+  end
+
+  describe '.build_from_preferences' do
+    it 'builds the form from a preference' do
+      form_object = described_class.build_from_preference(
+        preference:,
+      )
+
+      expect(form_object).to have_attributes(
+        preference:,
+        dynamic_location_preferences: false,
+      )
+    end
+  end
+
+  describe '#save' do
+    it 'updates a preference to add dynamic_location_preferences' do
+      create(:candidate_location_preference, candidate_preference: preference)
+      expect { form.save }.to change(preference, :dynamic_location_preferences).from(false).to(true)
+    end
+  end
+end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -1,0 +1,212 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate adds preferences' do
+  let(:location_preferences) { [home_location, choice_location] }
+  let(:home_location) { { within: 10, name: 'BN1 1AA' } }
+  let(:choice_location) { { within: 10, name: 'BN1 2AA' } }
+  let(:new_location) { { within: 10, name: 'BN1 3AA' } }
+  let(:updated_location) { { within: 20, name: 'BN1 4AA' } }
+
+  scenario 'Candidate opts in to find a candidate' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    visit new_candidate_interface_pool_opt_in_path
+    when_i_click('Continue')
+    then_i_get_an_error('Select weather to make your application details visible to other training providers')
+
+    and_i_opt_in_to_find_a_candidate
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_click('Back')
+    then_i_am_redirected_to_opt_in
+
+    when_i_click('Continue')
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_remove_all_locations
+    then_i_am_redirected_to_location_preferences([])
+    when_i_click('Continue')
+    then_i_get_an_error('Add location preferences')
+
+    when_i_click('Add another location')
+    and_i_input_a_location
+    when_i_click('Add location')
+    then_i_am_redirected_to_location_preferences([new_location])
+
+    when_i_click('Change')
+    and_i_edit_a_location
+    when_i_click('Update location')
+    then_i_am_redirected_to_location_preferences([updated_location])
+
+    when_i_check_dynamic_locations
+    when_i_click('Continue')
+    then_i_am_redirected_to_review_page([updated_location])
+
+    when_i_click('Back')
+    then_i_am_redirected_to_location_preferences([updated_location])
+    and_the_dynamic_locations_is_checked
+
+    when_i_click('Continue')
+    then_i_am_redirected_to_review_page([updated_location])
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_application_choices_with_success_message
+  end
+
+  scenario 'Candidate opts out of find a candidate' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    visit new_candidate_interface_pool_opt_in_path
+    and_i_opt_out_to_find_a_candidate
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_application_choices
+  end
+
+  def given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
+    @application = create(
+      :application_form,
+      :completed,
+      postcode: home_location,
+      candidate: @current_candidate,
+    )
+    provider = create(:provider)
+    site = create(
+      :site,
+      postcode: choice_location,
+      provider:,
+    )
+    course = create(:course, provider:)
+    course_option = create(
+      :course_option,
+      site:,
+      course:,
+    )
+    @choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application,
+      course_option:,
+    )
+  end
+
+  def and_i_opt_in_to_find_a_candidate
+    choose 'Yes'
+  end
+
+  def and_i_opt_out_to_find_a_candidate
+    choose 'No'
+  end
+
+  def when_i_click(button)
+    click_link_or_button(button)
+  end
+
+  def then_i_am_redirected_to_location_preferences(location_preferences)
+    expect(page).to have_content('Location Preferences')
+
+    location_preferences.each_with_index do |location, index|
+      within ".govuk-table__body .govuk-table__row:nth-of-type(#{index + 1})" do
+        expect(page).to have_content(location[:name])
+        expect(page).to have_content(location[:within])
+      end
+    end
+  end
+
+  def then_i_am_redirected_to_application_choices
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+  end
+
+  def then_i_am_redirected_to_opt_in
+    expect(page).to have_content('Do you want to make your application details visible to other training providers?')
+
+    yes_option = find_by_id('candidate-interface-pool-opt-ins-form-pool-status-opt-in-field')
+    expect(yes_option).to be_checked
+  end
+
+  def when_i_check_dynamic_locations
+    check 'Add new locations to my preferences when I apply to new courses'
+  end
+
+  def then_i_am_redirected_to_review_page(location_preferences)
+    expect(page).to have_content('Check your application sharing preferences')
+
+    locations_value = location_preferences.map do |location|
+      "Within #{location[:within]} miles of #{location[:name]}"
+    end.join(' ')
+
+    summary_list = [
+      {
+        label: 'Do you want to share your application details with other training providers?',
+        value: 'Yes',
+      },
+      {
+        label: 'Preferred locations',
+        value: locations_value,
+      },
+      {
+        label: 'Update my location preferences when I apply to a new course',
+        value: 'Yes',
+      },
+    ]
+
+    summary_list.each_with_index do |item, index|
+      within ".govuk-summary-list__row:nth-of-type(#{index + 1})" do
+        expect(page).to have_content(item[:label])
+        expect(page).to have_content(item[:value])
+      end
+    end
+  end
+
+  def and_the_dynamic_locations_is_checked
+    dynamic_locations = find_by_id('candidate-interface-preferences-form-dynamic-location-preferences-true-field')
+    expect(dynamic_locations).to be_checked
+  end
+
+  def then_i_am_redirected_application_choices_with_success_message
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+    expect(page).to have_content('You are sharing your application details with providers you have not applied to')
+  end
+
+  def then_i_get_an_error(error_message)
+    within '.govuk-error-summary' do
+      expect(page).to have_content(error_message)
+      expect(page).to have_css('.govuk-error-summary__list li', count: 1)
+    end
+  end
+
+  def when_i_click_remove_location
+    first('a', text: 'Remove').click
+  end
+
+  def then_i_am_redirected_to_remove_location_page
+    expect(page).to have_content('Do you want to remove this location?')
+  end
+
+  def when_i_remove_all_locations
+    location_preferences.each do
+      when_i_click_remove_location
+      then_i_am_redirected_to_remove_location_page
+      when_i_click('Yes, remove location')
+    end
+  end
+
+  def and_i_input_a_location
+    fill_in('Within', with: new_location[:within])
+    fill_in('of city, town or postcode', with: new_location[:name])
+  end
+
+  def and_i_edit_a_location
+    fill_in('Within', with: updated_location[:within])
+    fill_in('of city, town or postcode', with: updated_location[:name])
+  end
+
+  def and_feature_flag_is_enabled
+    FeatureFlag.activate(:candidate_preferences)
+  end
+end


### PR DESCRIPTION
## Context

This is a version of the candidate preferences form.

It's not the final version, changes will come after this, allowing the
candidate to not have any location preferences if they want and allowing
the candidate to come back to their preferences and update them.

We also need a way to integrate this form into the candidate flow, right
now the only way to get to this form is to know the url.

This is just a basic/complex CRUD, multi step form.

We have a controller and form object for every step. This makes it
easier to handle the redirect, back buttons and save/update logic.

After you opt in, we create location_preferences for you, based on home address and current application_choices. Further refactoring will come to handle international candidates.

We do pass around a `return_to` param to indicate to the form where to
return. Used on the review page.

I don't think we need to use the `candidate_location_preferece.status` column anymore. They don't really need to be selected, they are just attached to a `candidate_preference` which has a status column.

This tries to follow REST rails controllers.

Some flexing of these REST rules are required 😅 , for example:

This is the index page of `location_preferences`. It's more of a form but also can act index page 😆. There are no more checkboxes, whatever you have on this list are your location_preferences, they are already 'selected'
![Screenshot from 2025-03-27 11-38-45](https://github.com/user-attachments/assets/681deab4-9ca2-46c6-a5c5-ad1cde18dfc4)

This is the show page of the `draft_preferences`. This is where the user will see their preferences at a glance
![Screenshot from 2025-03-27 11-40-46](https://github.com/user-attachments/assets/5d4b3210-26c4-440a-b379-229187681ed0)



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/0ef0b5fe-e53d-4489-adfd-f9f808aa0719



Have a go at adding preferences on the review app. Use the back links, do try to break it a bit.

URL `/candidate/preferences-opt-in/new`

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
