### PR TITLE
 Change the Pool::Candidate query to use candidate preferences 

### DIFF
--- a/app/models/candidate_location_preference.rb
+++ b/app/models/candidate_location_preference.rb
@@ -1,4 +1,6 @@
 class CandidateLocationPreference < ApplicationRecord
   belongs_to :candidate_preference
   belongs_to :provider, optional: true
+
+  acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -145,7 +145,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/one_login_controller.rb",
-      "line": 71,
+      "line": 67,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(logout_one_login((Current.session.id_token_hint or SessionError.find_by(:id => session[:session_error_id]).id_token_hint)), :allow_other_host => true)",
       "render_path": null,
@@ -260,7 +260,7 @@
       "check_name": "UnscopedFind",
       "message": "Unscoped call to `Pool::Invite#find_by`",
       "file": "app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb",
-      "line": 36,
+      "line": 39,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
       "code": "Pool::Invite.find_by(:id => params.expect(:draft_invite_id), :provider_id => current_provider_user.provider_ids, :status => :draft)",
       "render_path": null,
@@ -417,6 +417,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "d41568e9920037df226a6b4adf5ab5643f1391d401dd93f8bfdfc7ca621033ad",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/pool/candidates.rb",
+      "line": 81,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.joins(:candidate => :published_preferences).joins(\"        join lateral (\\n          select * from candidate_location_preferences\\n          where candidate_location_preferences.candidate_preference_id = candidate_preferences.id\\n          group by id\\n          having(#{CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))} <= candidate_location_preferences.within)\\n          limit 1\\n        ) as candidate_location_preferences on true\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Pool::Candidates",
+        "method": "filter_by_distance"
+      },
+      "user_input": "CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "dec17808bfcb16d7a790ec0a75640bf5735beda9cb32f1c5c26d09eedaba85a5",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -438,5 +461,5 @@
       "note": ""
     }
   ],
-  "brakeman_version": "7.0.0"
+  "brakeman_version": "7.0.2"
 }

--- a/spec/factories/candidate_location_preference.rb
+++ b/spec/factories/candidate_location_preference.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     candidate_preference factory: %i[candidate_preference]
     name { Faker::Address.city }
     within { 10 }
+
+    trait :manchester do
+      name { 'Manchester' }
+      latitude { 53.4807593 }
+      longitude { -2.2426305 }
+    end
   end
 end

--- a/spec/factories/candidate_preference.rb
+++ b/spec/factories/candidate_preference.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     candidate factory: %i[candidate]
     pool_status { 'opt_in' }
     dynamic_location_preferences { true }
+    status { 'published' }
   end
 end

--- a/spec/forms/candidate_interface/location_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/location_preferences_form_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe CandidateInterface::LocationPreferencesForm, type: :model do
         expect(preference.location_preferences.last).to have_attributes(
           name: 'BN1 1AA',
           within: 20,
-          latitude: 51.4524877,
-          longitude: -0.1204749,
+          latitude: 53.4807593,
+          longitude: -2.2426305,
         )
       end
     end
@@ -75,8 +75,8 @@ RSpec.describe CandidateInterface::LocationPreferencesForm, type: :model do
       it 'updates a preference to opt out and publishes the preference' do
         expect { form.save }.to change(location_preference, :name).from(location_preference.name).to('BN1 1AA')
           .and change(location_preference, :within).from(location_preference.within).to(20)
-          .and change(location_preference, :latitude).from(location_preference.latitude).to(51.4524877)
-          .and change(location_preference, :longitude).from(location_preference.longitude).to(-0.1204749)
+          .and change(location_preference, :latitude).from(location_preference.latitude).to(53.4807593)
+          .and change(location_preference, :longitude).from(location_preference.longitude).to(-2.2426305)
       end
     end
   end

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -70,7 +70,7 @@ module CandidateInterface
       end
 
       context 'when updating a preference to opt out' do
-        let(:preference) { create(:candidate_preference) }
+        let(:preference) { create(:candidate_preference, status: 'draft') }
         let(:params) { { pool_status: 'opt_out' } }
 
         it 'updates a preference to opt out and publishes the preference and removes existing published ones' do

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -6,27 +6,33 @@ RSpec.describe Pool::Candidates do
       it 'returns application_forms that should be on candidate pool list' do
         providers = [create(:provider)]
 
-        rejected_candidate = create(:candidate, pool_status: 'opt_in')
+        rejected_candidate = create(:candidate)
+        create(:candidate_preference, candidate: rejected_candidate)
         rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
         create(:application_choice, :rejected, application_form: rejected_candidate_form)
 
