### PR TITLE
Ignore adviser interruption response when carrying over

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -6,7 +6,7 @@ class DuplicateApplication
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
-  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete equality_and_diversity equality_and_diversity_completed].freeze
+  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete equality_and_diversity equality_and_diversity_completed adviser_interruption_response].freeze
   IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
 
   def duplicate

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DuplicateApplication do
         recruitment_cycle_year:,
         references_count: 0,
         efl_completed: true,
+        adviser_interruption_response: true,
       )
       create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
@@ -42,6 +43,10 @@ RSpec.describe DuplicateApplication do
   it 'does not carry over any equality and diversity data' do
     expect(duplicate_application_form.equality_and_diversity).to be_nil
     expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
+  end
+
+  it 'does not carry over adviser response status' do
+    expect(duplicate_application_form.adviser_interruption_response).to be_nil
   end
 
   context 'when candidates has degrees' do


### PR DESCRIPTION
## Context

I think this [sentry error](https://dfe-teacher-services.sentry.io/issues/6531039869/?alert_rule_id=853774&alert_type=issue&notification_uuid=f0eb3b3c-44db-4615-abac-55d4cc4b4657&project=1765973&referrer=slack) was a fluke because the candidate tried to carry over in the middle of a deployment. But it made me realise we probably want to ignore this field when carrying over, continuing to encourage them to sign up with an adviser.

## Changes proposed in this pull request

Adding the adviser interruption response column to the ignored fields for duplicating applications

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
