### PR TITLE
Stagger the FAC Launch Email Worker

### DIFF
--- a/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
+++ b/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
@@ -7,7 +7,7 @@ module Chasers
         application_forms = FindACandidateFeatureLaunchEmailWorker.application_forms_to_send(application_form_ids)
 
         BatchDelivery.new(relation: application_forms, stagger_over: 1.hour, batch_size: 500).each do |batch_time, applications|
-          FindACandidateFeatureLaunchEmailWorker.perform_at(batch_time, applications.pluck)
+          FindACandidateFeatureLaunchEmailWorker.perform_at(batch_time, applications.pluck(:id))
         end
       end
     end

--- a/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
+++ b/app/workers/chasers/candidate/find_a_candidate_feature_launch_email_worker.rb
@@ -1,29 +1,46 @@
 module Chasers
   module Candidate
+    class StaggeredFindACandidateFeatureLaunchEmailWorker
+      include Sidekiq::Worker
+
+      def perform(application_form_ids)
+        application_forms = FindACandidateFeatureLaunchEmailWorker.application_forms_to_send(application_form_ids)
+
+        BatchDelivery.new(relation: application_forms, stagger_over: 1.hour, batch_size: 500).each do |batch_time, applications|
+          FindACandidateFeatureLaunchEmailWorker.perform_at(batch_time, applications.pluck)
+        end
+      end
+    end
+
     class FindACandidateFeatureLaunchEmailWorker
       include Sidekiq::Worker
 
-      def perform(application_form_ids, limit = 1000)
-        return unless FeatureFlag.active?(:candidate_preferences)
-
+      def self.application_forms_to_send(application_form_ids)
         application_form_ids_with_sent_chaser = ChaserSent
                                                   .where(chaser_type: 'find_a_candidate_feature_launch',
                                                          chased_type: 'ApplicationForm')
                                                   .select(:chased_id)
 
-        application_forms_to_send = ApplicationForm
-                                      .where(id: application_form_ids)
-                                      # Tier 1 & 2 application forms
-                                      .where(id: Pool::Candidates.application_forms_eligible_for_pool)
-                                      # Filter out candidates who should not receive nudge-like emails
-                                      # Filter out blocked and locked candidates
-                                      .joins(:candidate)
-                                      .merge(::Candidate.for_marketing_or_nudge_emails)
-                                      # Filter out application forms that have already received the chaser
-                                      .where.not(id: application_form_ids_with_sent_chaser)
-                                      # Filter out application forms without submitted application choices
-                                      .where.not(submitted_at: nil)
-                                      .distinct
+        ApplicationForm
+          .where(id: application_form_ids)
+          # Tier 1 & 2 application forms
+          .where(id: Pool::Candidates.application_forms_eligible_for_pool)
+          # Filter out candidates who should not receive nudge-like emails
+          # Filter out blocked and locked candidates
+          .joins(:candidate)
+          .merge(::Candidate.for_marketing_or_nudge_emails)
+          # Filter out application forms that have already received the chaser
+          .where.not(id: application_form_ids_with_sent_chaser)
+          # Filter out application forms without submitted application choices
+          .where.not(submitted_at: nil)
+          .distinct
+      end
+
+      def perform(application_form_ids, limit = 1000)
+        return unless FeatureFlag.active?(:candidate_preferences)
+
+        application_forms_to_send = FindACandidateFeatureLaunchEmailWorker
+                                      .application_forms_to_send(application_form_ids)
                                       .limit(limit)
 
         application_forms_to_send.in_batches do |application_forms|


### PR DESCRIPTION
## Context

This will send the emails in batches of 500 spread over 1 hour

On Monday the rest of tier 1 and all of tier 2 ~=2,000 - we'll send 4 lots of 500 at 15min intervals Tier 3 ~15000 - we'll send 500 emails every 2 mins for 1 hour

## Changes proposed in this pull request

- Introduced a `StaggeredFindACandidateFeatureLaunchEmailWorker` to stagger the delivery of emails

## Guidance to review

- Review code


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
