### PR TITLE
Share details flow

### DIFF
--- a/app/components/candidate_interface/manage_preferences_component.html.erb
+++ b/app/components/candidate_interface/manage_preferences_component.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-column-full govuk-!-margin-top-4">
+  <h2 class="govuk-heading-m">Sharing your application details</h2>
+  <% if pool_opt_in? %>
+    <p class="govuk-body">
+      You are sharing your application details with training providers that you have not submitted an application to.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      You are not sharing your application details with training providers that you have not submitted an application to.
+    </p>
+  <% end %>
+
+  <%= govuk_list(
+    [
+      govuk_link_to(
+        'Read about how sharing your application details works',
+        candidate_interface_share_details_path,
+      ),
+      govuk_link_to(
+        'Change your sharing and location settings',
+        path_to_change_preferences,
+      ),
+    ],
+    type: :bullet,
+  ) %>
+</div>

--- a/app/components/candidate_interface/manage_preferences_component.html.erb
+++ b/app/components/candidate_interface/manage_preferences_component.html.erb
@@ -1,23 +1,19 @@
-<div class="govuk-grid-column-full govuk-!-margin-top-4">
-  <h2 class="govuk-heading-m">Sharing your application details</h2>
+<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
+  <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
   <% if pool_opt_in? %>
-    <p class="govuk-body">
-      You are sharing your application details with training providers that you have not submitted an application to.
-    </p>
+    <p class="govuk-body"><%= t('.body_opt_in') %></p>
   <% else %>
