### PR TITLE
Add Adviser Sign Up Interruption page and conditional review controller logic for all sections

### DIFF
--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -1,7 +1,41 @@
 module CandidateInterface
   module AdviserSignUps
     class InterruptionsController < CandidateInterfaceController
-      def show; end
+      def show
+        @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new({ application_form:, proceed_to_request_adviser: params[:proceed_to_request_adviser] })
+        @application_form = application_form
+      end
+
+      def update
+        @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new(adviser_interruption_params.merge(application_form:))
+        @application_form = application_form
+
+        if @adviser_interruption_form.valid?
+          if @adviser_interruption_form.proceed_to_request_adviser?
+            application_form.update(adviser_interruption_responded_yes: true)
+            redirect_to new_candidate_interface_adviser_sign_up_path
+          else
+            application_form.update(adviser_interruption_responded_yes: false)
+            redirect_to_candidate_root
+          end
+        else
+          track_validation_error(@adviser_interruption_form)
+          render :show
+        end
+        binding.pry
+      end
+
+    private
+
+      def application_form
+        current_candidate.current_application
+      end
+
+      def adviser_interruption_params
+        params
+          .fetch(:candidate_interface_adviser_interruption_form, {})
+          .permit(:proceed_to_request_adviser)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  module AdviserSignUps
+    class InterruptionsController < CandidateInterfaceController
+      def show; end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -11,18 +11,17 @@ module CandidateInterface
         @application_form = application_form
 
         if @adviser_interruption_form.valid?
+          @adviser_interruption_form.save
+
           if @adviser_interruption_form.proceed_to_request_adviser?
-            application_form.update(adviser_interruption_responded_yes: true)
             redirect_to new_candidate_interface_adviser_sign_up_path
           else
-            application_form.update(adviser_interruption_responded_yes: false)
             redirect_to_candidate_root
           end
         else
           track_validation_error(@adviser_interruption_form)
           render :show
         end
-        binding.pry
       end
 
     private

--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -3,12 +3,10 @@ module CandidateInterface
     class InterruptionsController < CandidateInterfaceController
       def show
         @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new({ application_form:, proceed_to_request_adviser: params[:proceed_to_request_adviser] })
-        @application_form = application_form
       end
 
       def update
         @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new(adviser_interruption_params.merge(application_form:))
-        @application_form = application_form
 
         if @adviser_interruption_form.valid?
           @adviser_interruption_form.save

--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -8,11 +8,10 @@ module CandidateInterface
       def update
         @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new(adviser_interruption_params.merge(application_form:))
 
-        if @adviser_interruption_form.valid?
-          @adviser_interruption_form.save
+        if @adviser_interruption_form.save
 
           if @adviser_interruption_form.proceed_to_request_adviser?
-            redirect_to new_candidate_interface_adviser_sign_up_path
+            redirect_to new_candidate_interface_adviser_sign_ups_path
           else
             redirect_to_candidate_root
           end

--- a/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
@@ -10,24 +10,18 @@ module CandidateInterface
       @adviser_sign_up_form = Adviser::SignUpForm.new({ application_form:, preferred_teaching_subject_id: params[:preferred_teaching_subject_id] })
     end
 
-    def continue
+    def create
       @adviser_sign_up_form = Adviser::SignUpForm.new(adviser_sign_up_params.merge(application_form:))
 
       if @adviser_sign_up_form.valid?
-        redirect_to candidate_interface_adviser_sign_up_path(application_form.id, preferred_teaching_subject_id: @adviser_sign_up_form.preferred_teaching_subject_id)
+        @adviser_sign_up_form.save
+        flash[:success] = t('.create.flash.success')
+        track_adviser_sign_up
+        redirect_to candidate_interface_details_path
       else
         track_validation_error(@adviser_sign_up_form)
         render :new
       end
-    end
-
-    def create
-      @adviser_sign_up_form = Adviser::SignUpForm.new(adviser_sign_up_params.merge(application_form:))
-
-      @adviser_sign_up_form.save
-      flash[:success] = t('.create.flash.success')
-      track_adviser_sign_up
-      redirect_to candidate_interface_details_path
     end
 
   private

--- a/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
@@ -13,8 +13,7 @@ module CandidateInterface
     def create
       @adviser_sign_up_form = Adviser::SignUpForm.new(adviser_sign_up_params.merge(application_form:))
 
-      if @adviser_sign_up_form.valid?
-        @adviser_sign_up_form.save
+      if @adviser_sign_up_form.save
         flash[:success] = t('.create.flash.success')
         track_adviser_sign_up
         redirect_to candidate_interface_details_path

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class ContactDetails::ReviewController < SectionController
-
     def show
       @application_form = current_application
       @can_complete = ContactDetailsForm.build_from_application(current_application).valid_for_submission?
