### PR TITLE
[786] Move application form phone number from blocked to hidden

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -143,6 +143,7 @@ shared:
     - path
     - updated_at
   application_forms:
+    - phone_number
     - first_name
     - last_name
     - adviser_status

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -226,7 +226,6 @@
   - safeguarding_concerns
   - relationship_correction
   :application_forms:
-  - phone_number
   - address_line1
   - address_line2
   - address_line3

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,6 +1,7 @@
 ---
 shared:
   application_forms:
+    - phone_number
     - support_reference
     - candidate_id
     - first_name


### PR DESCRIPTION
## Context

At the request of the analytics team, we are moving the application-form `phone_number` field from `blocked` to hidden. It will require a backfill after merging

## Changes proposed in this pull request

move `phone_number` from one analytics file to another.

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [x] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
