### PR TITLE
Updated Notify Check to use the GENERIC_NOTIFY_TEMPLATE ID

### DIFF
--- a/lib/healthchecks/notify_check.rb
+++ b/lib/healthchecks/notify_check.rb
@@ -10,8 +10,6 @@ class Healthchecks::NotifyCheck < OkComputer::Check
     notify_client.send_email(
       email_address: 'simulate-delivered@notifications.service.gov.uk',
       template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
-      subject: 'Notify healthcheck',
-      body: 'Notify healthcheck',
     )
 
     mark_message 'Notify is working'

--- a/lib/healthchecks/notify_check.rb
+++ b/lib/healthchecks/notify_check.rb
@@ -11,7 +11,7 @@ class Healthchecks::NotifyCheck < OkComputer::Check
       email_address: 'simulate-delivered@notifications.service.gov.uk',
       template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
       personalisation: {
-        summary: 'Notify check',
+        subject: 'Notify check',
         body: 'This is a test email to check Notify is working',
       },
     )

--- a/lib/healthchecks/notify_check.rb
+++ b/lib/healthchecks/notify_check.rb
@@ -9,7 +9,9 @@ class Healthchecks::NotifyCheck < OkComputer::Check
 
     notify_client.send_email(
       email_address: 'simulate-delivered@notifications.service.gov.uk',
-      template_id: ENV.fetch('GOVUK_NOTIFY_TEST_TEMPLATE_ID'),
+      template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
+      subject: 'Notify healthcheck',
+      body: 'Notify healthcheck',
     )
 
     mark_message 'Notify is working'

--- a/lib/healthchecks/notify_check.rb
+++ b/lib/healthchecks/notify_check.rb
@@ -10,6 +10,10 @@ class Healthchecks::NotifyCheck < OkComputer::Check
     notify_client.send_email(
       email_address: 'simulate-delivered@notifications.service.gov.uk',
       template_id: ApplicationMailer::GENERIC_NOTIFY_TEMPLATE,
+      personalisation: {
+        summary: 'Notify check',
+        body: 'This is a test email to check Notify is working',
+      },
     )
 
     mark_message 'Notify is working'


### PR DESCRIPTION
## Context

We're making this change as the Test Template was deleted, causing our status to report as down, even though the service is fully operational. 
We have chosen to use the generic template as we would like to be alerted if this template is ever deleted, which would better reflect the service being down. 

## Changes proposed in this pull request

- Change test template id is health check

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
