### PR TITLE
Add candidate id to find a candidate feature

### DIFF
--- a/app/components/provider_interface/personal_information_component.rb
+++ b/app/components/provider_interface/personal_information_component.rb
@@ -26,6 +26,7 @@ module ProviderInterface
         nationality_row,
         right_to_work_or_study_row,
         residency_details_row,
+        candidate_id_number,
       ].compact
     end
 
@@ -67,6 +68,13 @@ module ProviderInterface
       {
         key: 'Residency details',
         value: FormatResidencyDetailsService.new(application_form:).residency_details_value,
+      }
+    end
+
+    def candidate_id_number
+      {
+        key: 'Candidate number',
+        value: application_form.candidate_id,
       }
     end
 

--- a/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
@@ -15,6 +15,7 @@ module ProviderInterface
           flash[:success] = t(
             '.success',
             candidate: invite.candidate.redacted_full_name_current_cycle,
+            candidate_id: invite.candidate_id,
             course: invite.course.name_code_and_course_provider,
           )
           redirect_to provider_interface_candidate_pool_root_path

--- a/app/frontend/styles/_div.scss
+++ b/app/frontend/styles/_div.scss
@@ -1,0 +1,5 @@
+.flex-content {
+  display: flex;
+
+  column-gap: govuk-spacing(2);
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -68,6 +68,7 @@ $govuk-new-link-styles: true;
 @import "status-indicator";
 @import "summary-card";
 @import "toc";
+@import "div";
 
 // Override utilities
 @import "overrides";

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -21,7 +21,10 @@
         <% @application_forms.each do |application_form| %>
           <%= body.with_row do |row| %>
             <%= row.with_cell do %>
-              <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
+              <div class="flex-content">
+                <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
+                <p class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</p>
+              </div>
             <% end %>
 
             <%= row.with_cell do %>

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render ServiceInformationBanner.new(namespace: :provider) %>
 
+    <h2 class="govuk-heading-m govuk-hint govuk-!-margin-bottom-0"><%= t('.candidate_number', candidate_id: @candidate.id) %></h2>
     <h1 class="govuk-heading-l"><%= @application_form.redacted_full_name %></h1>
     <%= govuk_button_to t('.invite'), new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate), method: :get %>
 

--- a/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('.title') %>
+<% content_for :browser_title, t('.title', candidate_name: @candidate.redacted_full_name_current_cycle) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_candidate_pool_candidate_path(@candidate)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
@@ -8,7 +8,10 @@
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key { t('.candidate') } %>
-        <% row.with_value { @candidate.redacted_full_name_current_cycle } %>
+        <% row.with_value do %>
+          <%= @candidate.redacted_full_name_current_cycle %>
+          <p class="govuk-body govuk-hint"><%= t('.candidate_id', candidate_id: @candidate.id) %> </p>
+        <% end %>
         <% row.with_action(text: t('.change'), href: provider_interface_candidate_pool_root_path(@candidate)) %>
       <% end %>
 

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -19,6 +19,7 @@ en:
           qualifications: Qualifications
           a_level_header: A levels and other qualifications
           a_level_subheader: Details of A levels and other qualifications
+          candidate_number: Candidate %{candidate_id}
       draft_invites:
         new:
           title: Select a course to invite %{candidate_name} to apply to
@@ -29,6 +30,7 @@ en:
           change: Change
           course: Course
           send_invitation: Send invitation
+          candidate_id: Candidate %{candidate_id}
         edit:
           title: Select a course to invite %{candidate_name} to apply to
         form:
@@ -36,7 +38,7 @@ en:
           continue: Continue
       publish_invites:
         create:
-          success: You have invited %{candidate} to apply to %{course}
+          success: You have invited %{candidate} (%{candidate_id}) to apply to %{course}
   activemodel:
     errors:
       models:

--- a/spec/components/provider_interface/personal_information_component_spec.rb
+++ b/spec/components/provider_interface/personal_information_component_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::PersonalInformationComponent do
+  let(:candidate_id) { '1234' }
   let(:application_form) do
     build_stubbed(
       :completed_application_form,
@@ -9,6 +10,7 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
       first_nationality: 'British',
       second_nationality: 'Irish',
       third_nationality: 'Spanish',
+      candidate_id:,
     )
   end
 
@@ -34,6 +36,10 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
 
   it 'renders the candidates nationalities' do
     expect(result.css('.govuk-summary-list__value').text).to include('British, Irish and Spanish')
+  end
+
+  it 'renders the candidate id' do
+    expect(result.css('.govuk-summary-list__value').text).to include(candidate_id)
   end
 
   it 'does not render right to work fields if nationality is British or Irish' do

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -166,7 +166,10 @@ RSpec.describe 'Providers invites candidates' do
       ignore_query: true,
     )
 
-    expect(page).to have_content "You have invited #{@candidate.redacted_full_name_current_cycle} to apply to #{course.name_code_and_course_provider}"
+    expect(page).to have_content(
+      "You have invited #{@candidate.redacted_full_name_current_cycle} (#{@candidate.id}) " \
+      "to apply to #{course.name_code_and_course_provider}",
+    )
   end
 
   def then_i_get_an_error(message)

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -138,11 +138,11 @@ RSpec.describe 'Providers views candidate pool list' do
   def then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
     candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
 
-    expect(candidates).to eq([
-      @rejected_candidate_form.redacted_full_name,
-      @declined_candidate_form.redacted_full_name,
-      @visa_sponsorship_form.redacted_full_name,
-    ])
+    expect(candidates).to contain_exactly(
+      candidate_name(@rejected_candidate_form),
+      candidate_name(@declined_candidate_form),
+      candidate_name(@visa_sponsorship_form),
+    )
   end
 
   def then_i_am_redirected_to_the_applications_page
@@ -167,11 +167,16 @@ RSpec.describe 'Providers views candidate pool list' do
 
   def then_i_expect_to_see_filtered_candidates(application_forms)
     candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
+    candidate_names = application_forms.map { |form| candidate_name(form) }
 
-    expect(candidates).to eq(application_forms.map(&:redacted_full_name))
+    expect(candidates).to match_array(candidate_names)
   end
 
   def when_i_click(button)
     click_link_or_button button
+  end
+
+  def candidate_name(application_form)
+    "#{application_form.redacted_full_name}\n(#{application_form.candidate_id})"
   end
 end


### PR DESCRIPTION
## Context

Providers have raised the point that is hard to keep track of what candidates they invited if the cannot see the name of the candidate.

So exposing the candidate id will help them with this.

Providers using the api already see the candidate id. So they will only be able to identify their own candidates in the find a candidate list

This is not an issue

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We add the candidate id to the find a candidate but also to the show page of an application


https://github.com/user-attachments/assets/39d3ae5d-dcb6-443c-b924-13899e8d9d52



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
