### PR TITLE
Dynamic location preferences

### DIFF
--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -1,85 +1,59 @@
-class CandidateInterface::PoolOptInsForm
-  include ActiveModel::Model
-  DEFAULT_RADIUS = 10
+module CandidateInterface
+  class PoolOptInsForm
+    include ActiveModel::Model
+    DEFAULT_RADIUS = 10
 
-  attr_accessor :pool_status
-  attr_reader :current_candidate, :preference
+    attr_accessor :pool_status
+    attr_reader :current_candidate, :preference
 
-  validates :pool_status, presence: true
+    validates :pool_status, presence: true
 
-  def initialize(current_candidate:, preference: nil, params: {})
-    @current_candidate = current_candidate
-    @preference = preference
-    super(params)
-  end
+    def initialize(current_candidate:, preference: nil, params: {})
+      @current_candidate = current_candidate
+      @preference = preference
+      super(params)
+    end
 
-  def self.build_from_preference(current_candidate:, preference:)
-    new(
-      current_candidate:,
-      preference:,
-      params: {
-        pool_status: preference.pool_status,
-      },
-    )
-  end
+    def self.build_from_preference(current_candidate:, preference:)
+      new(
+        current_candidate:,
+        preference:,
+        params: {
+          pool_status: preference.pool_status,
+        },
+      )
+    end
 
-  def save
-    return if invalid?
+    def save
+      return if invalid?
 
-    if preference.present?
-      ActiveRecord::Base.transaction do
-        preference.update!(pool_status: pool_status)
+      if preference.present?
+        ActiveRecord::Base.transaction do
+          preference.update!(pool_status: pool_status)
 
-        if preference.opt_out?
-          preference.published!
-          current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
-        end
-
-        true
-      end
-    else
-      ActiveRecord::Base.transaction do
-        @preference = current_candidate.preferences.create(pool_status:)
-
-        if @preference.opt_out?
-          ActiveRecord::Base.transaction do
-            # We publish the preference because if they opt out it's the end of the journey
-            @preference.published!
+          if preference.opt_out?
+            preference.published!
             current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
           end
-        else
-          add_default_location_preferences
+
+          true
         end
+      else
+        ActiveRecord::Base.transaction do
+          @preference = current_candidate.preferences.create(pool_status:)
 
-        true
-      end
-    end
-  end
+          if @preference.opt_out?
+            ActiveRecord::Base.transaction do
+              # We publish the preference because if they opt out it's the end of the journey
+              @preference.published!
+              current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
+            end
+          else
+            LocationPreferences.add_default_location_preferences(preference: @preference)
+          end
 
-private
-
-  def add_default_location_preferences
-    application_form = current_candidate.current_cycle_application_form
-    sites = application_form.application_choices.map(&:site)
-
-    ActiveRecord::Base.transaction do
-      unless application_form.international_address?
-        preference.location_preferences.create!(
-          name: application_form.postcode,
-          within: DEFAULT_RADIUS,
-          latitude: application_form.geocode.first,
-          longitude: application_form.geocode.last,
-        )
-      end
-
-      sites.each do |site|
-        preference.location_preferences.create!(
-          name: site.postcode,
-          within: DEFAULT_RADIUS,
-          latitude: site.latitude,
-          longitude: site.longitude,
-          provider_id: site.provider_id,
-        )
+          true
+        end
       end
     end
   end

--- a/app/lib/google_maps_api/client.rb
+++ b/app/lib/google_maps_api/client.rb
@@ -22,6 +22,7 @@ module GoogleMapsAPI
           language: 'en',
           input: query,
           components: 'country:uk',
+          region: 'uk',
           types: '(regions)',
         },
       )

