### PR TITLE
Added worker to send FAC feature launch emails

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -27,6 +27,16 @@ class Pool::Candidates
     new(providers: []).application_forms_in_the_pool
   end
 
+  def self.application_forms_eligible_for_pool
+    new(providers: []).application_forms_eligible_for_pool
+  end
+
+  def application_forms_eligible_for_pool
+    filtered_application_forms.joins(:candidate)
+                              .where(candidates: { submission_blocked: false, account_locked: false })
+                              .distinct
+  end
+
   def application_forms_in_the_pool
     opted_in_candidates = Candidate.joins(:published_preferences).where(published_preferences: { pool_status: 'opt_in' }).select(:id)
 

--- a/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
+++ b/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
@@ -1,0 +1,38 @@
+module Chasers
+  module Candidate
+    class FindACandidateFeatureLaunchEmailWorker
+      include Sidekiq::Worker
+
+      def perform(application_form_ids: [], limit: 1000)
+        return unless FeatureFlag.active?(:candidate_preferences)
+
+        application_form_ids_with_sent_chaser = ChaserSent
+                                                  .where(chaser_type: 'find_a_candidate_feature_launch',
+                                                         chased_type: 'ApplicationForm')
+                                                  .select(:chased_id)
+
+        application_forms_to_send = ApplicationForm
+                                      .where(id: application_form_ids)
+                                      # Tier 1 & 2 application forms
+                                      .merge(Pool::Candidates.application_forms_eligible_for_pool)
+                                      # Filter out candidates who should not receive nudge-like emails
+                                      # Filter out blocked and locked candidates
+                                      .joins(:candidate)
+                                      .merge(::Candidate.for_marketing_or_nudge_emails)
+                                      # Filter out application forms that have already received the chaser
+                                      .where.not(id: application_form_ids_with_sent_chaser)
+                                      # Filter out application forms without submitted application choices
+                                      .where.not(submitted_at: nil)
+                                      .distinct
+                                      .limit(limit)
+
+        application_forms_to_send.in_batches do |application_forms|
+          application_forms.each do |application_form|
+            ChaserSent.create!(chased: application_form, chaser_type: 'find_a_candidate_feature_launch')
+            CandidateMailer.find_a_candidate_feature_launch_email(application_form).deliver_later
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -7,11 +7,13 @@ FactoryBot.define do
     # `course_option` being present, as it will not exist until after the
     # record is saved.
     transient do
+      candidate { nil }
       course { nil }
       recruitment_cycle_year { nil }
       form_options {
         {
           recruitment_cycle_year:,
+          candidate:,
         }.compact_blank
       }
     end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -287,4 +287,16 @@ RSpec.describe Pool::Candidates do
       expect(results).to contain_exactly(rejected_candidate_form)
     end
   end
+
+  describe '.application_forms_eligible_for_pool' do
+    it 'returns application_forms that should be in the candidate pool' do
+      rejected_candidate_form = create(:application_form, :completed)
+      create(:application_choice, :rejected, application_form: rejected_candidate_form)
+      _accepted_application_form = create(:application_form, :with_accepted_offer)
+
+      results = described_class.application_forms_eligible_for_pool
+
+      expect(results).to contain_exactly(rejected_candidate_form)
+    end
+  end
 end

