### PR TITLE
[832] Bug - cannot mark reference as confidential when entering from support console

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -226,10 +226,20 @@ module SupportInterface
     def confidentiality_row
       return unless reference.feedback_provided?
 
-      {
+      row = {
         key: 'Can this reference be shared with the candidate?',
         value: confidentiality_value,
       }
+
+      return row unless @editable
+
+      row.merge(
+        action: {
+          text: 'Change',
+          href: support_interface_application_form_edit_reference_feedback_path(reference.application_form, reference),
+          visually_hidden_text: 'whether this reference can be shared with the candidate',
+        },
+      )
     end
 
     def history_row
@@ -272,7 +282,11 @@ module SupportInterface
     end
 
     def confidentiality_value
-      t("support_interface.references.confidential_warning.#{reference.confidential}")
+      if reference.confidential.nil?
+        t('support_interface.references.confidential_warning.unknown')
+      else
+        t("support_interface.references.confidential_warning.#{reference.confidential}")
+      end
     end
 
     attr_reader :reference

--- a/app/controllers/support_interface/application_forms/references_controller.rb
+++ b/app/controllers/support_interface/application_forms/references_controller.rb
@@ -39,7 +39,7 @@ module SupportInterface
       end
 
       def edit_reference_feedback_params
-        params.expect(support_interface_application_forms_edit_reference_feedback_form: %i[feedback audit_comment send_emails])
+        params.expect(support_interface_application_forms_edit_reference_feedback_form: %i[feedback audit_comment send_emails confidential])
       end
 
       def send_emails

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -13,7 +13,7 @@ module SupportInterface
     end
 
     def impersonate_and_give
-      redirect_to referee_interface_reference_relationship_path(token: @reference.refresh_feedback_token!)
+      redirect_to referee_interface_confidentiality_path(token: @reference.refresh_feedback_token!)
     end
 
     def impersonate_and_decline

--- a/app/forms/support_interface/application_forms/edit_reference_feedback_form.rb
+++ b/app/forms/support_interface/application_forms/edit_reference_feedback_form.rb
@@ -3,14 +3,15 @@ module SupportInterface
     class EditReferenceFeedbackForm
       include ActiveModel::Model
 
-      attr_accessor :feedback, :audit_comment, :send_emails
+      attr_accessor :feedback, :audit_comment, :send_emails, :confidential
 
+      validates :confidential, presence: true
       validates :feedback, presence: true, word_count: { maximum: 500 }
       validates :audit_comment, presence: true
       validates :send_emails, presence: true
 
       def self.build_from_reference(reference)
-        new(feedback: reference.feedback)
+        new(feedback: reference.feedback, confidential: reference.confidential)
       end
 
       def save(reference)
@@ -20,6 +21,7 @@ module SupportInterface
           reference.update!(
             feedback:,
             audit_comment:,
+            confidential:,
           )
         end
       end

--- a/app/views/support_interface/application_forms/references/edit_reference_feedback.html.erb
+++ b/app/views/support_interface/application_forms/references/edit_reference_feedback.html.erb
@@ -7,6 +7,16 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: 'Edit reference feedback', size: 'l' } do %>
+        <%= f.govuk_collection_radio_buttons(
+              :confidential,
+              [
+                Struct.new(:id, :name).new(true, t('support_interface.edit_reference_form.confidential.not_ok_to_share')),
+                Struct.new(:id, :name).new(false, t('support_interface.edit_reference_form.confidential.ok_to_share')),
+              ],
+              :id,
+              :name,
+              legend: { text: t('support_interface.edit_reference_form.confidential.legend') },
+            ) %>
         <%= f.govuk_text_area :feedback, label: { text: t('support_interface.edit_reference_form.feedback.label'), size: 'm' }, autocomplete: 'feedback' %>
         <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_reference_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_reference_form.audit_comment.hint') } %>
         <%= f.govuk_collection_radio_buttons :send_emails, [Struct.new(:id, :name).new(true, 'Yes'), Struct.new(:id, :name).new(false, 'No')], :id, :name, inline: true, legend: { text: t('support_interface.edit_reference_form.send_emails.label') } %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -2,6 +2,7 @@ en:
   support_interface:
     references:
       confidential_warning:
+        unknown: Unknown
         true: No, this reference is confidential. Do not share it.
         false: Yes, if they request it.
     page_titles:
@@ -27,6 +28,10 @@ en:
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
       send_emails:
         label: Send notification emails to candidate and referee?
+      confidential:
+        legend: Can the feedback be shared with the candidate?
+        ok_to_share: Yes, if the candidate requests it
+        not_ok_to_share: No, this reference is confidential
     edit_becoming_a_teacher_form:
       becoming_a_teacher:
         label: Edit personal statement