-        declined_candidate = create(:candidate, pool_status: 'opt_in')
+        declined_candidate = create(:candidate)
+        create(:candidate_preference, candidate: declined_candidate)
         declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
         create(:application_choice, :declined, application_form: declined_candidate_form)
 
-        withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        withdrawn_candidate = create(:candidate)
+        create(:candidate_preference, candidate: withdrawn_candidate)
         withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
         create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
-        conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+        conditions_not_met_candidate = create(:candidate)
+        create(:candidate_preference, candidate: conditions_not_met_candidate)
         conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
         create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
 
-        offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        offer_withdrawn_candidate = create(:candidate)
+        create(:candidate_preference, candidate: offer_withdrawn_candidate)
         offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
         create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
 
-        inactive_candidate = create(:candidate, pool_status: 'opt_in')
+        inactive_candidate = create(:candidate)
+        create(:candidate_preference, candidate: inactive_candidate)
         inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
         create(:application_choice, :inactive, application_form: inactive_candidate_form)
 
@@ -46,46 +52,55 @@ RSpec.describe Pool::Candidates do
         provider = create(:provider)
         providers = [provider]
 
-        opt_out_candidate = create(:candidate, pool_status: 'opt_out')
+        opt_out_candidate = create(:candidate)
+        create(:candidate_preference, pool_status: 'opt_out', candidate: opt_out_candidate)
         opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
         create(:application_choice, :rejected, application_form: opt_out_candidate_form)
 
-        dismissed_candidate = create(:candidate, pool_status: 'opt_in')
+        dismissed_candidate = create(:candidate)
+        create(:candidate_preference, candidate: dismissed_candidate)
         dismissed_candidate_form = create(:application_form, :completed, candidate: dismissed_candidate)
         create(:application_choice, :rejected, application_form: dismissed_candidate_form)
         create(:pool_dismissal, provider:, candidate: dismissed_candidate)
 
-        rejected_candidate = create(:candidate, pool_status: 'opt_in')
+        rejected_candidate = create(:candidate)
+        create(:candidate_preference, candidate: rejected_candidate)
         rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
         create(:application_choice, :rejected, application_form: rejected_candidate_form)
         create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
 
-        declined_candidate = create(:candidate, pool_status: 'opt_in')
+        declined_candidate = create(:candidate)
+        create(:candidate_preference, candidate: declined_candidate)
         declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
         create(:application_choice, :declined, application_form: declined_candidate_form)
         create(:application_choice, :interviewing, application_form: declined_candidate_form)
 
-        withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        withdrawn_candidate = create(:candidate)
+        create(:candidate_preference, candidate: withdrawn_candidate)
         withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
         create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
         create(:application_choice, :offer, application_form: withdrawn_candidate_form)
 
-        conditions_not_met_candidate = create(:candidate, pool_status: 'opt_in')
+        conditions_not_met_candidate = create(:candidate)
+        create(:candidate_preference, candidate: conditions_not_met_candidate)
         conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
         create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
         create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
 
-        offer_withdrawn_candidate = create(:candidate, pool_status: 'opt_in')
+        offer_withdrawn_candidate = create(:candidate)
+        create(:candidate_preference, candidate: offer_withdrawn_candidate)
         offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
         create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
         create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
 
-        inactive_candidate = create(:candidate, pool_status: 'opt_in')
+        inactive_candidate = create(:candidate)
+        create(:candidate_preference, candidate: inactive_candidate)
         inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
         create(:application_choice, :inactive, application_form: inactive_candidate_form)
         create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
 
-        candidate_with_too_many_choices = create(:candidate, pool_status: 'opt_in')
+        candidate_with_too_many_choices = create(:candidate)
+        create(:candidate_preference, candidate: candidate_with_too_many_choices)
         candidate_with_too_many_choices_form = create(:application_form, :completed, candidate: candidate_with_too_many_choices)
         create_list(:application_choice, 15, :offer_withdrawn, application_form: candidate_with_too_many_choices_form)
 
@@ -97,13 +112,9 @@ RSpec.describe Pool::Candidates do
 
     context 'with filters' do
       it 'returns application_forms based on filters' do
+        manchester_coordinates = [53.4807593, -2.2426305]
+
         provider = create(:provider)
-        aa_teamworks = create(
-          :site,
-          latitude: 51.4524877,
-          longitude: -0.1204749,
-          provider:,
-        )
         course = create(:course, provider:)
         tda_course = create(
           :course,
@@ -112,18 +123,15 @@ RSpec.describe Pool::Candidates do
         )
         course_option = create(
           :course_option,
-          site: aa_teamworks,
           course: course,
         )
         part_time_course_option = create(
           :course_option,
-          site: aa_teamworks,
           course: course,
           study_mode: :part_time,
         )
         part_time_tda_course_option = create(
           :course_option,
-          site: aa_teamworks,
           course: tda_course,
           study_mode: :part_time,
         )
