### PR TITLE
Added endpoint to convert experimental email link clicks

### DIFF
--- a/app/controllers/candidate_interface/candidate_feature_launch_emails_controller.rb
+++ b/app/controllers/candidate_interface/candidate_feature_launch_emails_controller.rb
@@ -1,0 +1,20 @@
+class CandidateInterface::CandidateFeatureLaunchEmailsController < CandidateInterface::CandidateInterfaceController
+  def show
+    experiment = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
+    experiment.convert(current_candidate, goal: :link_clicked)
+
+    redirect_to change_preferences_path
+  end
+
+private
+
+  def change_preferences_path
+    if current_candidate.published_preferences.last&.opt_out?
+      edit_candidate_interface_pool_opt_in_path(current_candidate.published_preferences.last)
+    elsif current_candidate.published_preferences.blank?
+      new_candidate_interface_pool_opt_in_path
+    else
+      candidate_interface_draft_preference_publish_preferences_path(current_candidate.published_preferences.last)
+    end
+  end
+end

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -23,6 +23,7 @@ namespace :candidate_interface, path: '/candidate' do
     resource :publish_preferences, only: %i[show create], path: 'publish-preferences'
     resources :location_preferences, path: 'location-preferences'
   end
+  resource :candidate_feature_launch_email, only: :show, path: 'feature-launch-email'
 
   resources :location_suggestions, only: :index, path: 'location-suggestions'
 


### PR DESCRIPTION
## Context

After the Candidate has clicked the email link, they need to be redirected based on their preference status. We also want to convert the participant against the field test experiment. 

## Changes proposed in this pull request

- Added `/candidate/feature-launch-email` route which redirects to opt-in preferences after marking the experiment as converted

## Guidance to review

- No visible change
- No records will be changed unless the Candidate is a participant in the experiment

Extracted from https://github.com/DFE-Digital/apply-for-teacher-training/pull/10598

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
