### PR TITLE
Fix provider candidate pool show page not showing application_choices

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -23,6 +23,7 @@ module ProviderInterface
           providers: current_provider_user.providers,
         )
         .select('*')
+        .includes(:application_choices)
         .find_by(candidate_id: params.expect(:id))
 
         @candidate = @application_form.candidate


### PR DESCRIPTION
## Context

Because we use the candidate pool query in the show page and we don't
include application_choices in the query, there's and edge case where
some application choices were not rendered on the show page.

This fixes this edge case, by including the application_choices in the
show controller action

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
