### PR TITLE
Fix for FAC email logic

### DIFF
--- a/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
+++ b/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
@@ -14,7 +14,7 @@ module Chasers
         application_forms_to_send = ApplicationForm
                                       .where(id: application_form_ids)
                                       # Tier 1 & 2 application forms
-                                      .merge(Pool::Candidates.application_forms_eligible_for_pool)
+                                      .where(id: Pool::Candidates.application_forms_eligible_for_pool)
                                       # Filter out candidates who should not receive nudge-like emails
                                       # Filter out blocked and locked candidates
                                       .joins(:candidate)

--- a/spec/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker_spec.rb
+++ b/spec/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Chasers::Candidate::FindACandidateFeatureLaunchEmailWorker do
                                   .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
       end
     end
+
+    context 'when the Application ID is not in the perform arguments' do
+      it 'does not send the email' do
+        candidate = create_candidate_eligible_for_pool
+        application_form = candidate.current_application
+
+        expect {
+          described_class.new.perform(application_form_ids: [])
+        }.not_to have_enqueued_job.on_queue('mailers')
+                                  .with('CandidateMailer', 'find_a_candidate_feature_launch_email', 'deliver_now', args: [application_form])
+      end
+    end
   end
 
 private


### PR DESCRIPTION
## Context

Previous code was including all eligible Application Forms as well as the ones that were passed to the job

## Changes proposed in this pull request

- Updated logic in FindACandidateFeatureLaunchEmailWorker

## Guidance to review

- 🤷‍♂️

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
