### PR TITLE
Exclude candidates from pool who no longer want to teach

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -54,6 +54,11 @@ private
             .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
             .select(:id),
       )
+      .where.not(
+        id: ApplicationForm.joins(application_choices: :withdrawal_reasons)
+          .where('withdrawal_reasons.reason LIKE ?', 'do-not-want-to-train-anymore%')
+          .select(:id),
+      )
   end
 
   def filter_by_distance(scope)

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -56,7 +56,7 @@ private
       )
       .where.not(
         id: ApplicationForm.joins(application_choices: :withdrawal_reasons)
-          .where('withdrawal_reasons.reason LIKE ?', 'do-not-want-to-train-anymore%')
+          .where('withdrawal_reasons.reason ILIKE ?', '%do-not-want-to-train-anymore%')
           .select(:id),
       )
   end

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Providers views candidate pool list' do
     set_rejected_candidate_form
     set_declined_candidate_form
     set_visa_sponsorship_candidate_form
+    set_withdrawn_no_longer_want_to_train_form
   end
 
   scenario 'View candidates' do
@@ -118,6 +119,32 @@ RSpec.describe 'Providers views candidate pool list' do
     )
   end
 
+  def set_withdrawn_no_longer_want_to_train_form
+    no_longer_wants_to_train_candidate = create(:candidate)
+    create(:candidate_preference, candidate: no_longer_wants_to_train_candidate)
+    @withdrawn_no_longer_wants_to_train_form = create(
+      :application_form,
+      :completed,
+      candidate: no_longer_wants_to_train_candidate,
+      submitted_at: 3.hours.ago,
+    )
+    course_option = create(
+      :course_option,
+      course: create(:course, provider: current_provider),
+    )
+    withdrawn_choice = create(
+      :application_choice,
+      :withdrawn,
+      application_form: @withdrawn_no_longer_wants_to_train_form,
+      course_option:,
+    )
+    create(
+      :withdrawal_reason,
+      application_choice: withdrawn_choice,
+      reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
+    )
+  end
+
   def and_provider_is_opted_in_to_candidate_pool
     create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
@@ -134,6 +161,8 @@ RSpec.describe 'Providers views candidate pool list' do
       candidate_name(@declined_candidate_form),
       candidate_name(@visa_sponsorship_form),
     )
+
+    expect(candidates).not_to include(candidate_name(@withdrawn_no_longer_wants_to_train_form))
   end
 
   def then_i_am_redirected_to_the_applications_page


### PR DESCRIPTION
## Context

Currently the find a candidate results don’t exclude candidates that withdrew with the reason: "I do not want to train to teach anymore".

## Changes proposed in this pull request

- Add section to `curated_application_forms` query to look up withdrawal reason and exclude from pool results if it matches.

## Guidance to review

- Create a candidate with this withdrawal reason.
- As a provider user, filter through search results in Find A Candidate to make sure they do not appear.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
