### PR TITLE
[777] Implement ability for support to unlink one login auths

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -89,10 +89,21 @@ module SupportInterface
     end
 
     def one_login_account_row
-      {
-        key: 'Has One Login account',
-        value: one_login? ? "Yes (#{candidate.one_login_auth.email_address})" : 'No',
-      }
+      if one_login?
+        {
+          key: 'Has GOV.UK One Login',
+          value: "Yes (#{candidate.one_login_auth.email_address})",
+          action: {
+            href: edit_support_interface_one_login_auths_path(application_form),
+            visually_hidden_text: 'candidate GOV.UK One Login',
+          },
+        }
+      else
+        {
+          key: 'Has GOV.UK One Login',
+          value: 'No',
+        }
+      end
     end
 
     def unsubscribed_from_emails

--- a/app/controllers/support_interface/one_login_auths_controller.rb
+++ b/app/controllers/support_interface/one_login_auths_controller.rb
@@ -1,0 +1,35 @@
+module SupportInterface
+  class OneLoginAuthsController < SupportInterfaceController
+    before_action :set_application_form
+    def edit
+      @candidate = @application_form.candidate
+      @unlink_form = UnlinkOneLoginAuthForm.new(candidate: @candidate)
+    end
+
+    def update
+      @candidate = @application_form.candidate
+      @unlink_form = UnlinkOneLoginAuthForm.new(audit_comment: form_params[:audit_comment], candidate: @candidate)
+
+      if @unlink_form.valid?
+        @unlink_form.save
+        flash[:success] = t('.success')
+
+        redirect_to support_interface_application_form_path(@application_form)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def set_application_form
+      @application_form = ApplicationForm.find(params[:application_form_id])
+    end
+
+    def form_params
+      params.expect(
+        support_interface_unlink_one_login_auth_form: :audit_comment,
+      )
+    end
+  end
+end

--- a/app/controllers/support_interface/one_login_auths_controller.rb
+++ b/app/controllers/support_interface/one_login_auths_controller.rb
@@ -1,13 +1,12 @@
 module SupportInterface
   class OneLoginAuthsController < SupportInterfaceController
-    before_action :set_application_form
+    before_action :set_application_form_and_candidate
+    before_action :redirect_if_one_login_auth_does_not_exist
     def edit
-      @candidate = @application_form.candidate
       @unlink_form = UnlinkOneLoginAuthForm.new(candidate: @candidate)
     end
 
     def update
-      @candidate = @application_form.candidate
       @unlink_form = UnlinkOneLoginAuthForm.new(audit_comment: form_params[:audit_comment], candidate: @candidate)
 
       if @unlink_form.valid?
@@ -22,8 +21,15 @@ module SupportInterface
 
   private
 
-    def set_application_form
+    def set_application_form_and_candidate
       @application_form = ApplicationForm.find(params[:application_form_id])
+      @candidate = @application_form.candidate
+    end
+
+    def redirect_if_one_login_auth_does_not_exist
+      return if @candidate.one_login_auth.present?
+
+      redirect_to support_interface_application_form_path(@application_form)
     end
 
     def form_params

--- a/app/forms/support_interface/unlink_one_login_auth_form.rb
+++ b/app/forms/support_interface/unlink_one_login_auth_form.rb
@@ -20,5 +20,9 @@ module SupportInterface
         )
       end
     end
+
+    def show_recovery_warning?
+      candidate.email_address != candidate.one_login_auth.email_address
+    end
   end
 end

--- a/app/forms/support_interface/unlink_one_login_auth_form.rb
+++ b/app/forms/support_interface/unlink_one_login_auth_form.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class UnlinkOneLoginAuthForm
+    include ActiveModel::Model
+
+    attr_accessor :audit_comment, :candidate
+
+    validates :audit_comment, presence: true
+    validates :audit_comment, word_count: { maximum: 200 }
+
+    def save
+      return unless valid?
+      return if candidate.one_login_auth.blank?
+
+      ActiveRecord::Base.transaction do
+        candidate.one_login_auth.destroy
+        candidate.account_recovery_request&.destroy
+        candidate.update!(
+          account_recovery_status: 'not_started',
+          audit_comment:,
+        )
+      end
+    end
+  end
+end

