### PR TITLE
Candidate preferences form improvements

### DIFF
--- a/app/forms/candidate_interface/preferences_form.rb
+++ b/app/forms/candidate_interface/preferences_form.rb
@@ -4,8 +4,6 @@ class CandidateInterface::PreferencesForm
   attr_accessor :dynamic_location_preferences
   attr_reader :preference
 
-  validate :location_preferences_presence
-
   def initialize(preference:, params: {})
     @preference = preference
     super(params)
@@ -21,16 +19,6 @@ class CandidateInterface::PreferencesForm
   end
 
   def save
-    return if invalid?
-
     preference.update!(dynamic_location_preferences:)
-  end
-
-private
-
-  def location_preferences_presence
-    if preference.location_preferences.blank?
-      errors.add(:base, :location_preferences_blank)
-    end
   end
 end

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -16,8 +16,12 @@
         <% row.with_key { t('.preferred_locations') } %>
         <% row.with_value do %>
           <%= govuk_list do %>
-            <% @preference.location_preferences.each do |location| %>
-              <%= tag.li t('.location', radius: location.within, location: location.name) %>
+            <% if @preference.location_preferences.blank? %>
+              <p class="govuk-body"><%= t('.no_location_preferences') %> </p>
+            <% else %>
+              <% @preference.location_preferences.each do |location| %>
+                <%= tag.li t('.location', radius: location.within, location: location.name) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -15,36 +15,46 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border' }) do |table| %>
-        <% table.with_head do |head| %>
-          <% head.with_row do |row| %>
-            <%= row.with_cell(text: t('.location')) %>
-            <%= row.with_cell(text: t('.distance_from_location')) %>
-          <% end %>
-        <% end %>
+      <% if @location_preferences.blank? %>
+        <p class="govuk-body"><%= t('.no_location_preferences') %></p>
 
-        <% table.with_body do |body| %>
-          <% @location_preferences.each_with_index do |location, index| %>
-            <% body.with_row do |row| %>
-              <%= row.with_cell(text: location.name) %>
-
-              <%= row.with_cell(text: location.within) %>
-              <%= row.with_cell do %>
-                <%= govuk_link_to t('.change'), edit_candidate_interface_draft_preference_location_preference_path(@preference, location) %>
-              <% end %>
-              <%= row.with_cell do %>
-                <%= govuk_link_to t('.remove'), candidate_interface_draft_preference_location_preference_path(@preference, location) %>
-              <% end %>
+        <%= govuk_button_link_to(
+          t('.add_another_location'),
+          new_candidate_interface_draft_preference_location_preference_path(@preference),
+          secondary: true,
+        ) %>
+      <% else %>
+        <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border' }) do |table| %>
+          <% table.with_head do |head| %>
+            <% head.with_row do |row| %>
+              <%= row.with_cell(text: t('.location')) %>
+              <%= row.with_cell(text: t('.distance_from_location')) %>
             <% end %>
           <% end %>
 
-          <% body.with_row do |row| %>
-            <%= row.with_cell do %>
-              <%= govuk_button_link_to(
-                t('.add_another_location'),
-                new_candidate_interface_draft_preference_location_preference_path(@preference),
-                secondary: true,
-              ) %>
+          <% table.with_body do |body| %>
+            <% @location_preferences.each_with_index do |location, index| %>
+              <% body.with_row do |row| %>
+                <%= row.with_cell(text: location.name) %>
+
+                <%= row.with_cell(text: location.within) %>
+                <%= row.with_cell do %>
+                  <%= govuk_link_to t('.change'), edit_candidate_interface_draft_preference_location_preference_path(@preference, location) %>
+                <% end %>
+                <%= row.with_cell do %>
+                  <%= govuk_link_to t('.remove'), candidate_interface_draft_preference_location_preference_path(@preference, location) %>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <% body.with_row do |row| %>
+              <%= row.with_cell do %>
+                <%= govuk_button_link_to(
+                  t('.add_another_location'),
+                  new_candidate_interface_draft_preference_location_preference_path(@preference),
+                  secondary: true,
+                ) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -16,8 +16,12 @@
         <% row.with_key { t('.preferred_locations') } %>
         <% row.with_value do %>
           <%= govuk_list do %>
