### PR TITLE
One login redirect to request referer

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -37,7 +37,7 @@ module CandidateInterface
     end
 
     def redirect_to_path_if_path_params_are_present
-      redirect_to params[:path] if params[:path].present?
+      redirect_to params[:path] if params[:path].present? && valid_app_path(params[:path])
     end
 
     def redirect_to_prefill_if_sandbox_user_has_blank_application

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
 
     def create_account_or_sign_in
       @create_account_or_sign_in_form = CreateAccountOrSignInForm.new
+      @referer_path = params[:path]
     end
 
     def create_account_or_sign_in_handler

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -40,7 +40,7 @@ private
   end
 
   def request_authentication
-    redirect_to candidate_interface_create_account_or_sign_in_path
+    redirect_to candidate_interface_create_account_or_sign_in_path(path: request.path)
   end
 
   def start_new_session_for(candidate:, id_token_hint: nil)

--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -6,7 +6,7 @@ class OneLoginController < ApplicationController
 
   def callback
     auth = request.env['omniauth.auth']
-    omniauth_params = request.env['omniauth.params']
+    omniauth_params = request.env['omniauth.params'] || {}
     id_token_hint = auth&.credentials&.id_token
     candidate = OneLoginUser.authenticate_or_create_by(auth)
 
@@ -16,7 +16,7 @@ class OneLoginController < ApplicationController
     )
 
     redirect_to candidate_interface_interstitial_path(
-      path: omniauth_params&.fetch('path', {}),
+      path: omniauth_params.fetch('path', nil),
     )
   rescue StandardError => e
     session_error = SessionError.create!(

--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -6,6 +6,7 @@ class OneLoginController < ApplicationController
 
   def callback
     auth = request.env['omniauth.auth']
+    omniauth_params = request.env['omniauth.params']
     id_token_hint = auth&.credentials&.id_token
     candidate = OneLoginUser.authenticate_or_create_by(auth)
 
@@ -14,7 +15,9 @@ class OneLoginController < ApplicationController
       id_token_hint:,
     )
 
-    redirect_to candidate_interface_interstitial_path
+    redirect_to candidate_interface_interstitial_path(
+      path: omniauth_params&.fetch('path', {}),
+    )
   rescue StandardError => e
     session_error = SessionError.create!(
       candidate: OneLoginUser.find_candidate(auth),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,6 +114,16 @@ module ApplicationHelper
     end
   end
 
+  def valid_app_path(path)
+    return false unless path.is_a?(String) && path.present?
+
+    route_hash = Rails.application.routes.recognize_path(path)
+
+    route_hash[:controller] != 'errors' && route_hash[:action] != 'not_found'
+  rescue ActionController::RoutingError
+    false
+  end
+
 private
 
   # Use characters rather than HTML entities for smart quotes this matches how

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -16,7 +16,10 @@
         <%= t('govuk.one_login_account_guidance') %>
       </p>
 
-      <%= govuk_button_to(t('continue'), OneLogin.bypass? ? '/auth/one-login-developer' : '/auth/one_login') %>
+      <%= govuk_button_to(
+        t('continue'),
+        OneLogin.bypass? ? '/auth/one-login-developer' : "/auth/one_login?path=#{@referer_path}",
+      ) %>
     <% else %>
      <%= form_with(
         model: @create_account_or_sign_in_form,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -113,4 +113,39 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe '#valid_app_path' do
+    it 'returns true if the path is valid within our app' do
+      call = helper.valid_app_path('/candidate/application/details')
+      expect(call).to be true
+    end
+
+    context 'when path is not a string' do
+      it 'returns false' do
+        call = helper.valid_app_path(12321)
+        expect(call).to be false
+      end
+    end
+
+    context 'when path is not a present' do
+      it 'returns false' do
+        call = helper.valid_app_path(nil)
+        expect(call).to be false
+      end
+    end
+
+    context 'when path is not in our routes' do
+      it 'returns false' do
+        call = helper.valid_app_path('/candidate/bad_path')
+        expect(call).to be false
+      end
+    end
+
+    context 'when path is not a path' do
+      it 'returns false' do
+        call = helper.valid_app_path('wrong path')
+        expect(call).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
@@ -67,7 +67,7 @@ private
   def then_i_am_logged_out
     expect(page).to have_title 'Create a GOV.UK One Login or sign in'
     expect(page).to have_content 'You need a GOV.UK One Login to sign in to this service. You can create one if you do not already have one.'
-    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(path: '/candidate/application/choices')
   end
 
   def when_i_login_again

--- a/spec/system/candidate_interface/one_login_signup/candidate_signs_in_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_signs_in_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe 'Candidate signs in' do
 
   def then_i_am_redirected_to_the_candidate_sign_in_path
     expect(page).to have_current_path(
-      candidate_interface_create_account_or_sign_in_path,
+      candidate_interface_create_account_or_sign_in_path(
+        path: '/candidate/application/details',
+      ),
     )
   end
 


### PR DESCRIPTION
## Context

Previously, when you would try to access a candidate url and you were
not logged in. You would be prompted to login but we would not
redirect you to the path you were trying to go.

We would just land you on your details or applications page.

This change will redirect the user to wherever they wanted to go.

We put the path we want to go in the url before sending a request to one
login. This path comes back to us in the callback method. This path is
set in our Authentication concern. Just before we ask the user to login
if they are not login.

We can use this path to redirect the user to wherever they wanted to go
after we confirm their one login.

Before we do this though, we need to check that the path value is an
actual path in our app. We use Rails.application.routes.recognize_path
for this. This will return the errors controller with the not_found
action if the url/string value is not a valid route within our app.

If the url is valid we redirect the user to that url. Otherwise we
default to the previous behaviour of redirecting the user to 'Your details'

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/8cb06981-93f7-44b7-bd23-391681c2eeff



Please take a few minutes to test this on QA. Because this changes a feature used by all our candidates

- Login normally by not visiting any other path before signin in.
- Log out
- Visit a path within the candidate interface, like `/candidate/about-the-teacher-training-application-process`. You should be asked to login and after you do, you should be redirected to the `/candidate/about-the-teacher-training-application-process`

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
