### PR TITLE
Fix location preference show view

### DIFF
--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -72,6 +72,12 @@ module CandidateInterface
 
     def set_location_preference
       @location_preference = @preference.location_preferences.find_by(id: params[:id])
+
+      if @location_preference.blank?
+        redirect_to candidate_interface_draft_preference_location_preferences_path(
+          @preference,
+        )
+      end
     end
 
     def location_preference_params


### PR DESCRIPTION
## Context

There's an edge case where a user can delete a location preference in one browser tab but on another browser tab, this location preference might still appear because the user didn't refresh the page.

This commit redirects the user to the location preferences index page if there's not a location preference found in DB. Fixing this issue.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/7be28774-6657-40e1-89db-21a90c14d55f



Go and edit/remove a location preference that doesn't exist in DB, changing the last ID in the URL does the trick

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