--- a/app/services/candidate_interface/location_preferences.rb
+++ b/app/services/candidate_interface/location_preferences.rb
@@ -1,0 +1,60 @@
+module CandidateInterface
+  class LocationPreferences
+    DEFAULT_RADIUS = 10
+    attr_reader :preference, :application_choice
+
+    def initialize(preference:, application_choice: nil)
+      @preference = preference
+      @application_choice = application_choice
+    end
+
+    def self.add_default_location_preferences(preference:)
+      new(preference:).add_default_location_preferences
+    end
+
+    def add_default_location_preferences
+      application_form = preference.candidate.current_cycle_application_form
+      sites = application_form.application_choices.map(&:site)
+
+      ActiveRecord::Base.transaction do
+        unless application_form.international_address?
+          preference.location_preferences.create!(
+            name: application_form.postcode,
+            within: DEFAULT_RADIUS,
+            latitude: application_form.geocode.first,
+            longitude: application_form.geocode.last,
+          )
+        end
+
+        sites.each do |site|
+          preference.location_preferences.create!(
+            name: site.postcode,
+            within: DEFAULT_RADIUS,
+            latitude: site.latitude,
+            longitude: site.longitude,
+            provider_id: site.provider_id,
+          )
+        end
+      end
+    end
+
+    def self.add_dynamic_location(preference:, application_choice:)
+      new(preference:, application_choice:).add_dynamic_location
+    end
+
+    def add_dynamic_location
+      return if preference.nil? || preference.opt_out?
+
+      site = application_choice.site
+      return if preference.location_preferences.pluck(:name).include?(site.postcode)
+
+      preference.location_preferences.create!(
+        name: site.postcode,
+        within: DEFAULT_RADIUS,
+        latitude: site.latitude,
+        longitude: site.longitude,
+        provider_id: site.provider_id,
+      )
+    end
+  end
+end

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -24,6 +24,11 @@ module CandidateInterface
 
         SendNewApplicationEmailToProvider.new(application_choice:).call
         CandidateMailer.application_choice_submitted(application_choice).deliver_later
+
+        LocationPreferences.add_dynamic_location(
+          preference: application_form.candidate.published_preferences.last,
+          application_choice:,
+        )
       end
     end
 

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -1,106 +1,90 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::PoolOptInsForm, type: :model do
-  subject(:form) do
-    described_class.new(current_candidate:, preference:, params:)
-  end
-
-  let(:current_candidate) { create(:candidate) }
-  let(:preference) { nil }
-  let(:params) { { pool_status: 'opt_in' } }
-  let(:application_form) do
-    create(:application_form, :completed, candidate: current_candidate)
-  end
-  let!(:application_choice) do
-    create(:application_choice, :awaiting_provider_decision, application_form:)
-  end
-
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:pool_status) }
-  end
-
-  describe '.build_from_preferences' do
-    let(:preference) { create(:candidate_preference) }
-
-    it 'builds the form from a preference' do
-      form_object = described_class.build_from_preference(
-        current_candidate:,
-        preference:,
-      )
-
-      expect(form_object).to have_attributes(
-        current_candidate:,
-        preference:,
-        pool_status: 'opt_in',
-      )
+module CandidateInterface
+  RSpec.describe CandidateInterface::PoolOptInsForm, type: :model do
+    subject(:form) do
+      described_class.new(current_candidate:, preference:, params:)
     end
-  end
 
-  describe '#save' do
-    context 'when creating a preference' do
-      it 'creates a preference and adds location preferences' do
-        expect { form.save }.to change(CandidatePreference, :count).by(1)
-          .and change { CandidateLocationPreference.count }.by(2)
+    let(:current_candidate) { create(:candidate) }
+    let(:preference) { nil }
+    let(:params) { { pool_status: 'opt_in' } }
+    let(:application_form) do
+      create(:application_form, :completed, candidate: current_candidate)
+    end
+    let!(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, application_form:)
+    end
 
-        preference_record = CandidatePreference.last
-        expect(preference_record.pool_status).to eq('opt_in')
-        expect(preference_record.location_preferences.count).to eq(2)
+    describe 'validations' do
+      it { is_expected.to validate_presence_of(:pool_status) }
+    end
+
+    describe '.build_from_preferences' do
+      let(:preference) { create(:candidate_preference) }
+
+      it 'builds the form from a preference' do
+        form_object = described_class.build_from_preference(
+          current_candidate:,
+          preference:,
+        )
+
+        expect(form_object).to have_attributes(
+          current_candidate:,
+          preference:,
+          pool_status: 'opt_in',
+        )
       end
+    end
 
-      context 'when creating a for an international candidate' do
-        let(:application_form) do
-          create(
-            :application_form,
-            :international_address,
-            :completed,
-            candidate: current_candidate,
-          )
-        end
+    describe '#save' do
+      context 'when creating a preference' do
+        it 'creates a preference' do
+          allow(LocationPreferences).to receive(:add_default_location_preferences)
+            .and_return(nil)
 
-        it 'creates a preference and adds location preferences only for the application choices, not the home address' do
           expect { form.save }.to change(CandidatePreference, :count).by(1)
-            .and change { CandidateLocationPreference.count }.by(1)
 
           preference_record = CandidatePreference.last
           expect(preference_record.pool_status).to eq('opt_in')
-          expect(preference_record.location_preferences.count).to eq(1)
+          expect(LocationPreferences).to have_received(:add_default_location_preferences)
         end
       end
-    end
 
