### PR TITLE
Add degree preview to FAC index

### DIFF
--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -24,4 +24,43 @@ class ApplicationQualificationDecorator < SimpleDelegator
       { qualification.subject => qualification.grade }
     end
   end
+
+  def degree_type_with_honours(degree)
+    if degree.grade&.include?('honours')
+      "#{abbreviate_degree(degree.qualification_type)} (Hons)"
+    else
+      abbreviate_degree(degree.qualification_type)
+    end
+  end
+
+  def abbreviate_degree(name)
+    Hesa::DegreeType.find_by_name(name)&.abbreviation || name
+  end
+
+  def degree_type_and_subject(degree)
+    "#{degree_type_with_honours(degree)} #{degree.subject}"
+  end
+
+  def formatted_grade(degree)
+    return nil if degree.grade.blank?
+
+    short_form = grade_short_form(degree.grade)
+
+    if degree.predicted_grade?
+      "#{short_form} (predicted)"
+    else
+      short_form
+    end
+  end
+
+private
+
+  def grade_short_form(full_grade)
+    {
+      'First-class honours' => '1st',
+      'Upper second-class honours (2:1)' => '2:1',
+      'Lower second-class honours (2:2)' => '2:2',
+      'Third-class honours' => '3rd',
+    }[full_grade] || full_grade
+  end
 end

--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -25,42 +25,51 @@ class ApplicationQualificationDecorator < SimpleDelegator
     end
   end
 
-  def degree_type_with_honours(degree)
-    if degree.grade&.include?('honours')
-      "#{abbreviate_degree(degree.qualification_type)} (Hons)"
-    else
-      abbreviate_degree(degree.qualification_type)
-    end
+  def formatted_degree_and_grade
+    return nil unless qualification.degree?
+
+    subject = degree_type_and_subject
+    grade = formatted_grade
+
+    [subject, grade].compact.join(', ')
   end
 
-  def abbreviate_degree(name)
-    Hesa::DegreeType.find_by_name(name)&.abbreviation || name
-  end
+private
 
-  def degree_type_and_subject(degree)
-    "#{degree_type_with_honours(degree)} #{degree.subject}"
-  end
+  def formatted_grade
+    return nil if qualification.grade.blank?
 
-  def formatted_grade(degree)
-    return nil if degree.grade.blank?
+    short_form = grade_short_form(qualification.grade)
 
-    short_form = grade_short_form(degree.grade)
-
-    if degree.predicted_grade?
+    if qualification.predicted_grade?
       "#{short_form} (predicted)"
     else
       short_form
     end
   end
 
-private
-
   def grade_short_form(full_grade)
     {
-      'First-class honours' => '1st',
+      'First-class honours' => 'First',
       'Upper second-class honours (2:1)' => '2:1',
       'Lower second-class honours (2:2)' => '2:2',
       'Third-class honours' => '3rd',
     }[full_grade] || full_grade
+  end
+
+  def degree_type_and_subject
+    "#{degree_type_with_honours} #{qualification.subject.titleize}"
+  end
+
+  def degree_type_with_honours
+    if qualification.grade&.include?('honours')
+      "#{abbreviate_degree(qualification.qualification_type)} (Hons)"
+    else
+      abbreviate_degree(qualification.qualification_type)
+    end
+  end
+
+  def abbreviate_degree(name)
+    Hesa::DegreeType.find_by_name(name)&.abbreviation || name
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -706,6 +706,10 @@ class ApplicationForm < ApplicationRecord
     current_cycle? && Time.zone.now.between?(apply_opens_at, apply_deadline_at)
   end
 
+  def last_degree
+    application_qualifications.degrees.order('award_year').last
+  end
+
 private
 
   def geocode_address_and_update_region_if_required

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -706,10 +706,6 @@ class ApplicationForm < ApplicationRecord
     current_cycle? && Time.zone.now.between?(apply_opens_at, apply_deadline_at)
   end
 
-  def last_degree
-    application_qualifications.degrees.order('award_year').last
-  end
-
 private
 
   def geocode_address_and_update_region_if_required

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -23,11 +23,15 @@
             <%= row.with_cell do %>
             <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
             <span class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</span>
-              <% if application_form.last_degree %>
-                <% decorated_degree = ApplicationQualificationDecorator.new(application_form.last_degree) %>
-                <p class="govuk-body app-qualification__value--caption"><%= "#{decorated_degree.degree_type_and_subject(application_form.last_degree)}, #{decorated_degree.formatted_grade(application_form.last_degree)}" %></p>
+              <% if application_form.application_qualifications.degrees.present? %>
+                <% application_form.application_qualifications.degrees.order(award_year: :desc).each do |degree| %>
+                  <% decorated_degree = ApplicationQualificationDecorator.new(degree) %>
+                  <p class="govuk-body app-qualification__value--caption govuk-!-margin-bottom-1">
+                    <%= decorated_degree.formatted_degree_and_grade %>
+                  </p>
+                <% end %>
               <% else %>
