### PR TITLE
Improve location preferences form and location suggestions

### DIFF
--- a/app/frontend/packs/controllers/location_autocomplete_controller.js
+++ b/app/frontend/packs/controllers/location_autocomplete_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
   static targets = ['input']
   static values = {
     path: String,
-    minLength: { type: Number, default: 3 },
+    minLength: { type: Number, default: 2 },
     debounce: { type: Number, default: 200 }
   }
 

--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -25,5 +25,5 @@
 }
 
 .location-autocomplete-input .autocomplete__wrapper {
-  width: 25%;
+ width: 50%;
 }

--- a/app/lib/google_maps_api/client.rb
+++ b/app/lib/google_maps_api/client.rb
@@ -22,7 +22,7 @@ module GoogleMapsAPI
           language: 'en',
           input: query,
           components: 'country:uk',
-          types: 'geocode',
+          types: '(regions)',
         },
       )
 

--- a/app/views/candidate_interface/location_preferences/_form.html.erb
+++ b/app/views/candidate_interface/location_preferences/_form.html.erb
@@ -3,7 +3,7 @@
 
   <h1 class="govuk-heading-l"><%= title %></h1>
 
-  <%= f.govuk_text_field :within, suffix_text: t('.miles'), class: 'govuk-!-width-one-quarter', label: { text: t('.within'), size: 'm' } %>
+  <%= f.govuk_text_field :within, type: :number, suffix_text: t('.miles'), class: 'govuk-!-width-one-quarter', label: { text: t('.within'), size: 'm' } %>
 
   <div class="location-autocomplete-input">
     <%= f.govuk_text_field(

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -88,8 +88,12 @@ en:
         candidate_interface/location_preferences_form:
           attributes:
             within:
-              blank: Add a location radius
+              blank: Enter a location radius
+              greater_than_or_equal_to: The location radius must be 0 miles or more
+              not_a_number: Enter a number for location radius
             name:
-              blank: Add a location name
-            base:
-              invalid_location: Enter a real city, town or postcode
+              blank: Enter a city, town or postcode
+              invalid_location: City, town or postcode must be in the United Kingdom
+              too_short: The city, town or postcode must be %{count} characters or more
+
+

--- a/spec/lib/google_maps_api/client_spec.rb
+++ b/spec/lib/google_maps_api/client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GoogleMapsAPI::Client do
   describe '#autocomplete' do
     let(:query) { 'London' }
     let(:autocomplete_api_path) do
-      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&input=#{query}&key=#{api_key}&language=en&types=geocode"
+      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&input=#{query}&key=#{api_key}&language=en&types=(regions)"
     end
     let(:body) { Pathname.new(Rails.root.join('spec/examples/google_maps_api/autocomplete_london.json')).read }
 

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -6,9 +6,20 @@ RSpec.describe 'Candidate adds preferences' do
   let(:home_location) { { within: 10, name: 'BN1 1AA' } }
   let(:choice_location) { { within: 10, name: 'BN1 2AA' } }
   let(:new_location) { { within: 10, name: 'BN1 3AA' } }
-  let(:updated_location) { { within: 20, name: 'BN1 4AA' } }
+  let(:updated_location) { { within: 20, name: 'BN1 3AA' } }
   let(:new_locations) { [home_location, choice_location, new_location] }
   let(:updated_locations) { [home_location, choice_location, updated_location] }
+  let(:client) { instance_double(GoogleMapsAPI::Client) }
+  let(:api_response) do
+    [
+      { name: 'BN1 3AA', place_id: 'test_id' },
+    ]
+  end
+
+  before do
+    allow(GoogleMapsAPI::Client).to receive(:new).and_return(client)
+    allow(client).to receive(:autocomplete).and_return(api_response)
+  end
 
   after { FeatureFlag.deactivate(:candidate_preferences) }
 


### PR DESCRIPTION
## Context

This validates the location imputed by the user in location preferences.

Determining what's a real location and what's not is hard.

Geocoder.search can return places that are not actually real locations.
But the LocationSuggestions service uses the autocomplete google api.

This returns real places. So we can use this endpoint to validate the
user input.

We take the first suggestion the user imputed and save it in the
database. This means that if the user Added 'M20' the value in the DB
will be Manchester M20.

If the user imputed 123 there won't be any suggestions so we'll show an
error.

This way we can guarentee that whatever location is ending up in the
database is a real location and has lat/long values.

We use the place_id from the location to get the coordinates

I think we can get away with this approach because we cache the sugestion results. So most of the time we won't actually make 2 API calls but hit the cache of the autocomplete endpoint. This is because the cache will be warmed up when the user types in more than 1 character in the location field.


The PR also includes other cosmetic changes.


## Changes proposed in this pull request


## Guidance to review



https://github.com/user-attachments/assets/568dc38c-1c76-45cb-831e-3eb34b2f715f




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
