### PR TITLE
Redirect to application choices if the candidate preference is blank

### DIFF
--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -33,6 +33,10 @@ module CandidateInterface
 
     def set_preference
       @preference = current_candidate.preferences.find_by(id: params[:id])
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
     end
 
     def redirect_to_root_path_if_flag_is_inactive

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -68,6 +68,10 @@ module CandidateInterface
 
     def set_preference
       @preference = current_candidate.preferences.find_by(id: params[:draft_preference_id])
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
     end
 
     def set_location_preference

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -68,6 +68,10 @@ module CandidateInterface
 
     def set_preference
       @preference = current_candidate.preferences.find_by(id: params[:id])
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
     end
 
     def set_back_path

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -36,6 +36,10 @@ module CandidateInterface
 
     def set_preference
       @preference = current_candidate.preferences.find_by(id: params[:draft_preference_id])
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
     end
 
     def redirect_to_root_path_if_flag_is_inactive


### PR DESCRIPTION
## Context

There are edge cases, probably from creating candidate preferences in separate tabs where the ids of the preferences can get lost because records are being updated/removed in a different browser tab.

This adds some guard rails, if the form loses the preference record it redirects the user back to the application choices page.

This fixes the rare edge cases where the in the url doesn't what we have in DB anymore.

This should fix

[sentry error 1](https://dfe-teacher-services.sentry.io/issues/6505231275/?environment=production&project=1765973&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=4)
[sentry error 2](https://dfe-teacher-services.sentry.io/issues/6560888860/?environment=production&project=1765973&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=3)
[sentry error 3](https://dfe-teacher-services.sentry.io/issues/6531222071/?environment=production&project=1765973&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=2)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
