### PR TITLE
FAC location search query fix

### DIFF
--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -36,7 +36,7 @@
             <% end %>
             <%= row.with_cell do %>
               <% if @filter.applied_location_search? %>
-                <% if application_form.site_distance == 0.0 && application_form.candidate.preference_opt_in_with_no_location_preferences? %>
+                <% if application_form.site_distance == -1 && application_form.candidate.preference_opt_in_with_no_location_preferences? %>
                   <%= t('.no_preferences') %>
                 <% else %>
                   <%= t('.miles', count: application_form.site_distance.round(1)) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,6 +26,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "10b9a6bf2230b30e653c61f38691d355cafe53f4a125c3df7f2e75250864539f",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/pool/candidates.rb",
+      "line": 114,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.joins(:candidate => :published_preferences).joins(\"        join lateral (\\n          (\\n            select (#{CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))}) as site_distance from candidate_location_preferences\\n            where candidate_location_preferences.candidate_preference_id = candidate_preferences.id\\n            and #{CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))} <= candidate_location_preferences.within\\n            limit 1\\n          )\\n          union\\n          (\\n            select -1 as site_distance\\n            where not exists(\\n             select 1 from candidate_location_preferences\\n             where candidate_location_preferences.candidate_preference_id = candidate_preferences.id\\n            )\\n          )\\n        ) as candidate_location_preferences on true\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Pool::Candidates",
+        "method": "filter_by_distance"
+      },
+      "user_input": "CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "28d64e5d66c0dce5bb41ca5b85a1751bdd7190b07aa55b1af003c090e7f8863a",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -155,6 +178,29 @@
         "method": "change"
       },
       "user_input": "field",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "512bf94e58322dbc63dd44ad16de998aa0fb246fa2d16edcd7efd03bd1ab955d",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/pool/candidates.rb",
+      "line": 113,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.joins(:candidate => :published_preferences).joins(\"        join lateral (\\n          (select (#{CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))}) as site_distance from candidate_location_preferences\\n          where candidate_location_preferences.candidate_preference_id = candidate_preferences.id\\n          and #{CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))} <= candidate_location_preferences.within\\n          limit 1)\\n          union\\n          (select -1 as site_distance\\n           where not exists(\\n             select 1 from candidate_location_preferences\\n             where candidate_location_preferences.candidate_preference_id = candidate_preferences.id)\\n          )\\n        ) as candidate_location_preferences on true\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Pool::Candidates",
+        "method": "filter_by_distance"
+      },
+      "user_input": "CandidateLocationPreference.distance_sql(Struct.new(:latitude, :longitude).new(:latitude => filters.fetch(:origin).first, :longitude => filters.fetch(:origin).last))",
       "confidence": "Medium",
       "cwe_id": [
         89

--- a/spec/factories/candidate_location_preference.rb
+++ b/spec/factories/candidate_location_preference.rb
@@ -6,8 +6,14 @@ FactoryBot.define do
 
     trait :manchester do
       name { 'Manchester' }
-      latitude { 53.9807593 }
-      longitude { -2.9426305 }
+      latitude { 53.4807593 }
+      longitude { -2.2426305 }
+    end
+
+    trait :liverpool do
+      name { 'Liverpool' }
+      latitude { 53.3991849 }
+      longitude { -2.9924405 }
     end
   end
 end

--- a/spec/forms/candidate_interface/location_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/location_preferences_form_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe CandidateInterface::LocationPreferencesForm, type: :model do
         expect(preference.location_preferences.last).to have_attributes(
           name: 'BN1 1AA',
           within: 20,
-          latitude: 53.8807593,
-          longitude: -2.8426305,
+          latitude: 53.4706519,
+          longitude: -2.2954452,
         )
       end
     end
@@ -75,8 +75,8 @@ RSpec.describe CandidateInterface::LocationPreferencesForm, type: :model do
       it 'updates a preference to opt out and publishes the preference' do
         expect { form.save }.to change(location_preference, :name).from(location_preference.name).to('BN1 1AA')
           .and change(location_preference, :within).from(location_preference.within).to(20)
-          .and change(location_preference, :latitude).from(location_preference.latitude).to(53.8807593)
-          .and change(location_preference, :longitude).from(location_preference.longitude).to(-2.8426305)
+          .and change(location_preference, :latitude).from(location_preference.latitude).to(53.4706519)
+          .and change(location_preference, :longitude).from(location_preference.longitude).to(-2.2954452)
       end
     end
   end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Pool::Candidates do
     context 'with filters' do
       it 'returns application_forms based on filters' do
         manchester_coordinates = [53.4807593, -2.2426305]
+        liverpool_coordinates = [53.4076650, -2.9781493]
 
         provider = create(:provider)
         course = create(:course, provider:)
@@ -154,7 +155,6 @@ RSpec.describe Pool::Candidates do
           subject_candidate_form.id,
           part_time_candidate_form.id,
           undergraduate_candidate_form.id,
-          visa_sponsorship_candidate_form.id,
         )
 
         filters = { origin: manchester_coordinates, subject: [subject.id.to_s] }
