### PR TITLE
Find a candidate in support interface

### DIFF
--- a/app/components/provider_interface/location_filter_component.html.erb
+++ b/app/components/provider_interface/location_filter_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-form-group">
   <div class="govuk-input__wrapper location-autocomplete"
     data-controller="location-autocomplete"
-    data-location-autocomplete-path-value="<%= provider_interface_location_suggestions_path %>">
+    data-location-autocomplete-path-value="<%= filter[:path_to_location_suggestions] %>">
 
     <input class="govuk-input"
     id="original-location"

--- a/app/controllers/support_interface/find_candidates_controller.rb
+++ b/app/controllers/support_interface/find_candidates_controller.rb
@@ -1,0 +1,30 @@
+module SupportInterface
+  class FindCandidatesController < SupportInterfaceController
+    def index
+      @filter = SupportInterface::CandidatePoolFilter.new(
+        filter_params:,
+      )
+
+      @pagy, @application_forms = pagy(
+        Pool::Candidates.application_forms_for_provider(
+          providers: [],
+          filters: @filter.applied_filters,
+        ),
+      )
+    end
+
+  private
+
+    def filter_params
+      params.permit(
+        :within,
+        :original_location,
+        :remove,
+        subject: [],
+        study_mode: [],
+        course_type: [],
+        visa_sponsorship: [],
+      )
+    end
+  end
+end

--- a/app/controllers/support_interface/location_suggestions_controller.rb
+++ b/app/controllers/support_interface/location_suggestions_controller.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class LocationSuggestionsController < SupportInterfaceController
+    def index
+      return render(json: [], status: :bad_request) if params[:query].blank?
+
+      render json: { suggestions: LocationSuggestions.new(params[:query]).call }
+    end
+  end
+end

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -6,7 +6,14 @@ import { initAutocomplete } from './autocompletes/init-autocomplete'
 import { supportAutocompleteInputs } from './autocompletes/support/support-autocomplete-inputs'
 import sortByFilter from './sort-by-filter'
 
+// stimulus
+import { Application } from '@hotwired/stimulus'
+import LocationAutocompleteController from './controllers/location_autocomplete_controller'
+
 require.context('govuk-frontend/dist/govuk/assets')
+
+window.Stimulus = Application.start()
+window.Stimulus.register('location-autocomplete', LocationAutocompleteController)
 
 govUKFrontendInitAll()
 

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -76,6 +76,11 @@ class NavigationItems
             href: support_interface_docs_path,
             active: active?(current_controller, %w[docs]),
           },
+          {
+            text: 'Find a candidate',
+            href: support_interface_find_candidates_path,
+            active: active?(current_controller, %w[find_candidates]),
+          },
         ]
       else
         []

--- a/app/models/support_interface/candidate_pool_filter.rb
+++ b/app/models/support_interface/candidate_pool_filter.rb
@@ -1,18 +1,13 @@
-module ProviderInterface
+module SupportInterface
   class CandidatePoolFilter
     include FilterParamsHelper
     include ActionView::Helpers::TagHelper
     include Rails.application.routes.url_helpers
 
-    FILTERS = %w[original_location subject study_mode course_type visa_sponsorship].freeze
-
     attr_reader :filter_params
 
-    def initialize(filter_params:, current_provider_user:)
-      @filter_params = set_filters(
-        compact_params(filter_params),
-        current_provider_user,
-      )
+    def initialize(filter_params:)
+      @filter_params = compact_params(filter_params)
     end
 
     def filters
@@ -23,7 +18,7 @@ module ProviderInterface
           name: 'location_search',
           original_location: filter_params[:original_location],
           title: 'Candidate location preferences',
