### PR TITLE
Only allow performance reports to run in production

### DIFF
--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -6,6 +6,8 @@ module Publications
     end
 
     def call
+      return unless HostingEnvironment.production?
+
       schedule_national_report
       schedule_provider_report
     end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Clockwork, :clockwork do
 
   context 'when the performance report is out season' do
     before do
-      allow(CycleTimetable).to receive(:current_cycle_week).and_return(2)
+      allow(RecruitmentPerformanceReportTimetable).to receive(:report_season?).and_return(false)
     end
 
     it 'does not run the report scheduler every Monday' do


### PR DESCRIPTION
## Context

The performance reports can only be created in production because of the way big query credentials work. This makes that explicit in the code so we don't get [this sentry error](https://dfe-teacher-services.sentry.io/issues/6488635131/?alert_rule_id=853774&alert_type=issue&notification_uuid=687f0242-3592-4e39-8355-7ef52a35e229&project=1765973&referrer=slack). 

## Changes proposed in this pull request

Early return if not in production when scheduling the reports.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