@@ -19,7 +18,7 @@ module CandidateInterface
         redirect_to candidate_interface_contact_information_review_path
       elsif @section_complete_form.save(current_application, :contact_details_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -17,7 +17,7 @@ module CandidateInterface
         flash[:warning] = 'You cannot mark this section complete with incomplete contact details.'
         redirect_to candidate_interface_contact_information_review_path
       elsif @section_complete_form.save(current_application, :contact_details_completed)
-        if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -17,7 +17,11 @@ module CandidateInterface
         flash[:warning] = 'You cannot mark this section complete with incomplete contact details.'
         redirect_to candidate_interface_contact_information_review_path
       elsif @section_complete_form.save(current_application, :contact_details_completed)
-        redirect_to_candidate_root
+        if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class ContactDetails::ReviewController < SectionController
+
     def show
       @application_form = current_application
       @can_complete = ContactDetailsForm.build_from_application(current_application).valid_for_submission?
@@ -13,11 +14,11 @@ module CandidateInterface
       @can_complete = ContactDetailsForm.build_from_application(current_application).valid_for_submission?
       @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
-      if ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed) && !details_complete?
+      if @section_complete_form.completed? && !details_complete?
         flash[:warning] = 'You cannot mark this section complete with incomplete contact details.'
         redirect_to candidate_interface_contact_information_review_path
       elsif @section_complete_form.save(current_application, :contact_details_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   module Degrees
     class ReviewController < BaseController
-
       before_action :set_completed_if_only_foundation_degrees
 
       def show
@@ -20,7 +19,7 @@ module CandidateInterface
           redirect_to candidate_interface_degree_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
           if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path
           else
             redirect_to_candidate_root
           end

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           redirect_to candidate_interface_degree_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
-          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           redirect_to candidate_interface_degree_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
-          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser?
+          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module Degrees
     class ReviewController < BaseController
+
       before_action :set_completed_if_only_foundation_degrees
 
       def show
@@ -14,12 +15,11 @@ module CandidateInterface
         @application_form = current_application
         @section_complete_form = SectionCompleteForm.new(application_form_params)
 
-        if @application_form.incomplete_degree_information? &&
-           ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if @application_form.incomplete_degree_information? && @section_complete_form.completed?
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           redirect_to candidate_interface_degree_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
-          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -19,7 +19,11 @@ module CandidateInterface
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           redirect_to candidate_interface_degree_review_path
         elsif @section_complete_form.save(current_application, :degrees_completed)
-          redirect_to_candidate_root
+          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser?
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          else
+            redirect_to_candidate_root
+          end
         else
           track_validation_error(@section_complete_form)
           render :show

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -19,7 +19,11 @@ module CandidateInterface
         @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
         if @section_complete_form.save(current_application, :efl_completed)
-          redirect_to @return_to[:back_path]
+          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          else
+            redirect_to_candidate_root
+          end
         else
           track_validation_error(@section_complete_form)
           render :show

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
         @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
         if @section_complete_form.save(current_application, :efl_completed)
-          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -20,7 +20,7 @@ module CandidateInterface
 
         if @section_complete_form.save(current_application, :efl_completed)
           if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path
           else
             redirect_to_candidate_root
           end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class EqualityAndDiversityController < SectionController
+
     before_action :set_review_back_link
     before_action :check_that_candidate_should_be_asked_about_free_school_meals, only: [:edit_free_school_meals]
 
@@ -96,7 +97,7 @@ module CandidateInterface
       @section_complete_form = EqualityAndDiversityCompleteForm.new(form_params.merge(current_application:))
 
       if @section_complete_form.save(current_application, :equality_and_diversity_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class EqualityAndDiversityController < SectionController
-
     before_action :set_review_back_link
     before_action :check_that_candidate_should_be_asked_about_free_school_meals, only: [:edit_free_school_meals]
 
@@ -98,7 +97,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :equality_and_diversity_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -96,7 +96,11 @@ module CandidateInterface
       @section_complete_form = EqualityAndDiversityCompleteForm.new(form_params.merge(current_application:))
 
       if @section_complete_form.save(current_application, :equality_and_diversity_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :review

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class Gcse::ReviewController < Gcse::BaseController
-
     before_action :set_field_name
     before_action :render_application_feedback_component, except: :complete
     before_action :redirect_to_type, unless: -> { current_qualification }, only: :show
@@ -23,7 +22,7 @@ module CandidateInterface
         redirect_to candidate_interface_gcse_review_path(subject: @subject)
       elsif @section_complete_form.save(current_application, @field_name.to_sym)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
         flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
         redirect_to candidate_interface_gcse_review_path(subject: @subject)
       elsif @section_complete_form.save(current_application, @field_name.to_sym)
-        if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -22,7 +22,11 @@ module CandidateInterface
         flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
         redirect_to candidate_interface_gcse_review_path(subject: @subject)
       elsif @section_complete_form.save(current_application, @field_name.to_sym)
-        redirect_to_candidate_root
+        if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class Gcse::ReviewController < Gcse::BaseController
+
     before_action :set_field_name
     before_action :render_application_feedback_component, except: :complete
     before_action :redirect_to_type, unless: -> { current_qualification }, only: :show
@@ -17,12 +18,11 @@ module CandidateInterface
       @application_qualification = current_qualification
       @section_complete_form = SectionCompleteForm.new(completed: application_form_params[:completed])
 
-      if @application_qualification.incomplete_gcse_information? &&
-         ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+      if @application_qualification.incomplete_gcse_information? && @section_complete_form.completed?
         flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
         redirect_to candidate_interface_gcse_review_path(subject: @subject)
       elsif @section_complete_form.save(current_application, @field_name.to_sym)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/interview_availability_controller.rb
+++ b/app/controllers/candidate_interface/interview_availability_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class InterviewAvailabilityController < SectionController
+
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.interview_preferences_completed)
@@ -44,7 +45,7 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :interview_preferences_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/interview_availability_controller.rb
+++ b/app/controllers/candidate_interface/interview_availability_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class InterviewAvailabilityController < SectionController
-
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.interview_preferences_completed)
@@ -46,7 +45,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :interview_preferences_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/interview_availability_controller.rb
+++ b/app/controllers/candidate_interface/interview_availability_controller.rb
@@ -44,7 +44,11 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :interview_preferences_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < OtherQualifications::BaseController
+
     def show
       redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications
 
@@ -18,7 +19,7 @@ module CandidateInterface
 
         render :show
       elsif @section_complete_form.save(current_application, :other_qualifications_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -18,7 +18,11 @@ module CandidateInterface
 
         render :show
       elsif @section_complete_form.save(current_application, :other_qualifications_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < OtherQualifications::BaseController
-
     def show
       redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications
 
@@ -20,7 +19,7 @@ module CandidateInterface
         render :show
       elsif @section_complete_form.save(current_application, :other_qualifications_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   module PersonalDetails
     class ReviewController < SectionController
-
       before_action :finish_immigration_status, if: -> { ImmigrationStatus.new(current_application: current_application).incomplete? }, only: :show
       def show
         @application_form = current_application
@@ -48,7 +47,7 @@ module CandidateInterface
       def save_section_complete_form
         if @section_complete_form.save(current_application, :personal_details_completed)
           if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path
           else
             redirect_to_candidate_root
           end

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module PersonalDetails
     class ReviewController < SectionController
+
       before_action :finish_immigration_status, if: -> { ImmigrationStatus.new(current_application: current_application).incomplete? }, only: :show
       def show
         @application_form = current_application
@@ -46,7 +47,7 @@ module CandidateInterface
 
       def save_section_complete_form
         if @section_complete_form.save(current_application, :personal_details_completed)
-          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -46,7 +46,11 @@ module CandidateInterface
 
       def save_section_complete_form
         if @section_complete_form.save(current_application, :personal_details_completed)
-          redirect_to_candidate_root
+          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          else
+            redirect_to_candidate_root
+          end
         else
           track_validation_error(@section_complete_form)
           render :show

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -46,7 +46,7 @@ module CandidateInterface
 
       def save_section_complete_form
         if @section_complete_form.save(current_application, :personal_details_completed)
-          if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -63,7 +63,11 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :becoming_a_teacher_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class PersonalStatementController < SectionController
+
     before_action :render_application_feedback_component
     def show
       @application_form = current_application
@@ -63,7 +64,7 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :becoming_a_teacher_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class PersonalStatementController < SectionController
-
     before_action :render_application_feedback_component
     def show
       @application_form = current_application
@@ -65,7 +64,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :becoming_a_teacher_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module References
     class ReviewController < BaseController
+
       before_action :set_references, only: %i[show complete]
       before_action :set_destroy_backlink, only: %i[confirm_destroy_reference]
       before_action :redirect_to_review_page, unless: -> { @reference }, only: %i[confirm_destroy_reference destroy]
@@ -20,7 +21,7 @@ module CandidateInterface
         )
 
         if @application_form.complete_references_information? && @section_complete_form.save(current_application, :references_completed)
-          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
             redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
           else
             redirect_to_candidate_root

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   module References
     class ReviewController < BaseController
-
       before_action :set_references, only: %i[show complete]
       before_action :set_destroy_backlink, only: %i[confirm_destroy_reference]
       before_action :redirect_to_review_page, unless: -> { @reference }, only: %i[confirm_destroy_reference destroy]
@@ -22,7 +21,7 @@ module CandidateInterface
 
         if @application_form.complete_references_information? && @section_complete_form.save(current_application, :references_completed)
           if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path
           else
             redirect_to_candidate_root
           end

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -20,7 +20,11 @@ module CandidateInterface
         )
 
         if @application_form.complete_references_information? && @section_complete_form.save(current_application, :references_completed)
-          redirect_to_candidate_root
+          if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+            redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          else
+            redirect_to_candidate_root
+          end
         else
           track_validation_error(@section_complete_form)
           render :show

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class RestructuredWorkHistory::ReviewController < RestructuredWorkHistory::BaseController
-
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
@@ -14,7 +13,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :work_history_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -12,7 +12,11 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
       if @section_complete_form.save(current_application, :work_history_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class RestructuredWorkHistory::ReviewController < RestructuredWorkHistory::BaseController
+
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
@@ -12,7 +13,7 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
       if @section_complete_form.save(current_application, :work_history_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -42,7 +42,11 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :safeguarding_issues_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -43,7 +43,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :safeguarding_issues_completed)
         if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -42,7 +42,11 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(section_complete_form_params)
 
       if @section_complete_form.save(current_application, :training_with_a_disability_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class TrainingWithADisabilityController < SectionController
+
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.training_with_a_disability_completed)
@@ -42,7 +43,7 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(section_complete_form_params)
 
       if @section_complete_form.save(current_application, :training_with_a_disability_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class TrainingWithADisabilityController < SectionController
-
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.training_with_a_disability_completed)
@@ -44,7 +43,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :training_with_a_disability_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class Volunteering::ReviewController < Volunteering::BaseController
+
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.volunteering_completed)
@@ -10,7 +11,7 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :volunteering_completed)
-        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+        if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
           redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
         else
           redirect_to_candidate_root

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class Volunteering::ReviewController < Volunteering::BaseController
-
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.volunteering_completed)
@@ -12,7 +11,7 @@ module CandidateInterface
 
       if @section_complete_form.save(current_application, :volunteering_completed)
         if current_application.meets_conditions_for_adviser_interruption? && @section_complete_form.completed?
