### PR TITLE
[720] Recruitment cycle timetables

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
 
   def current_user; end
 
+  def current_timetable
+    @current_timetable ||= RecruitmentCycleTimetable.current_timetable
+  end
+
   # Makes PG::QueryCanceled statement timeout errors appear in Skylight
   # against the controller action that triggered them
   # instead of bundling them with every other ErrorsController#internal_server_error

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
     before_action :track_email_click
     before_action :authenticate_candidate!, unless: -> { one_login_enabled? }
     before_action :set_user_context
+    before_action :set_current_timetable
     before_action :check_cookie_preferences
     before_action :check_account_locked
     layout 'application'
@@ -26,6 +27,10 @@ module CandidateInterface
       return unless authenticated?
 
       Sentry.set_tags(application_support_url: support_interface_application_form_url(current_application))
+    end
+
+    def set_current_timetable
+      @current_timetable = current_timetable
     end
 
     def check_cookie_preferences

--- a/app/controllers/candidate_interface/guidance_controller.rb
+++ b/app/controllers/candidate_interface/guidance_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     before_action :set_back_link
 
     def index
-      @recruitment_cycle_year = CycleTimetable.current_year
+      @recruitment_cycle_year = current_timetable.recruitment_cycle_year
     end
 
   private

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -52,7 +52,7 @@ module CandidateInterface
 
     def test_application_options
       {
-        recruitment_cycle_year: RecruitmentCycle.current_year,
+        recruitment_cycle_year: @current_timetable.recruitment_cycle_year,
         states: [:unsubmitted_with_completed_references],
         courses_to_apply_to: Course.current_cycle.joins(:course_options).merge(CourseOption.available),
         candidate: current_candidate,

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -39,7 +39,7 @@ module ProviderInterface
     def service_guidance_provider; end
 
     def dates_and_deadlines
-      @timetables = [RecruitmentCycleTimetable.current_timetable, RecruitmentCycleTimetable.next_timetable]
+      @timetables = [current_timetable, current_timetable.relative_next_timetable]
     end
 
     def roadmap

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -13,6 +13,7 @@ module ProviderInterface
   class ProviderInterfaceController < ApplicationController
     before_action :authenticate_provider_user!
     before_action :set_user_context
+    before_action :set_current_timetable
     before_action :redirect_if_setup_required
     before_action :check_cookie_preferences
 
@@ -79,6 +80,10 @@ module ProviderInterface
 
       Sentry.set_user(id: "provider_#{current_provider_user.id}")
       Sentry.set_extras(current_user_details)
+    end
+
+    def set_current_timetable
+      @current_timetable = current_timetable
     end
 
     def append_info_to_payload(payload)

--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -75,7 +75,7 @@ module ProviderInterface
 
     def require_deferred_offer_from_previous_cycle
       unless @application_choice.status == 'offer_deferred' &&
-             @application_choice.recruitment_cycle == RecruitmentCycle.previous_year
+             @application_choice.recruitment_cycle == current_timetable.relative_previous_year
         redirect_to provider_interface_application_choice_path(@application_choice.id) and return
       end
     end

--- a/app/controllers/provider_interface/reports/hesa_exports_controller.rb
+++ b/app/controllers/provider_interface/reports/hesa_exports_controller.rb
@@ -6,8 +6,7 @@ module ProviderInterface
       include StreamableDataExport
 
       def index
-        @current_timetable = RecruitmentCycleTimetable.current_timetable
-        @previous_timetable = RecruitmentCycleTimetable.previous_timetable
+        @previous_timetable = @current_timetable.relative_previous_timetable
       end
 
       def show

--- a/app/controllers/provider_interface/reports/status_of_active_applications_controller.rb
+++ b/app/controllers/provider_interface/reports/status_of_active_applications_controller.rb
@@ -8,7 +8,7 @@ module ProviderInterface
         respond_to do |format|
           format.csv do
             csv_data = ProviderInterface::StatusOfActiveApplicationsExport.new(provider: @provider).call
-            send_data csv_data, disposition: 'attachment', filename: csv_filename(export_name: 'status-of-active-applications', cycle_years: [RecruitmentCycle.current_year], providers: [@provider])
+            send_data csv_data, disposition: 'attachment', filename: csv_filename(export_name: 'status-of-active-applications', cycle_years: [current_timetable.recruitment_cycle_year], providers: [@provider])
           end
           format.html do
             @active_application_status_data = ActiveApplicationStatusesByProvider.new(@provider).call

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -35,7 +35,7 @@ module SupportInterface
 
     def reasons_for_rejection_application_choices
       @application_choices = ReasonsForRejectionApplicationsQuery.new(params.with_defaults(page: 1)).call
-      @recruitment_cycle_year = params.fetch(:recruitment_cycle_year, RecruitmentCycle.current_year).to_i
+      @recruitment_cycle_year = params.fetch(:recruitment_cycle_year, @current_timetable.recruitment_cycle_year).to_i
     end
 
     def unavailable_choices
@@ -84,7 +84,7 @@ module SupportInterface
     end
 
     def year_param
-      params.fetch(:year, RecruitmentCycle.current_year)
+      params.fetch(:year, @current_timetable.recruitment_cycle_year)
     end
   end
 end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -104,7 +104,7 @@ module SupportInterface
 
       stream_csv(
         data: SupportInterface::ProviderCoursesCSVExport.new(provider:).rows,
-        filename: "#{provider.name_and_code.parameterize}-courses-#{RecruitmentCycle.current_year}.csv",
+        filename: "#{provider.name_and_code.parameterize}-courses-#{current_timetable.recruitment_cycle_year}.csv",
       )
     end
 

--- a/app/controllers/support_interface/recruitment_cycle_timetables_controller.rb
+++ b/app/controllers/support_interface/recruitment_cycle_timetables_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class RecruitmentCycleTimetablesController < SupportInterfaceController
     def index
-      @timetable_presenter = SupportInterface::RecruitmentCycleTimetablePresenter.new(RecruitmentCycleTimetable.current_timetable)
+      @timetable_presenter = SupportInterface::RecruitmentCycleTimetablePresenter.new(current_timetable)
     end
 
     def edit

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -5,6 +5,7 @@ module SupportInterface
     layout 'support_layout'
     before_action :authenticate_support_user!
     before_action :set_user_context
+    before_action :set_current_timetable
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     helper_method :current_support_user, :dfe_sign_in_user
@@ -37,6 +38,10 @@ module SupportInterface
       return unless current_support_user
 
       Sentry.set_user(id: "support_#{current_support_user.id}")
+    end
+
+    def set_current_timetable
+      @current_timetable = current_timetable
     end
 
     def append_info_to_payload(payload)

--- a/app/lib/equality_and_diversity/values_checker.rb
+++ b/app/lib/equality_and_diversity/values_checker.rb
@@ -1,6 +1,6 @@
 module EqualityAndDiversity
   class ValuesChecker
-    def initialize(application_form:, recruitment_cycle_year: RecruitmentCycle.current_year)
+    def initialize(application_form:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
       @initial_values = application_form.equality_and_diversity&.transform_keys(&:to_sym)
       @hesa_converter = HesaConverter.new(application_form:, recruitment_cycle_year:)
     end

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -34,7 +34,7 @@ class TimeLimitConfig
 
     [
       Rule.new(nil, nil, working_days),
-      Rule.new(Time.zone.local(RecruitmentCycle.current_year, 6, 30, 23, 59, 59), nil, 20),
+      Rule.new(Time.zone.local(RecruitmentCycleTimetable.current_year, 6, 30, 23, 59, 59), nil, 20),
     ]
   end
 

--- a/app/models/recruitment_cycle_timetable.rb
+++ b/app/models/recruitment_cycle_timetable.rb
@@ -154,6 +154,10 @@ class RecruitmentCycleTimetable < ApplicationRecord
     end
   end
 
+  def find_reopens_at
+    relative_next_timetable.find_opens_at
+  end
+
   def cycle_week_date_range(cycle_week)
     cycle_week %= 52
     cycle_week -= 1

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -14,7 +14,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
   <% if !@application_form.submitted? && !@application_form.can_add_course_choice? %>
     <p class="govuk-body govuk-!-width-two-thirds">
-      You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
+      You can find courses from 9am on <%= @current_timetable.find_reopens_at.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
     </p>
   <% else %>
     <%= render(

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -25,13 +25,13 @@
 
             table.with_body do |body|
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.find_opens.to_fs(:govuk_date_and_time))
+                row.with_cell(text: @current_timetable.find_opens_at.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "Start #{govuk_link_to('finding postgraduate teacher training courses', find_url)} you might want to apply to.".html_safe
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_opens.to_fs(:govuk_date_and_time))
+                row.with_cell(text: @current_timetable.apply_opens_at.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "<p class=\"govuk-body\">Start applying to courses. You can apply to #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES} courses, they can fill up quickly so you should apply as soon as you can.</p>
                    <p class=\"govuk-body\">You can withdraw an application at any time and apply to a different course if you want to.</p>
@@ -40,11 +40,11 @@
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time))
+                row.with_cell(text: @current_timetable.apply_deadline_at.to_fs(:govuk_date_and_time))
                 row.with_cell(text: 'The last day to submit any applications.')
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time))
+                row.with_cell(text: @current_timetable.reject_by_default_at.to_fs(:govuk_date_and_time))
                 row.with_cell(text: "The last day for training providers to make a decision on all applications for courses starting in September #{@recruitment_cycle_year}.")
               end
             end

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -10,7 +10,7 @@ Need help writing a strong application? You can [get a teacher training adviser]
 
 # If you’re not ready to submit your application
 