-            <% @preference.location_preferences.each do |location| %>
-              <%= tag.li t('.location', radius: location.within, location: location.name) %>
+            <% if @preference.location_preferences.blank? %>
+              <p class="govuk-body"><%= t('.no_location_preferences') %> </p>
+            <% else %>
+              <% @preference.location_preferences.each do |location| %>
+                <%= tag.li t('.location', radius: location.within, location: location.name) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -11,6 +11,7 @@ en:
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
+        no_location_preferences: You have no location preferences
     preferences:
       show: Check your application sharing preferences
       share_question: Do you want to share your application details with other training providers?
@@ -27,6 +28,7 @@ en:
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
+        no_location_preferences: You have no location preferences
     pool_opt_ins:
       new:
         title: Do you want to make your application details visible to other training providers?
@@ -57,6 +59,7 @@ en:
         update_location_preferences: Add new locations to my preferences when I apply to new courses
         remove: Remove
         add_another_location: Add another location
+        no_location_preferences: You have no location preferences
       new:
         title: Add a location
         submit_text: Add location

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -46,6 +46,26 @@ RSpec.describe CandidateInterface::PoolOptInsForm, type: :model do
         expect(preference_record.pool_status).to eq('opt_in')
         expect(preference_record.location_preferences.count).to eq(2)
       end
+
+      context 'when creating a for an international candidate' do
+        let(:application_form) do
+          create(
+            :application_form,
+            :international_address,
+            :completed,
+            candidate: current_candidate,
+          )
+        end
+
+        it 'creates a preference and adds location preferences only for the application choices, not the home address' do
+          expect { form.save }.to change(CandidatePreference, :count).by(1)
+            .and change { CandidateLocationPreference.count }.by(1)
+
+          preference_record = CandidatePreference.last
+          expect(preference_record.pool_status).to eq('opt_in')
+          expect(preference_record.location_preferences.count).to eq(1)
+        end
+      end
     end
 
     context 'when creating a preference to opt out' do

--- a/spec/forms/candidate_interface/preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/preferences_form_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe CandidateInterface::PreferencesForm, type: :model do
   end
   let(:params) { { dynamic_location_preferences: true } }
 
