### PR TITLE
Add conditional TTA content to candidate emails

### DIFF
--- a/app/views/candidate_mailer/_application_rejected_get_help.text.erb
+++ b/app/views/candidate_mailer/_application_rejected_get_help.text.erb
@@ -1,4 +1,17 @@
 # Get help
+
+<% if @application_choice.application_form.adviser_status == 'assigned' %>
+Your teacher training adviser can help you improve your application. They can support you with:
+
+* acting on any feedback
+* making your application stronger before you apply again
+
+Your adviser has years of teaching experience and knows the application process inside and out.
+
+Contact your teacher training adviser to talk about your next steps.
+
+## Contact our support team
+<% else %>
 A teacher training adviser can provide free support to help you improve your application. They can support you with:
 
 * acting on any feedback
@@ -7,8 +20,6 @@ A teacher training adviser can provide free support to help you improve your app
 All our advisers have years of teaching experience and know the application process inside and out.
 
 [Learn more about teacher training advisers](<%= t('get_into_teaching.url_get_an_adviser_start') %>).
-
+<% end %>
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
 <%= t('get_into_teaching.opening_times') %>.
-
-

--- a/app/views/candidate_mailer/_application_rejected_get_help.text.erb
+++ b/app/views/candidate_mailer/_application_rejected_get_help.text.erb
@@ -1,6 +1,6 @@
 # Get help
 
-<% if @application_choice.application_form.adviser_status == 'assigned' %>
+<% if @application_choice.application_form.adviser_status_assigned? %>
 Your teacher training adviser can help you improve your application. They can support you with:
 
 * acting on any feedback

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 
 [Submit your application for teacher training](<%= application_choices_link %>) as soon as you can to get on a course starting in the <%= @application_form.academic_year_range_name %> academic year.
 
-<%=  "The deadline to submit your application is #{@application_form.apply_deadline_at.to_fs(:govuk_time)} on #{@application_form.apply_deadline_at.to_fs(:govuk_date)} but courses may fill up before then." %>
+<%= "The deadline to submit your application is #{@application_form.apply_deadline_at.to_fs(:govuk_time)} on #{@application_form.apply_deadline_at.to_fs(:govuk_date)} but courses may fill up before then." %>
 
 Courses fill up quickly at this time of year.
 