-          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path
         else
           redirect_to_candidate_root
         end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -10,7 +10,11 @@ module CandidateInterface
       @section_complete_form = SectionCompleteForm.new(form_params)
 
       if @section_complete_form.save(current_application, :volunteering_completed)
-        redirect_to_candidate_root
+        if current_application.meets_conditions_for_adviser_interruption? && ActiveModel::Type::Boolean.new.cast(@section_complete_form.completed)
+          redirect_to candidate_interface_adviser_sign_ups_interruption_path(@current_application.id)
+        else
+          redirect_to_candidate_root
+        end
       else
         track_validation_error(@section_complete_form)
         render :show

--- a/app/forms/candidate_interface/adviser_interruption_form.rb
+++ b/app/forms/candidate_interface/adviser_interruption_form.rb
@@ -8,6 +8,14 @@ module CandidateInterface
 
     validates :proceed_to_request_adviser, presence: true
 
+    def save
+      if proceed_to_request_adviser?
+        application_form.update(adviser_interruption_responded_yes: true)
+      else
+        application_form.update(adviser_interruption_responded_yes: false)
+      end
+    end
+
     def proceed_to_request_adviser?
       proceed_to_request_adviser == 'yes'
     end

--- a/app/forms/candidate_interface/adviser_interruption_form.rb
+++ b/app/forms/candidate_interface/adviser_interruption_form.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class AdviserInterruptionForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :application_form
+    attribute :proceed_to_request_adviser
+
+    validates :proceed_to_request_adviser, presence: true
+
+    def proceed_to_request_adviser?
+      proceed_to_request_adviser == 'yes'
+    end
+  end
+end

--- a/app/forms/candidate_interface/adviser_interruption_form.rb
+++ b/app/forms/candidate_interface/adviser_interruption_form.rb
@@ -9,6 +9,8 @@ module CandidateInterface
     validates :proceed_to_request_adviser, presence: true
 
     def save
+      return false if invalid?
+
       if proceed_to_request_adviser?
         application_form.update(adviser_interruption_response: true)
       else

--- a/app/forms/candidate_interface/adviser_interruption_form.rb
+++ b/app/forms/candidate_interface/adviser_interruption_form.rb
@@ -10,9 +10,9 @@ module CandidateInterface
 
     def save
       if proceed_to_request_adviser?
-        application_form.update(adviser_interruption_responded_yes: true)
+        application_form.update(adviser_interruption_response: true)
       else
-        application_form.update(adviser_interruption_responded_yes: false)
+        application_form.update(adviser_interruption_response: false)
       end
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -706,11 +706,6 @@ class ApplicationForm < ApplicationRecord
     current_cycle? && Time.zone.now.between?(apply_opens_at, apply_deadline_at)
   end
 
-  def meets_conditions_for_adviser_interruption?
-    eligible_to_sign_up_for_a_teaching_training_adviser? &&
-      adviser_interruption_response != false
-  end
-
 private
 
   def geocode_address_and_update_region_if_required

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -708,7 +708,7 @@ class ApplicationForm < ApplicationRecord
 
   def meets_conditions_for_adviser_interruption?
     eligible_to_sign_up_for_a_teaching_training_adviser? &&
-      adviser_interruption_responded_yes != false
+      adviser_interruption_response != false
   end
 
 private

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -706,6 +706,11 @@ class ApplicationForm < ApplicationRecord
     current_cycle? && Time.zone.now.between?(apply_opens_at, apply_deadline_at)
   end
 
+  def meets_conditions_for_adviser_interruption?
+    eligible_to_sign_up_for_a_teaching_training_adviser? &&
+      adviser_interruption_responded_yes != false
+  end
+
 private
 
   def geocode_address_and_update_region_if_required

--- a/app/models/concerns/adviser_eligibility.rb
+++ b/app/models/concerns/adviser_eligibility.rb
@@ -37,6 +37,11 @@ module AdviserEligibility
     end
   end
 
+  def meets_conditions_for_adviser_interruption?
+    eligible_to_sign_up_for_a_teaching_training_adviser? &&
+      adviser_interruption_response != false
+  end
+
 private
 
   def refresh_adviser_status

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -13,7 +13,7 @@
 
           <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
 
-          <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like')}) do %>
+          <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like') }) do %>
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
           <% end %>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -10,7 +10,14 @@
 
       <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
 
-      <p class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold"><%= t('.would_you_like') %></p>
+      <%= form_with(model: @adviser_interruption_form, url: candidate_interface_update_adviser_sign_ups_interruption_response_path(@application_form.id), method: :patch) do |f| %>
+        <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like')}) do %>
+          <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
+          <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
+        <% end %>
+
+        <%= f.govuk_submit t('.submit_text') %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -17,8 +17,9 @@
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
           <% end %>
+
       </div>
+          <%= f.govuk_submit t('.submit_text') %>
+        <% end %>
   </div>
 </div>
-      <%= f.govuk_submit t('.submit_text') %>
-      <% end %>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -9,16 +9,17 @@
         <div class="app-grid-column--grey">
           <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
           <p class="govuk-body"><%= t('.eligible') %></p>
+          <p class="govuk-body"><%= t('.eligible_2') %></p>
           <p class="govuk-body"><%= t('.support') %></p>
 
           <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
 
-          <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like') }) do %>
+      </div>
+          <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.request_legend') }) do %>
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
             <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
           <% end %>
 
-      </div>
           <%= f.govuk_submit t('.submit_text') %>
         <% end %>
   </div>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -1,8 +1,16 @@
