### PR TITLE
Return only cities, towns or postcodes from maps autocomplete endpoint

### DIFF
--- a/app/lib/google_maps_api/client.rb
+++ b/app/lib/google_maps_api/client.rb
@@ -23,7 +23,7 @@ module GoogleMapsAPI
           input: query,
           components: 'country:uk',
           region: 'uk',
-          types: '(regions)',
+          types: 'locality|sublocality|postal_code',
         },
       )
 

--- a/spec/lib/google_maps_api/client_spec.rb
+++ b/spec/lib/google_maps_api/client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GoogleMapsAPI::Client do
   describe '#autocomplete' do
     let(:query) { 'London' }
     let(:autocomplete_api_path) do
-      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&region=uk&input=#{query}&key=#{api_key}&language=en&types=(regions)"
+      "https://maps.googleapis.com/maps/api/place/autocomplete/json?components=country%3Auk&region=uk&input=#{query}&key=#{api_key}&language=en&types=locality%7Csublocality%7Cpostal_code"
     end
     let(:body) { Pathname.new(Rails.root.join('spec/examples/google_maps_api/autocomplete_london.json')).read }
 


### PR DESCRIPTION
## Context

This should only returns English spelled cities, towns or postcode in the UK. Previously we would also get some Spanish or German spelling for some places.

The endpoint is quite specific to Find a candidate but it can be refactored easily in the future.

Docs for the API here if your interested https://developers.google.com/maps/documentation/places/web-service/autocomplete#types

## Changes proposed in this pull request

## Guidance to review

![image (4)](https://github.com/user-attachments/assets/492bc145-c1b5-4c24-843c-2ecf2dc5f6a3)


Go on review and input Yorkshire, you should not get Yorkshire del Oeste. Try also to input your postcode, does it return what you expect?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