@@ -14,6 +14,10 @@ Courses fill up quickly at this time of year.
 
 If you have questions about your application, you can [get in touch with us on the phone or through live chat](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 
+<% if @application_form.adviser_status == 'assigned' %>
+You can also contact your teacher training adviser for support with writing your application.
+<% else %>
 You can also [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support to help you write a strong application.
+<% end %>
 
 <%= render "unsubscribe_from_emails_like_this" %>

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -14,7 +14,7 @@ Courses fill up quickly at this time of year.
 
 If you have questions about your application, you can [get in touch with us on the phone or through live chat](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 You can also contact your teacher training adviser for support with writing your application.
 <% else %>
 You can also [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support to help you write a strong application.

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -6,7 +6,11 @@ Dear <%= @application_form.first_name %>
 
 [Sign in to your account to submit your application](<%= application_choices_link %>).
 
+<% if @application_form.adviser_status == 'assigned' %>
+Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.
+<% else %>
 Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.
+<% end %>
 
 # If you’re not ready to submit your application
 

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -6,7 +6,7 @@ Dear <%= @application_form.first_name %>
 
 [Sign in to your account to submit your application](<%= application_choices_link %>).
 
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.
 <% else %>
 Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -15,7 +15,7 @@ Some subjects and courses have bursaries of up to £29,000 and scholarships of u
 [Check if your subject has a bursary or scholarship](<%= email_link_with_utm_params t('get_into_teaching.url_scholarships_and_bursaries_funding_widget'), 'nudge_unsubmitted', @application_form.phase %>)
 
 # Get help
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 Your teacher training adviser can help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.
 
 ## Contact our support team

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -15,13 +15,18 @@ Some subjects and courses have bursaries of up to £29,000 and scholarships of u
 [Check if your subject has a bursary or scholarship](<%= email_link_with_utm_params t('get_into_teaching.url_scholarships_and_bursaries_funding_widget'), 'nudge_unsubmitted', @application_form.phase %>)
 
 # Get help
+<% if @application_form.adviser_status == 'assigned' %>
+Your teacher training adviser can help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.
 
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
+<% else %>
 A teacher training adviser could help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
-
+<% end %>
 <%= t('get_into_teaching.opening_times') %>.
 
 <%= render 'gain_insights_into_life_as_a_teacher' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -16,7 +16,7 @@ Some subjects and courses have bursaries of up to £29,000 and scholarships of u
 
 # Get support with your application
 
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 Your teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.
 <% else %>
 A teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.
@@ -28,7 +28,7 @@ If you are training to teach certain secondary subjects (or primary mathematics)
 
 [Find out about subject knowledge enhancement courses](<%= email_link_with_utm_params t('get_into_teaching.url_subject_knowledge_enhancement'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
 
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 ## Contact our support team
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>).
 <% else %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -16,15 +16,24 @@ Some subjects and courses have bursaries of up to £29,000 and scholarships of u
 
 # Get support with your application
 
+<% if @application_form.adviser_status == 'assigned' %>
+Your teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.
+<% else %>
 A teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
+<% end %>
 
 If you are training to teach certain secondary subjects (or primary mathematics), you could also do a subject knowledge enhancement (SKE) course to improve your knowledge on a subject.
 
 [Find out about subject knowledge enhancement courses](<%= email_link_with_utm_params t('get_into_teaching.url_subject_knowledge_enhancement'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
 
+<% if @application_form.adviser_status == 'assigned' %>
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>).
+<% else %>
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>).
+<% end %>
 
 <%= t('get_into_teaching.opening_times') %>.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -5,13 +5,18 @@ You have not marked your personal statement as complete.
 [Sign in to your account to complete your teacher training application](<%= @personal_statement_link %>)
 
 # Get help with your personal statement
+<% if @application_form.adviser_status == 'assigned' %>
+Your teacher training adviser can help you understand what to put in your personal statement.
 
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
+<% else %>
 A teacher training adviser can help you understand what to put in your personal statement.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
-
+<% end %>
 <%= t('get_into_teaching.opening_times') %>.
 
 You can also find out what to include and what makes a successful personal statement on the [Get Into Teaching website](<%= email_link_with_utm_params t('get_into_teaching.url_apply_personal_statement'),'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase  %>).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -5,7 +5,7 @@ You have not marked your personal statement as complete.
 [Sign in to your account to complete your teacher training application](<%= @personal_statement_link %>)
 
 # Get help with your personal statement
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned?  %>
 Your teacher training adviser can help you understand what to put in your personal statement.
 
 ## Contact our support team

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
@@ -20,7 +20,7 @@ In their reference, they will be asked:
 - whether they want you to be able to see their reference of if it is confidential
 
 # Get help
-<% if @application_form.adviser_status == 'assigned' %>
+<% if @application_form.adviser_status_assigned? %>
 Your teacher training adviser can give advice on references.
 
 ## Contact our support team

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
@@ -20,13 +20,18 @@ In their reference, they will be asked:
 - whether they want you to be able to see their reference of if it is confidential
 
 # Get help
+<% if @application_form.adviser_status == 'assigned' %>
+Your teacher training adviser can give advice on references.
 
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
+<% else %>
 A teacher training adviser can give advice on references:
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
-
+<% end %>
 <%= t('get_into_teaching.opening_times') %>.
 
 # Submit your application as soon as you are ready

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -396,12 +396,10 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_choice) { create(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
-    let(:email) { described_class.application_rejected(application_choice) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
+    let(:application_choice) { create(:application_choice, :rejected, application_form: application_form_with_adviser_eligibility) }
 
-    before do
-      application_choice.application_form.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.application_rejected(application_choice) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Your teacher training adviser can help you improve your application. They can support you with:'
@@ -411,8 +409,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for non-assigned adviser status' do
-    let(:application_choice) { create(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
-    let(:email) { described_class.application_rejected(application_choice) }
+    let(:application_choice) { create(:application_choice, :rejected) }
+
+    subject(:email) { described_class.application_rejected(application_choice) }
 
     it 'refers to the process for getting an adviser' do
       expect(email.body).to have_content 'A teacher training adviser can provide free support to help you improve your application. They can support you with:'

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe CandidateMailer do
       email = described_class.application_rejected(application_choice)
 
       expect(email.body).to have_no_text('Improve your personal statement') # heading not rendered when only one selection
-      expect(email.body).to have_text('A teacher training adviser can provide free support to help you improve your personal statement.').once
+      expect(email.body).to have_text('Get help').once
       expect(email.body).to have_text('Learn more about teacher training advisers').twice # In the footer as well as the advice
     end
 
@@ -392,6 +392,32 @@ RSpec.describe CandidateMailer do
     it 'only shows the free text between cycles', time: after_apply_deadline do
       expect(email.body).to have_content 'Text the provider has written'
       expect(email.body).to have_no_content 'There are still courses with placements available'
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_choice) { create(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
+    let(:email) { described_class.application_rejected(application_choice) }
+
+    before do
+      application_choice.application_form.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Your teacher training adviser can help you improve your application. They can support you with:'
+      expect(email.body).to have_content 'making your application stronger before you apply again'
+      expect(email.body).to have_content 'Contact your teacher training adviser to talk about your next steps.'
+    end
+  end
+
+  describe 'tailored teacher training adviser text for non-assigned adviser status' do
+    let(:application_choice) { create(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
+    let(:email) { described_class.application_rejected(application_choice) }
+
+    it 'refers to the process for getting an adviser' do
+      expect(email.body).to have_content 'A teacher training adviser can provide free support to help you improve your application. They can support you with:'
+      expect(email.body).to have_content 'All our advisers have years of teaching experience and know the application process inside and out.'
+      expect(email.body).to have_content 'Learn more about teacher training advisers'
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe CandidateMailer do
         expect(email.body).to include("as soon as you can to get on a course starting in the #{current_timetable.academic_year_range_name} academic year.")
         expect(email.body).to include("The deadline to submit your application is 6pm on #{current_timetable.apply_deadline_at.to_fs(:govuk_date)}")
       end
+
+      it 'renders adviser sign up text if not already assigned' do
+        expect(email.body).to include('You can also [get a teacher training adviser]')
+      end
     end
 
     context 'includes utm parameters' do
@@ -33,6 +37,19 @@ RSpec.describe CandidateMailer do
         expect(email.body).to include('utm_campaign=eoc_deadline_reminder')
         expect(email.body).to include('utm_content=apply_1')
       end
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.eoc_first_deadline_reminder(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'You can also contact your teacher training adviser for support with writing your application.'
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -41,12 +41,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.eoc_first_deadline_reminder(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.eoc_first_deadline_reminder(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'You can also contact your teacher training adviser for support with writing your application.'

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -25,12 +25,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.eoc_second_deadline_reminder(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.eoc_second_deadline_reminder(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.'

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -18,5 +18,22 @@ RSpec.describe CandidateMailer do
     )
 
     it_behaves_like 'an email with unsubscribe option'
+
+    it 'renders adviser sign up text if not already assigned' do
+      expect(email.body).to include('Need help writing a strong application? You can [get a teacher training adviser]')
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.eoc_second_deadline_reminder(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.'
+    end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
@@ -16,5 +16,24 @@ RSpec.describe CandidateMailer do
     )
 
     it_behaves_like 'an email with unsubscribe option'
+
+    it 'renders adviser sign up text if not already assigned' do
+      expect(email.body).to include('A teacher training adviser could help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.')
+      expect(email.body).to include('Alternatively, call')
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.nudge_unsubmitted(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Your teacher training adviser can help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.'
+      expect(email.body).to have_content 'Contact our support team'
+    end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.nudge_unsubmitted(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.nudge_unsubmitted(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Your teacher training adviser can help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.nudge_unsubmitted_with_incomplete_courses(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.nudge_unsubmitted_with_incomplete_courses(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Your teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
@@ -16,5 +16,24 @@ RSpec.describe CandidateMailer do
     )
 
     it_behaves_like 'an email with unsubscribe option'
+
+    it 'renders adviser sign up text if not already assigned' do
+      expect(email.body).to include('A teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.')
+      expect(email.body).to include('Alternatively, call')
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.nudge_unsubmitted_with_incomplete_courses(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Your teacher training adviser could help you choose a course, if you are not sure about what you would like to teach.'
+      expect(email.body).to have_content 'Contact our support team'
+    end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.nudge_unsubmitted_with_incomplete_personal_statement(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.nudge_unsubmitted_with_incomplete_personal_statement(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Your teacher training adviser can help you understand what to put in your personal statement.'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
@@ -16,5 +16,24 @@ RSpec.describe CandidateMailer do
     )
 
     it_behaves_like 'an email with unsubscribe option'
+
+    it 'renders adviser sign up text if not already assigned' do
+      expect(email.body).to include('A teacher training adviser can help you understand what to put in your personal statement.')
+      expect(email.body).to include('Alternatively, call')
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.nudge_unsubmitted_with_incomplete_personal_statement(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Your teacher training adviser can help you understand what to put in your personal statement.'
+      expect(email.body).to have_content 'Contact our support team'
+    end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe CandidateMailer do
       )
 
       it_behaves_like 'an email with unsubscribe option'
+
+      it 'renders adviser sign up text if not already assigned' do
+        expect(email.body).to include('A teacher training adviser can give advice on references:')
+        expect(email.body).to include('Alternatively, call')
+      end
+    end
+  end
+
+  describe 'tailored teacher training adviser text for "assigned" adviser status' do
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
+    let(:email) { described_class.nudge_unsubmitted_with_incomplete_references(application_form_with_adviser_eligibility) }
+
+    before do
+      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
+    end
+
+    it 'refers to existing adviser' do
+      expect(email.body).to have_content 'Your teacher training adviser can give advice on references.'
+      expect(email.body).to have_content 'Contact our support team'
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
@@ -27,12 +27,9 @@ RSpec.describe CandidateMailer do
   end
 
   describe 'tailored teacher training adviser text for "assigned" adviser status' do
-    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser) }
-    let(:email) { described_class.nudge_unsubmitted_with_incomplete_references(application_form_with_adviser_eligibility) }
+    let(:application_form_with_adviser_eligibility) { create(:application_form_eligible_for_adviser, adviser_status: 'assigned') }
 
-    before do
-      application_form_with_adviser_eligibility.update(adviser_status: 'assigned')
-    end
+    subject(:email) { described_class.nudge_unsubmitted_with_incomplete_references(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
       expect(email.body).to have_content 'Your teacher training adviser can give advice on references.'


### PR DESCRIPTION
## Context

At various points in the Candidate journey on Apply for Teacher Training we encourage and direct candidates to sign up for a Teacher Training Advisor (TTA).

In our emails to candidates we tell them to apply for a TTA, but some will already have one. In these cases we should prompt them to contact their TTA instead of request one.

## Changes proposed in this pull request

Conditional text changes to the following emails:
- Rejected
- Deadline reminder 1
- Deadline reminder 2
- Nudge unsubmitted
- Nudge incomplete - courses
- Nudge incomplete - personal statement
- Nudge incomplete - references 

## Guidance to review

Please review the relevant mailer previews. To see the alternative text, change the if statement condition in each `text.erb` file from `if @application_form.adviser_status == 'assigned'` to `'unassigned'`.

Previews:
- http://localhost:3000/rails/mailers/candidate_mailer/application_rejected
- http://localhost:3000/rails/mailers/candidate_mailer/eoc_first_deadline_reminder
- http://localhost:3000/rails/mailers/candidate_mailer/eoc_second_deadline_reminder
- http://localhost:3000/rails/mailers/candidate_mailer/nudge_unsubmitted
- http://localhost:3000/rails/mailers/candidate_mailer/nudge_unsubmitted_with_incomplete_courses
- http://localhost:3000/rails/mailers/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement
- http://localhost:3000/rails/mailers/candidate_mailer/nudge_unsubmitted_with_incomplete_references

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