-          path_to_location_suggestions: provider_interface_location_suggestions_path,
+          path_to_location_suggestions: support_interface_location_suggestions_path,
         },
         {
           type: :checkbox_filter,
@@ -78,20 +73,6 @@ module ProviderInterface
     end
 
   private
-
-    def set_filters(filters, current_provider_user)
-      return filters if current_provider_user.blank?
-
-      any_filters = filters.keys.intersect?(FILTERS)
-
-      if filters[:remove] == 'true' && !any_filters
-        current_provider_user.update!(find_a_candidate_filters: {})
-      elsif any_filters
-        current_provider_user.update!(find_a_candidate_filters: filters)
-      end
-
-      current_provider_user.find_a_candidate_filters.with_indifferent_access
-    end
 
     def visa_sponsorship_options
       [['required', 'Needs a visa'], ['not required', 'Does not need a visa']].map do |value, label|

--- a/app/views/support_interface/find_candidates/index.html.erb
+++ b/app/views/support_interface/find_candidates/index.html.erb
@@ -1,0 +1,56 @@
+<% content_for :browser_title, t('.title') %>
+<%= render ServiceInformationBanner.new(namespace: :support) %>
+
+<h1 class="govuk-heading-l"><%= t('.title') %></h1>
+<p class="govuk-body"><%= t('.candidate_information_agreement') %></p>
+<p class="govuk-body"><%= t('.review_candidates') %></p>
+
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>
+  <% if @application_forms.present? %>
+    <h2 class="govuk-heading-m"><%= t('.candidates_found', count: @pagy.count) %></h2>
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: t('.name')) %>
+          <% if @filter.applied_location_search? %>
+            <%= row.with_cell(text: t('.distance_from', origin: @filter.applied_filters[:original_location]), width: 'govuk-!-width-one-half') %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= table.with_body do |body| %>
+        <% @application_forms.each do |application_form| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell do %>
+            <%= govuk_link_to application_form.redacted_full_name, support_interface_application_form_path(application_form) %>
+            <span class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</span>
+              <% if application_form.application_qualifications.degrees.present? %>
+                <% application_form.application_qualifications.degrees.order(award_year: :desc).each do |degree| %>
+                  <% decorated_degree = ApplicationQualificationDecorator.new(degree) %>
+                  <p class="govuk-body app-qualification__value--caption govuk-!-margin-bottom-1">
+                    <%= decorated_degree.formatted_degree_and_grade %>
+                  </p>
+                <% end %>
+              <% else %>
+                <p class="govuk-body app-qualification__value--caption govuk-!-margin-bottom-1"><%= t('.no_degree') %></p>
+              <% end %>
+            <% end %>
+            <%= row.with_cell do %>
+              <% if @filter.applied_location_search? %>
+                <% if application_form.site_distance == -1 && application_form.candidate.preference_opt_in_with_no_location_preferences? %>
+                  <%= t('.no_preferences') %>
+                <% else %>
+                  <%= t('.miles', count: application_form.site_distance.round(1)) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_pagination(pagy: @pagy) %>
+  <% else %>
+    <p class="govuk-body"><%= t('.no_candidates') %></p>
+  <% end %>
+<% end %>

--- a/config/locales/support_interface/find_candidates.yml
+++ b/config/locales/support_interface/find_candidates.yml
@@ -1,0 +1,19 @@
+en:
+  support_interface:
+    find_candidates:
+      index:
+        title: Find candidates
+        no_candidates: No candidates
+        candidate_information_agreement: Candidates can choose to share their application details.
+        review_candidates: When they have no open applications, you can review their details and decide whether to invite them to apply.
+        candidates_found:
+          one: "%{count} candidate found"
+          other: "%{count} candidates found"
+        name: Name
+        distance_from: Distance from %{origin}
+        no_degree: No degree
+        miles:
+          zero: "%{count} miles"
+          one: "%{count} mile"
+          other: "%{count} miles"
+        no_preferences: Open to courses anywhere

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -101,6 +101,10 @@ namespace :support_interface, path: '/support' do
 
   get '/candidates' => 'candidates#index'
 