+<% content_for :title, t('page_titles.new_adviser_sign_up') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_details_path, t('.back')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="app-grid-column--grey">
-      <h1 class="govuk-heading-l">You are eligible for a free teacher training adviser</h1>
+      <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
+      <p class="govuk-body"><%= t('.eligible') %></p>
+      <p class="govuk-body"><%= t('.support') %></p>
+
+      <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
+
+      <p class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold"><%= t('.would_you_like') %></p>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -1,0 +1,8 @@
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="app-grid-column--grey">
+      <h1 class="govuk-heading-l">You are eligible for a free teacher training adviser</h1>
+    </div>
+  </div>
+</div>

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-      <%= form_with(model: @adviser_interruption_form, url: candidate_interface_update_adviser_sign_ups_interruption_response_path(@application_form.id), method: :patch) do |f| %>
+      <%= form_with(model: @adviser_interruption_form, url: candidate_interface_update_adviser_sign_ups_interruption_response_path(@adviser_interruption_form.application_form.id), method: :patch) do |f| %>
         <%= f.govuk_error_summary %>
 
         <div class="app-grid-column--grey">

--- a/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/interruptions/show.html.erb
@@ -1,23 +1,24 @@
-<% content_for :title, t('page_titles.new_adviser_sign_up') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.new_adviser_sign_up'), @adviser_interruption_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_details_path, t('.back')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <div class="app-grid-column--grey">
-      <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
-      <p class="govuk-body"><%= t('.eligible') %></p>
-      <p class="govuk-body"><%= t('.support') %></p>
-
-      <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
-
       <%= form_with(model: @adviser_interruption_form, url: candidate_interface_update_adviser_sign_ups_interruption_response_path(@application_form.id), method: :patch) do |f| %>
-        <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like')}) do %>
-          <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
-          <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
-        <% end %>
+        <%= f.govuk_error_summary %>
 
-        <%= f.govuk_submit t('.submit_text') %>
-      <% end %>
-    </div>
+        <div class="app-grid-column--grey">
+          <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
+          <p class="govuk-body"><%= t('.eligible') %></p>
+          <p class="govuk-body"><%= t('.support') %></p>
+
+          <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3'), t('.help_with_4')], type: :bullet %>
+
+          <%= f.govuk_radio_buttons_fieldset(:proceed_to_request_adviser, inline: true, legend: { size: 'm', text: t('.would_you_like')}) do %>
+            <%= f.govuk_radio_button :proceed_to_request_adviser, 'yes', label: { text: 'Yes' }, link_errors: true %>
+            <%= f.govuk_radio_button :proceed_to_request_adviser, 'no', label: { text: 'No' } %>
+          <% end %>
+      </div>
   </div>
 </div>
+      <%= f.govuk_submit t('.submit_text') %>
+      <% end %>

--- a/app/views/candidate_interface/adviser_sign_ups/new.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/new.html.erb
@@ -9,8 +9,14 @@
       <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
 
       <p class="govuk-body"><%= t('.introduction') %></p>
+      <p class="govuk-body"><%= t('.your_adviser') %></p>
+      <p class="govuk-body"><%= t('.support') %></p>
 
       <%= govuk_list [t('.help_with_1'), t('.help_with_2'), t('.help_with_3')], type: :bullet %>
+
+      <p class="govuk-body"><%= t('.be_matched') %></p>
+      <p class="govuk-body"><%= t('.frequency') %></p>
+      <p class="govuk-body"><%= t('.contact') %></p>
 
       <%= f.govuk_radio_buttons_fieldset(:preferred_teaching_subject_id, legend: { size: 'm' }) do %>
         <% @adviser_sign_up_form.primary_teaching_subjects_for_select.each do |subject| %>

--- a/app/views/candidate_interface/adviser_sign_ups/new.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @adviser_sign_up_form, url: continue_candidate_interface_adviser_sign_ups_path) do |f| %>
+    <%= form_with(model: @adviser_sign_up_form, url: candidate_interface_adviser_sign_ups_path) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l"><%= t('.heading') %></h1>

--- a/app/views/candidate_interface/adviser_sign_ups/show.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.new_adviser_sign_up') %>
-<% content_for :before_content, govuk_back_link_to(new_candidate_interface_adviser_sign_up_path(preferred_teaching_subject_id: @adviser_sign_up_form.preferred_teaching_subject_id), t('.back')) %>
+<% content_for :before_content, govuk_back_link_to(new_candidate_interface_adviser_sign_ups_path(preferred_teaching_subject_id: @adviser_sign_up_form.preferred_teaching_subject_id), t('.back')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -13,7 +13,7 @@
         <% summary_list.with_row do |row| %>%
           <% row.with_key { t('.subject') } %>%
           <% row.with_value { @adviser_sign_up_form.preferred_teaching_subject.title } %>
-          <% row.with_action(text: t('.change'), href: new_candidate_interface_adviser_sign_up_path(preferred_teaching_subject_id: @adviser_sign_up_form.preferred_teaching_subject_id), visually_hidden_text: t('.change')) %>
+          <% row.with_action(text: t('.change'), href: new_candidate_interface_adviser_sign_ups_path(preferred_teaching_subject_id: @adviser_sign_up_form.preferred_teaching_subject_id), visually_hidden_text: t('.change')) %>
         <% end %>
       <% end %>
 

--- a/app/views/candidate_interface/course_choices/go_to_find/new.html.erb
+++ b/app/views/candidate_interface/course_choices/go_to_find/new.html.erb
@@ -17,7 +17,7 @@
     </ul>
 
     <% if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? %>
-      <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_up_path %> to help you understand your course options.</p>
+      <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_ups_path %> to help you understand your course options.</p>
     <% elsif current_application.waiting_to_be_assigned_to_an_adviser? || current_application.already_assigned_to_an_adviser? %>
       <p class="govuk-body">Your teacher training adviser can help you understand your course options.</p>
     <% else %>

--- a/app/views/candidate_interface/details/_adviser_call_to_action.html.erb
+++ b/app/views/candidate_interface/details/_adviser_call_to_action.html.erb
@@ -11,7 +11,7 @@
     <p class="govuk-body-s">
       <%= govuk_link_to(
             t('.available.button_text'),
-            new_candidate_interface_adviser_sign_up_path,
+            new_candidate_interface_adviser_sign_ups_path,
           ) %>
     </p>
   </aside>

--- a/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
@@ -12,7 +12,7 @@
         <p class="govuk-body">Some training providers may let you do an equivalency test to show you have the required skills.</p>
 
         <% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
-          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', new_candidate_interface_adviser_sign_up_path, utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
+          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', new_candidate_interface_adviser_sign_ups_path, utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
         <% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
           <p class="govuk-body">Contact your teacher training adviser or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
         <% else %>

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -9,7 +9,7 @@
 <%= render 'guidance' %>
 
 <% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
-  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_up_path) %>.</p>
+  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_ups_path) %>.</p>
 <% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
   <p class="govuk-body">Ask your teacher training adviser for help with your personal statement.</p>
 <% else %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -14,7 +14,6 @@ shared:
     - latitude
     - longitude
     - candidate_preference_id
-    - provider_id
     - created_at
     - updated_at
   candidates:

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -14,6 +14,7 @@ shared:
     - latitude
     - longitude
     - candidate_preference_id
