### PR TITLE
[801] Bug fix, updating a condition on the support console deletes any ske conditions

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -226,10 +226,17 @@ module SupportInterface
     def confidentiality_row
       return unless reference.feedback_provided?
 
-      {
+      row =  {
         key: 'Can this reference be shared with the candidate?',
         value: confidentiality_value,
       }
+      return row unless @editable
+
+      row.merge(
+        action: {
+          href: support_interface_application_form_edit_reference_details_path(reference.application_form, reference),
+        },
+      )
     end
 
     def history_row
@@ -272,7 +279,11 @@ module SupportInterface
     end
 
     def confidentiality_value
-      t("support_interface.references.confidential_warning.#{reference.confidential}")
+      if reference.confidential.nil?
+        t('support_interface.references.confidential_warning.not_answered')
+      else
+        t("support_interface.references.confidential_warning.#{reference.confidential}")
+      end
     end
 
     attr_reader :reference

--- a/app/controllers/support_interface/application_forms/references_controller.rb
+++ b/app/controllers/support_interface/application_forms/references_controller.rb
@@ -35,7 +35,7 @@ module SupportInterface
     private
 
       def edit_reference_details_params
-        params.expect(support_interface_application_forms_edit_reference_details_form: %i[name email_address relationship audit_comment])
+        params.expect(support_interface_application_forms_edit_reference_details_form: %i[name email_address relationship audit_comment confidential])
       end
 
       def edit_reference_feedback_params

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -13,7 +13,7 @@ module SupportInterface
     end
 
     def impersonate_and_give
-      redirect_to referee_interface_reference_relationship_path(token: @reference.refresh_feedback_token!)
+      redirect_to referee_interface_confidentiality_path(token: @reference.refresh_feedback_token!)
     end
 
     def impersonate_and_decline

--- a/app/forms/support_interface/application_forms/edit_reference_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_reference_details_form.rb
@@ -3,18 +3,20 @@ module SupportInterface
     class EditReferenceDetailsForm
       include ActiveModel::Model
 
-      attr_accessor :name, :email_address, :relationship, :audit_comment
+      attr_accessor :name, :email_address, :relationship, :audit_comment, :confidential
 
       validates :name, presence: true, length: { minimum: 2, maximum: 200 }
       validates :email_address, presence: true, valid_for_notify: true, length: { maximum: 100 }
       validates :relationship, presence: true, word_count: { maximum: 50 }
       validates :audit_comment, presence: true
+      validates :confidential, presence: true
 
       def self.build_from_reference(reference)
         new(
           name: reference.name,
           email_address: reference.email_address,
           relationship: reference.relationship,
+          confidential: reference.confidential,
         )
       end
 
@@ -27,6 +29,7 @@ module SupportInterface
             email_address:,
             relationship:,
             audit_comment:,
+            confidential: ActiveModel::Type::Boolean.new.cast(confidential),
           )
         end
       end

--- a/app/views/support_interface/application_forms/references/edit_reference_details.html.erb
+++ b/app/views/support_interface/application_forms/references/edit_reference_details.html.erb
@@ -11,6 +11,10 @@
         <%= f.govuk_text_field :email_address, label: { text: t('support_interface.edit_reference_form.email_address.label'), size: 'm' }, hint: { text: t('support_interface.edit_reference_form.email_address.hint_text') }, autocomplete: 'email_addess' %>
         <%= f.govuk_text_field :relationship, label: { text: t('support_interface.edit_reference_form.relationship.label'), size: 'm' }, autocomplete: 'relationship' %>
         <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
+        <%= f.govuk_radio_buttons_fieldset :confidential, legend: { text: t('support_interface.edit_reference_form.confidential.legend') } do %>
+          <%= f.govuk_radio_button :confidential, false, label: { text: t('support_interface.edit_reference_form.confidential.ok_to_share') }, link_errors: true %>
+          <%= f.govuk_radio_button :confidential, true, label: { text: t('support_interface.edit_reference_form.confidential.not_ok_to_share') } %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit 'Update reference' %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -2,6 +2,7 @@ en:
   support_interface:
     references:
       confidential_warning:
+        not_answered: The Referee has not told us if their feedback is confidential
         true: No, this reference is confidential. Do not share it.
         false: Yes, if they request it.
     page_titles:
@@ -13,6 +14,10 @@ en:
       remove: Remove support user
       restore: Restore support user
     edit_reference_form:
+      confidential:
+        legend: Can the feedback be shared with the candidate?
+        ok_to_share: Yes, if the candidate requests it
+        not_ok_to_share: No, this reference is confidential
       name:
         label: What is the referee’s name?
       email_address:
@@ -73,7 +78,7 @@ en:
       ske_reasons:
         different_degree: Their degree subject was not %{degree_subject}
         outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
-    links: 
+    links:
       service_manual:
         subscription_messages: https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#subscription-messages
   activemodel:
@@ -213,6 +218,8 @@ en:
             relationship:
               blank: Relationship cannot be blank
               too_long: Relationship must be %{count} characters or fewer
+            confidential:
+              blank: Select whether or not the feedback may be shared with the candidate
             audit_comment:
               blank: You must provide an audit comment
         support_interface/application_forms/edit_becoming_a_teacher_form:

--- a/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
-  let(:reference) { create(:reference, name: 'John Doe', email_address: 'john.doe@example.com', relationship: 'Colleague') }
+  let(:reference) { create(:reference, name: 'John Doe', email_address: 'john.doe@example.com', relationship: 'Colleague', confidential: true) }
 
   describe 'validations' do
     subject { described_class.new }
@@ -12,6 +12,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
     it { is_expected.not_to allow_value('invalid-email').for(:email_address) }
     it { is_expected.to validate_presence_of(:relationship) }
     it { is_expected.to validate_presence_of(:audit_comment) }
+    it { is_expected.to validate_presence_of(:confidential).with_message('Select whether or not the feedback may be shared with the candidate') }
   end
 
   describe '.build_from_reference' do
@@ -21,6 +22,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
       expect(form.name).to eq('John Doe')
       expect(form.email_address).to eq('john.doe@example.com')
       expect(form.relationship).to eq('Colleague')
+      expect(form.confidential).to be true
     end
   end
 
@@ -33,6 +35,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
         email_address: 'jane.doe@example.com',
         relationship: 'Manager',
         audit_comment: 'Updated reference details',
+        confidential: 'false',
       }
     end
 
@@ -43,6 +46,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
         expect(reference.name).to eq('Jane Doe')
         expect(reference.email_address).to eq('jane.doe@example.com')
         expect(reference.relationship).to eq('Manager')
+        expect(reference.confidential).to be false
       end
     end
 
@@ -70,6 +74,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
         expect(reference.name).to eq('Jane Doe')
         expect(reference.email_address).to eq('jane.doe@example.com')
         expect(reference.relationship).to eq('Manager')
+        expect(reference.confidential).to be false
       end
     end
   end


### PR DESCRIPTION
## Context

Identified when a support user was updating a SKE condition.
When a support user updates conditions, all SKE conditions were deleted.

## Changes proposed in this pull request

We were not populating the edit form with existing SKE conditions. As a result, when the form was saved, it looked like all the conditions were unchecked.

The change here is to just include the existing conditions in the form so they are not removed when the form is updated. Added a system test as well.

## Guidance to review

Sign in to support
Find a candidate with an offer or pending conditions and edit the conditions. The SKE conditions should be preserved. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
