### PR TITLE
[801] Bug fix support console when deleting a ske condition

### DIFF
--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -72,7 +72,7 @@ module SupportInterface
 
     def ske_condition_models
       @ske_condition_models ||= ske_conditions.map do |index, attrs|
-        SkeConditionField.new(attrs.merge(id: index))
+        SkeConditionField.new(attrs.merge(id: index, ske_required: true))
       end
     end
 
@@ -122,7 +122,9 @@ module SupportInterface
     end
 
     def ske_condition_language_course_model_for(language, index)
-      SkeConditionField.new(id: index, subject: language, subject_type: 'language')
+      ske_condition_models.find do |ske|
+        ske.subject == language
+      end.presence || SkeConditionField.new(id: index, subject: language, subject_type: 'language')
     end
 
     def ske_course?

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -53,8 +53,6 @@
                   <% end %>
                 <% end %>
               <% end %>
-              <%= f.govuk_radio_divider %>
-              <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
             <% end %>
           <% else %>
             <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>

--- a/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe 'Add course to submitted application' do
     then_i_see_the_updated_ske_condition
 
     when_i_click_on_change_conditions
+    and_i_remove_one_ske_condition
+    then_i_see_only_one_condition_has_been_removed
+
+    when_i_click_on_change_conditions
     and_i_delete_the_ske_condition
     then_i_see_that_the_ske_condition_has_been_removed
   end
@@ -111,11 +115,23 @@ RSpec.describe 'Add course to submitted application' do
       choose('8 weeks')
     end
     check('German')
-    within('#support-interface-conditions-form-ske-conditions-2-ske-required-german-conditional') do
+    within('#support-interface-conditions-form-ske-conditions-1-ske-required-german-conditional') do
       choose('Their degree subject was not German')
       choose('16 weeks')
     end
     click_link_or_button 'Update conditions'
+  end
+
+  def and_i_remove_one_ske_condition
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    uncheck 'French'
+    click_link_or_button 'Update conditions'
+  end
+
+  def then_i_see_only_one_condition_has_been_removed
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content('Reason Their degree subject was not German')
+    expect(page).to have_no_content('Their degree subject was not French')
   end
 
   def then_i_see_the_updated_ske_condition
@@ -126,9 +142,7 @@ RSpec.describe 'Add course to submitted application' do
 
   def and_i_delete_the_ske_condition
     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
-    uncheck('French')
     uncheck('German')
-    check('No, a SKE course is not required')
     click_link_or_button 'Update conditions'
   end
 


### PR DESCRIPTION
## Context

Identified when a support user was updating a SKE condition.
When a support user updates conditions, all SKE conditions were deleted.

## Changes proposed in this pull request

We were not populating the edit form with existing SKE conditions. As a result, when the form was saved, it looked like all the conditions were unchecked.

The change here is to just include the existing conditions in the form so they are not removed when the form is updated. Added a system test as well.

## Guidance to review

Sign in to support
Find a candidate with an offer or pending conditions and edit the conditions. The SKE conditions should be preserved.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