+    - provider_id
     - created_at
     - updated_at
   candidates:

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -2,7 +2,7 @@ en:
   helpers:
     legend:
       adviser_sign_up_form:
-        preferred_teaching_subject_id: What are you interested in teaching?
+        preferred_teaching_subject_id: What subject are you interested in teaching?
     hint:
       adviser_sign_up_form:
         preferred_teaching_subject_id: We’re asking this so that a dedicated adviser can be assigned to you.
@@ -23,32 +23,37 @@ en:
       interruptions:
         show:
           back: Back to your details
-          heading: You are eligible for a free teacher training adviser
-          eligible: Based on the information in your application, you're eligible for your own dedicated teacher training adviser.
-          support: "Our advisers have years of teaching experience and can help with:"
-          help_with_1: answering questions you have about teacher training and being a teacher
-          help_with_2: understanding your different training options
-          help_with_3: reviewing your personal statement so it highlights your relevant skills and experience
+          heading: A teacher training adviser could support with your application
+          eligible: Because you've said you have a bachelor's degree with a predicted or actual grade higher than a 2:2, you are eligible for a teacher training adviser.
+          eligible_2: You can get free one-to-one support from an adviser with years of teaching experience, they can talk you through the application process step by step.
+          support: "They can support you with:"
+          help_with_1: answering questions about teacher training or being a teacher
+          help_with_2: writing your personal statement
+          help_with_3: understanding your different training options
           help_with_4: preparing for any interviews
-          would_you_like: Would you like a teacher training adviser to contact you?
+          request_legend: Do you want to request a teacher training adviser?
           submit_text: Continue
       new:
         back: Back
         heading: Get a teacher training adviser
-        introduction: |-
-          Our advisers were experienced teachers and can answer all your questions about how to put together the best application. They’ll help you with:
+        introduction: Get free one-to-one support from an adviser with years of teaching experience.
+        your_adviser: Your adviser can talk you through the application process step by step.
+        support: "They can support you with:"
         help_with_1: writing your personal statement
         help_with_2: understanding your different training options
         help_with_3: preparing for interviews
+        be_matched: You’ll be matched with your own dedicated adviser. You’ll have the same adviser throughout your journey into teaching.
+        frequency: How often you talk to them is up to you – this could be every week for more than a year, or just a few times for some one-to-one support.
+        contact: You can chat by phone, or by email, text or WhatsApp.
         disclaimer: |-
-          If you continue, we will share your personal details and the status of your application with a dedicated adviser.
+          When you select Request an adviser, we will share your personal details and the status of any applications you have with a teacher training adviser.
           We will not share your personal statement, qualifications or work history with them.
-        submit_text: Continue
+        submit_text: Request an adviser
       show:
         back: Back
         heading: Get a teacher training adviser
         introduction: |-
-          Our advisers were experienced teachers and can answer all your questions about how to put together the best application. They’ll help you with:
+          Advisers with years of teaching experience can answer all your questions about how to put together the best application. They’ll help you with:
         help_with_1: writing your personal statement
         help_with_2: understanding your different training options
         help_with_3: preparing for interviews
@@ -60,4 +65,4 @@ en:
         request: Request adviser
       create:
         flash:
-          success: An adviser will contact you by email within 5 working days.
+          success: Your teacher training adviser will contact you by email within 5 working days.

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -20,6 +20,19 @@ en:
           heading: Speak to your teacher training adviser
           text: Your adviser can give you free, one-to-one help with your application.
     adviser_sign_ups:
+      interruptions:
+        show:
+          back: Back to your details
+          heading: You are eligible for a free teacher training adviser
+          eligible: Based on the information in your application, you're eligible for your own dedicated teacher training adviser.
+          support: "Our advisers have years of teaching experience and can help with:"
+          help_with_1: answering questions you have about teacher training and being a teacher
+          help_with_2: understanding your different training options
+          help_with_3: reviewing your personal statement so it highlights your relevant skills and experience
+          help_with_4: preparing for any interviews
+          would_you_like: Would you like a teacher training adviser to contact you?
+          yes: Yes
+          no: No
       new:
         back: Back
         heading: Get a teacher training adviser

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -24,7 +24,7 @@ en:
         show:
           back: Back to your details
           heading: A teacher training adviser could support with your application
-          eligible: Because you've said you have a bachelor's degree with a predicted or actual grade higher than a 2:2, you are eligible for a teacher training adviser.
+          eligible: Because you’ve said you have a bachelor’s degree with a predicted or actual grade higher than a 2:2, you are eligible for a teacher training adviser.
           eligible_2: You can get free one-to-one support from an adviser with years of teaching experience, they can talk you through the application process step by step.
           support: "They can support you with:"
           help_with_1: answering questions about teacher training or being a teacher

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -33,6 +33,7 @@ en:
           would_you_like: Would you like a teacher training adviser to contact you?
           yes: Yes
           no: No
+          submit_text: Continue
       new:
         back: Back
         heading: Get a teacher training adviser

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -31,8 +31,6 @@ en:
           help_with_3: reviewing your personal statement so it highlights your relevant skills and experience
           help_with_4: preparing for any interviews
           would_you_like: Would you like a teacher training adviser to contact you?
-          yes: Yes
-          no: No
           submit_text: Continue
       new:
         back: Back

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,7 +451,7 @@ en:
         candidate_interface/adviser_interruption_form:
           attributes:
             proceed_to_request_adviser:
-              blank: Select whether you would like a teacher training adviser to contact you
+              blank: Select whether you would like to request a teacher training adviser
         candidate_interface/prefill_application_or_not_form:
           attributes:
             prefill:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,6 +448,10 @@ en:
           attributes:
             provider_id:
               blank: Select a provider
+        candidate_interface/adviser_interruption_form:
+          attributes:
+            proceed_to_request_adviser:
+              blank: Select whether you would like a teacher training adviser to contact you
         candidate_interface/prefill_application_or_not_form:
           attributes:
             prefill:

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -99,6 +99,7 @@ namespace :candidate_interface, path: '/candidate' do
       end
 
       get '/interruption/:id' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
+      patch '/interruption/:id' => 'adviser_sign_ups/interruptions#update', as: :update_adviser_sign_ups_interruption_response
     end
 
     scope '/personal-details' do

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -92,7 +92,7 @@ namespace :candidate_interface, path: '/candidate' do
     post '/carry-over' => 'carry_over#create', as: :carry_over
 
     scope '/adviser-sign-ups' do
-      resources :adviser_sign_ups, only: %i[new create show] do
+      resources :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show] do
         collection do
           post :continue
         end

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -91,10 +91,10 @@ namespace :candidate_interface, path: '/candidate' do
     get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
     post '/carry-over' => 'carry_over#create', as: :carry_over
 
-    resources :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show]
+    resource :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show]
 
-    get 'adviser-sign-ups/interruption/:id' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
-    patch 'adviser-sign-ups/interruption/:id' => 'adviser_sign_ups/interruptions#update', as: :update_adviser_sign_ups_interruption_response
+    get 'adviser-sign-ups/interruption' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
+    patch 'adviser-sign-ups/interruption' => 'adviser_sign_ups/interruptions#update', as: :update_adviser_sign_ups_interruption_response
 
     scope '/personal-details' do
       get '/', to: redirect('/candidate/application/personal-information')

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -91,10 +91,14 @@ namespace :candidate_interface, path: '/candidate' do
     get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
     post '/carry-over' => 'carry_over#create', as: :carry_over
 