-If you’re not ready to apply now, you can continue preparing your application. <%= "From #{l(@timetable.apply_reopens_at.to_date, format: :no_year)} you’ll be able to apply for courses starting in the #{RecruitmentCycle.cycle_name(RecruitmentCycle.next_year)} academic year." %>
+If you’re not ready to apply now, you can continue preparing your application. <%= "From #{l(@timetable.apply_reopens_at.to_date, format: :no_year)} you’ll be able to apply for courses starting in the #{@timetable.next_available_academic_year_range} academic year." %>
 
 <%= render 'gain_insights_into_life_as_a_teacher' %>
 

--- a/app/views/provider_interface/reports/diversity_reports/show.html.erb
+++ b/app/views/provider_interface/reports/diversity_reports/show.html.erb
@@ -64,7 +64,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">About this data</h2>
         <p class="govuk-body">
-          This data comes from candidates who submitted an application from <%= RecruitmentCycleTimetable.current_timetable.apply_opens_at.to_fs(:govuk_date) %>.
+          This data comes from candidates who submitted an application from <%= @current_timetable.apply_opens_at.to_fs(:govuk_date) %>.
         </p>
         <p class="govuk-body">
           The sex, disability and ethnicity data comes from candidates who filled in a questionnaire when they applied to your organisation.

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -14,7 +14,7 @@
       <% unless RecruitmentPerformanceReportTimetable.report_season? %>
         <%= t(
               '.available_in_the_future_html',
-              current_cycle_range: RecruitmentCycleTimetable.current_cycle_range_name,
+              current_cycle_range: @current_timetable.cycle_range_name,
               first_publication_date: RecruitmentPerformanceReportTimetable.first_publication_date.to_fs(:govuk_date),
               first_publication_date_no_year: RecruitmentPerformanceReportTimetable.first_publication_date.to_fs(:day_and_month),
             ) %>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -5,7 +5,7 @@
   <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-      <p class="govuk-hint">All courses shown are from the current recruitment cycle (<%= CycleTimetable.current_year %>).</p>