-    context 'when creating a preference to opt out' do
-      let(:params) { { pool_status: 'opt_out' } }
+      context 'when creating a preference to opt out' do
+        let(:params) { { pool_status: 'opt_out' } }
 
-      it 'creates a preference and removes any existing published preferences' do
-        existing_published_preference = create(
-          :candidate_preference,
-          candidate: current_candidate,
-          status: 'published',
-        )
+        it 'creates a preference and removes any existing published preferences' do
+          existing_published_preference = create(
+            :candidate_preference,
+            candidate: current_candidate,
+            status: 'published',
+          )
 
-        form.save
+          form.save
 
-        preference_record = CandidatePreference.last
-        expect(preference_record.pool_status).to eq('opt_out')
-        expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          preference_record = CandidatePreference.last
+          expect(preference_record.pool_status).to eq('opt_out')
+          expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
-    end
 
-    context 'when updating a preference to opt out' do
-      let(:preference) { create(:candidate_preference) }
-      let(:params) { { pool_status: 'opt_out' } }
+      context 'when updating a preference to opt out' do
+        let(:preference) { create(:candidate_preference) }
+        let(:params) { { pool_status: 'opt_out' } }
 
-      it 'updates a preference to opt out and publishes the preference and removes existing published ones' do
-        existing_published_preference = create(
-          :candidate_preference,
-          candidate: current_candidate,
-          status: 'published',
-        )
+        it 'updates a preference to opt out and publishes the preference and removes existing published ones' do
+          existing_published_preference = create(
+            :candidate_preference,
+            candidate: current_candidate,
+            status: 'published',
+          )
 
-        expect { form.save }.to change(preference, :pool_status).from('opt_in').to('opt_out')
-          .and change(preference, :status).from('draft').to('published')
+          expect { form.save }.to change(preference, :pool_status).from('opt_in').to('opt_out')
+            .and change(preference, :status).from('draft').to('published')
 
-        expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { existing_published_preference.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
     end
   end

--- a/spec/lib/google_maps_api/client_spec.rb
+++ b/spec/lib/google_maps_api/client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GoogleMapsAPI::Client do
   describe '#autocomplete' do
     let(:query) { 'London' }
     let(:autocomplete_api_path) do
-      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&input=#{query}&key=#{api_key}&language=en&types=(regions)"
+      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&region=uk&input=#{query}&key=#{api_key}&language=en&types=(regions)"
     end
     let(:body) { Pathname.new(Rails.root.join('spec/examples/google_maps_api/autocomplete_london.json')).read }
 

--- a/spec/services/candidate_interface/location_preferences_spec.rb
+++ b/spec/services/candidate_interface/location_preferences_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::LocationPreferences do
+  let(:preference) { create(:candidate_preference) }
+  let(:application_form) do
+    create(:application_form, :completed, candidate: preference&.candidate || create(:candidate))
+  end
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+  end
+
+  describe '.add_default_location_preferences' do
+    context 'with UK candidate' do
+      it 'adds default location preferences' do
+        expect { described_class.add_default_location_preferences(preference:) }.to(
+          change(preference.location_preferences, :count).by(2),
+        )
+
+        expect(preference.location_preferences.first.name).to eq(application_form.postcode)
+        expect(preference.location_preferences.last.name).to eq(application_choice.site.postcode)
+      end
+    end
+
+    context 'with international candidate' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :international_address,
+          :completed,
+          candidate: preference.candidate,
+        )
+      end
+
+      it 'adds default location preferences only for the choice' do
+        expect { described_class.add_default_location_preferences(preference:) }.to(
+          change(preference.location_preferences, :count).by(1),
+        )
+
+        expect(preference.location_preferences.last.name).to eq(application_choice.site.postcode)
+      end
+    end
+  end
+
+  describe '.add_dynamic_location' do
+    context 'when preference is opt in' do
+      it 'adds a location preference from application_choice' do
+        expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
+          change(preference.location_preferences, :count).by(1),
+        )
+
+        expect(preference.location_preferences.last.name).to eq(application_choice.site.postcode)
+      end
+    end
+
+    context 'when preference is nil' do
+      let(:preference) { nil }
+
+      it 'does not add a location preference from application_choice' do
+        expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
+          not_change(CandidateLocationPreference, :count),
+        )
+      end
+    end
+
+    context 'when preference is opt out' do
+      let(:preference) { create(:candidate_preference, pool_status: 'opt_out') }
+
+      it 'does not add a location preference from application_choice' do
+        expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
+          not_change(preference.location_preferences, :count),
+        )
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -1,131 +1,147 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::SubmitApplicationChoice do
-  subject(:submit_application) { described_class.new(application_choice).call }
+module CandidateInterface
+  RSpec.describe SubmitApplicationChoice do
+    subject(:submit_application) { described_class.new(application_choice).call }
 