--- a/spec/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker_spec.rb
+++ b/spec/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Chasers::Candidate::FindACandidateFeatureLaunchEmailWorker do
+  before do
+    FeatureFlag.activate(:candidate_preferences)
+  end
+
+  describe '#perform' do
+    it 'sends the find_a_candidate_feature_launch_email to applications that are eligible for the pool' do
+      candidate = create_candidate_eligible_for_pool
+      application_form = candidate.current_application
+
+      expect {
+        described_class.new.perform(application_form_ids: [application_form.id])
+      }.to have_enqueued_job.on_queue('mailers')
+                            .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
+        .and change(ChaserSent, :count).from(0).to(1)
+    end
+
+    context 'when the candidate has already received the email' do
+      it 'does not send the email again' do
+        candidate = create_candidate_eligible_for_pool
+        application_form = candidate.current_application
+        create(:chaser_sent, chased: application_form, chaser_type: 'find_a_candidate_feature_launch')
+
+        expect {
+          described_class.new.perform(application_form_ids: [application_form.id])
+        }.not_to have_enqueued_job.on_queue('mailers')
+                              .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
+      end
+    end
+
+    context 'when the candidate has opted out of marketing emails' do
+      it 'does not send the email' do
+        candidate = create_candidate_eligible_for_pool(unsubscribed_from_emails: true)
+        application_form = candidate.current_application
+
+        expect {
+          described_class.new.perform(application_form_ids: [application_form.id])
+        }.not_to have_enqueued_job.on_queue('mailers')
+                                  .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
+      end
+    end
+
+    context 'when the candidate is not eligible for pool' do
+      it 'does not send the email' do
+        application_form = create(:application_form)
+
+        expect {
+          described_class.new.perform(application_form_ids: [application_form.id])
+        }.not_to have_enqueued_job.on_queue('mailers')
+                                  .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
+      end
+    end
+  end
+
+private
+
+  def create_candidate_eligible_for_pool(**candidate_attributes)
+    candidate = create(:candidate, **candidate_attributes)
+    create(:application_choice, :rejected, candidate:)
+
+    candidate
+  end
+end


### PR DESCRIPTION
## Context

We want to have a worker that can take a list of Application Form ids and send the FAC feature launch email to a sample of 1000 Candidates. 

The emails will initially be sent to a sample of 1000 Application Forms - the list of application_form_ids will be supplied by the Data team.
Checks for eligibility, previously sent and locked, blocked and unsubscribed will take place before limiting the sample to 1000.

Candidates will be sent a variant of the `find_a_candidate_feature_launch_email` which they will automatically be assigned to.

For tier 3 Candidates, we will remove the `.merge(Pool::Candidates.application_forms_eligible_for_pool)` as we want to target all Candidates which have submitted an Application

## Changes proposed in this pull request

- Added FindACandidateFeatureLaunchEmailWorker

## Guidance to review

- Visit Review App - requires logging in as a Candidate
- Visit [`/candidate/feature-launch-email/share_details`][link_clicked_share_details] or [`/candidate/feature-launch-email/invitation`][link_clicked_invitation]
    - optionally set preferences
- View experiment results at [`/support/field-test`][experiment_dashboard]
- View email previews
    - [`/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email`][mailer_preview] will be a random variant
    - [`/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email?variant=share_details`][mailer_preview_share_details] will be the share_details variant
    - [`/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email?variant=invitation`][mailer_preview_invitation] will be the invitation variant

[link_clicked_share_details]: https://apply-review-10598.test.teacherservices.cloud/candidate/feature-launch-email/share_details
[link_clicked_invitation]: https://apply-review-10598.test.teacherservices.cloud/candidate/feature-launch-email/invitation
[experiment_dashboard]: https://apply-review-10598.test.teacherservices.cloud/support/field-test
[mailer_preview]: https://apply-review-10598.test.teacherservices.cloud/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email
[mailer_preview_share_details]: https://apply-review-10598.test.teacherservices.cloud/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email?variant=share_details
[mailer_preview_invitation]: https://apply-review-10598.test.teacherservices.cloud/rails/mailers/candidate_mailer/find_a_candidate_feature_launch_email?variant=invitation

## [Spike] Context

This ~is a~ was originally a spike to identify issues or gaps in understanding when it comes to implementation of this feature. 

## [Spike] Changes proposed in this pull request

- Added [field_test gem](https://github.com/ankane/field_test) - extracted to #10605
- Set up an experiment called “find_a_candidate/candidate_feature_launch_email”. - extracted to #10605 
    - With 2 variants “share_details” and “invitation”, to represent the different emails that we plan on sending
    - With 3 goals "opt_in", "opt_out" and "link_clicked"
- Added the Field Test dashboard at `/support/field_test` ~*without authentication*~ - extracted to #10605

## Considerations

- [x] After sign in, Candidates are not redirected to the page they tried to access - #10602 
- [x] We need a subject for the emails - #10610
- [x] Check content - show diffs between variants - #10610 
- [x] Build service to send emails to specific Candidates - this PR
- [x] Remove variant setting in controller - #10611 
- [x] Split the migrations out of this PR - #10605 
- [x] Secure experiment dashboard - #10605 
- [x] Move field test tables/columns out of analytics_blocklist - #10605 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