@@ -162,7 +162,6 @@ RSpec.describe Pool::Candidates do
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
-          visa_sponsorship_candidate_form.id,
           part_time_candidate_form.id,
           subject_candidate_form.id,
           undergraduate_candidate_form.id,
@@ -177,7 +176,6 @@ RSpec.describe Pool::Candidates do
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
-          visa_sponsorship_candidate_form.id,
           part_time_candidate_form.id,
           undergraduate_candidate_form.id,
         )
@@ -192,12 +190,11 @@ RSpec.describe Pool::Candidates do
         application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
-          visa_sponsorship_candidate_form.id,
           undergraduate_candidate_form.id,
         )
 
         filters = {
-          origin: manchester_coordinates,
+          origin: liverpool_coordinates,
           subject: [subject.id.to_s],
           study_mode: ['part_time'],
           course_type: ['TDA'],
@@ -263,7 +260,7 @@ RSpec.describe Pool::Candidates do
     def create_visa_sponsorship_candidate_form(course_option)
       visa_sponsorship_candidate = create(:candidate)
       candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
-      create(:candidate_location_preference, :manchester, candidate_preference:)
+      create(:candidate_location_preference, :liverpool, candidate_preference:)
       visa_sponsorship_candidate_form = create(
         :application_form,
         :completed,

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
         {
           original_location: 'Manchester',
           visa_sponsorship: ['required'],
-          origin: [53.8807593, -2.8426305],
+          origin: [53.4706519, -2.2954452],
         }.with_indifferent_access,
       )
     end

--- a/spec/support/geocode_test_helper.rb
+++ b/spec/support/geocode_test_helper.rb
@@ -5,8 +5,8 @@ module GeocodeTestHelper
     Geocoder::Lookup::Test.set_default_stub(
       [
         {
-          'coordinates' => [53.8807593, -2.8426305],
-          'address' => 'Manchester',
+          'coordinates' => [53.4706519, -2.2954452],
+          'address' => 'Salford',
           'state' => 'England',
           'country' => 'United Kingdom',
           'country_code' => 'UK',


### PR DESCRIPTION
## Context

In trying to add people with no location preference to the candidate
pool. We've accidentally included everyone that opted in regardless of
the distance, when searching by location.

This is because of the left join we did, which returns all the candidate
preferences that opted in.

This commit fixes this by removing the left join and adding 2 sub
queries in union to the join with candidate preferences

In the first subquery we get all the candidate location preferences
within the range of the searched location and in the second we get all
the opt in candidate_preferences without location preferences.

This way we include both candidates within range but also candidates
without a location preferences.

We set -1 to the candidates without location preferences to make sure
they come at the top. 0.0 was not good enough as there was a possibility
that another candidate with a location preferences would be within 0.0
of a location.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/29b118c6-ccd4-4611-8e82-f52996e3dfc7



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
