### PR TITLE
[809] Less restrictive maxLength API documentation

### DIFF
--- a/app/exports/common_columns/_personal_information.yml
+++ b/app/exports/common_columns/_personal_information.yml
@@ -35,7 +35,7 @@ phone_number:
 postcode:
   type: string
   description: The candidate’s postcode
-  maxLength: 8
+  maxLength: 25
   example: SK2 6AA
   nullable: true
 

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -353,7 +353,7 @@ components:
         postcode:
           type: string
           description: The candidate’s postcode
-          maxLength: 8
+          maxLength: 25
           example: SK2 6AA
           nullable: true
         country:

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -690,7 +690,7 @@ components:
         postcode:
           type: string
           description: The candidate’s postcode
-          maxLength: 8
+          maxLength: 25
           example: SK2 6AA
           nullable: true
         country:


### PR DESCRIPTION
## Context

One provider has taken our char limits on postcodes very seriously -- the API says it is 8 chars. In the past, we haven't stripped trailing white space, so we could have postcodes like '  SW12 8BN '. We are now stripping white space when adding / editing post codes, but we are not backfilling the changes. 

## Changes proposed in this pull request

This change just notes that even though UK postcodes are generally 5-8 chars long, they might be longer. 

We could strip trailing white space from the API response, but this might have a knock on effect for anyone who has saved the post codes with the whitespace in the first place -- it might look like a change when it isn't. 

## Guidance to review

View api docs on the review app https://apply-review-10573.test.teacherservices.cloud/api-docs/v1.6/reference#contactdetails-object

They should now say the max is 25 chars, not 8.

Are you happy with this approach? Should we also strip the trailing white space on the API response?


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
