### PR TITLE
Declaring an experiment winner

### DIFF
--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -8,6 +8,7 @@ experiments:
       - opt_out
       - link_clicked
     ended_at: Apr 25, 2025 5 pm BST
+    winner: :invitation
 
 exclude:
   bots: true

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -8,7 +8,7 @@ experiments:
       - opt_out
       - link_clicked
     ended_at: Apr 25, 2025 5 pm BST
-    winner: :invitation
+    winner: invitation
 
 exclude:
   bots: true

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -568,13 +568,6 @@ class CandidateMailerPreview < ActionMailer::Preview
       :application_form,
       :minimum_info,
     )
-    experiment = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
-
-    variant = params.fetch('variant', nil)
-    if variant.present? && variant.in?(experiment.variants)
-      experiment.variant(application_form.candidate, variant:)
-    end
-
     CandidateMailer.find_a_candidate_feature_launch_email(application_form)
   end
 


### PR DESCRIPTION
## Context

Sending emails will always send the "invitation" variant. Metrics will stop being recorded.

## Changes proposed in this pull request

Sets a winner for the experiment 

## Guidance to review

n/a

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