-    <p class="govuk-body">
-      You are not sharing your application details with training providers that you have not submitted an application to.
-    </p>
+    <p class="govuk-body"><%= t('.body_opt_out') %></p>
   <% end %>
 
   <%= govuk_list(
     [
       govuk_link_to(
-        'Read about how sharing your application details works',
+        t('.read_about_sharing_details'),
         candidate_interface_share_details_path,
       ),
       govuk_link_to(
-        'Change your sharing and location settings',
+        t('.change_sharing_details'),
         path_to_change_preferences,
       ),
     ],

--- a/app/components/candidate_interface/manage_preferences_component.rb
+++ b/app/components/candidate_interface/manage_preferences_component.rb
@@ -1,0 +1,26 @@
+class CandidateInterface::ManagePreferencesComponent < ViewComponent::Base
+  attr_reader :current_candidate, :application_form
+
+  def initialize(current_candidate:, application_form:)
+    @current_candidate = current_candidate
+    @application_form = application_form
+  end
+
+  def render?
+    FeatureFlag.active?(:candidate_preferences) && application_form.submitted_applications?
+  end
+
+  def pool_opt_in?
+    current_candidate.published_preferences&.last&.opt_in?
+  end
+
+private
+
+  def path_to_change_preferences
+    if current_candidate.published_preferences.any?
+      candidate_interface_draft_preference_publish_preferences_path(current_candidate.published_preferences.last)
+    else
+      new_candidate_interface_pool_opt_in_path
+    end
+  end
+end

--- a/app/components/candidate_interface/share_details_component.html.erb
+++ b/app/components/candidate_interface/share_details_component.html.erb
@@ -1,0 +1,30 @@
+<p class="govuk-body">
+  You can choose to make your application details visible to training providers
+  who you have not submitted an application to.
+</p>
+<p class="govuk-body">
+  They can search a list of candidates and view their application details.
+  If you meet the eligibility criteria for their course, they can invite you to apply directly.
+</p>
+
+<%= govuk_button_to('Continue', path_to_continue, method: :get) %>
+
+<div class="app-card app-card--light-blue">
+  <h2 class="govuk-heading-m">How this works with the current application process </h2>
+  <p class="govuk-body">
+    This feature should be used alongside the current application process.
+    You should continue to choose courses and submit applications yourself.
+  </p>
+  <p class="govuk-body">
+    Your application details will only be visible to training providers if all
+    of your active applications are unsuccessful. Each time you submit a new
+    application, you will stop being searchable by other providers.
+  </p>
+  <p class="govuk-body">
+    You can still submit up to 4 application choices at a time. Any that you
+    are invited to apply to will count towards this total.
+  </p>
+  <p class="govuk-body">
+    You can change your decision to share your application details at any time.
+  </p>
+<div>

--- a/app/components/candidate_interface/share_details_component.rb
+++ b/app/components/candidate_interface/share_details_component.rb
@@ -1,0 +1,19 @@
+class CandidateInterface::ShareDetailsComponent < ViewComponent::Base
+  attr_reader :current_candidate
+
+  def initialize(current_candidate)
+    @current_candidate = current_candidate
+  end
+
+private
+
+  def path_to_continue
+    if current_candidate.published_preferences.any?
+      candidate_interface_draft_preference_publish_preferences_path(
+        current_candidate.published_preferences.last,
+      )
+    else
+      new_candidate_interface_pool_opt_in_path
+    end
+  end
+end

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -51,7 +51,11 @@ module CandidateInterface
       CandidateInterface::SubmitApplicationChoice.new(@application_choice).call
       flash[:success] = t('application_form.submit_application_success.title')
 
-      redirect_to candidate_interface_application_choices_path
+      if FeatureFlag.active?(:candidate_preferences) && current_candidate.published_preferences.blank?
+        redirect_to candidate_interface_share_details_path
+      else
+        redirect_to candidate_interface_application_choices_path
+      end
     end
 
     def application_choice

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -6,6 +6,10 @@ module CandidateInterface
     before_action :redirect_to_root_path_if_flag_is_inactive
 
     def index
+      if @preference.published?
+        @preference = @preference.create_draft_dup
+      end
+
       @location_preferences = @preference.location_preferences
       @preference_form = PreferencesForm.build_from_preference(
         preference: @preference,

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -9,6 +9,10 @@ module CandidateInterface
     end
 
     def edit
+      if @preference.published?
+        @preference = @preference.create_draft_dup
+      end
+
       @preference_form = PoolOptInsForm.build_from_preference(
         current_candidate:,
         preference: @preference,
@@ -27,6 +31,7 @@ module CandidateInterface
             @preference_form.preference,
           )
         else
+          flash[:success] = t('.opt_out_message')
           redirect_to candidate_interface_application_choices_path
         end
       else
@@ -45,6 +50,7 @@ module CandidateInterface
         if @preference.reload.opt_in?
           redirect_to @back_path || candidate_interface_draft_preference_location_preferences_path(@preference)
         else
+          flash[:success] = t('.opt_out_message')
           redirect_to candidate_interface_application_choices_path
         end
       else

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -3,10 +3,12 @@ module CandidateInterface
     before_action :set_preference
     before_action :redirect_to_root_path_if_flag_is_inactive
 
+    def show; end
+
     def create
       ActiveRecord::Base.transaction do
         @preference.published!
-        @preference.location_preferences.update_all(status: 'published')
+        current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
       end
 
       flash[:success] = t('.success')

--- a/app/controllers/candidate_interface/share_details_controller.rb
+++ b/app/controllers/candidate_interface/share_details_controller.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class ShareDetailsController < CandidateInterfaceController
+    before_action :redirect_to_root_path_if_flag_is_inactive
+
+    def index; end
+
+  private
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+  end
+end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -28,6 +28,7 @@ class Candidate < ApplicationRecord
   has_many :pool_dismissals, dependent: :destroy, class_name: 'Pool::Dismissal'
   has_many :pool_invites, dependent: :destroy, class_name: 'Pool::Invite'
   has_many :preferences, dependent: :destroy, class_name: 'CandidatePreference'
+  has_many :published_preferences, -> { where(status: 'published') }, dependent: :destroy, class_name: 'CandidatePreference'
 
   PUBLISHED_FIELDS = %w[email_address].freeze
 

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -11,4 +11,27 @@ class CandidatePreference < ApplicationRecord
     draft: 'draft',
     published: 'published',
   }
+
+  def create_draft_dup
+    dup_record = dup
+    dup_record.status = 'draft'
+
+    location_preferences_attributes = []
+
+    location_preferences.map do |location|
+      location_preferences_attributes << location.attributes.except(
+        'id',
+        'candidate_preference_id',
+        'created_at',
+        'updated_at',
+      )
+    end
+
+    ActiveRecord::Base.transaction do
+      dup_record.save!
+      dup_record.location_preferences.insert_all!(location_preferences_attributes)
+    end
+
+    dup_record
+  end
 end

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -7,6 +7,7 @@ class CandidateInterface::ChoicesControllerMatcher
     'candidate_interface/decisions', # withdrawing from a course offer, the old way
     'candidate_interface/withdrawal_reasons', # Withdrawing the new way
     'candidate_interface/apply_from_find',
+    'candidate_interface/share_details',
   ].freeze
 
   def self.choices_controller?(current_application:, controller_path:, request:)

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -43,4 +43,6 @@
       current_tab_name: params[:current_tab_name],
     ) %>
   </div>