-                <p class="govuk-body app-qualification__value--caption"><%= t('.no_degree') %></p>
+                <p class="govuk-body app-qualification__value--caption govuk-!-margin-bottom-1"><%= t('.no_degree') %></p>
               <% end %>
             <% end %>
             <%= row.with_cell do %>

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -22,11 +22,12 @@
           <%= body.with_row do |row| %>
             <%= row.with_cell do %>
             <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
+            <span class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</span>
               <% if application_form.last_degree %>
                 <% decorated_degree = ApplicationQualificationDecorator.new(application_form.last_degree) %>
-                <p class="govuk-body"><%= "#{decorated_degree.degree_type_and_subject(application_form.last_degree)}, #{decorated_degree.formatted_grade(application_form.last_degree)}" %></p>
+                <p class="govuk-body app-qualification__value--caption"><%= "#{decorated_degree.degree_type_and_subject(application_form.last_degree)}, #{decorated_degree.formatted_grade(application_form.last_degree)}" %></p>
               <% else %>
-                <p class="govuk-body"><%= t('.no_degree') %></p>
+                <p class="govuk-body app-qualification__value--caption"><%= t('.no_degree') %></p>
               <% end %>
             <% end %>
             <%= row.with_cell do %>

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -21,12 +21,14 @@
         <% @application_forms.each do |application_form| %>
           <%= body.with_row do |row| %>
             <%= row.with_cell do %>
-              <div class="flex-content">
-                <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
-                <p class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</p>
-              </div>
+            <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
+              <% if application_form.last_degree %>
+                <% decorated_degree = ApplicationQualificationDecorator.new(application_form.last_degree) %>
+                <p class="govuk-body"><%= "#{decorated_degree.degree_type_and_subject(application_form.last_degree)}, #{decorated_degree.formatted_grade(application_form.last_degree)}" %></p>
+              <% else %>
+                <p class="govuk-body"><%= t('.no_degree') %></p>
+              <% end %>
             <% end %>
-
             <%= row.with_cell do %>
               <% if @filter.applied_location_search? %>
                 <%= t('.miles', count: application_form.site_distance.round(1)) %>

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -9,6 +9,7 @@ en:
           review_candidates: When they have no open applications, you can review their details and decide whether to invite them to apply.
           name: Name
           distance_from: Distance from %{origin}
+          no_degree: No degree
           miles:
             zero: "%{count} miles"
             one: "%{count} miles"

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe ApplicationQualificationDecorator do
           expect(abbreviated_degree).to include('BA English Literature')
         end
       end
+
+      context 'when it is an international degree or another qualification type' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:non_uk_degree_qualification,
+                  qualification_type: 'Bachelor',
+                  subject: 'Modern Languages',
+                  predicted_grade: false,
+                  grade: '89'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:abbreviated_degree) { decorated_degree.degree_type_and_subject(application_form.last_degree) }
+
+        it 'renders the unstructured free text' do
+          expect(abbreviated_degree).to include('Bachelor Modern Languages')
+        end
+      end
     end
 
     describe '#formatted_grade' do
@@ -139,6 +157,24 @@ RSpec.describe ApplicationQualificationDecorator do
 
         it 'renders the short form grade' do
           expect(formatted_grade).to include('2:2 (predicted)')
+        end
+      end
+
+      context 'when it is an international degree or another grade type' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:non_uk_degree_qualification,
+                  qualification_type: 'Bachelor',
+                  subject: 'Modern Languages',
+                  predicted_grade: false,
+                  grade: '89'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:formatted_grade) { decorated_degree.formatted_grade(application_form.last_degree) }
+
+        it 'renders the unstructured free text' do
+          expect(formatted_grade).to include('89')
         end
       end
     end

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe ApplicationQualificationDecorator do
           )
         }
 
-        it 'returns unstructured degree and raw grade' do
+        it 'returns unstructured free text degree and grade' do
           expect(described_class.new(degree).formatted_degree_and_grade).to eq('Bachelor Modern Languages, 89')
         end
       end

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -66,5 +66,81 @@ RSpec.describe ApplicationQualificationDecorator do
         end
       end
     end
