### PR TITLE
Do not log error if current generation date is in the future

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -14,6 +14,7 @@ class DetectInvariantsDailyCheck
 
   def detect_if_the_monthly_statistics_has_not_run
     return unless HostingEnvironment.production?
+    return if MonthlyStatisticsTimetable.current_generation_date.after? Time.zone.now
 
     latest_monthly_report = Publications::MonthlyStatistics::MonthlyStatisticsReport.last
 


### PR DESCRIPTION
## Context

We received this false alarm from [Sentry today](https://dfe-teacher-services.sentry.io/issues/6451100276/?alert_rule_id=853774&alert_type=issue&notification_uuid=82f1a5f9-12a2-4953-978f-7fa55627e65a&project=1765973&referrer=slack).

It is because the `.current_generation_date` is actually in the future -- there are some real issues with how the `MonthlyStatisticsTimetable` works, but that is beyond the scope of this fix.

## Changes proposed in this pull request

For now, just not logging an error if the `current_generation_date`. In the future, we should probably have a serious look at this class. 

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