+
+  <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>
 </div>

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, t('.title') %>
+<% content_for :before_content, govuk_back_link(href: candidate_interface_application_choices_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.share_information') } %>
+        <% row.with_value { @preference.pool_status == 'opt_in' ? 'Yes' : 'No' } %>
+        <% row.with_action(text: t('.change'), href: edit_candidate_interface_pool_opt_in_path(@preference, return_to: 'review')) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.preferred_locations') } %>
+        <% row.with_value do %>
+          <%= govuk_list do %>
+            <% @preference.location_preferences.each do |location| %>
+              <%= tag.li t('.location', radius: location.within, location: location.name) %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% row.with_action(
+          text: t('.change'),
+          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+        ) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.dynamic_locations') } %>
+        <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
+        <% row.with_action(
+          text: t('.change'),
+          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+        ) %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_button_to(
+      t('.submit'),
+      candidate_interface_draft_preference_publish_preferences_path(@preference),
+    ) %>
+
+  </div>
+</div>

--- a/app/views/candidate_interface/share_details/index.html.erb
+++ b/app/views/candidate_interface/share_details/index.html.erb
@@ -1,0 +1,10 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_choices_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+    <%= render CandidateInterface::ShareDetailsComponent.new(current_candidate) %>
+  </div>
+</div>

--- a/config/locales/candidate_interface/manage_preferences_component.yml
+++ b/config/locales/candidate_interface/manage_preferences_component.yml
@@ -1,0 +1,8 @@
+en:
+  candidate_interface:
+    manage_preferences_component:
+      title: Sharing your application details
+      body_opt_in: You are sharing your application details with training providers that you have not submitted an application to.
+      body_opt_out: You are not sharing your application details with training providers that you have not submitted an application to.
+      read_about_sharing_details: Read about how sharing your application details works
+      change_sharing_details: Change your sharing and location settings

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -3,6 +3,14 @@ en:
     publish_preferences:
       create:
         success: You are sharing your application details with providers you have not applied to
+      show:
+        title: Check your application sharing preferences
+        share_information: Do you want to share your application details with other training providers?
+        preferred_locations: Preferred locations
+        dynamic_locations: Update my location preferences when I apply to a new course
+        change: Change
+        submit: Submit preferences
+        location: Within %{radius} miles of %{location}
     preferences:
       show: Check your application sharing preferences
       share_question: Do you want to share your application details with other training providers?
@@ -31,6 +39,10 @@ en:
         dynamic_locations: Update my location preferences when I apply to a new course
         change: Change
         submit: Submit preferences
+      create:
+        opt_out_message: You are not sharing your application details with providers you have not applied to
+      update:
+        opt_out_message: You are not sharing your application details with providers you have not applied to
       form:
         title: Do you want to make your application details visible to other training providers?
         body: When you have no applications that are waiting for a decision from a provider, other providers will be able to see your application details and invite you to apply to their courses.

--- a/config/locales/candidate_interface/share_details.yml
+++ b/config/locales/candidate_interface/share_details.yml
@@ -1,0 +1,11 @@
+en:
+  candidate_interface:
+    application_choices:
+      index:
+        share_title: Sharing your application details
+        share_body: You are sharing your application details with training providers that you have not submitted an application to.
+        change_share: Change your sharing and location settings
+        how_sharing_works: Read about how sharing your application details works
+    share_details:
+      index:
+        title: Increase your chances of success by sharing your application details

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -16,6 +16,8 @@ namespace :candidate_interface, path: '/candidate' do
 
   resources :account_recovery_requests, only: %i[new create], path: 'account-recovery-requests'
 
+  resources :share_details, only: :index, path: 'share-details'
+
   resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in'
   resources :draft_preferences, only: %i[show update], path: 'preferences' do
     resources :publish_preferences, only: %i[create], path: 'publish-preferences'

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -20,7 +20,7 @@ namespace :candidate_interface, path: '/candidate' do
 
   resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in'
   resources :draft_preferences, only: %i[show update], path: 'preferences' do
-    resources :publish_preferences, only: %i[create], path: 'publish-preferences'
+    resource :publish_preferences, only: %i[show create], path: 'publish-preferences'
     resources :location_preferences, path: 'location-preferences'
   end
 

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
     context 'when candidate preference feature flag is not enabled' do
       it 'renders the component' do
+        FeatureFlag.deactivate(:candidate_preferences)
         application_form = create(:application_form, :with_accepted_offer)
 
         component = described_class.new(current_candidate: application_form.candidate, application_form:)

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  describe '#render' do
+    context 'when candidate preference feature flag is enabled' do
+      it 'renders the component' do
+        FeatureFlag.activate(:candidate_preferences)
+        application_form = create(:application_form, :with_accepted_offer)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).not_to be_blank
+      end
+    end
+
+    context 'when candidate preference feature flag is not enabled' do
+      it 'renders the component' do
+        application_form = create(:application_form, :with_accepted_offer)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).to be_blank
+      end
+    end
+
+    context 'when candidate preference feature flag is enabled but no sent applications' do
+      it 'renders the component' do
+        FeatureFlag.activate(:candidate_preferences)
+        application_form = create(:application_form)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).to be_blank
+      end
+    end
+  end
+
+  describe '#pool_opt_in?' do
+    it 'returns true when candidate has opted in' do
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        candidate:,
+      )
+      application_form = build(:application_form)
+
+      component = described_class.new(current_candidate: candidate, application_form:)
+      expect(component.pool_opt_in?).to be true
+    end
+
+    it 'returns false when candidate has opted out' do
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_out',
+        status: 'published',
+        candidate:,
+      )
+      application_form = build(:application_form)
+
+      component = described_class.new(current_candidate: candidate, application_form:)
+      expect(component.pool_opt_in?).to be false
+    end
+  end
+
+  describe '#path_to_change_preferences' do
+    it 'returns the published show path if the candidate has a published preference' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      preference = create(
+        :candidate_preference,
+        status: 'published',
+        candidate:,
+      )
+      application_form = create(:application_form, :with_accepted_offer)
+
+      render_inline(
+        described_class.new(current_candidate: candidate, application_form:),
+      )
+
+      expect(page).to have_link(
+        'Change your sharing and location settings',
+        href: candidate_interface_draft_preference_publish_preferences_path(preference),
+      )
+    end
+
+    it 'returns the new opt in path if the candidate does not have a published preference' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        status: 'draft',
+        candidate:,
+      )
+      application_form = create(:application_form, :with_accepted_offer)
+
+      render_inline(
+        described_class.new(current_candidate: candidate, application_form:),
+      )
+
+      expect(page).to have_link(
+        'Change your sharing and location settings',
+        href: new_candidate_interface_pool_opt_in_path,
+      )
+    end
+  end
+end

