### PR TITLE
Content changes candidate preferences

### DIFF
--- a/app/components/candidate_interface/share_details_component.html.erb
+++ b/app/components/candidate_interface/share_details_component.html.erb
@@ -3,28 +3,31 @@
   who you have not submitted an application to.
 </p>
 <p class="govuk-body">
-  They can search a list of candidates and view their application details.
-  If you meet the eligibility criteria for their course, they can invite you to apply directly.
+  They can search a list of candidates and view your application details.
+  If they think you are suitable for their course, they can invite you to apply directly.
 </p>
 
-<%= govuk_button_to('Continue', path_to_continue, method: :get) %>
+<% if submit_application %>
+  <%= govuk_button_to('Continue', path_to_continue, method: :get) %>
+<% end %>
 
-<div class="app-card app-grid-column--grey">
-  <h2 class="govuk-heading-m">How this works with the current application process </h2>
+<div class="<%= app_card_class %>">
+  <h2 class="govuk-heading-m">How this works with the current application process</h2>
   <p class="govuk-body">
-    This feature should be used alongside the current application process.
-    You should continue to choose courses and submit applications yourself.
+    This feature should be used alongside <%= govuk_link_to 'the current application process', candidate_interface_guidance_path %>.
+    You must continue to choose courses and submit applications yourself.
   </p>
   <p class="govuk-body">
-    Your application details will only be visible to training providers if all
-    of your active applications are unsuccessful. Each time you submit a new
-    application, you will stop being searchable by other providers.
-  </p>
-  <p class="govuk-body">
-    You can still submit up to 4 application choices at a time. Any that you
-    are invited to apply to will count towards this total.
+    You can still submit up to 4 application choices at a time.
+    If a provider invites you to apply and you submit an application, it will count towards your total.
   </p>
   <p class="govuk-body">
     You can change your decision to share your application details at any time.
   </p>
-<div>
+</div>
+
+<% if !submit_application %>
+  <p class="govuk-body">
+    <%= govuk_link_to('Change your sharing and location settings', path_to_continue) %>
+  </p>
+<% end %>

--- a/app/components/candidate_interface/share_details_component.rb
+++ b/app/components/candidate_interface/share_details_component.rb
@@ -1,11 +1,20 @@
 class CandidateInterface::ShareDetailsComponent < ViewComponent::Base
-  attr_reader :current_candidate
+  attr_reader :current_candidate, :submit_application
 
-  def initialize(current_candidate)
+  def initialize(current_candidate, submit_application: false)
     @current_candidate = current_candidate
+    @submit_application = submit_application
+  end
+
+  def render?
+    FeatureFlag.active?(:candidate_preferences)
   end
 
 private
+
+  def app_card_class
+    submit_application ? 'app-card app-grid-column--grey' : ''
+  end
 
   def path_to_continue
     if current_candidate.published_preferences.last&.opt_out?

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -52,7 +52,7 @@ module CandidateInterface
       flash[:success] = t('application_form.submit_application_success.title')
 
       if FeatureFlag.active?(:candidate_preferences) && current_candidate.published_preferences.blank?
-        redirect_to candidate_interface_share_details_path
+        redirect_to candidate_interface_share_details_path(submit_application: true)
       else
         redirect_to candidate_interface_application_choices_path
       end

--- a/app/controllers/candidate_interface/share_details_controller.rb
+++ b/app/controllers/candidate_interface/share_details_controller.rb
@@ -2,7 +2,9 @@ module CandidateInterface
   class ShareDetailsController < CandidateInterfaceController
     before_action :redirect_to_root_path_if_flag_is_inactive
 
-    def index; end
+    def index
+      @submit_application = params[:submit_application] == 'true'
+    end
 
   private
 

--- a/app/frontend/styles/_list.scss
+++ b/app/frontend/styles/_list.scss
@@ -15,3 +15,7 @@
     margin-top: govuk-spacing(2);
   }
 }
