### PR TITLE
Add counter to the FAC index page

### DIFF
--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -7,6 +7,7 @@
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>
   <% if @application_forms.present? %>
+    <h2 class="govuk-heading-m"><%= t('.candidates_found', count: @application_forms.count) %></h2>
     <%= govuk_table do |table| %>
       <%= table.with_head do |head| %>
         <%= head.with_row do |row| %>

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -7,6 +7,9 @@ en:
           no_candidates: No candidates
           candidate_information_agreement: Candidates can choose to share their application details.
           review_candidates: When they have no open applications, you can review their details and decide whether to invite them to apply.
+          candidates_found:
+            one: "%{count} candidate found"
+            other: "%{count} candidates found"
           name: Name
           distance_from: Distance from %{origin}
           no_degree: No degree

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -22,14 +22,17 @@ RSpec.describe 'Providers views candidate pool list' do
     when_i_visit_the_find_candidates_page
 
     then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    and_i_expect_to_see_the_total_results_count
 
     when_i_filter_by_location
     then_i_expect_to_see_filtered_candidates([@declined_candidate_form, @rejected_candidate_form, @visa_sponsorship_form])
     when_i_filter_by_visa_sponsorship
     then_i_expect_to_see_filtered_candidates([@visa_sponsorship_form])
+    and_i_expect_to_see_the_updated_results_count
 
     when_i_click('Clear filters')
     then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    and_i_expect_to_see_the_total_results_count
   end
 
   scenario 'Provider cannot view candidates if not invited' do
@@ -204,5 +207,13 @@ RSpec.describe 'Providers views candidate pool list' do
 
   def candidate_name(application_form)
     "#{application_form.redacted_full_name} (#{application_form.candidate_id})"
+  end
+
+  def and_i_expect_to_see_the_total_results_count
+    expect(page).to have_content('3 candidates found')
+  end
+
+  def and_i_expect_to_see_the_updated_results_count
+    expect(page).to have_content('1 candidate found')
   end
 end


### PR DESCRIPTION
## Context

UR indicated that some users were overwhelmed by the number of results in their searches. Currently the only way to get a sense of the size of the results list is to look at how many pages there are at the bottom.

This change will allow us to show the total number of results which updates each time a filter is applied or removed to better demonstrate how to manage the list of results by applying filters.

## Changes proposed in this pull request

- Add counter to the FAC index (provider interface)

## Guidance to review

- Review the index page and test the counter's accuracy with different filters applied. 
- Check that the h2 counter disappears when there are no results.

## Screenshots

<img width="1014" alt="Screenshot 2025-04-25 at 14 17 39" src="https://github.com/user-attachments/assets/c9f954e1-da1c-4876-8256-4937491d5112" />
<img width="1004" alt="Screenshot 2025-04-25 at 14 17 50" src="https://github.com/user-attachments/assets/e163646c-6e1c-49d6-90ba-df47fddb56d4" />
<img width="957" alt="Screenshot 2025-04-25 at 14 18 05" src="https://github.com/user-attachments/assets/53b90154-86d5-449a-bb1a-33678ec37ecc" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