+  resources :find_candidates, only: %i[index], path: 'find-a-candidate'
+
+  resources :location_suggestions, only: :index, path: 'location-suggestions'
+
   scope path: '/candidates' do
     resource :bulk_unsubscribe, only: %i[new create], path: '/bulk-unsubscribe', module: :candidates
   end

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::CandidatePoolFilter do
+  include Rails.application.routes.url_helpers
+
   describe '#filters' do
     it 'returns the filters' do
       current_provider_user = create(:provider_user)
@@ -13,6 +15,7 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
           name: 'location_search',
           original_location: nil,
           title: 'Candidate location preferences',
+          path_to_location_suggestions: provider_interface_location_suggestions_path,
         },
         {
           type: :checkbox_filter,
@@ -116,6 +119,82 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
           .from({ 'visa_sponsorship' => ['required'] })
           .to(filter_params),
         )
+      end
+    end
+
+    context 'when current_provider_user is nil' do
+      it 'stores updated filters' do
+        filter = described_class.new(filter_params: {}, current_provider_user: nil)
+
+        expect(filter.filters).to eq([
+          {
+            type: :location_search,
+            heading: 'Town, city or postcode:',
+            name: 'location_search',
+            original_location: nil,
+            title: 'Candidate location preferences',
+            path_to_location_suggestions: provider_interface_location_suggestions_path,
+          },
+          {
+            type: :checkbox_filter,
+            heading: 'Subjects previously applied to',
+            name: 'subject',
+            options: [],
+            hide_tags: true,
+            title: 'Candidate course preferences',
+          },
+          {
+            type: :checkboxes,
+            heading: 'Study type',
+            name: 'study_mode',
+            options: [
+              {
+                value: 'full_time',
+                label: 'Full time',
+                checked: nil,
+              },
+              {
+                value: 'part_time',
+                label: 'Part time',
+                checked: nil,
+              },
+            ],
+          },
+          {
+            type: :checkboxes,
+            heading: 'Course type',
+            name: 'course_type',
+            options: [
+              {
+                value: 'TDA',
+                label: 'Undergraduate',
+                checked: nil,
+              },
+              {
+                value: 'HE,HES,SD,SS,SC,SSC,TA',
+                label: 'Postgraduate',
+                checked: nil,
+              },
+            ],
+          },
+          {
+            type: :checkboxes,
+            heading: '<h3 class="govuk-heading-m govuk-!-margin-bottom-0">Candidate’s visa requirements</h3>',
+            name: 'visa_sponsorship',
+            options: [
+              {
+                value: 'required',
+                label: 'Needs a visa',
+                checked: nil,
+              },
+              {
+                value: 'not required',
+                label: 'Does not need a visa',
+                checked: nil,
+              },
+            ],
+          },
+        ])
       end
     end
   end