+
+.govuk-list--bullet > li {
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -5,7 +5,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
     <p class="govuk-body"><%= t('.body') %></p>
-
     <h2 class="govuk-heading-m"><%= t('.select_locations') %></h2>
 
     <%= form_with(

--- a/app/views/candidate_interface/share_details/index.html.erb
+++ b/app/views/candidate_interface/share_details/index.html.erb
@@ -5,6 +5,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
-    <%= render CandidateInterface::ShareDetailsComponent.new(current_candidate) %>
+    <%= render(
+      CandidateInterface::ShareDetailsComponent.new(
+        current_candidate,
+        submit_application: @submit_application,
+      ),
+    ) %>
   </div>
 </div>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -8,7 +8,7 @@ en:
         title: Check your application sharing preferences
         share_information: Do you want to make your application details visible to other training providers?
         preferred_locations: Preferred locations
-        dynamic_locations: Add new locations to my preferences when I apply to new course
+        dynamic_locations: Add new course locations to my preferences when I apply to new courses
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
@@ -28,7 +28,7 @@ en:
         title: Check your application sharing preferences
         share_information: Do you want to make your application details visible to other training providers?
         preferred_locations: Preferred locations
-        dynamic_locations: Add new locations to my preferences when I apply to new course
+        dynamic_locations: Add new course locations to my preferences when I apply to new courses
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
@@ -45,7 +45,6 @@ en:
         title: Check your application sharing preferences
         share_information: Do you want to share your application details with other training providers?
         preferred_locations: Preferred locations
-        dynamic_locations: Update my location preferences when I apply to a new course
         change: Change
         submit: Submit preferences
       create:
@@ -58,16 +57,16 @@ en:
     location_preferences:
       index:
         title: Location preferences
-        body: Training providers will use the locations you enter here to search for candidates near their courses.
+        body: Training providers will use the locations you enter here to search for candidates near their courses. You should add all areas that you can travel to for training.
         select_locations: Add, change or remove preferred locations
         location: Location
         distance_from_location: Distance from location
         change: Change
-        update_location_preferences: Add new locations to my preferences when I apply to new courses
+        update_location_preferences: Add new course locations to my preferences when I apply to new courses
         remove: Remove
         add_another_location: Add another location
         add_location: Add a location
-        no_location_preferences: You have no location preferences
+        no_location_preferences: You have no location preferences. Providers will assume you can train anywhere in England.
         within: "%{within} miles"
       new:
         title: Add a location
@@ -94,7 +93,7 @@ en:
         candidate_interface/pool_opt_ins_form:
           attributes:
             pool_status:
-              blank: Select weather to make your application details visible to other training providers
+              blank: Select whether to make your application details visible to other training providers
         candidate_interface/location_preferences_form:
           attributes:
             within:

--- a/spec/components/candidate_interface/share_details_component_spec.rb
+++ b/spec/components/candidate_interface/share_details_component_spec.rb
@@ -3,34 +3,14 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::ShareDetailsComponent, type: :component do
   include Rails.application.routes.url_helpers
 
+  before { FeatureFlag.activate(:candidate_preferences) }
+
   describe '#render' do
-    context 'when candidate has published preference' do
-      it 'renders the component with continue link to published preference show' do
-        candidate = create(:candidate)
-        preference = create(
-          :candidate_preference,
-          candidate:,
-          status: 'published',
-        )
+    context 'when submit_application is true' do
+      it 'renders the component with continue button to new pool opt in' do
+        candidate = build(:candidate)
+        render_inline(described_class.new(candidate, submit_application: true))
 
-        render_inline(described_class.new(candidate))
-        expected_path = candidate_interface_draft_preference_publish_preferences_path(preference)
-
-        expect(page).to have_button('Continue')
-        expect(page).to have_css("form[action='#{expected_path}']")
-      end
-    end
-
-    context 'when candidate has no published preference' do
-      it 'renders the component with continue link to new pool opt in' do
-        candidate = create(:candidate)
-        _preference = create(
-          :candidate_preference,
-          candidate:,
-          status: 'draft',
-        )
-
-        render_inline(described_class.new(candidate))
         expected_path = new_candidate_interface_pool_opt_in_path
 
         expect(page).to have_button('Continue')
@@ -38,23 +18,60 @@ RSpec.describe CandidateInterface::ShareDetailsComponent, type: :component do
       end
     end
 
-    context 'when candidate has published preference but opted out' do
-      it 'renders the component with continue link to edit pool opt in' do
-        candidate = create(:candidate)
-        preference = create(
-          :candidate_preference,
-          candidate:,
-          status: 'published',
-          pool_status: 'opt_out',
-        )
+    context 'when submit_application is false' do
+      context 'when candidate has published preference' do
+        it 'renders the component with continue link to published preference show' do
+          candidate = create(:candidate)
+          preference = create(
+            :candidate_preference,
+            candidate:,
+            status: 'published',
+          )
 
-        render_inline(described_class.new(candidate))
-        expected_path = edit_candidate_interface_pool_opt_in_path(
-          preference,
-        )
+          render_inline(described_class.new(candidate))
 
-        expect(page).to have_button('Continue')
-        expect(page).to have_css("form[action='#{expected_path}']")
+          expect(page).to have_link(
+            'Change your sharing and location settings',
+            href: candidate_interface_draft_preference_publish_preferences_path(preference),
+          )
+        end
+      end
+
+      context 'when candidate has no published preference' do
+        it 'renders the component with continue link to new pool opt in' do
+          candidate = create(:candidate)
+          _preference = create(
+            :candidate_preference,
+            candidate:,
+            status: 'draft',
+          )
+
+          render_inline(described_class.new(candidate))
+
+          expect(page).to have_link(
+            'Change your sharing and location settings',
+            href: new_candidate_interface_pool_opt_in_path,
+          )
+        end
+      end
+
+      context 'when candidate has published preference but opted out' do
+        it 'renders the component with continue link to edit pool opt in' do
+          candidate = create(:candidate)
+          preference = create(
+            :candidate_preference,
+            candidate:,
+            status: 'published',
+            pool_status: 'opt_out',
+          )
+
+          render_inline(described_class.new(candidate))
+
+          expect(page).to have_link(
+            'Change your sharing and location settings',
+            href: edit_candidate_interface_pool_opt_in_path(preference),
+          )
+        end
       end
     end
   end

--- a/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Block submission from blocked candidates' do
                  submit_answer: true,
                },
              }