@@ -132,7 +140,7 @@ RSpec.describe Pool::Candidates do
         create(:course_subject, subject:, course:)
         create(:course_subject, subject:, course: tda_course)
 
-        manchester_candidate_form = create_manchester_candidate_form(provider, aa_teamworks)
+        manchester_candidate_form = create_manchester_candidate_form(provider)
         subject_candidate_form = create_subject_candidate_form(course_option)
         part_time_candidate_form = create_part_time_candidate_form(part_time_course_option)
         undergraduate_candidate_form = create_undergraduate_candidate_form(part_time_tda_course_option)
@@ -142,7 +150,7 @@ RSpec.describe Pool::Candidates do
         withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
         create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
 
-        filters = { origin: [51.4524877, -0.1204749] }
+        filters = { origin: manchester_coordinates }
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
@@ -153,7 +161,7 @@ RSpec.describe Pool::Candidates do
           visa_sponsorship_candidate_form.id,
         )
 
-        filters = { origin: [51.4524877, -0.1204749], subject: [subject.id.to_s] }
+        filters = { origin: manchester_coordinates, subject: [subject.id.to_s] }
 
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
@@ -165,7 +173,7 @@ RSpec.describe Pool::Candidates do
         )
 
         filters = {
-          origin: [51.4524877, -0.1204749],
+          origin: manchester_coordinates,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
         }
