### PR TITLE
Don't add location preferences that don't have geocoordinates

### DIFF
--- a/spec/services/candidate_interface/location_preferences_spec.rb
+++ b/spec/services/candidate_interface/location_preferences_spec.rb
@@ -5,9 +5,18 @@ RSpec.describe CandidateInterface::LocationPreferences do
   let(:application_form) do
     create(:application_form, :completed, candidate: preference&.candidate || create(:candidate))
   end
+  let(:provider) { create(:provider) }
   let!(:application_choice) do
-    create(:application_choice, :awaiting_provider_decision, application_form:)
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form:,
+      course_option:,
+    )
   end
+  let(:course_option) { create(:course_option, course:, site:) }
+  let(:course) { create(:course, provider:) }
+  let(:site) { create(:site, latitude: 53.4807593, longitude: -2.2426305, provider:) }
 
   describe '.add_default_location_preferences' do
     context 'with UK candidate' do
@@ -39,10 +48,31 @@ RSpec.describe CandidateInterface::LocationPreferences do
         expect(preference.location_preferences.last.name).to eq(application_choice.site.postcode)
       end
     end
+
+    context 'when application_form.geocode is nil' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :international_address,
+          :completed,
+          candidate: preference.candidate,
+        )
+      end
+
+      it 'adds default location preferences only for the choice' do
+        allow(application_form).to receive(:geocode).and_return(nil)
+
+        expect { described_class.add_default_location_preferences(preference:) }.to(
+          change(preference.location_preferences, :count).by(1),
+        )
+
+        expect(preference.location_preferences.last.name).to eq(application_choice.site.postcode)
+      end
+    end
   end
 
   describe '.add_dynamic_location' do
-    context 'when preference is opt in' do
+    context 'when preference is opt in and dynamic_location is true' do
       it 'adds a location preference from application_choice' do
         expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
           change(preference.location_preferences, :count).by(1),
@@ -80,6 +110,16 @@ RSpec.describe CandidateInterface::LocationPreferences do
           dynamic_location_preferences: false,
         )
       end
+
+      it 'does not add a location preference from application_choice' do
+        expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(
+          not_change(preference.location_preferences, :count),
+        )
+      end
+    end
+
+    context 'when site is not geocoded' do
+      let(:site) { create(:site, provider:, latitude: nil, longitude: nil) }
 
       it 'does not add a location preference from application_choice' do
         expect { described_class.add_dynamic_location(preference:, application_choice:) }.to(

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -118,6 +118,8 @@ RSpec.describe 'Candidate adds preferences' do
     site = create(
       :site,
       postcode: choice_location[:name],
+      latitude: 53.4807593,
+      longitude: -2.2426305,
       provider:,
     )
     course = create(:course, provider:)


### PR DESCRIPTION
## Context

There might be some edge cases when application forms or site don't have lat/long coordinates. This stops those locations being added to location preferences.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Quite hard to test this. It's quite an edge case when we don't have sites or application_forms that don't have lat/long

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
