### PR TITLE
Stop opted out candidates from viewing the preferences review page

### DIFF
--- a/app/components/candidate_interface/manage_preferences_component.rb
+++ b/app/components/candidate_interface/manage_preferences_component.rb
@@ -17,10 +17,12 @@ class CandidateInterface::ManagePreferencesComponent < ViewComponent::Base
 private
 
   def path_to_change_preferences
-    if current_candidate.published_preferences.any?
-      candidate_interface_draft_preference_publish_preferences_path(current_candidate.published_preferences.last)
-    else
+    if current_candidate.published_preferences.last&.opt_out?
+      edit_candidate_interface_pool_opt_in_path(current_candidate.published_preferences.last)
+    elsif current_candidate.published_preferences.blank?
       new_candidate_interface_pool_opt_in_path
+    else
+      candidate_interface_draft_preference_publish_preferences_path(current_candidate.published_preferences.last)
     end
   end
 end

--- a/app/components/candidate_interface/share_details_component.rb
+++ b/app/components/candidate_interface/share_details_component.rb
@@ -8,12 +8,12 @@ class CandidateInterface::ShareDetailsComponent < ViewComponent::Base
 private
 
   def path_to_continue
-    if current_candidate.published_preferences.any?
-      candidate_interface_draft_preference_publish_preferences_path(
-        current_candidate.published_preferences.last,
-      )
-    else
+    if current_candidate.published_preferences.last&.opt_out?
+      edit_candidate_interface_pool_opt_in_path(current_candidate.published_preferences.last)
+    elsif current_candidate.published_preferences.blank?
       new_candidate_interface_pool_opt_in_path
+    else
+      candidate_interface_draft_preference_publish_preferences_path(current_candidate.published_preferences.last)
     end
   end
 end

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -11,7 +11,11 @@ module CandidateInterface
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
       end
 
-      flash[:success] = t('.success')
+      flash[:success] = if @preference.opt_in?
+                          t('.success_opt_in')
+                        else
+                          t('.success_opt_out')
+                        end
       redirect_to candidate_interface_application_choices_path
     end
 

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -2,7 +2,8 @@ en:
   candidate_interface:
     publish_preferences:
       create:
-        success: You are sharing your application details with providers you have not applied to
+        success_opt_in: You are sharing your application details with providers you have not applied to
+        success_opt_out: You are not sharing your application details with providers you have not applied to
       show:
         title: Check your application sharing preferences
         share_information: Do you want to share your application details with other training providers?

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -111,5 +111,28 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
         href: new_candidate_interface_pool_opt_in_path,
       )
     end
+
+    it 'returns the edit opt in path if the published preference is opted out' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      preference = create(
+        :candidate_preference,
+        status: 'published',
+        pool_status: 'opt_out',
+        candidate:,
+      )
+      application_form = create(:application_form, :with_accepted_offer)
+
+      render_inline(
+        described_class.new(current_candidate: candidate, application_form:),
+      )
+
+      expect(page).to have_link(
+        'Change your sharing and location settings',
+        href: edit_candidate_interface_pool_opt_in_path(
+          preference,
+        ),
+      )
+    end
   end
 end

--- a/spec/components/candidate_interface/share_details_component_spec.rb
+++ b/spec/components/candidate_interface/share_details_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::ShareDetailsComponent, type: :component do
     end
 
     context 'when candidate has no published preference' do
-      it 'renders the component with continue link new pool opt in' do
+      it 'renders the component with continue link to new pool opt in' do
         candidate = create(:candidate)
         _preference = create(
           :candidate_preference,
@@ -32,6 +32,26 @@ RSpec.describe CandidateInterface::ShareDetailsComponent, type: :component do
 
         render_inline(described_class.new(candidate))
         expected_path = new_candidate_interface_pool_opt_in_path
+
+        expect(page).to have_button('Continue')
+        expect(page).to have_css("form[action='#{expected_path}']")
+      end
+    end
+
+    context 'when candidate has published preference but opted out' do
+      it 'renders the component with continue link to edit pool opt in' do
+        candidate = create(:candidate)
+        preference = create(
+          :candidate_preference,
+          candidate:,
+          status: 'published',
+          pool_status: 'opt_out',
+        )
+
+        render_inline(described_class.new(candidate))
+        expected_path = edit_candidate_interface_pool_opt_in_path(
+          preference,
+        )
 
         expect(page).to have_button('Continue')
         expect(page).to have_css("form[action='#{expected_path}']")


### PR DESCRIPTION
## Context

We don't really want candidates who opted out of the find a candidate feature to get to the review page of the candidate_preferences.

This commit adds some logic to redirect the user to the edit opt in page if they have a published preference with an opt out option.

Effectively prompting them to opt in to get to the review page.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Optional, go to review, opt out of the find a candidate feature. Come back to edit your candidate preferences.


https://github.com/user-attachments/assets/3dfb77c8-4c62-470c-a9c1-60f3fb47f5b8



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