+      <p class="govuk-hint">All courses shown are from the current recruitment cycle (<%= @current_timetable.recruitment_cycle_year %>).</p>
 
       <% if @options_from_same_provider.present? %>
         <h2 class="govuk-heading-s">Courses from the same provider (<%= @application_choice.current_provider.name_and_code %>)</h2>

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -34,8 +34,8 @@
       <%= f.govuk_text_field :site_code, label: { text: 'Site code', size: 's' }, width: 5 %>
 
       <%= f.govuk_radio_buttons_fieldset :recruitment_cycle_year, legend: { text: 'Recruitment cycle year', size: 's' } do %>
-        <%= f.govuk_radio_button :recruitment_cycle_year, RecruitmentCycle.current_year, label: { text: RecruitmentCycle.current_year } %>
-        <%= f.govuk_radio_button :recruitment_cycle_year, RecruitmentCycle.previous_year, label: { text: RecruitmentCycle.previous_year } %>
+        <%= f.govuk_radio_button :recruitment_cycle_year, @current_timetable.recruitment_cycle_year, label: { text: @current_timetable.recruitment_cycle_year } %>
+        <%= f.govuk_radio_button :recruitment_cycle_year, @current_timetable.relative_previous_year, label: { text: @current_timetable.relative_previous_year } %>
       <% end %>
 
       <%= f.govuk_text_field(

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -10,7 +10,7 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <%= govuk_link_to(
-      "#{RecruitmentCycle.cycle_name} (starts #{RecruitmentCycle.current_year}) - current",
+      "#{@current_timetable.cycle_range_name} (starts #{@current_timetable.recruitment_cycle_year}) - current",
       support_interface_reasons_for_rejection_dashboard_path,
     ) %>
   </li>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,15 +1,15 @@
 <%= render 'provider_navigation', title: 'Courses' %>
 
 <% if @provider.courses.current_cycle.any? || @provider.accredited_courses.current_cycle.any? %>
-  <%= govuk_button_link_to "Download #{RecruitmentCycle.current_year} courses and ratified courses as CSV", support_interface_provider_courses_csv_path, secondary: true, class: 'govuk-!-margin-bottom-5' %>
+  <%= govuk_button_link_to "Download #{@current_timetable.recruitment_cycle_year} courses and ratified courses as CSV", support_interface_provider_courses_csv_path, secondary: true, class: 'govuk-!-margin-bottom-5' %>
 <% end %>
 
 <% if @provider.courses.any? %>
   <% @courses_by_year.each do |year, courses| %>
     <% if courses.any? %>
-      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open?) %> Open) <%= t('.not_yet_published') if RecruitmentCycle.next_year == year %></h2>
+      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open?) %> Open) <%= t('.not_yet_published') if @current_timetable.relative_next_year == year %></h2>
 
