### PR TITLE
Scope the candidate_pool query to current cycle and return less columns

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -21,7 +21,10 @@ module ProviderInterface
       def show
         @application_form = Pool::Candidates.application_forms_for_provider(
           providers: current_provider_user.providers,
-        ).find_by(candidate_id: params.expect(:id))
+        )
+        .select('*')
+        .find_by(candidate_id: params.expect(:id))
+
         @candidate = @application_form.candidate
       end
 

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -21,6 +21,13 @@ class Pool::Candidates
       .where.not(candidate: dismissed_candidates)
       .order(order_by)
       .distinct
+      .select(
+        'application_forms.id, ' \
+        'application_forms.candidate_id, ' \
+        'application_forms.first_name, ' \
+        'application_forms.last_name, ' \
+        'application_forms.submitted_at',
+      )
   end
 
   def self.application_forms_in_the_pool
@@ -63,14 +70,14 @@ private
         status: %i[rejected declined withdrawn conditions_not_met offer_withdrawn inactive],
       })
       .where.not(
-        id: ApplicationForm.joins(:application_choices).where(
+        id: ApplicationForm.current_cycle.joins(:application_choices).where(
           application_choices: {
             status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited offer_deferred],
           },
         ).select(:id),
       )
       .where(
-        id: ApplicationForm.joins(:application_choices)
+        id: ApplicationForm.current_cycle.joins(:application_choices)
             .where(application_choices: { status: ApplicationStateChange::UNSUCCESSFUL_STATES })
             .group(:id)
             # Inactive doesn't count as an unsuccessful state, so need to exclude it when counting
@@ -78,7 +85,7 @@ private
             .select(:id),
       )
       .where.not(
-        id: ApplicationForm.joins(application_choices: :withdrawal_reasons)
+        id: ApplicationForm.current_cycle.joins(application_choices: :withdrawal_reasons)
           .where('withdrawal_reasons.reason ILIKE ?', '%do-not-want-to-train-anymore%')
           .select(:id),
       )
@@ -110,7 +117,7 @@ private
           limit 1
         ) as candidate_location_preferences on true
       SQL
-      .select("application_forms.*, #{calculate_distance_sql} as site_distance")
+      .select("#{calculate_distance_sql} as site_distance")
   end
 
   def filter_by_subject(scope)
@@ -144,10 +151,10 @@ private
     filter_values = filters[:visa_sponsorship].flat_map do |value|
       if value == 'required'
         # required means no right_to_work_or_study
-        ApplicationForm.right_to_work_or_studies['no']
+        ApplicationForm.current_cycle.right_to_work_or_studies['no']
       else
         # else means all other enums + nil because we don't set this enum in most cases if candidate has right to work
-        ApplicationForm.right_to_work_or_studies.except('no').values << nil
+        ApplicationForm.current_cycle.right_to_work_or_studies.except('no').values << nil
       end
     end
 


### PR DESCRIPTION
## Context

It turns out that in some of our subqueries we were not scoping the application_form to the current cycle.

Also, when we return all the columns of the application form, ordering them is slower then returning only the columns we need for the view.

These 2 changes have almost half the query time. On my local.

With 82k candidate_preferences.
Before the change the query would take about 1.6-1.7 seconds after it takes around .7-.8 seconds

This improvement is good but there's a catch. Because we do pagination on this page. For the pagination to work, we need to execute this query twice. One for displaying the results and one to count them. Pagy needs an exact count to do pagination the way we want.

This is a standard feature of pagination. So the view will take at least twice the amount of this query to load + whatever else it needs to load.

On my local it took about 2 seconds to load the page with 82k candidate preferences.

We can further improve this with an index on the recruitment_cycle_year on the application form. That will follow in a different commit

Used this tool that illustrates the SQL explain result

Before: https://explain.dalibo.com/plan/gf63e4d3ch36fe72
After: https://explain.dalibo.com/plan/1e259e81c4518196


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