--- a/spec/components/candidate_interface/share_details_component_spec.rb
+++ b/spec/components/candidate_interface/share_details_component_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ShareDetailsComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  describe '#render' do
+    context 'when candidate has published preference' do
+      it 'renders the component with continue link to published preference show' do
+        candidate = create(:candidate)
+        preference = create(
+          :candidate_preference,
+          candidate:,
+          status: 'published',
+        )
+
+        render_inline(described_class.new(candidate))
+        expected_path = candidate_interface_draft_preference_publish_preferences_path(preference)
+
+        expect(page).to have_button('Continue')
+        expect(page).to have_css("form[action='#{expected_path}']")
+      end
+    end
+
+    context 'when candidate has no published preference' do
+      it 'renders the component with continue link new pool opt in' do
+        candidate = create(:candidate)
+        _preference = create(
+          :candidate_preference,
+          candidate:,
+          status: 'draft',
+        )
+
+        render_inline(described_class.new(candidate))
+        expected_path = new_candidate_interface_pool_opt_in_path
+
+        expect(page).to have_button('Continue')
+        expect(page).to have_css("form[action='#{expected_path}']")
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -48,13 +48,39 @@ RSpec.describe CandidateInterface::PoolOptInsForm, type: :model do
       end
     end
 
+    context 'when creating a preference to opt out' do
+      let(:params) { { pool_status: 'opt_out' } }
+
+      it 'creates a preference and removes any existing published preferences' do
+        existing_published_preference = create(
+          :candidate_preference,
+          candidate: current_candidate,
+          status: 'published',
+        )
+
+        form.save
+
+        preference_record = CandidatePreference.last
+        expect(preference_record.pool_status).to eq('opt_out')
+        expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context 'when updating a preference to opt out' do
       let(:preference) { create(:candidate_preference) }
       let(:params) { { pool_status: 'opt_out' } }
 