-    resources :adviser_sign_ups, only: %i[new create show], path: 'adviser-sign-ups' do
-      collection do
-        post :continue
+    scope '/adviser-sign-ups' do
+      resources :adviser_sign_ups, only: %i[new create show] do
+        collection do
+          post :continue
+        end
       end
+
+      get '/interruption/:id' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
     end
 
     scope '/personal-details' do

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -91,16 +91,10 @@ namespace :candidate_interface, path: '/candidate' do
     get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
     post '/carry-over' => 'carry_over#create', as: :carry_over
 
-    scope '/adviser-sign-ups' do
-      resources :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show] do
-        collection do
-          post :continue
-        end
-      end
+    resources :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show]
 
-      get '/interruption/:id' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
-      patch '/interruption/:id' => 'adviser_sign_ups/interruptions#update', as: :update_adviser_sign_ups_interruption_response
-    end
+    get 'adviser-sign-ups/interruption/:id' => 'adviser_sign_ups/interruptions#show', as: :adviser_sign_ups_interruption
+    patch 'adviser-sign-ups/interruption/:id' => 'adviser_sign_ups/interruptions#update', as: :update_adviser_sign_ups_interruption_response
 
     scope '/personal-details' do
       get '/', to: redirect('/candidate/application/personal-information')

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -485,6 +485,9 @@ module CandidateHelper
     click_link_or_button 'English GCSE or equivalent'
     candidate_fills_in_their_english_gcse
 
+    choose 'No'
+    click_link_or_button 'Continue'
+
     click_link_or_button(international ? 'Other qualifications' : 'A levels and other qualifications')
     candidate_fills_in_their_other_qualifications
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -75,6 +75,9 @@ module CandidateHelper
     click_link_or_button 'English GCSE or equivalent'
     candidate_fills_in_their_english_gcse
 
+    choose 'No'
+    click_link_or_button 'Continue'
+
     click_link_or_button(international ? 'Other qualifications' : 'A levels and other qualifications')
     candidate_fills_in_their_other_qualifications
 

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
     allow(DfE::Analytics).to receive(:enabled?).and_return(true)
   end
 
-  def and_the_adviser_sign_up_feature_flag_is_disabled
-    FeatureFlag.deactivate(:adviser_sign_up)
-  end
-
   def and_i_visit_the_details_page
     visit candidate_interface_details_path
   end
@@ -41,10 +37,6 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
       matchback_candidate: nil,
     )
     allow(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to receive(:new) { api_double }
-  end
-
-  def when_the_adviser_sign_up_feature_flag_is_enabled
-    FeatureFlag.activate(:adviser_sign_up)
   end
 
   def when_i_have_completed_my_application

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate selects no on adviser interruption', :js do
+RSpec.describe 'Candidate selects no on adviser interruption' do
   include CandidateHelper
 
   it 'does not reappear when the candidate has selected no once' do
@@ -59,7 +59,7 @@ RSpec.describe 'Candidate selects no on adviser interruption', :js do
   end
 
   def and_i_mark_this_section_as_completed
-    choose t('application_form.completed_radio')
+    choose 'Yes, I have completed this section'
   end
 
   def and_i_click_continue
@@ -72,15 +72,11 @@ RSpec.describe 'Candidate selects no on adviser interruption', :js do
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content(
-      t('activemodel.errors.models.candidate_interface/adviser_interruption_form.attributes.proceed_to_request_adviser.blank'),
-    )
+    expect(page).to have_content('Select whether you would like a teacher training adviser to contact you')
   end
 
   def when_i_select_no
-    within('fieldset.govuk-fieldset') do
-      choose 'candidate-interface-adviser-interruption-form-proceed-to-request-adviser-no-field'
-    end
+    choose 'No'
   end
 
   def then_i_see_my_details_page
@@ -93,8 +89,6 @@ RSpec.describe 'Candidate selects no on adviser interruption', :js do
   end
 
   def and_the_adviser_call_to_action_is_still_visible
-    expect(page).to have_content(
-      t('candidate_interface.details.adviser_call_to_action.available.button_text'),
-    )
+    expect(page).to have_content('Get an adviser')
   end
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Candidate selects no on adviser interruption' do
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content('Select whether you would like a teacher training adviser to contact you')
+    expect(page).to have_content('Select whether you would like to request a teacher training adviser')
   end
 
   def when_i_select_no

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate selects no on adviser interruption' do
   alias_method :when_i_click_continue, :and_i_click_continue
 
   def then_i_see_the_interruption_page
-    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path(@eligible_application_form.id))
+    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path)
   end
 
   def then_i_see_a_validation_error

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate selects no on adviser interruption', :js do
+  include CandidateHelper
+
+  it 'does not reappear when the candidate has selected no once' do
+    given_i_am_signed_in_with_one_login
+    and_enqueued_jobs_are_not_performed
+    and_the_api_call_is_stubbed
+    and_analytics_is_enabled
+    and_i_have_an_eligible_application # value of adviser_interruption_response is 'nil' by default
+
+    when_i_visit_my_details_page
+    and_i_navigate_to_a_section_which_determines_eligibilty # can be personal details, contact details, English/Maths, degree
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_see_the_interruption_page
+
+    when_i_click_continue
+    then_i_see_a_validation_error
+
+    when_i_select_no
+    and_i_click_continue
+    then_i_see_my_details_page
+
+    when_i_navigate_to_a_section_which_determines_eligibilty
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_do_not_see_the_interruption_page
+    and_the_adviser_call_to_action_is_still_visible
+  end
+
+  def and_enqueued_jobs_are_not_performed
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  def and_the_api_call_is_stubbed
+    api_double = instance_double(
+      GetIntoTeachingApiClient::TeacherTrainingAdviserApi,
+      matchback_candidate: nil,
+    )
+    allow(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to receive(:new) { api_double }
+  end
+
+  def and_analytics_is_enabled
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+  end
+
+  def and_i_have_an_eligible_application
+    @eligible_application_form = create(:application_form_eligible_for_adviser, candidate: @current_candidate)
+  end
+
+  def when_i_visit_my_details_page
+    visit candidate_interface_details_path
+  end
+
+  def and_i_navigate_to_a_section_which_determines_eligibilty
+    click_link_or_button 'Degree'
+  end
+
+  def and_i_mark_this_section_as_completed
+    choose t('application_form.completed_radio')
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def then_i_see_the_interruption_page
+    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path(@eligible_application_form.id))
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content(
+      t('activemodel.errors.models.candidate_interface/adviser_interruption_form.attributes.proceed_to_request_adviser.blank'),
+    )
+  end
+
+  def when_i_select_no
+    within('fieldset.govuk-fieldset') do
+      choose 'candidate-interface-adviser-interruption-form-proceed-to-request-adviser-no-field'
+    end
+  end
+
+  def then_i_see_my_details_page
+    expect(page).to have_current_path(candidate_interface_details_path)
+  end
+  alias_method :then_i_do_not_see_the_interruption_page, :then_i_see_my_details_page
+
+  def when_i_navigate_to_a_section_which_determines_eligibilty
+    click_link_or_button 'Contact information'
+  end
+
+  def and_the_adviser_call_to_action_is_still_visible
+    expect(page).to have_content(
+      t('candidate_interface.details.adviser_call_to_action.available.button_text'),
+    )
+  end
+end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_no_on_adviser_interruption_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe 'Candidate selects no on adviser interruption' do
   include CandidateHelper
 