--- a/app/views/support_interface/one_login_auths/edit.html.erb
+++ b/app/views/support_interface/one_login_auths/edit.html.erb
@@ -7,8 +7,19 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <%= t('.heading', name: @application_form.full_name.presence || @candidate.email_address) %>
+        <%= t('.heading', name: @candidate.one_login_auth.email_address) %>
       </h1>
+
+      <div class="govuk-inset-text">
+        <p>
+          <%= t('.cannot_be_undone') %>
+        </p>
+        <% if @unlink_form.show_recovery_warning? %>
+          <p>
+            <%= t('.recovery_warning_html', candidate_email: @candidate.email_address) %>
+          </p>
+        <% end %>
+      </div>
 
       <%= f.govuk_text_field(
           :audit_comment,

--- a/app/views/support_interface/one_login_auths/edit.html.erb
+++ b/app/views/support_interface/one_login_auths/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @unlink_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @unlink_form, url: support_interface_one_login_auths_path(@application_form), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= t('.heading', name: @application_form.full_name.presence || @candidate.email_address) %>
+      </h1>
+
+      <%= f.govuk_text_field(
+          :audit_comment,
+          label: { text: t('.audit_log_comment_label'), size: 'm' },
+          hint: { text: t('.audit_log_comment_hint') },
+        ) %>
+
+      <%= f.govuk_submit t('.continue') %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('.cancel'), support_interface_application_form_path(@application_form) %>
+    </p>
+  </div>
+</div>

--- a/config/locales/support_interface/one_login_auths.yml
+++ b/config/locales/support_interface/one_login_auths.yml
@@ -1,0 +1,18 @@
+en:
+  support_interface:
+    one_login_auths:
+      edit:
+        title: Unlinking GOV.UK One Login
+        heading: Do you want to unlink GOV.UK One Login for %{name}?
+        continue: Continue
+        cancel: Cancel
+        audit_log_comment_label: Audit log comment
+        audit_log_comment_hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
+      update:
+        success: GOV.UK One Login has been unlinked
+  activemodel:
+    errors:
+      models:
+        support_interface/unlink_one_login_auth_form:
+          blank: Enter a comment for the audit log
+          too_many_words: Audit log comment should be fewer than %{maximum} words

--- a/config/locales/support_interface/one_login_auths.yml
+++ b/config/locales/support_interface/one_login_auths.yml
@@ -6,6 +6,11 @@ en:
         heading: Do you want to unlink GOV.UK One Login for %{name}?
         continue: Continue
         cancel: Cancel
+        cannot_be_undone: This action cannot be undone.
+        recovery_warning_html: >
+          The email for this candidate is <b>%{candidate_email}</b>. If they use a different email to login next time, they will
+          need to follow the process to recover their account to see any details they have already completed on their
+          application.
         audit_log_comment_label: Audit log comment
         audit_log_comment_hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
       update:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -84,6 +84,8 @@ namespace :support_interface, path: '/support' do
       get 'volunteering-roles/:volunteering_role_id' => 'application_forms/volunteering_roles#edit', as: :application_form_edit_volunteering_role
       post 'volunteering-roles/:volunteering_role_id' => 'application_forms/volunteering_roles#update', as: :application_form_update_volunteering_role
     end
+
+    resource :one_login_auths, only: %i[edit update], path: '/one-login-auths'
   end
 
   get '/duplicate-matches' => 'duplicate_matches#index', as: :duplicate_matches

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -720,22 +720,9 @@ If `candidate.account_recovery_status == 'dismissed'`
 candidate.account_recovery_request.destroy
 candidate.update(account_recovery_status: 'not_started')
 ```
-
 Now the candidate should be able to see the banner and proceed as expected.
 Note that if the candidate has submitted any application choices on their new account, they will not be able to link it with an old account.
 
-If `candidate.account_recovery_status == 'recovered'`
-- Only proceed if `!candidate.application_choices_submitted?`
-- Confirm with support what this candidate wants to do, because we might have a data breach problem if they have managed to link themselves to the wrong candidate.
-- You might also need to confirm with policy as it is not clear how a candidate would get into the state.
-
-Assuming there is a good reason for it:
-
-```ruby
-candidate.one_login_auth.destroy
-candidate.account_recovery_request.destroy
-candidate.update(account_recovery_status: 'not_started')
-```
 
 Now they will have to start the whole One Login journey over again.
 

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
 
         result = render_inline(described_class.new(application_form:))
 
-        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__key').text).to include('Has GOV.UK One Login')
         expect(result.css('.govuk-summary-list__value').text).to include('Yes (some_other_email_address@gmail.com)')
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
 
         result = render_inline(described_class.new(application_form:))
 
-        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__key').text).to include('Has GOV.UK One Login')
         expect(result.css('.govuk-summary-list__value').text).to include('No')
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
 
         result = render_inline(described_class.new(application_form:))
 
-        expect(result.css('.govuk-summary-list__key').text).to include('Has One Login account')
+        expect(result.css('.govuk-summary-list__key').text).to include('Has GOV.UK One Login')
         expect(result.css('.govuk-summary-list__value').text).to include('No')
       end
     end

--- a/spec/system/support_interface/unlinking_candidate_one_login_spec.rb
+++ b/spec/system/support_interface/unlinking_candidate_one_login_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe 'Unlinking candidate one login', :with_audited do
+  include DfESignInHelpers
+
+  scenario 'unlinking where account recovery has taken place' do
+    given_i_am_a_support_user
+    and_a_candidate_with_a_one_login_auth_account_and_account_recovery_request_exist
+    when_i_visit_the_application_form_summary
+    and_i_click_on('Change candidate GOV.UK One Login')
+    then_i_see_the_unlink_form
+
+    when_i_add_an_audit_comment
+    and_i_click_on('Continue')
+    i_see_the_success_message
+    and_the_one_login_auth_record_is_deleted
+    and_the_account_recovery_request_is_deleted
+    and_the_audit_has_been_logged
+  end
+
+  scenario 'unlinking where there has been no account recovery' do
+    given_i_am_a_support_user
+    and_a_candidate_with_a_one_login_auth_account_and_no_account_recovery_request
+    when_i_visit_the_application_form_summary
+    and_i_click_on('Change candidate GOV.UK One Login')
+    then_i_see_the_unlink_form
+
+    when_i_add_an_audit_comment
+    and_i_click_on('Continue')
+    i_see_the_success_message
+    and_the_one_login_auth_record_is_deleted
+    and_the_audit_has_been_logged
+  end
+
+  scenario 'navigation' do
+    given_i_am_a_support_user
+    and_a_candidate_with_a_one_login_auth_account_and_no_account_recovery_request
+    when_i_visit_the_application_form_summary
+    and_i_click_on('Change candidate GOV.UK One Login')
+    then_i_see_the_unlink_form
+    when_i_click_on('Back')
+    then_i_am_on_the_application_form_summary
+
+    and_i_click_on('Change candidate GOV.UK One Login')
+    and_i_click_on('Cancel')
+    then_i_am_on_the_application_form_summary
+  end
+
+  scenario 'errors' do
+    given_i_am_a_support_user
+    and_a_candidate_with_a_one_login_auth_account_and_no_account_recovery_request
+    when_i_visit_the_application_form_summary
+    and_i_click_on('Change candidate GOV.UK One Login')
+
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Enter a comment for the audit log')
+
+    when_i_enter_a_very_long_audit_log_comment
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Audit log comment should be fewer than 200 words')
+  end
+
+private
+
+  def and_i_click_on(string)
+    click_on string
+  end
+  alias_method :when_i_click_on, :and_i_click_on
+
+  def then_i_see_the_error_message(message)
+    expect(page).to have_content(message).twice
+  end
+
+  def when_i_enter_a_very_long_audit_log_comment
+    fill_in 'Audit log comment', with: 'hi there ' * 101
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_a_candidate_with_a_one_login_auth_account_and_account_recovery_request_exist
+    @application_form = create(:application_form)
+    @candidate = @application_form.candidate
+    @candidate.update(account_recovery_status: 'recovered')
+
+    create(:one_login_auth, candidate: @candidate)
+    create(:account_recovery_request, candidate: @candidate)
+  end
+
+  def and_a_candidate_with_a_one_login_auth_account_and_no_account_recovery_request
+    @application_form = create(:application_form)
+    @candidate = @application_form.candidate
+
+    create(:one_login_auth, candidate: @candidate)
+  end
+
+  def when_i_visit_the_application_form_summary
+    visit support_interface_application_form_path(@application_form)
+  end
+
+  def then_i_see_the_unlink_form
+    expect(page).to have_content "Do you want to unlink GOV.UK One Login for #{@candidate.email_address}"
+  end
+
+  def then_i_am_on_the_application_form_summary
+    expect(page).to have_current_path support_interface_application_form_path(@application_form), ignore_query: true
+  end
+
+  def when_i_add_an_audit_comment
+    fill_in 'Audit log comment', with: 'This is a comment about one login auth'
+  end
+
+  def i_see_the_success_message
+    expect(page).to have_content 'GOV.UK One Login has been unlinked'
+  end
+
+  def and_the_one_login_auth_record_is_deleted
+    @candidate.reload
+    expect(@candidate.one_login_auth).to be_nil
+  end
+
+  def and_the_account_recovery_request_is_deleted
+    expect(@candidate.account_recovery_request).to be_nil
+    expect(@candidate.account_recovery_status).to eq 'not_started'
+  end
+
+  def and_the_audit_has_been_logged
+    expect(@candidate.audits.last.comment).to eq 'This is a comment about one login auth'
+  end
+end

--- a/spec/system/support_interface/unlinking_candidate_one_login_spec.rb
+++ b/spec/system/support_interface/unlinking_candidate_one_login_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Unlinking candidate one login', :with_audited do
     when_i_visit_the_application_form_summary
     and_i_click_on('Change candidate GOV.UK One Login')
     then_i_see_the_unlink_form
+    and_i_see_the_recovery_warning
 
     when_i_add_an_audit_comment
     and_i_click_on('Continue')
@@ -24,6 +25,7 @@ RSpec.describe 'Unlinking candidate one login', :with_audited do
     when_i_visit_the_application_form_summary
     and_i_click_on('Change candidate GOV.UK One Login')
     then_i_see_the_unlink_form
+    and_i_do_not_see_the_recovery_warning
 
     when_i_add_an_audit_comment
     and_i_click_on('Continue')
@@ -92,7 +94,7 @@ private
     @application_form = create(:application_form)
     @candidate = @application_form.candidate
 
-    create(:one_login_auth, candidate: @candidate)
+    create(:one_login_auth, candidate: @candidate, email_address: @candidate.email_address)
   end
 
   def when_i_visit_the_application_form_summary
@@ -100,7 +102,15 @@ private
   end
 
   def then_i_see_the_unlink_form
-    expect(page).to have_content "Do you want to unlink GOV.UK One Login for #{@candidate.email_address}"
+    expect(page).to have_content "Do you want to unlink GOV.UK One Login for #{@candidate.one_login_auth.email_address}"
+  end
+
+  def and_i_see_the_recovery_warning
+    expect(page).to have_content "The email for this candidate is #{@candidate.email_address}."
+  end
+
+  def and_i_do_not_see_the_recovery_warning
+    expect(page).to have_no_content "The email for this candidate is #{@candidate.email_address}."
   end
 
   def then_i_am_on_the_application_form_summary


### PR DESCRIPTION
## Context

We are receiving multiple requests each day to unlink GOV.UK One Login. This currently requires a dev intervention, PIM request, etc. This allows support to do it directly. 

## Changes proposed in this pull request

https://github.com/user-attachments/assets/60209027-ab28-4edc-a222-769a3c7e02e4

## Guidance to review

Should there be any restrictions / logic around resetting the recovery request and status? Maybe only do it if the status is dismissed? But if the account has actually been recovered, maybe we shouldn't reset it? 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
