### PR TITLE
Preserve the order the location preferences are created in

### DIFF
--- a/app/forms/candidate_interface/location_preferences_form.rb
+++ b/app/forms/candidate_interface/location_preferences_form.rb
@@ -32,7 +32,7 @@ class CandidateInterface::LocationPreferencesForm
     if location_preference.present?
       location_preference.update(
         within:,
-        name: suggested_location[:name],
+        name: name == location_preference.name ? name : suggested_location[:name],
         latitude: location_coordinates&.latitude,
         longitude: location_coordinates&.longitude,
         provider_id: name == location_preference.name ? location_preference.provider_id : nil,

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -16,20 +16,19 @@ class CandidatePreference < ApplicationRecord
     dup_record = dup
     dup_record.status = 'draft'
 
-    location_preferences_attributes = []
-
-    location_preferences.map do |location|
-      location_preferences_attributes << location.attributes.except(
-        'id',
-        'candidate_preference_id',
-        'created_at',
-        'updated_at',
-      )
-    end
-
     ActiveRecord::Base.transaction do
       dup_record.save!
-      dup_record.location_preferences.insert_all!(location_preferences_attributes)
+
+      location_preferences.order(:created_at).each do |location|
+        dup_record.location_preferences.create!(
+          location.attributes.except(
+            'id',
+            'candidate_preference_id',
+            'created_at',
+            'updated_at',
+          ),
+        )
+      end
     end
 
     dup_record


### PR DESCRIPTION
## Context

Because of the way our multi step form works for the candidate preferences. The order of the location preferences would change.

This is because we dup the published preference into a draft preference when the candidate edits a published preference.

The dup method was using insert_all which is performant but will result in all the location preferences having the same created at. So the order would be lost.

This changes that and also stops updating the location preference name with the suggestion name if the name of the location preference has not changed.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