-  it 'does not reappear when the candidate has selected no once' do
-    given_i_am_signed_in_with_one_login
-    and_enqueued_jobs_are_not_performed
+  before do
     and_the_api_call_is_stubbed
     and_analytics_is_enabled
+  end
+
+  it 'does not reappear when the candidate has selected no once' do
+    given_i_am_signed_in_with_one_login
     and_i_have_an_eligible_application # value of adviser_interruption_response is 'nil' by default
 
     when_i_visit_my_details_page
@@ -28,10 +30,6 @@ RSpec.describe 'Candidate selects no on adviser interruption' do
     and_i_click_continue
     then_i_do_not_see_the_interruption_page
     and_the_adviser_call_to_action_is_still_visible
-  end
-
-  def and_enqueued_jobs_are_not_performed
-    ActiveJob::Base.queue_adapter = :test
   end
 
   def and_the_api_call_is_stubbed

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
   end
 
   def then_i_see_the_interruption_page
-    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path(@eligible_application_form.id))
+    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path)
   end
   alias_method :then_i_see_the_interruption_page_again, :then_i_see_the_interruption_page
 
@@ -112,7 +112,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
   end
 
   def then_i_see_the_select_a_subject_page
-    expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path)
+    expect(page).to have_current_path(new_candidate_interface_adviser_sign_ups_path)
   end
 
   def when_i_click_back

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate selects yes on adviser interruption', :js do
+RSpec.describe 'Candidate selects yes on adviser interruption' do
   include CandidateHelper
 
   it 'proceeds to adviser sign up flow' do
@@ -95,7 +95,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption', :js do
   end
 
   def and_i_mark_this_section_as_completed
-    choose t('application_form.completed_radio')
+    choose 'Yes, I have completed this section'
   end
 
   def and_i_click_continue
@@ -109,9 +109,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption', :js do
   alias_method :then_i_see_the_interruption_page_again, :then_i_see_the_interruption_page
 
   def when_i_select_yes
-    within('fieldset.govuk-fieldset') do
-      choose 'candidate-interface-adviser-interruption-form-proceed-to-request-adviser-yes-field'
-    end
+    choose 'Yes'
   end
 
   def then_i_see_the_select_a_subject_page
@@ -144,8 +142,6 @@ RSpec.describe 'Candidate selects yes on adviser interruption', :js do
   end
 
   def and_the_adviser_call_to_action_is_no_longer_visible
-    expect(page).to have_no_content(
-      t('candidate_interface.details.adviser_call_to_action.available.button_text'),
-    )
+    expect(page).to have_no_content('Get an adviser')
   end
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate selects yes on adviser interruption', :js do
+  include CandidateHelper
+
+  it 'proceeds to adviser sign up flow' do
+    given_i_am_signed_in_with_one_login
+    and_adviser_teaching_subjects_exist
+    and_rails_cache_is_enabled
+    and_analytics_is_enabled
+    and_enqueued_jobs_are_not_performed
+    and_the_adviser_sign_up_feature_flag_is_enabled
+    and_the_get_into_teaching_api_is_accepting_sign_ups
+    and_adviser_sign_up_jobs_can_be_enqueued
+    and_i_have_an_eligible_application # value of adviser_interruption_response is 'nil' by default
+
+    when_i_visit_my_details_page
+    and_i_navigate_to_a_section_which_determines_eligibilty # can be personal details, contact details, English/Maths, degree
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_see_the_interruption_page
+
+    when_i_select_yes
+    and_i_click_continue
+    then_i_see_the_select_a_subject_page
+
+    when_i_click_back
+    then_i_see_my_details_page
+
+    when_i_navigate_to_a_section_which_determines_eligibilty
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_see_the_interruption_page_again
+
+    when_i_select_yes
+    and_i_click_continue
+    then_i_see_the_select_a_subject_page
+
+    when_i_select_a_subject
+    and_i_click_continue
+    then_i_see_the_review_page
+
+    when_i_click_request_adviser
+    then_i_see_my_details_page
+
+    when_i_navigate_to_a_section_which_determines_eligibilty
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_do_not_see_the_interruption_page
+    and_the_adviser_call_to_action_is_no_longer_visible
+  end
+
+  def and_rails_cache_is_enabled
+    in_memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+    allow(Rails).to receive(:cache).and_return(in_memory_store)
+    Rails.cache.clear
+  end
+
+  def and_i_have_an_eligible_application
+    @eligible_application_form = create(:application_form_eligible_for_adviser, candidate: @current_candidate)
+  end
+
+  def and_adviser_teaching_subjects_exist
+    @teaching_subject_nuclear_physics = create(:adviser_teaching_subject, title: 'Primary Nuclear Physics', external_identifier: 'PNP001')
+    @teaching_subject_optometry = create(:adviser_teaching_subject, title: 'Primary Optometry', external_identifier: 'PO001')
+  end
+
+  def and_analytics_is_enabled
+    allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+  end
+
+  def and_enqueued_jobs_are_not_performed
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  def and_the_adviser_sign_up_feature_flag_is_enabled
+    FeatureFlag.activate(:adviser_sign_up)
+  end
+
+  def and_the_get_into_teaching_api_is_accepting_sign_ups
+    @api_double = instance_double(GetIntoTeachingApiClient::TeacherTrainingAdviserApi, :sign_up_teacher_training_adviser_candidate, matchback_candidate: nil)
+    allow(GetIntoTeachingApiClient::TeacherTrainingAdviserApi).to receive(:new) { @api_double }
+  end
+
+  def and_adviser_sign_up_jobs_can_be_enqueued
+    allow(AdviserSignUpWorker).to receive(:perform_async)
+  end
+
+  def when_i_visit_my_details_page
+    visit candidate_interface_details_path
+  end
+
+  def and_i_navigate_to_a_section_which_determines_eligibilty
+    click_link_or_button 'English GCSE or equivalent'
+  end
+
+  def and_i_mark_this_section_as_completed
+    choose t('application_form.completed_radio')
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def then_i_see_the_interruption_page
+    expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path(@eligible_application_form.id))
+  end
+  alias_method :then_i_see_the_interruption_page_again, :then_i_see_the_interruption_page
+
+  def when_i_select_yes
+    within('fieldset.govuk-fieldset') do
+      choose 'candidate-interface-adviser-interruption-form-proceed-to-request-adviser-yes-field'
+    end
+  end
+
+  def then_i_see_the_select_a_subject_page
+    expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path)
+  end
+
+  def when_i_click_back
+    click_link_or_button 'Back to your details'
+  end
+
+  def then_i_see_my_details_page
+    expect(page).to have_current_path(candidate_interface_details_path)
+  end
+  alias_method :then_i_do_not_see_the_interruption_page, :then_i_see_my_details_page
+
+  def when_i_navigate_to_a_section_which_determines_eligibilty
+    click_link_or_button 'Personal information'
+  end
+
+  def when_i_select_a_subject
+    choose 'Primary Optometry'
+  end
+
+  def then_i_see_the_review_page
+    expect(page).to have_current_path(candidate_interface_adviser_sign_up_path(@eligible_application_form.id, preferred_teaching_subject_id: @teaching_subject_optometry.external_identifier))
+  end
+
+  def when_i_click_request_adviser
+    click_link_or_button 'Request adviser'
+  end
+
+  def and_the_adviser_call_to_action_is_no_longer_visible
+    expect(page).to have_no_content(
+      t('candidate_interface.details.adviser_call_to_action.available.button_text'),
+    )
+  end
+end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
     then_i_see_the_select_a_subject_page
 
     when_i_select_a_subject
