### PR TITLE
Added experiement conversions for setting a preference

### DIFF
--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -20,6 +20,16 @@ module CandidateInterface
                         else
                           t('.success_opt_out')
                         end
+
+      # This will have no effect if the candidate has not been sent the email
+      exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
+      participants = FieldTest::Participant.standardize(current_candidate)
+      if @preference.opt_in?
+        exp.convert(participants, goal: :opt_in)
+      else
+        exp.convert(participants, goal: :opt_out)
+      end
+
       redirect_to candidate_interface_application_choices_path
     end
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -23,11 +23,10 @@ module CandidateInterface
 
       # This will have no effect if the candidate has not been sent the email
       exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
-      participants = FieldTest::Participant.standardize(current_candidate)
       if @preference.opt_in?
-        exp.convert(participants, goal: :opt_in)
+        exp.convert(current_candidate, goal: :opt_in)
       else
-        exp.convert(participants, goal: :opt_out)
+        exp.convert(current_candidate, goal: :opt_out)
       end
 
       redirect_to candidate_interface_application_choices_path

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -62,8 +62,7 @@ module CandidateInterface
 
       # This will have no effect if the candidate has not been sent the email
       exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
-      participants = FieldTest::Participant.standardize(current_candidate)
-      exp.convert(participants, goal: :opt_out)
+      exp.convert(current_candidate, goal: :opt_out)
     end
   end
 end

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -32,8 +32,7 @@ module CandidateInterface
           preference.update!(pool_status: pool_status)
 
           if preference.opt_out?
-            preference.published!
-            current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
+            preference_opt_out!(preference)
           end
 
           true
@@ -43,11 +42,7 @@ module CandidateInterface
           @preference = current_candidate.preferences.create(pool_status:)
 
           if @preference.opt_out?
-            ActiveRecord::Base.transaction do
-              # We publish the preference because if they opt out it's the end of the journey
-              @preference.published!
-              current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
-            end
+            preference_opt_out!(@preference)
           else
             LocationPreferences.add_default_location_preferences(preference: @preference)
           end
@@ -55,6 +50,20 @@ module CandidateInterface
           true
         end
       end
+    end
+
+  private
+
+    def preference_opt_out!(preference)
+      ActiveRecord::Base.transaction do
+        preference.published!
+        current_candidate.published_preferences.where.not(id: preference.id).destroy_all
+      end
+
+      # This will have no effect if the candidate has not been sent the email
+      exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
+      participants = FieldTest::Participant.standardize(current_candidate)
+      exp.convert(participants, goal: :opt_out)
     end
   end
 end


### PR DESCRIPTION
## Context

Prepares intended actions to record Candidate (involved in the experiment) actions

## Changes proposed in this pull request

Triggers a conversion when the Candidate either opts in or out against the relevant goals

## Guidance to review

No change to current flow, we have no Candidates in the experiment (until we trigger the emails) this should do nothing unless the Candidate is a Participant in the experiment. 
The `field_test_events` table will only populate if the Candidate is a Participant 👌

Extracted from #10131 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