-        expect(response).to redirect_to(candidate_interface_share_details_path)
+        expect(response).to redirect_to(candidate_interface_share_details_path(submit_application: true))
         follow_redirect!
         expect(response.body).to include(t('application_form.submit_application_success.title'))
       end

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Submit to continuous apps' do
     end
 
     it 'be successful' do
-      expect(response).to redirect_to(candidate_interface_share_details_path)
+      expect(response).to redirect_to(candidate_interface_share_details_path(submit_application: true))
       follow_redirect!
       expect(response.body).to include(I18n.t('application_form.submit_application_success.title'))
     end

--- a/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Candidate submits application with feedback form previously comp
   end
 
   def and_i_see_the_application_dashboard_and_success_message
-    expect(page).to have_current_path(candidate_interface_share_details_path)
+    expect(page).to have_current_path(candidate_interface_share_details_path(submit_application: true))
     expect(page).to have_content('Application submitted')
   end
 end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe 'Candidate adds preferences' do
     and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
 
-    when_i_click('Continue')
+    when_i_click('Change your sharing and location settings')
     then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
-    then_i_get_an_error('Select weather to make your application details visible to other training providers')
+    then_i_get_an_error('Select whether to make your application details visible to other training providers')
 
     and_i_opt_in_to_find_a_candidate
     when_i_click('Continue')
@@ -74,10 +74,10 @@ RSpec.describe 'Candidate adds preferences' do
     and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
 
-    when_i_click('Continue')
+    when_i_click('Change your sharing and location settings')
     then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
-    then_i_get_an_error('Select weather to make your application details visible to other training providers')
+    then_i_get_an_error('Select whether to make your application details visible to other training providers')
 
     and_i_opt_in_to_find_a_candidate
     when_i_click('Continue')
@@ -177,7 +177,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def when_i_check_dynamic_locations
-    check 'Add new locations to my preferences when I apply to new courses'
+    check 'Add new course locations to my preferences when I apply to new courses'
   end
 
   def then_i_am_redirected_to_review_page
@@ -199,7 +199,7 @@ RSpec.describe 'Candidate adds preferences' do
         value: locations,
       },
       {
-        label: 'Add new locations to my preferences when I apply to new course',
+        label: 'Add new course locations to my preferences when I apply to new courses',
         value: 'Yes',
       },
     ]

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -97,6 +97,6 @@ RSpec.describe 'Candidate edits published preference' do
   end
 
   def and_i_untick_dynamic_locations
-    uncheck 'Add new locations to my preferences when I apply to new courses'
+    uncheck 'Add new course locations to my preferences when I apply to new courses'
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   def then_i_am_redirected_to_share_details_page
-    expect(page).to have_current_path(candidate_interface_share_details_path)
+    expect(page).to have_current_path(candidate_interface_share_details_path(submit_application: true))
 
     expect(page).to have_content('Application submitted')
     expect(page).to have_content('Increase your chances of success by sharing your application details')

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'International candidate submits the application' do
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted
-    expect(page).to have_current_path candidate_interface_share_details_path
+    expect(page).to have_current_path candidate_interface_share_details_path(submit_application: true)
     expect(page).to have_content 'Application submitted'
   end
 


### PR DESCRIPTION
## Context

The CandidateInterface::ShareDetailsComponent needs to behave a bit
different depending how the user gets to it.

If they see this component after submitting an application the content
is different than when they come back to this component to read about
how the find a candidate feature works.

We do this through a param in the url

## Changes proposed in this pull request

| Normal component | Component after application submission |
| ------ | ------ |
| ![Screenshot from 2025-04-14 12-31-00](https://github.com/user-attachments/assets/947bd64b-2458-4017-876f-b3308ef3dc79) | ![Screenshot from 2025-04-14 12-31-37](https://github.com/user-attachments/assets/326a4114-141d-4980-9764-fee3ffeee4eb)|
## Guidance to review

This will be reviewed by product on the review app.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