-      it 'updates a preference to opt out and publishes the preference' do
+      it 'updates a preference to opt out and publishes the preference and removes existing published ones' do
+        existing_published_preference = create(
+          :candidate_preference,
+          candidate: current_candidate,
+          status: 'published',
+        )
+
         expect { form.save }.to change(preference, :pool_status).from('opt_in').to('opt_out')
           .and change(preference, :status).from('draft').to('published')
+
+        expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/models/candidate_preference_spec.rb
+++ b/spec/models/candidate_preference_spec.rb
@@ -5,4 +5,14 @@ RSpec.describe CandidatePreference do
     it { is_expected.to belong_to(:candidate) }
     it { is_expected.to have_many(:location_preferences).class_name('CandidateLocationPreference') }
   end
+
+  describe '#create_draft_dup' do
+    it 'creates a draft duplication of the preference and associated location_preferences' do
+      candidate_preference = create(:candidate_preference, status: 'published')
+      _location_preferences = create(:candidate_location_preference, candidate_preference:)
+
+      expect { candidate_preference.create_draft_dup }.to change(described_class.draft, :count).by(1)
+        .and change(CandidateLocationPreference, :count).by(1)
+    end
+  end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Candidate do
     it { is_expected.to have_many(:pool_dismissals).dependent(:destroy) }
     it { is_expected.to have_many(:pool_invites).dependent(:destroy) }
     it { is_expected.to have_many(:preferences).dependent(:destroy) }
+    it { is_expected.to have_many(:published_preferences).conditions(status: 'published').dependent(:destroy) }
     it { is_expected.to have_one(:one_login_auth).dependent(:destroy) }
     it { is_expected.to have_one(:account_recovery_request).dependent(:destroy) }
   end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe 'Candidate adds preferences' do
   scenario 'Candidate opts in to find a candidate' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
+    given_i_am_on_the_share_details_page
 
-    visit new_candidate_interface_pool_opt_in_path
+    when_i_click('Continue')
+    then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
     then_i_get_an_error('Select weather to make your application details visible to other training providers')
 
@@ -120,6 +122,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   def then_i_am_redirected_to_application_choices
     expect(page).to have_current_path(candidate_interface_application_choices_path)
+    expect(page).to have_content('You are not sharing your application details with providers you have not applied to')
   end
 
   def then_i_am_redirected_to_opt_in