-      <% if RecruitmentCycle.next_year == year %>
+      <% if @current_timetable.relative_next_year == year %>
         <p class="govuk-body"><%= t('.courses_published_recruitment_opens') %></p>
       <% end %>
 

--- a/app/views/support_interface/recruitment_cycle_timetables/index.html.erb
+++ b/app/views/support_interface/recruitment_cycle_timetables/index.html.erb
@@ -6,7 +6,7 @@
       <%= t('.today_is', date: Time.zone.now.to_fs(:govuk_date)) %>
     </span>
     <h1 class="govuk-heading-l">
-      <%= t(".#{@timetable_presenter.cycle_state}", year: RecruitmentCycleTimetable.current_year) %>
+      <%= t(".#{@timetable_presenter.cycle_state}", year: @current_timetable.recruitment_cycle_year) %>
     </h1>
 
     <p class="govuk-body">
@@ -20,8 +20,8 @@
 
       <%= govuk_list(
             [
-              govuk_link_to(RecruitmentCycleTimetable.current_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: RecruitmentCycleTimetable.current_year)),
-              govuk_link_to(RecruitmentCycleTimetable.next_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: RecruitmentCycleTimetable.next_year)),
+              govuk_link_to(@current_timetable.recruitment_cycle_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: @current_timetable.recruitment_cycle_year)),
+              govuk_link_to(@current_timetable.relative_next_year, support_interface_edit_recruitment_cycle_timetable_path(recruitment_cycle_year: @current_timetable.relative_next_year)),
             ],
           ) %>
 