+
+    describe '#degree_type_and_subject' do
+      context 'when it is a completed honours degree' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:degree_qualification,
+                  qualification_type: 'Bachelor of Science',
+                  subject: 'Mathematics',
+                  predicted_grade: false,
+                  grade: 'First-class honours'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:abbreviated_degree) { decorated_degree.degree_type_and_subject(application_form.last_degree) }
+
+        it 'renders the abbreviated degree with (hons)' do
+          expect(abbreviated_degree).to include('BSc (Hons) Mathematics')
+        end
+      end
+
+      context 'when it is a completed degree without honours' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:degree_qualification,
+                  qualification_type: 'Bachelor of Arts',
+                  subject: 'English Literature',
+                  predicted_grade: false,
+                  grade: 'Third-class'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:abbreviated_degree) { decorated_degree.degree_type_and_subject(application_form.last_degree) }
+
+        it 'renders the abbreviated degree without (hons)' do
+          expect(abbreviated_degree).to include('BA English Literature')
+        end
+      end
+    end
+
+    describe '#formatted_grade' do
+      context 'when it is a completed degree with a grade' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:degree_qualification,
+                  qualification_type: 'Bachelor of Education',
+                  subject: 'European History',
+                  predicted_grade: false,
+                  grade: 'Third-class honours'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:formatted_grade) { decorated_degree.formatted_grade(application_form.last_degree) }
+
+        it 'renders the short form grade' do
+          expect(formatted_grade).to include('3rd')
+        end
+      end
+
+      context 'when it is a incomplete degree with a predicted grade' do
+        let(:application_form) {
+          create(:application_form, :completed, application_qualifications: [
+            build(:degree_qualification,
+                  qualification_type: 'Bachelor of Engineering',
+                  subject: 'Civil Engineering',
+                  predicted_grade: true,
+                  grade: 'Lower second-class honours (2:2)'),
+          ])
+        }
+        let(:decorated_degree) { described_class.new(application_form.last_degree) }
+        let(:formatted_grade) { decorated_degree.formatted_grade(application_form.last_degree) }
+
+        it 'renders the short form grade' do
+          expect(formatted_grade).to include('2:2 (predicted)')
+        end
+      end
+    end
   end
 end

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -156,13 +156,17 @@ RSpec.describe 'Providers views candidate pool list' do
   def then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
     candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
 
-    expect(candidates).to contain_exactly(
+    expected_candidates = [
       candidate_name(@rejected_candidate_form),
       candidate_name(@declined_candidate_form),
       candidate_name(@visa_sponsorship_form),
-    )
+    ]
 
-    expect(candidates).not_to include(candidate_name(@withdrawn_no_longer_wants_to_train_form))
+    expected_candidates.each do |candidate_text|
+      expect(candidates).to have_text(candidate_text)
+    end
+
+    expect(page).to have_no_text(candidate_name(@withdrawn_no_longer_wants_to_train_form))
   end
 
   def then_i_am_redirected_to_the_applications_page
@@ -189,7 +193,9 @@ RSpec.describe 'Providers views candidate pool list' do
     candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
     candidate_names = application_forms.map { |form| candidate_name(form) }
 
-    expect(candidates).to match_array(candidate_names)
+    candidate_names.each do |name|
+      expect(candidates).to have_text(name)
+    end
   end
 
   def when_i_click(button)
@@ -197,6 +203,6 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def candidate_name(application_form)
-    "#{application_form.redacted_full_name}\n(#{application_form.candidate_id})"
+    "#{application_form.redacted_full_name} (#{application_form.candidate_id})"
   end
 end


### PR DESCRIPTION
## Context

Recent user research showed that often the first thing a provider will check on an application is the candidate’s qualifications - primarily their degree.

In order to help providers do an initial assessment of candidates without having to click on each candidate, we would like to include a short line under each candidate’s name summarising their degree.

## Changes proposed in this pull request

- Add a line below the candidate's redacted name with a preview of their degrees and grade, if applicable.

<img width="648" alt="Screenshot 2025-04-17 at 08 31 55" src="https://github.com/user-attachments/assets/ea7b9f82-2083-44a3-ac3b-d72a3a523833" />

<img width="652" alt="Screenshot 2025-04-17 at 08 32 07" src="https://github.com/user-attachments/assets/99ce023b-963a-4e6d-82c8-d8e12217a95a" />

## Guidance to review

The degree line should follow the format:

‘[degree type] [subject], [grade]’

Incomplete degrees with predicted grades should be:

‘[degree type] [subject], [grade] (predicted)’

The grade should be in the short-form - ie, ‘2:1’ rather than 'Upper second-class honours'.

For UK degrees, type and grade are structured data, for non-UK degrees this would come from freetext but can still be output in this same format.

If the candidate does not have a degree, it should instead say 'No degree'.

- Log in as a provider
- Populate the 'Find a candidate' index with candidates with a range of characteristics, including with degrees of different types, different grades, including unstructured types/grades and no degree
- Search for a location and check formatting

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