@@ -208,5 +211,15 @@ RSpec.describe 'Candidate adds preferences' do
 
   def and_feature_flag_is_enabled
     FeatureFlag.activate(:candidate_preferences)
+  end
+
+  def given_i_am_on_the_share_details_page
+    visit candidate_interface_share_details_path
+
+    expect(page).to have_content('Increase your chances of success by sharing your application details')
+  end
+
+  def then_i_am_redirected_to_opt_in_page
+    expect(page).to have_content('Do you want to make your application details visible to other training providers?')
   end
 end

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate edits published preference' do
+  scenario 'Candidate edits share preferences' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click_change_share_preference
+    and_i_choose_not_to_share_my_details
+
+    when_i_click('Continue')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+  end
+
+  scenario 'Candidate edits location_preferences' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click_dynamic_locations
+    and_i_untick_dynamic_locations
+
+    when_i_click('Continue')
+    then_i_am_redirected_to_preference_review_page
+    when_i_click('Submit preferences')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+  end
+
+  def given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
+    @application = create(
+      :application_form,
+      :completed,
+      candidate: @current_candidate,
+    )
+    @choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application,
+    )
+    @existing_candidate_preference = create(
+      :candidate_preference,
+      candidate: @current_candidate,
+      status: 'published',
+    )
+    _location_preferences = create(
+      :candidate_location_preference,
+      candidate_preference: @existing_candidate_preference,
+    )
+  end
+
+  def and_feature_flag_is_enabled
+    FeatureFlag.activate(:candidate_preferences)
+  end
+
+  def given_i_am_on_the_application_choices_page
+    visit candidate_interface_application_choices_path
+  end
+
+  def when_i_click(button)
+    click_link_or_button(button)
+  end
+
+  def then_i_am_redirected_to_preference_review_page
+    expect(page).to have_content('Check your application sharing preferences')
+  end
+
+  def when_i_click_change_share_preference
+    first('a', text: 'Change').click
+  end
+
+  def and_i_choose_not_to_share_my_details
+    choose 'No'
+  end
+
+  def then_i_am_redirected_on_the_application_choices_page
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+  end
+
+  def and_the_candidate_preference_id_is_changed
+    @current_candidate.published_preferences.last != @existing_candidate_preference
+  end
+
+  def when_i_click_dynamic_locations
+    all('a', text: 'Change').last.click
+  end
+
+  def and_i_untick_dynamic_locations
+    uncheck 'Add new locations to my preferences when I apply to new courses'
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe 'Candidate submits the application' do
     then_i_am_on_your_details_page
   end
 
+  scenario 'Candidate views the share details page after submission' do
+    given_the_candidate_preferences_feature_flag_is_activated
+    given_i_am_signed_in_with_one_login
+    when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    when_i_continue_without_editing
+    when_i_click_to_submit_my_application
+    then_i_am_redirected_to_share_details_page
+  end
+
   def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     given_i_have_a_primary_course_choice(application_form_completed: true)
   end
@@ -221,5 +233,16 @@ RSpec.describe 'Candidate submits the application' do
     expect(
       @application_choice.audits.where(user_id: @current_candidate.id).any?,
     ).to be_truthy
+  end
+
+  def given_the_candidate_preferences_feature_flag_is_activated
+    FeatureFlag.activate(:candidate_preferences)
+  end
+
+  def then_i_am_redirected_to_share_details_page
+    expect(page).to have_current_path(candidate_interface_share_details_path)
+
+    expect(page).to have_content('Application submitted')
+    expect(page).to have_content('Increase your chances of success by sharing your application details')
   end
 end


### PR DESCRIPTION
## Context

We need a page to funnel users to add their candidate preferences.

This PR has two parts, adding the share details page and editing a published preference flow.

Please review by commit because of this.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on to the review app and submit an application choice. Add preferences after and then edit the published preferences.


https://github.com/user-attachments/assets/e527467c-1690-43d2-b460-3ed8e8d33e3e



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