-  let(:application_form) { application_choice.application_form }
+    let(:application_form) { application_choice.application_form }
 
-  describe '#call' do
-    context 'when application is already submitted' do
-      let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+    describe '#call' do
+      context 'when application is already submitted' do
+        let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
 
-      it 'raises error' do
-        expect {
-          submit_application
-        }.to raise_error(
-          CandidateInterface::ApplicationNotReadyToSendError,
-          'Tried to send an application in the awaiting_provider_decision state to a provider',
-        )
-      end
-    end
-
-    context 'when application is unsubmitted' do
-      let(:application_choice) { create(:application_choice, :unsubmitted) }
-
-      it 'updates timestamps relevant to submitting an application' do
-        submitted_at_time = 5.minutes.ago
-        travel_temporarily_to(submitted_at_time) do
-          submit_application
-          expect(application_form.submitted_at).to be_within(1.second).of(submitted_at_time)
-          expect(application_choice.sent_to_provider_at).to be_within(1.second).of(submitted_at_time)
+        it 'raises error' do
+          expect {
+            submit_application
+          }.to raise_error(
+            CandidateInterface::ApplicationNotReadyToSendError,
+            'Tried to send an application in the awaiting_provider_decision state to a provider',
+          )
         end
       end
 
-      it 'does not updated submitted_at for a second application choice' do
-        submit_application
+      context 'when application is unsubmitted' do
+        let(:application_choice) { create(:application_choice, :unsubmitted) }
 
-        new_application_choice = create(:application_choice, :unsubmitted, application_form: application_form)
-        expect {
-          described_class.new(new_application_choice).call
-        }.not_to(change { application_form.reload.submitted_at })
-      end
-
-      it 'updates inactive date for application' do
-        travel_temporarily_to(Time.zone.local(2023, 10, 20)) do
-          submit_application
-          expect(application_choice.reject_by_default_at).to be_within(1.second).of(Time.zone.parse('01 Dec 2023 23:59:59 GMT'))
-          expect(application_choice.reject_by_default_days).to eq 30
+        it 'updates timestamps relevant to submitting an application' do
+          submitted_at_time = 5.minutes.ago
+          travel_temporarily_to(submitted_at_time) do
+            submit_application
+            expect(application_form.submitted_at).to be_within(1.second).of(submitted_at_time)
+            expect(application_choice.sent_to_provider_at).to be_within(1.second).of(submitted_at_time)
+          end
         end
-      end
 
-      it 'updates application choice status' do
-        expect(application_choice).to be_unsubmitted
-        submit_application
-        expect(application_choice).to be_awaiting_provider_decision
-      end
-
-      it 'sets the personal_statement to the value of the application form becoming_a_teacher' do
-        submit_application
-        expect(application_choice.personal_statement).to eq application_form.becoming_a_teacher
-      end
-
-      it 'sends the candidate an email notifying them of their submission' do
-        expect {
+        it 'does not updated submitted_at for a second application choice' do
           submit_application
-        }.to have_enqueued_mail(CandidateMailer, :application_choice_submitted)
-      end
 
-      it 'sends the provider an email notifying them of the submission' do
-        provider = application_choice.course.provider
-        provider.provider_users << create(:provider_user, :with_notifications_enabled)
+          new_application_choice = create(:application_choice, :unsubmitted, application_form: application_form)
+          expect {
+            described_class.new(new_application_choice).call
+          }.not_to(change { application_form.reload.submitted_at })
+        end
 
-        expect {
+        it 'updates inactive date for application' do
+          travel_temporarily_to(Time.zone.local(2023, 10, 20)) do
+            submit_application
+            expect(application_choice.reject_by_default_at).to be_within(1.second).of(Time.zone.parse('01 Dec 2023 23:59:59 GMT'))
+            expect(application_choice.reject_by_default_days).to eq 30
+          end
+        end
+
+        it 'updates application choice status' do
+          expect(application_choice).to be_unsubmitted
           submit_application
-        }.to have_enqueued_mail(ProviderMailer, :application_submitted)
-      end
+          expect(application_choice).to be_awaiting_provider_decision
+        end
 