-    and_i_click_continue
+    and_i_click_request_an_adviser
     then_i_see_the_review_page
 
     when_i_click_request_adviser
@@ -102,6 +102,10 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
     click_link_or_button 'Continue'
   end
   alias_method :when_i_click_continue, :and_i_click_continue
+
+  def and_i_click_request_an_adviser
+    click_link_or_button 'Request an adviser'
+  end
 
   def then_i_see_the_interruption_page
     expect(page).to have_current_path(candidate_interface_adviser_sign_ups_interruption_path(@eligible_application_form.id))

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -3,15 +3,17 @@ require 'rails_helper'
 RSpec.describe 'Candidate selects yes on adviser interruption' do
   include CandidateHelper
 
-  it 'proceeds to adviser sign up flow' do
-    given_i_am_signed_in_with_one_login
-    and_adviser_teaching_subjects_exist
+  before do
     and_rails_cache_is_enabled
     and_analytics_is_enabled
-    and_enqueued_jobs_are_not_performed
     and_the_adviser_sign_up_feature_flag_is_enabled
     and_the_get_into_teaching_api_is_accepting_sign_ups
     and_adviser_sign_up_jobs_can_be_enqueued
+  end
+
+  it 'proceeds to adviser sign up flow' do
+    given_i_am_signed_in_with_one_login
+    and_adviser_teaching_subjects_exist
     and_i_have_an_eligible_application # value of adviser_interruption_response is 'nil' by default
 
     when_i_visit_my_details_page
@@ -64,10 +66,6 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
 
   def and_analytics_is_enabled
     allow(DfE::Analytics).to receive(:enabled?).and_return(true)
-  end
-
-  def and_enqueued_jobs_are_not_performed
-    ActiveJob::Base.queue_adapter = :test
   end
 
   def and_the_adviser_sign_up_feature_flag_is_enabled

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_selects_yes_on_adviser_interruption_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
 
     when_i_select_a_subject
     and_i_click_request_an_adviser
-    then_i_see_the_review_page
-
-    when_i_click_request_adviser
     then_i_see_my_details_page
 
     when_i_navigate_to_a_section_which_determines_eligibilty
@@ -135,14 +132,6 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
 
   def when_i_select_a_subject
     choose 'Primary Optometry'
-  end
-
-  def then_i_see_the_review_page
-    expect(page).to have_current_path(candidate_interface_adviser_sign_up_path(@eligible_application_form.id, preferred_teaching_subject_id: @teaching_subject_optometry.external_identifier))
-  end
-
-  def when_i_click_request_adviser
-    click_link_or_button 'Request adviser'
   end
 
   def and_the_adviser_call_to_action_is_no_longer_visible

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -20,22 +20,12 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
     when_i_click_on_the_adviser_cta
     then_i_am_on_the_adviser_sign_up_page
 
-    when_i_click_the_continue_button
+    when_i_click_request_an_adviser
     then_i_see_validation_errors_for_preferred_teaching_subject
     and_the_validation_error_is_tracked
 
     when_i_select_a_preferred_teaching_subject
-    and_i_click_the_continue_button
-    then_i_am_redirected_to_the_review_page
-
-    when_i_click_the_change_link
-    then_i_am_returned_to_the_adviser_sign_up_page
-
-    when_i_change_my_subject_selection
-    and_i_click_the_continue_button
-    then_my_choice_is_updated_on_the_review_page
-
-    when_i_click_request_adviser
+    and_i_click_request_an_adviser
     then_i_am_redirected_to_your_details_page
     and_i_see_the_success_message
     and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
@@ -95,10 +85,10 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
     expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path(preferred_teaching_subject_id: @preferred_teaching_subject1.external_identifier))
   end
 
-  def when_i_click_the_continue_button
-    click_link_or_button t('candidate_interface.adviser_sign_ups.new.submit_text')
+  def when_i_click_request_an_adviser
+    click_link_or_button 'Request an adviser'
   end
-  alias_method :and_i_click_the_continue_button, :when_i_click_the_continue_button
+  alias_method :and_i_click_request_an_adviser, :when_i_click_request_an_adviser
 
   def then_i_see_validation_errors_for_preferred_teaching_subject
     expect(page).to have_content(
@@ -143,21 +133,5 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   def then_i_am_redirected_to_the_review_page
     expect(page).to have_link(t('candidate_interface.adviser_sign_ups.show.change'))
     expect(page).to have_button(t('candidate_interface.adviser_sign_ups.show.request'))
-  end
-
-  def when_i_click_the_change_link
-    click_link_or_button t('candidate_interface.adviser_sign_ups.show.change')
-  end
-
-  def when_i_change_my_subject_selection
-    find('label', text: @preferred_teaching_subject2.title).click
-  end
-
-  def then_my_choice_is_updated_on_the_review_page
-    find('dd', text: @preferred_teaching_subject2.title)
-  end
-
-  def when_i_click_request_adviser
-    click_link_or_button t('candidate_interface.adviser_sign_ups.show.request')
   end
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def then_i_am_on_the_adviser_sign_up_page
-    expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path)
+    expect(page).to have_current_path(new_candidate_interface_adviser_sign_ups_path)
   end
 
   def then_i_am_returned_to_the_adviser_sign_up_page
-    expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path(preferred_teaching_subject_id: @preferred_teaching_subject1.external_identifier))
+    expect(page).to have_current_path(new_candidate_interface_adviser_sign_ups_path(preferred_teaching_subject_id: @preferred_teaching_subject1.external_identifier))
   end
 
   def when_i_click_request_an_adviser

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -71,6 +71,9 @@ RSpec.describe 'International candidate submits the application' do
     click_link_or_button 'English GCSE or equivalent'
     candidate_fills_in_their_english_gcse
 
+    choose 'No'
+    click_link_or_button 'Continue'
+
     click_link_or_button 'Your personal statement'
     candidate_fills_in_personal_statement
 


### PR DESCRIPTION
## Context

Add adviser interruption page to appear if the candidate is eligible and has not already declined the offer.

## Changes proposed in this pull request

- Add interruption view and routes
- Add interruption form and controller
- Add conditional logic to complete action in review controllers of all sections

## Guidance to review

- Sign in as an eligible candidate and select 'Yes' (this section is complete) on the review page of any section
- Review the interruption page and select 'Yes'
- Review the subject selection page but go back before clicking 'Request Adviser'
- Complete any section again and you should still see the interruption 
- Now select 'No' and confirm that you do not see the controller again when completing a relevant section
- Eligibility criteria means that candidates who do request an adviser will not see the interruption page again but feel free to confirm this in the UI by resetting your application_form.adviser_status to "unassigned" and adviser_interrupted_responded_yes to "nil".

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