--- a/spec/models/support_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/support_interface/candidate_pool_filter_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidatePoolFilter do
+  include Rails.application.routes.url_helpers
+
+  describe '#filters' do
+    it 'returns the filters' do
+      filter = described_class.new(filter_params: {})
+
+      expect(filter.filters).to eq([
+        {
+          type: :location_search,
+          heading: 'Town, city or postcode:',
+          name: 'location_search',
+          original_location: nil,
+          title: 'Candidate location preferences',
+          path_to_location_suggestions: support_interface_location_suggestions_path,
+        },
+        {
+          type: :checkbox_filter,
+          heading: 'Subjects previously applied to',
+          name: 'subject',
+          options: [],
+          hide_tags: true,
+          title: 'Candidate course preferences',
+        },
+        {
+          type: :checkboxes,
+          heading: 'Study type',
+          name: 'study_mode',
+          options: [
+            {
+              value: 'full_time',
+              label: 'Full time',
+              checked: nil,
+            },
+            {
+              value: 'part_time',
+              label: 'Part time',
+              checked: nil,
+            },
+          ],
+        },
+        {
+          type: :checkboxes,
+          heading: 'Course type',
+          name: 'course_type',
+          options: [
+            {
+              value: 'TDA',
+              label: 'Undergraduate',
+              checked: nil,
+            },
+            {
+              value: 'HE,HES,SD,SS,SC,SSC,TA',
+              label: 'Postgraduate',
+              checked: nil,
+            },
+          ],
+        },
+        {
+          type: :checkboxes,
+          heading: '<h3 class="govuk-heading-m govuk-!-margin-bottom-0">Candidate’s visa requirements</h3>',
+          name: 'visa_sponsorship',
+          options: [
+            {
+              value: 'required',
+              label: 'Needs a visa',
+              checked: nil,
+            },
+            {
+              value: 'not required',
+              label: 'Does not need a visa',
+              checked: nil,
+            },
+          ],
+        },
+      ])
+    end
+  end
+
+  describe '#applied_filters' do
+    it 'returns the applied filters' do
+      filter_params = {
+        original_location: 'Manchester',
+        visa_sponsorship: ['required'],
+      }
+      filter = described_class.new(filter_params:)
+
+      expect(filter.applied_filters).to eq(
+        {
+          original_location: 'Manchester',
+          visa_sponsorship: ['required'],
+          origin: [53.4706519, -2.2954452],
+        },
+      )
+    end
+  end
+
+  describe '#applied_location_search?' do
+    it 'returns true if location search is applied' do
+      filter_params = { original_location: 'Manchester' }
+      filter = described_class.new(filter_params:)
+
+      expect(filter.applied_location_search?).to be_truthy
+    end
+
+    it 'returns false if location search is applied' do
+      filter = described_class.new(filter_params: {})
+
+      expect(filter.applied_location_search?).to be_falsey
+    end
+  end
+end