-  describe 'validations' do
-    context 'when there are no location preferences' do
-      it 'adds location preferences blank error' do
-        expect(form.valid?).to be_falsey
-        expect(form.errors[:base]).to eq(['Add location preferences'])
-      end
-    end
-  end
-
   describe '.build_from_preferences' do
     it 'builds the form from a preference' do
       form_object = described_class.build_from_preference(

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate adds preferences' do
+  let(:provider) { create(:provider) }
   let(:location_preferences) { [home_location, choice_location] }
   let(:home_location) { { within: 10, name: 'BN1 1AA' } }
   let(:choice_location) { { within: 10, name: 'BN1 2AA' } }
   let(:new_location) { { within: 10, name: 'BN1 3AA' } }
   let(:updated_location) { { within: 20, name: 'BN1 4AA' } }
+  let(:new_locations) { [home_location, choice_location, new_location] }
+  let(:updated_locations) { [home_location, choice_location, updated_location] }
 
   after { FeatureFlag.deactivate(:candidate_preferences) }
 
@@ -30,31 +33,53 @@ RSpec.describe 'Candidate adds preferences' do
     when_i_click('Continue')
     then_i_am_redirected_to_location_preferences(location_preferences)
 
-    when_i_remove_all_locations
-    then_i_am_redirected_to_location_preferences([])
-    when_i_click('Continue')
-    then_i_get_an_error('Add location preferences')
-
     when_i_click('Add another location')
     and_i_input_a_location
     when_i_click('Add location')
-    then_i_am_redirected_to_location_preferences([new_location])
+    then_i_am_redirected_to_location_preferences(new_locations)
 
-    when_i_click('Change')
+    when_i_click_change_on_the_last_location
     and_i_edit_a_location
     when_i_click('Update location')
-    then_i_am_redirected_to_location_preferences([updated_location])
+    then_i_am_redirected_to_location_preferences(updated_locations)
 
     when_i_check_dynamic_locations
     when_i_click('Continue')
-    then_i_am_redirected_to_review_page([updated_location])
+    then_i_am_redirected_to_review_page
 
     when_i_click('Back')
-    then_i_am_redirected_to_location_preferences([updated_location])
+    then_i_am_redirected_to_location_preferences(updated_locations)
     and_the_dynamic_locations_is_checked
 
     when_i_click('Continue')
-    then_i_am_redirected_to_review_page([updated_location])
+    then_i_am_redirected_to_review_page
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_application_choices_with_success_message
+  end
+
+  scenario 'Candidate opts in to find a candidate without any locations' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Continue')
+    then_i_am_redirected_to_opt_in_page
+    when_i_click('Continue')
+    then_i_get_an_error('Select weather to make your application details visible to other training providers')
+
+    and_i_opt_in_to_find_a_candidate
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_remove_all_locations
+    then_i_am_redirected_to_location_preferences_without_locations
+
+    when_i_check_dynamic_locations
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_review_page_without_locations
 
     when_i_click('Submit preferences')
     then_i_am_redirected_application_choices_with_success_message
@@ -76,13 +101,12 @@ RSpec.describe 'Candidate adds preferences' do
     @application = create(
       :application_form,
       :completed,
-      postcode: home_location,
+      postcode: home_location[:name],
       candidate: @current_candidate,
     )
-    provider = create(:provider)
     site = create(
       :site,
-      postcode: choice_location,
+      postcode: choice_location[:name],
       provider:,
     )
     course = create(:course, provider:)
@@ -122,6 +146,11 @@ RSpec.describe 'Candidate adds preferences' do
     end
   end
 
+  def then_i_am_redirected_to_location_preferences_without_locations
+    expect(page).to have_content('Location Preferences')
+    expect(page).to have_content('You have no location preferences')
+  end
+
   def then_i_am_redirected_to_application_choices
     expect(page).to have_current_path(candidate_interface_application_choices_path)
     expect(page).to have_content('You are not sharing your application details with providers you have not applied to')
@@ -138,12 +167,14 @@ RSpec.describe 'Candidate adds preferences' do
     check 'Add new locations to my preferences when I apply to new courses'
   end
 
-  def then_i_am_redirected_to_review_page(location_preferences)
+  def then_i_am_redirected_to_review_page
     expect(page).to have_content('Check your application sharing preferences')
 
-    locations_value = location_preferences.map do |location|
-      "Within #{location[:within]} miles of #{location[:name]}"
-    end.join(' ')
+    locations = [
+      "Within #{home_location[:within]} miles of #{home_location[:name]}",
+      "Within #{choice_location[:within]} miles of #{choice_location[:name]} (#{provider.name})",
+      "Within #{updated_location[:within]} miles of #{updated_location[:name]}",
+    ].join(' ')
 
     summary_list = [
       {
@@ -152,7 +183,7 @@ RSpec.describe 'Candidate adds preferences' do
       },
       {
         label: 'Preferred locations',
-        value: locations_value,
+        value: locations,
       },
       {
         label: 'Update my location preferences when I apply to a new course',
@@ -166,6 +197,11 @@ RSpec.describe 'Candidate adds preferences' do
         expect(page).to have_content(item[:value])
       end
     end
+  end
+
+  def then_i_am_redirected_to_review_page_without_locations
+    expect(page).to have_content('Check your application sharing preferences')
+    expect(page).to have_content('You have no location preferences')
   end
 
   def and_the_dynamic_locations_is_checked
@@ -223,5 +259,9 @@ RSpec.describe 'Candidate adds preferences' do
 
   def then_i_am_redirected_to_opt_in_page
     expect(page).to have_content('Do you want to make your application details visible to other training providers?')
+  end
+
+  def when_i_click_change_on_the_last_location
+    all('a', text: 'Change').last.click
   end
 end


### PR DESCRIPTION
## Context

A few changes to the candidate flow. We will allow candidate to not have
any location preferences. This will be treated as an anywhere in the
country preference.

Other changes:
- Added provider name next to location preferences from application
  choices
- Don't add home location preference for international candidates

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review. As an optional, you can go on review page and add preferences without location preferences.


https://github.com/user-attachments/assets/b6c629dc-0fd4-4ae2-aba8-a9ba28eb2e0a



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
