### PR TITLE
[392] Block submission from candidates with student and skilled worker visas

### DIFF
--- a/app/validators/immigration_status_validator.rb
+++ b/app/validators/immigration_status_validator.rb
@@ -3,17 +3,24 @@ class ImmigrationStatusValidator < ActiveModel::EachValidator
   include GovukLinkHelper
   include GovukVisuallyHiddenHelper
 
+  VISAS_REQUIRING_SPONSORSHIP = %w[student_visa skilled_worker_visa].freeze
+
   def validate_each(record, attribute, application_choice)
     return if did_not_add_nationality_yet?(application_choice) ||
-              immigration_right_to_work?(application_choice) ||
+              british_or_irish?(application_choice) ||
+              not_requiring_sponsorship?(application_choice) ||
               course_can_sponsor_visa?(application_choice)
 
     record.errors.add(attribute, :immigration_status, link_to_find:)
   end
 
-  def immigration_right_to_work?(application_choice)
-    application_choice.application_form.british_or_irish? ||
-      application_choice.application_form.right_to_work_or_study_yes?
+  def british_or_irish?(application_choice)
+    application_choice.application_form.british_or_irish?
+  end
+
+  def not_requiring_sponsorship?(application_choice)
+    application_choice.application_form.right_to_work_or_study_yes? &&
+      !application_choice.application_form.immigration_status.in?(VISAS_REQUIRING_SPONSORSHIP)
   end
 
   def course_can_sponsor_visa?(application_choice)

--- a/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe 'Candidate with no right to work or study' do
   end
 
   scenario 'when candidate did not add their nationality yet neither right to work study' do
-    and_i_add_a_course_that_can_not_sponsor_student_visa
+    and_i_add_a_course_that_cannot_sponsor_student_visa
     then_i_do_not_see_an_error_message_that_the_course_does_not_sponsor_visa
   end
 
-  scenario 'when submit a course that can not sponsor student visa' do
+  scenario 'when submit a course that cannot sponsor student visa' do
     when_i_have_completed_my_foreign_application
-    and_i_add_a_course_that_can_not_sponsor_student_visa
+    and_i_add_a_course_that_cannot_sponsor_student_visa
     then_i_see_an_error_message_that_the_course_does_not_sponsor_visa
   end
 
-  scenario 'when submit a course that can not sponsor skilled worker visa' do
+  scenario 'when submit a course that cannot sponsor skilled worker visa' do
     when_i_have_completed_my_foreign_application
-    and_i_add_a_course_that_can_not_sponsor_skilled_worker
+    and_i_add_a_course_that_cannot_sponsor_skilled_worker
     then_i_see_an_error_message_that_the_course_does_not_sponsor_visa
   end
 
@@ -41,6 +41,26 @@ RSpec.describe 'Candidate with no right to work or study' do
     then_i_can_see_my_application_has_been_successfully_submitted
   end
 
+  scenario 'when i have a skilled worker visa and course does not sponsor' do
+    when_i_complete_an_application_with_skilled_worker_visa
+    and_i_add_a_course_that_cannot_sponsor_skilled_worker
+    then_i_see_an_error_message_that_the_course_does_not_sponsor_visa
+  end
+
+  scenario 'when i have a student visa and course does not sponsor' do
+    when_i_complete_an_application_with_student_visa
+    and_i_add_a_course_that_cannot_sponsor_student_visa
+    then_i_see_an_error_message_that_the_course_does_not_sponsor_visa
+  end
+
+  scenario 'when I have a student visa and the course I select sponsors visas' do
+    when_i_complete_an_application_with_student_visa
+    and_i_add_a_course_that_can_sponsor_student_visa
+    then_i_do_not_see_an_error_message_that_the_course_does_not_sponsor_visa
+    and_i_submit_the_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+  end
+
   def and_there_are_course_options
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     @course_can_sponsor_student_visa = create(
@@ -53,7 +73,7 @@ RSpec.describe 'Candidate with no right to work or study' do
       can_sponsor_student_visa: true,
       funding_type: 'fee',
     )
-    @course_can_not_sponsor_student_visa = create(
+    @course_cannot_sponsor_student_visa = create(
       :course,
       :open,
       name: 'English',
@@ -73,7 +93,7 @@ RSpec.describe 'Candidate with no right to work or study' do
       can_sponsor_student_visa: false,
       funding_type: 'salary',
     )
-    @course_can_not_sponsor_skilled_worker_visa = create(
+    @course_cannot_sponsor_skilled_worker_visa = create(
       :course,
       :open,
       name: 'Physics',
@@ -84,9 +104,9 @@ RSpec.describe 'Candidate with no right to work or study' do
       funding_type: 'salary',
     )
     create(:course_option, course: @course_can_sponsor_student_visa)
-    create(:course_option, course: @course_can_not_sponsor_student_visa)
+    create(:course_option, course: @course_cannot_sponsor_student_visa)
     create(:course_option, course: @course_can_sponsor_skilled_worker_visa)
-    create(:course_option, course: @course_can_not_sponsor_skilled_worker_visa)
+    create(:course_option, course: @course_cannot_sponsor_skilled_worker_visa)
   end
 
   def when_i_have_completed_my_foreign_application
@@ -102,15 +122,43 @@ RSpec.describe 'Candidate with no right to work or study' do
     )
   end
 
-  def and_i_add_a_course_that_can_not_sponsor_student_visa
+  def when_i_complete_an_application_with_skilled_worker_visa
+    @application_form = create(
+      :application_form,
+      :completed,
+      :with_degree,
+      candidate: current_candidate,
+      first_nationality: 'Indian',
+      second_nationality: nil,
+      right_to_work_or_study: 'yes',
+      immigration_status: 'skilled_worker_visa',
+      efl_completed: true,
+    )
+  end
+
+  def when_i_complete_an_application_with_student_visa
+    @application_form = create(
+      :application_form,
+      :completed,
+      :with_degree,
+      candidate: current_candidate,
+      first_nationality: 'Indian',
+      second_nationality: nil,
+      right_to_work_or_study: 'yes',
+      immigration_status: 'student_visa',
+      efl_completed: true,
+    )
+  end
+
+  def and_i_add_a_course_that_cannot_sponsor_student_visa
     when_i_choose_a_provider
-    choose @course_can_not_sponsor_student_visa.name
+    choose @course_cannot_sponsor_student_visa.name
     and_i_click_continue
   end
 
-  def and_i_add_a_course_that_can_not_sponsor_skilled_worker
+  def and_i_add_a_course_that_cannot_sponsor_skilled_worker
     when_i_choose_a_provider
-    choose @course_can_not_sponsor_skilled_worker_visa.name
+    choose @course_cannot_sponsor_skilled_worker_visa.name
     and_i_click_continue
   end
 


### PR DESCRIPTION
## Context

When candidates say they have a right to work / study, but indicate that their visa type is skilled_worker, or student, they require sponsorship. This PR blocks submission from those candidates to courses that do not sponsor visas.

## Changes proposed in this pull request

- Conditional on the immigration status validation that checks that the visa type is not student or skilled_worker.
-  fixed some misspellings

## Guidance to review
- Under Personal details, indicate that your have the right to work or study.
- Select either student or skilled worker visa from the list of possible immigration statuses
- Create a draft application to a course that DOES NOT sponsor visas. You should not see the submit button.
- Create a draft application to a course that DOES sponsor visas. You should be able to submit.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