--- a/spec/system/support_interface/find_a_candidate_spec.rb
+++ b/spec/system/support_interface/find_a_candidate_spec.rb
@@ -1,0 +1,192 @@
+require 'rails_helper'
+
+RSpec.describe 'Support user views candidate pool list' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  let(:current_provider) { create(:provider) }
+
+  before do
+    set_rejected_candidate_form
+    set_declined_candidate_form
+    set_visa_sponsorship_candidate_form
+    set_withdrawn_no_longer_want_to_train_form
+  end
+
+  scenario 'View candidates' do
+    given_i_am_a_support_user
+    and_i_visit_support_find_a_candidate
+
+    then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    and_i_expect_to_see_the_total_results_count
+
+    when_i_filter_by_location
+    then_i_expect_to_see_filtered_candidates([@declined_candidate_form, @rejected_candidate_form, @visa_sponsorship_form])
+    when_i_filter_by_visa_sponsorship
+    then_i_expect_to_see_filtered_candidates([@visa_sponsorship_form])
+    and_i_expect_to_see_the_updated_results_count
+
+    when_i_click('Clear filters')
+    then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    and_i_expect_to_see_the_total_results_count
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def set_declined_candidate_form
+    declined_candidate = create(:candidate)
+    create(:candidate_preference, candidate: declined_candidate)
+    @declined_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: declined_candidate,
+      submitted_at: Time.zone.today,
+    )
+    create(:application_choice, :declined, application_form: @declined_candidate_form)
+
+    previous_cycle_form = create(
+      :application_form,
+      :completed,
+      first_name: 'test',
+      last_name: 'test',
+      recruitment_cycle_year: previous_year,
+      submitted_at: 1.year.ago,
+      candidate: declined_candidate,
+    )
+    create(:application_choice, :declined, application_form: previous_cycle_form)
+  end
+
+  def set_rejected_candidate_form
+    rejected_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: rejected_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
+    @rejected_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: rejected_candidate,
+      submitted_at: 1.day.ago,
+    )
+    course_option = create(
+      :course_option,
+      course: create(:course, provider: current_provider),
+    )
+    create(
+      :application_choice,
+      :rejected,
+      application_form: @rejected_candidate_form,
+      course_option:,
+    )
+  end
+
+  def set_visa_sponsorship_candidate_form
+    visa_sponsorship_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
+    @visa_sponsorship_form = create(
+      :application_form,
+      :completed,
+      candidate: visa_sponsorship_candidate,
+      submitted_at: 6.hours.ago,
+      right_to_work_or_study: :no,
+    )
+    course_option = create(
+      :course_option,
+      course: create(:course, provider: current_provider),
+    )
+    create(
+      :application_choice,
+      :rejected,
+      application_form: @visa_sponsorship_form,
+      course_option:,
+    )
+  end
+
+  def set_withdrawn_no_longer_want_to_train_form
+    no_longer_wants_to_train_candidate = create(:candidate)
+    create(:candidate_preference, candidate: no_longer_wants_to_train_candidate)
+    @withdrawn_no_longer_wants_to_train_form = create(
+      :application_form,
+      :completed,
+      candidate: no_longer_wants_to_train_candidate,
+      submitted_at: 3.hours.ago,
+    )
+    course_option = create(
+      :course_option,
+      course: create(:course, provider: current_provider),
+    )
+    withdrawn_choice = create(
+      :application_choice,
+      :withdrawn,
+      application_form: @withdrawn_no_longer_wants_to_train_form,
+      course_option:,
+    )
+    create(
+      :withdrawal_reason,
+      application_choice: withdrawn_choice,
+      reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
+    )
+  end
+
+  def then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
+    candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
+
+    expected_candidates = [
+      candidate_name(@rejected_candidate_form),
+      candidate_name(@declined_candidate_form),
+      candidate_name(@visa_sponsorship_form),
+    ]
+
+    expected_candidates.each do |candidate_text|
+      expect(candidates).to have_text(candidate_text)
+    end
+
+    expect(page).to have_no_text(candidate_name(@withdrawn_no_longer_wants_to_train_form))
+  end
+
+  def and_find_candidates_is_not_in_my_navigation
+    within('#service-navigation') do
+      expect(page).to have_no_css('li', text: 'Find candidates')
+    end
+  end
+
+  def when_i_filter_by_location
+    fill_in('original_location', with: 'Manchester')
+    click_link_or_button('Apply filters')
+  end
+
+  def when_i_filter_by_visa_sponsorship
+    check('visa_sponsorship-required')
+    click_link_or_button('Apply filters')
+  end
+
+  def then_i_expect_to_see_filtered_candidates(application_forms)
+    candidates = page.all('.govuk-table__body .govuk-table__row td:first-child').map(&:text)
+    candidate_names = application_forms.map { |form| candidate_name(form) }
+
+    candidate_names.each do |name|
+      expect(candidates).to have_text(name)
+    end
+  end
+
+  def when_i_click(button)
+    click_link_or_button button
+  end
+
+  def candidate_name(application_form)
+    "#{application_form.redacted_full_name} (#{application_form.candidate_id})"
+  end
+
+  def and_i_expect_to_see_the_total_results_count
+    expect(page).to have_content('3 candidates found')
+  end
+
+  def and_i_expect_to_see_the_updated_results_count
+    expect(page).to have_content('1 candidate found')
+  end
+
+  def and_i_visit_support_find_a_candidate
+    visit support_interface_find_candidates_path
+  end
+end


### PR DESCRIPTION
## Context

Putting the find a candidate pool in support will allow us to quickly asses what candidates are in the pool and also allows us to test the performance of the query with live data.

This will only show the list of the find a candidate feature, and allow you to filter.

The filters would not save if you leave the page, you can't get to the show page by clicking on a candidate.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/8ca2e69d-3f93-43b5-85b9-643c4fe76383

Can also go to review app and login as support


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
