### PR TITLE
[805] clean up draft candidate preferences

### DIFF
--- a/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
+++ b/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
@@ -1,0 +1,9 @@
+class Candidate::DeleteDraftCandidatePreferencesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform
+    CandidatePreference.draft.where('updated_at < ?', 3.days.ago).delete_all
+  end
+end

--- a/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
+++ b/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
@@ -1,4 +1,4 @@
-class DeleteDraftWithdrawalReasonRecordsWorker
+class Candidate::DeleteDraftWithdrawalReasonRecordsWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :low_priority

--- a/app/workers/delete_all_drafts_worker.rb
+++ b/app/workers/delete_all_drafts_worker.rb
@@ -1,0 +1,11 @@
+class DeleteAllDraftsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform
+    Candidate::DeleteDraftWithdrawalReasonRecordsWorker.perform_async
+    Provider::DeleteDraftPoolInvitesWorker.perform_async
+    Candidate::DeleteDraftCandidatePreferencesWorker.perform_async
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -28,8 +28,7 @@ class Clock
 
   # Daily jobs
   every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_async }
-  every(1.day, 'DeleteDraftWithdrawalReasonRecordsWorker', at: '4:01') { DeleteDraftWithdrawalReasonRecordsWorker.perform_async }
-  every(1.day, 'DeleteDraftPoolInvites', at: '4:02') { Provider::DeleteDraftPoolInvitesWorker.perform_async }
+  every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_async }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
 
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }

--- a/spec/workers/candidate/delete_draft_candidate_preferences_worker_spec.rb
+++ b/spec/workers/candidate/delete_draft_candidate_preferences_worker_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Candidate::DeleteDraftCandidatePreferencesWorker do
+  describe '#perform' do
+    it 'deletes draft withdrawal reason records that are over 3 days old' do
+      create(:candidate_preference, :published, updated_at: 3.days.ago)
+      create(:candidate_preference, :published, updated_at: 4.days.ago)
+      create(:candidate_preference, :draft, updated_at: 3.days.ago)
+      create(:candidate_preference, :draft, updated_at: Time.zone.now)
+      deletable_record = create(:candidate_preference, :draft, updated_at: 4.days.ago)
+
+      expect { described_class.new.perform }.to change { CandidatePreference.count }.by(-1)
+
+      expect { deletable_record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/workers/candidate/delete_draft_withdrawal_reason_records_worker_spec.rb
+++ b/spec/workers/candidate/delete_draft_withdrawal_reason_records_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe DeleteDraftWithdrawalReasonRecordsWorker do
+RSpec.describe Candidate::DeleteDraftWithdrawalReasonRecordsWorker do
   describe '#perform' do
     it 'deletes draft withdrawal reason records that are over 3 days old' do
       create(:withdrawal_reason, :published, updated_at: 3.days.ago)

--- a/spec/workers/delete_all_drafts_worker_spec.rb
+++ b/spec/workers/delete_all_drafts_worker_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DeleteAllDraftsWorker do
+  describe '#perform' do
+    let(:delete_drafts) { described_class.new.perform }
+
+    it 'queues up delete draft withdrawal reasons worker' do
+      expect { delete_drafts }.to change(
+        Candidate::DeleteDraftWithdrawalReasonRecordsWorker.jobs, :size
+      ).by(1)
+    end
+
+    it 'queues up delete draft pool invites worker' do
+      expect { delete_drafts }.to change(
+        Provider::DeleteDraftPoolInvitesWorker.jobs, :size
+      ).by(1)
+    end
+
+    it 'queues up delete draft candidate preferences worker' do
+      expect { delete_drafts }.to change(
+        Candidate::DeleteDraftCandidatePreferencesWorker.jobs, :size
+      ).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We can end up with abandoned draft candidate preferences. 

## Changes proposed in this pull request

- Job for delete draft candidate preferences that are over 3 days since updated
- A job for grouping all the 'delete draft jobs' together
- move the delete draft withdrawal reasons job into a candidate directory to follow the same pattern as the other jobs.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
