### PR TITLE
Add recruitment_cycle_year index to application form

### DIFF
--- a/db/migrate/20250424133016_add_recruitment_cycle_index_to_application_form.rb
+++ b/db/migrate/20250424133016_add_recruitment_cycle_index_to_application_form.rb
@@ -1,0 +1,7 @@
+class AddRecruitmentCycleIndexToApplicationForm < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :application_forms, :recruitment_cycle_year, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_17_120838) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_24_133016) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -257,6 +257,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_17_120838) do
     t.boolean "university_degree"
     t.boolean "adviser_interruption_response"
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
+    t.index ["recruitment_cycle_year"], name: "index_application_forms_on_recruitment_cycle_year"
     t.index ["submitted_at"], name: "index_application_forms_on_submitted_at"
     t.index ["updated_at"], name: "index_application_forms_on_updated_at", order: :desc
   end


### PR DESCRIPTION
## Context

In my testing, with 82k candidate preferences an index on the recruitment_cycle_year would improve the candidate pool query by about 100ms

Not much but it can add up. I did this on my local so it's not the most accurate thing but I don't see a harm in adding this index.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