-      it 'duplicates the work experiences on the application_choice' do
-        work_experience = create(
-          :application_work_experience,
-          experienceable: application_form,
-        )
-
-        expect {
+        it 'sets the personal_statement to the value of the application form becoming_a_teacher' do
           submit_application
-        }.to change(application_choice.work_experiences, :count).by(1)
+          expect(application_choice.personal_statement).to eq application_form.becoming_a_teacher
+        end
 
-        expect(application_choice.work_experiences.pluck(:details)).to eq(
-          [work_experience.details],
-        )
-        expect(application_choice.work_experiences.ids).not_to eq(
-          application_form.application_work_experiences.ids,
-        )
-      end
+        it 'sends the candidate an email notifying them of their submission' do
+          expect {
+            submit_application
+          }.to have_enqueued_mail(CandidateMailer, :application_choice_submitted)
+        end
 
-      it 'duplicates the volunteering experiences on the application_choice' do
-        volunteering_experience = create(
-          :application_volunteering_experience,
-          experienceable: application_form,
-        )
+        it 'sends the provider an email notifying them of the submission' do
+          provider = application_choice.course.provider
+          provider.provider_users << create(:provider_user, :with_notifications_enabled)
 
-        expect {
+          expect {
+            submit_application
+          }.to have_enqueued_mail(ProviderMailer, :application_submitted)
+        end
+
+        it 'duplicates the work experiences on the application_choice' do
+          work_experience = create(
+            :application_work_experience,
+            experienceable: application_form,
+          )
+
+          expect {
+            submit_application
+          }.to change(application_choice.work_experiences, :count).by(1)
+
+          expect(application_choice.work_experiences.pluck(:details)).to eq(
+            [work_experience.details],
+          )
+          expect(application_choice.work_experiences.ids).not_to eq(
+            application_form.application_work_experiences.ids,
+          )
+        end
+
+        it 'duplicates the volunteering experiences on the application_choice' do
+          volunteering_experience = create(
+            :application_volunteering_experience,
+            experienceable: application_form,
+          )
+
+          expect {
+            submit_application
+          }.to change(application_choice.volunteering_experiences, :count).by(1)
+
+          expect(application_choice.volunteering_experiences.pluck(:details)).to eq(
+            [volunteering_experience.details],
+          )
+          expect(application_choice.volunteering_experiences.ids).not_to eq(
+            application_form.application_volunteering_experiences.ids,
+          )
+        end
+
+        it 'duplicates the work history breaks on the application_choice' do
+          work_history_break = create(
+            :application_work_history_break,
+            breakable: application_form,
+          )
+
+          expect {
+            submit_application
+          }.to change(application_choice.work_history_breaks, :count).by(1)
+
+          expect(application_choice.work_history_breaks.pluck(:reason)).to eq(
+            [work_history_break.reason],
+          )
+          expect(application_choice.work_history_breaks.ids).not_to eq(
+            application_form.application_work_history_breaks.ids,
+          )
+        end
+
+        it 'calls LocationPreferences.add_dynamic_location' do
+          allow(LocationPreferences).to receive(:add_dynamic_location).with(
+            preference: nil,
+            application_choice:,
+          ).and_return(nil)
+
           submit_application
-        }.to change(application_choice.volunteering_experiences, :count).by(1)
 
-        expect(application_choice.volunteering_experiences.pluck(:details)).to eq(
-          [volunteering_experience.details],
-        )
-        expect(application_choice.volunteering_experiences.ids).not_to eq(
-          application_form.application_volunteering_experiences.ids,
-        )
-      end
-
-      it 'duplicates the work history breaks on the application_choice' do
-        work_history_break = create(
-          :application_work_history_break,
-          breakable: application_form,
-        )
-
-        expect {
-          submit_application
-        }.to change(application_choice.work_history_breaks, :count).by(1)
-
-        expect(application_choice.work_history_breaks.pluck(:reason)).to eq(
-          [work_history_break.reason],
-        )
-        expect(application_choice.work_history_breaks.ids).not_to eq(
-          application_form.application_work_history_breaks.ids,
-        )
+          expect(LocationPreferences).to have_received(:add_dynamic_location).with(
+            preference: nil,
+            application_choice:,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

When candidates Candidates opt in into the find a candidate feature and
set their location preferences to be updated as they apply for other
courses(:dynamic_locations).

We need to update their location_preferences with these new locations.

This commit adds a LocationPreferences service that can add the default
locations when creating the preferences but also add 1 location to the
candidate preference.

This is called in the submit application choice service.

To not add duplicate locations we check the names off the location
preferences against the new site postcode.

I've also added a small tweak to the autocomplete endpoint, to better scope the locations to the UK.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/1d77f8d7-ef3c-4d08-8b72-e8e660f26d83



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
