### PR TITLE
Sentry Only run monthly statistics in production

### DIFF
--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -4,6 +4,7 @@ class GenerateMonthlyStatistics
   sidekiq_options retry: 3, queue: :default
 
   def perform
+    return false unless HostingEnvironment.production?
     return false unless MonthlyStatisticsTimetable.generate_monthly_statistics?
 
     Publications::ITTMonthlyReportGenerator.new(

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -2,68 +2,80 @@ require 'rails_helper'
 
 RSpec.describe GenerateMonthlyStatistics, :sidekiq do
   include DfE::Bigquery::TestHelper
-  before { stub_bigquery_application_metrics_request }
 
-  context 'when third Monday, but within the first month of the cycle' do
-    before do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 10, 21))
-    end
-
+  context 'not production' do
     it 'returns false' do
       expect(described_class.new.perform).to be false
-      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
     end
   end
 
-  context 'when second Monday of the month' do
+  context 'production' do
     before do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2023, 11, 13))
+      allow(HostingEnvironment).to receive(:production?).and_return true
+      stub_bigquery_application_metrics_request
     end
 
-    it 'returns false' do
-      expect(described_class.new.perform).to be false
-      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
-    end
-  end
+    context 'when third Monday, but within the first month of the cycle' do
+      before do
+        TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 10, 21))
+      end
 
-  context 'when fourth Monday of the month' do
-    before do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2023, 11, 27))
-    end
-
-    it 'returns false' do
-      expect(described_class.new.perform).to be false
-      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
-    end
-  end
-
-  context 'when third Monday of the month' do
-    subject(:report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.first }
-
-    before do
-      TestSuiteTimeMachine.travel_permanently_to(2023, 11, 20)
+      it 'returns false' do
+        expect(described_class.new.perform).to be false
+        expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
+      end
     end
 
-    it 'generates new monthly statistics report' do
-      described_class.new.perform
-      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be 1
-      expect(report.month).to eq('2023-11')
-      expect(report.generation_date).to eq(Date.new(2023, 11, 20))
-      expect(report.publication_date).to eq(Date.new(2023, 11, 27))
-      expect(report.statistics.keys).to eq(%w[meta data formats])
-      expect(report.statistics['data'].keys).to eq(%w[
-        candidate_headline_statistics
-        candidate_age_group
-        candidate_sex
-        candidate_area
-        candidate_phase
-        candidate_route_into_teaching
-        candidate_primary_subject
-        candidate_secondary_subject
-        candidate_provider_region
-        candidate_provider_region_and_subject
-        candidate_area_and_subject
-      ])
+    context 'when second Monday of the month' do
+      before do
+        TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2023, 11, 13))
+      end
+
+      it 'returns false' do
+        expect(described_class.new.perform).to be false
+        expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
+      end
+    end
+
+    context 'when fourth Monday of the month' do
+      before do
+        TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2023, 11, 27))
+      end
+
+      it 'returns false' do
+        expect(described_class.new.perform).to be false
+        expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
+      end
+    end
+
+    context 'when third Monday of the month' do
+      subject(:report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.first }
+
+      before do
+        TestSuiteTimeMachine.travel_permanently_to(2023, 11, 20)
+      end
+
+      it 'generates new monthly statistics report' do
+        described_class.new.perform
+        expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be 1
+        expect(report.month).to eq('2023-11')
+        expect(report.generation_date).to eq(Date.new(2023, 11, 20))
+        expect(report.publication_date).to eq(Date.new(2023, 11, 27))
+        expect(report.statistics.keys).to eq(%w[meta data formats])
+        expect(report.statistics['data'].keys).to eq(%w[
+          candidate_headline_statistics
+          candidate_age_group
+          candidate_sex
+          candidate_area
+          candidate_phase
+          candidate_route_into_teaching
+          candidate_primary_subject
+          candidate_secondary_subject
+          candidate_provider_region
+          candidate_provider_region_and_subject
+          candidate_area_and_subject
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

For this [sentry](https://dfe-teacher-services.sentry.io/issues/6306599347/?alert_rule_id=853774&alert_type=issue&notification_uuid=6e5b0866-934a-415b-8a01-78e924ad2586&project=1765973&referrer=slack#threads). We shouldn't try to run this reports in anything but production because we don't have credentials for other environments. 

I thought I had already done this, but apparently only for the weekly performance statistics. Not sure why we didn't catch it last month. 

## Changes proposed in this pull request

Early return unless we are in production. 
Relevant tests

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