@@ -179,7 +187,7 @@ RSpec.describe Pool::Candidates do
         )
 
         filters = {
-          origin: [51.4524877, -0.1204749],
+          origin: manchester_coordinates,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
           course_type: ['TDA'],
@@ -193,7 +201,7 @@ RSpec.describe Pool::Candidates do
         )
 
         filters = {
-          origin: [51.4524877, -0.1204749],
+          origin: manchester_coordinates,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
           course_type: ['TDA'],
@@ -208,13 +216,14 @@ RSpec.describe Pool::Candidates do
       end
     end
 
-    def create_manchester_candidate_form(provider, aa_teamworks)
-      manchester_candidate = create(:candidate, pool_status: 'opt_in')
+    def create_manchester_candidate_form(provider)
+      manchester_candidate = create(:candidate)
+      candidate_preference = create(:candidate_preference, candidate: manchester_candidate)
+      create(:candidate_location_preference, :manchester, candidate_preference:)
       manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
       course = create(:course, provider:)
       course_option = create(
         :course_option,
-        site: aa_teamworks,
         course: course,
       )
       create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
@@ -223,7 +232,9 @@ RSpec.describe Pool::Candidates do
     end
 
     def create_subject_candidate_form(course_option)
-      subject_candidate = create(:candidate, pool_status: 'opt_in')
+      subject_candidate = create(:candidate)
+      candidate_preference = create(:candidate_preference, candidate: subject_candidate)
+      create(:candidate_location_preference, :manchester, candidate_preference:)
       subject_candidate_form = create(:application_form, :completed, candidate: subject_candidate)
       create(:application_choice, :rejected, application_form: subject_candidate_form, course_option:)
 
@@ -231,14 +242,18 @@ RSpec.describe Pool::Candidates do
     end
 
     def create_part_time_candidate_form(course_option)
-      part_time_candidate = create(:candidate, pool_status: 'opt_in')
+      part_time_candidate = create(:candidate)
+      candidate_preference = create(:candidate_preference, candidate: part_time_candidate)
+      create(:candidate_location_preference, :manchester, candidate_preference:)
       part_time_candidate_form = create(:application_form, :completed, candidate: part_time_candidate)
       create(:application_choice, :rejected, application_form: part_time_candidate_form, course_option:)
       part_time_candidate_form
     end
 
     def create_undergraduate_candidate_form(course_option)
-      undergraduate_candidate = create(:candidate, pool_status: 'opt_in')
+      undergraduate_candidate = create(:candidate)
+      candidate_preference = create(:candidate_preference, candidate: undergraduate_candidate)
+      create(:candidate_location_preference, :manchester, candidate_preference:)
       undergraduate_candidate_form = create(
         :application_form,
         :completed,
@@ -249,7 +264,9 @@ RSpec.describe Pool::Candidates do
     end
 
     def create_visa_sponsorship_candidate_form(course_option)
-      visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
+      visa_sponsorship_candidate = create(:candidate)
+      candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
+      create(:candidate_location_preference, :manchester, candidate_preference:)
       visa_sponsorship_candidate_form = create(
         :application_form,
         :completed,

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
         {
           original_location: 'Manchester',
           visa_sponsorship: ['required'],
-          origin: [51.4524877, -0.1204749],
+          origin: [53.4807593, -2.2426305],
         }.with_indifferent_access,
       )
     end

--- a/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
+++ b/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'ProviderInterface::CandidatePool::PublishInvitesController' do
     end
 
     it 'redirects to candidate_interface_interstitial_path' do
-      candidate = create(:candidate, pool_status: 'opt_in')
+      candidate = create(:candidate)
+      create(:candidate_preference, candidate:)
       application_form = create(:application_form, :completed, candidate:)
       course = create(:course, provider:, exposed_in_find: true)
       course_option = create(:course_option, course: course)

--- a/spec/support/geocode_test_helper.rb
+++ b/spec/support/geocode_test_helper.rb
@@ -5,8 +5,8 @@ module GeocodeTestHelper
     Geocoder::Lookup::Test.set_default_stub(
       [
         {
-          'coordinates' => [51.4524877, -0.1204749],
-          'address' => 'AA Teamworks W Yorks SCITT, School Street, Greetland, Halifax, West Yorkshire HX4 8JB',
+          'coordinates' => [53.4807593, -2.2426305],
+          'address' => 'Manchester',
           'state' => 'England',
           'country' => 'United Kingdom',
           'country_code' => 'UK',

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -102,7 +102,8 @@ RSpec.describe 'Providers invites candidates' do
   end
 
   def and_there_are_candidates_for_candidate_pool
-    @candidate = create(:candidate, pool_status: 'opt_in')
+    @candidate = create(:candidate)
+    create(:candidate_preference, candidate: @candidate)
     rejected_candidate_form = create(
       :application_form,
       :completed,

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def and_there_are_candidates_for_candidate_pool
-    @rejected_candidate = create(:candidate, pool_status: 'opt_in')
+    @rejected_candidate = create(:candidate)
+    create(:candidate_preference, candidate: @rejected_candidate)
     @rejected_candidate_form = create(
       :application_form,
       :completed,
@@ -40,7 +41,8 @@ RSpec.describe 'Providers views candidate pool list' do
     )
     create(:application_choice, :rejected, application_form: @rejected_candidate_form)
 
-    declined_candidate = create(:candidate, pool_status: 'opt_in')
+    declined_candidate = create(:candidate)
+    create(:candidate_preference, candidate: declined_candidate)
     @declined_candidate_form = create(
       :application_form,
       :completed,

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def set_declined_candidate_form
-    declined_candidate = create(:candidate, pool_status: 'opt_in')
+    declined_candidate = create(:candidate)
+    create(:candidate_preference, candidate: declined_candidate)
     @declined_candidate_form = create(
       :application_form,
       :completed,
@@ -73,22 +74,17 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def set_rejected_candidate_form
-    rejected_candidate = create(:candidate, pool_status: 'opt_in')
+    rejected_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: rejected_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
     @rejected_candidate_form = create(
       :application_form,
       :completed,
       candidate: rejected_candidate,
       submitted_at: 1.day.ago,
     )
-    aa_teamworks = create(
-      :site,
-      latitude: 51.4524877,
-      longitude: -0.1204749,
-      provider: current_provider,
-    )
     course_option = create(
       :course_option,
-      site: aa_teamworks,
       course: create(:course, provider: current_provider),
     )
     create(
@@ -100,7 +96,9 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def set_visa_sponsorship_candidate_form
-    visa_sponsorship_candidate = create(:candidate, pool_status: 'opt_in')
+    visa_sponsorship_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
     @visa_sponsorship_form = create(
       :application_form,
       :completed,
@@ -108,15 +106,8 @@ RSpec.describe 'Providers views candidate pool list' do
       submitted_at: 6.hours.ago,
       right_to_work_or_study: :no,
     )
-    aa_teamworks = create(
-      :site,
-      latitude: 51.5249377,
-      longitude: -0.1204752,
-      provider: current_provider,
-    )
     course_option = create(
       :course_option,
-      site: aa_teamworks,
       course: create(:course, provider: current_provider),
     )
     create(


### PR DESCRIPTION
## Context

Previously the query that was used on the find a candidate index page
was looking within the sites of the candidate application choices.

This needs to change. We need to use the candidate preferences to show
results on the find a candidate view, in the provider interface.

This changes the query. It calculates the distance from the provider
location to each candidate_location_preference and returns the first result if
any of the location_preferences are within distance.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app, login as a provider and filter by a location


https://github.com/user-attachments/assets/d7c4739e-beff-4bae-bd4f-5c852ad0b4c1



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