@@ -73,7 +78,7 @@ en:
       ske_reasons:
         different_degree: Their degree subject was not %{degree_subject}
         outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
-    links: 
+    links:
       service_manual:
         subscription_messages: https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#subscription-messages
   activemodel:
@@ -267,6 +272,8 @@ en:
               blank: You must provide an audit comment
             send_emails:
               blank: You must select an email option
+            confidential:
+              blank: Select whether or not the feedback can be shared with the candidate
         support_interface/application_forms/edit_address_details_form:
           attributes:
             address_line1:

--- a/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
   subject { described_class.new }
 
-  let(:reference) { create(:reference, feedback: 'Some feedback') }
+  let(:reference) { create(:reference, feedback: 'Some feedback', confidential: false) }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:feedback) }
@@ -16,6 +16,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
       form = described_class.build_from_reference(reference)
 
       expect(form.feedback).to eq('Some feedback')
+      expect(form.confidential).to be false
     end
   end
 
@@ -27,6 +28,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
         feedback: 'Updated feedback',
         audit_comment: 'Audit comment',
         send_emails: true,
+        confidential: true,
       }
     end
 
@@ -34,6 +36,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
       it 'updates the reference with the provided attributes' do
         form.save(reference)
         expect(reference.reload.feedback).to eq('Updated feedback')
+        expect(reference.reload.confidential).to be true
       end
     end
 

--- a/spec/requests/support_interface/update_reference_feedback_spec.rb
+++ b/spec/requests/support_interface/update_reference_feedback_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Support interface - POST /support/applications/:application_id/r
           feedback: 'some feedback',
           audit_comment: 'ticket',
           send_emails: 'false',
+          confidential: 'true',
         },
         application_form_id: application_form.id,
         reference_id: reference.id,

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe 'Editing reference' do
   end
 
   def then_i_see_relevant_blank_error_messages
+    expect(page).to have_content 'Select whether or not the feedback can be shared with the candidate'
     expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.feedback.blank')
     expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.audit_comment.blank')
     expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.send_emails.blank')
@@ -114,10 +115,12 @@ RSpec.describe 'Editing reference' do
     fill_in 'support_interface_application_forms_edit_reference_feedback_form[feedback]', with: 'Harry is a good egg'
     fill_in 'support_interface_application_forms_edit_reference_feedback_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12346'
     choose 'Yes'
+    choose 'Yes, if the candidate requests it'
   end
 
   def and_i_see_the_new_feedback
     expect(page).to have_content 'Harry is a good egg'
+    expect(page).to have_content 'Yes, if they request it.'
   end
 
   def and_i_see_my_feedback_comment_in_the_audit_log

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Support user can access the RefereeInterface' do
 
     when_i_visit_the_application_form_page
     and_click_the_provide_feedback_link
+    then_i_see_the_confidentiality_page
+    when_i_select_not_to_share_and_continue
     then_i_see_the_reference_relationship_page
 
     when_i_visit_the_application_form_page
@@ -37,6 +39,15 @@ RSpec.describe 'Support user can access the RefereeInterface' do
 
   def and_click_the_provide_feedback_link
     click_link_or_button 'Give feedback'
+  end
+
+  def then_i_see_the_confidentiality_page
+    expect(page).to have_content "Can your reference be shared with #{@application.full_name}?"
+  end
+
+  def when_i_select_not_to_share_and_continue
+    choose 'No, it should be treated as confidential'
+    click_on 'Save and continue'
   end
 
   def then_i_see_the_reference_relationship_page


### PR DESCRIPTION
## Context

When a support user added feedback to a reference on behalf of the referee, there was no option to indicate whether it could be shared (confidential == false) or not (confidential == true). (a bit of confusion -- the field is called 'confidential', but the question we ask is if it is shareable. So No => true and Yes => false)

## Changes proposed in this pull request

First change -- when a support user clicks on 'Give feedback', they see the first screen asking them if the reference can be shared with the candidate. 

Second change -- when clicking on 'Add' or 'Change' in the feedback row, the radio buttons requiring the the support user to indicate if the reference is shareable or not. 

https://github.com/user-attachments/assets/631b686c-7b68-4320-90e0-1e81a882cf59

## Guidance to review

Sign in as a support user, and look at any user in conditions pending / offered. 
For a reference where feedback exists, click 'Change' in the feedback row. You should be required to indicate whether or not the reference is confidential
For a reference that has been requested, click on 'Give feedback' in the 'Sign in as a referee' row. The first question you are asked now is whether or not the reference is shareable.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