@@ -36,10 +36,10 @@
     </h2>
 
     <%= render SummaryListComponent.new(rows: {
-      'Previous cycle year' => RecruitmentCycleTimetable.previous_year,
-      'Current cycle year' => RecruitmentCycleTimetable.current_year,
-      'Next cycle year' => RecruitmentCycleTimetable.next_year,
-      'Years visible to providers' => [RecruitmentCycleTimetable.current_year, RecruitmentCycleTimetable.next_year].to_sentence,
+      'Previous cycle year' => @current_timetable.relative_previous_year,
+      'Current cycle year' => @current_timetable.recruitment_cycle_year,
+      'Next cycle year' => @current_timetable.relative_next_year,
+      'Years visible to providers' => [@current_timetable.recruitment_cycle_year, @current_timetable.relative_next_year].to_sentence,
       'Current cycle week' => RecruitmentCycleTimetable.current_cycle_week,
     }) %>
 
@@ -47,10 +47,10 @@
       <%= t('.deadlines') %>
     </h2>
 
-    <%= render Publications::RecruitmentCycleTimetableCard.new(RecruitmentCycleTimetable.current_timetable) %>
+    <%= render Publications::RecruitmentCycleTimetableCard.new(@current_timetable) %>
 
-    <% if RecruitmentCycleTimetable.next_timetable.present? %>
-      <%= render Publications::RecruitmentCycleTimetableCard.new(RecruitmentCycleTimetable.next_timetable) %>
+    <% if @current_timetable.relative_next_timetable.present? %>
+      <%= render Publications::RecruitmentCycleTimetableCard.new(@current_timetable.relative_next_timetable) %>
     <% end %>
 
   </div>

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Are you sure you want to cancel all unsubmitted applications?</h1>
 
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">This should be run shortly after the apply deadline closes at midnight on <%= CycleTimetable.date(:apply_deadline).to_fs(:govuk_date) %>.</p>
+      <p class="govuk-body">This should be run shortly after the apply deadline closes at midnight on <%= @current_timetable.apply_deadline_at.to_fs(:govuk_date) %>.</p>
 
       <%= f.govuk_submit 'Yes, I’m sure – cancel all unsubmitted applications', warning: true %>
 

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">End-of-cycle: Cancel unsubmitted applications</h2>
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_deadline).to_fs(:govuk_date) %>.</p>
+      <p class="govuk-body">It should be run shortly after the Apply deadline closes at midnight on <%= @current_timetable.apply_deadline_at.to_fs(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_button_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, warning: true %>
@@ -44,7 +44,7 @@
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Generate test applications for the <%= RecruitmentCycle.current_year %> recruitment cycle</h2>
+        <h2 class="govuk-heading-m">Generate test applications for the <%= @current_timetable.recruitment_cycle_year %> recruitment cycle</h2>
         <p class="govuk-body">This task generates ~10 mostly-random test applications in all of the states.</p>
       </div>
       <div class="govuk-grid-column-one-third">
@@ -56,11 +56,11 @@
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Generate test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle</h2>
-        <p class="govuk-body">This task generates mostly-random test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle.</p>
+        <h2 class="govuk-heading-m">Generate test applications for the <%= @current_timetable.relative_next_year %> recruitment cycle</h2>
+        <p class="govuk-body">This task generates mostly-random test applications for the <%= @current_timetable.relative_next_year %> recruitment cycle.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= govuk_button_to "Generate #{RecruitmentCycle.next_year} recruitment cycle test applications", support_interface_run_task_path('generate_next_cycle_test_applications'), secondary: true %>
+        <%= govuk_button_to "Generate #{@current_timetable.relative_next_year} recruitment cycle test applications", support_interface_run_task_path('generate_next_cycle_test_applications'), secondary: true %>
       </div>
     </div>
   </section>

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -1,6 +1,6 @@
 class ValidRecruitmentCycleYear
   def self.matches?(request)
-    [RecruitmentCycle.current_year, RecruitmentCycle.previous_year].include?(request.params['year'].to_i)
+    [RecruitmentCycleTimetable.current_year, RecruitmentCycleTimetable.previous_year].include?(request.params['year'].to_i)
   end
 end
 

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -66,20 +66,22 @@ desc 'Sync some pilot-enabled providers'
 task sync_dev_providers: :environment do
   puts 'Syncing data from TTAPI...'
 
+  DataMigrations::AddAllRecruitmentCycleTimetablesToDatabase.new.change if RecruitmentCycleTimetable.none?
+
   provider_codes = %w[U80 24J 24P D39 S72 1ZW 1N1 Y50 L34 D86 K60 H72 W53 1TZ]
   provider_codes.each do |code|
     provider_from_api = TeacherTrainingPublicAPI::Provider
-        .where(year: RecruitmentCycle.current_year)
+        .where(year: RecruitmentCycleTimetable.current_year)
         .find(code).first
 
     TeacherTrainingPublicAPI::SyncSubjects.new.perform
 
     TeacherTrainingPublicAPI::SyncProvider.new(
-      provider_from_api:, recruitment_cycle_year: RecruitmentCycle.previous_year,
+      provider_from_api:, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
     ).call(run_in_background: false)
 
     TeacherTrainingPublicAPI::SyncProvider.new(
-      provider_from_api:, recruitment_cycle_year: RecruitmentCycle.current_year,
+      provider_from_api:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
     ).call(run_in_background: false)
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -153,16 +153,16 @@ private
   end
 
   def and_i_see_the_banner_content_for_before_find_opens
-    next_relative_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
-    apply_reopen_date = next_relative_timetable.apply_opens_at.to_fs(:day_and_month)
-    cycle_range = next_relative_timetable.academic_year_range_name
+    relative_next_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
+    apply_reopen_date = relative_next_timetable.apply_opens_at.to_fs(:day_and_month)
+    cycle_range = relative_next_timetable.academic_year_range_name
     expect(page).to have_content("From #{apply_reopen_date} you will be able to apply for courses starting in the #{cycle_range} academic year.")
   end
 
   def and_i_see_the_banner_content_for_after_find_opens
-    next_relative_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
-    apply_reopen_date = next_relative_timetable.apply_opens_at.to_fs(:day_and_month)
-    academic_year_range = next_relative_timetable.academic_year_range_name
+    relative_next_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
+    apply_reopen_date = relative_next_timetable.apply_opens_at.to_fs(:day_and_month)
+    academic_year_range = relative_next_timetable.academic_year_range_name
     expect(page).to have_content("You can prepare applications for courses starting in the #{academic_year_range} academic year.")
     expect(page).to have_content("You will be able to apply for these courses from #{apply_reopen_date}.")
   end


### PR DESCRIPTION
## Context

This is the last 'easy' recruitment timetable PR. it removes the use of the `CycleTimetable` and `RecruitmentCycle` from controllers, views, and a few remaining classes. 

## Changes proposed in this pull request

Using the RecruitmentCycleTimetable in some controllers, views, and a few other remaining classes.

## Guidance to review

It's pretty small and repetitive, but might be easier to review commit by commit.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
