### PR TITLE
Fix dynamic location preferences

### DIFF
--- a/app/services/candidate_interface/location_preferences.rb
+++ b/app/services/candidate_interface/location_preferences.rb
@@ -43,7 +43,7 @@ module CandidateInterface
     end
 
     def add_dynamic_location
-      return if preference.nil? || preference.opt_out?
+      return if preference.nil? || preference.opt_out? || !preference.dynamic_location_preferences
 
       site = application_choice.site
       return if preference.location_preferences.pluck(:name).include?(site.postcode)

--- a/spec/services/candidate_interface/location_preferences_spec.rb
+++ b/spec/services/candidate_interface/location_preferences_spec.rb
@@ -71,5 +71,21 @@ RSpec.describe CandidateInterface::LocationPreferences do
         )
       end
     end
+
+    context 'when preference dynamic_location is false' do
+      let(:preference) do
+        create(
+          :candidate_preference,
+          pool_status: 'opt_in',
+          dynamic_location_preferences: false,
+        )
+      end
+
+      it 'does not add a location preference from application_choice' do
+        expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
+          not_change(preference.location_preferences, :count),
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We didn't actually check the dynamic_location_preference boolean before adding new locations preferences to candidate preferences when submitting a new application

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Can go on to the review app and submit a new application when you have explicitly unchecked the 'Add new locations to my preferences when I apply to new courses'

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
