### PR TITLE
Add data migration for backfilling reference confidential data.

### DIFF
--- a/app/services/data_migrations/backfill_confidential_data.rb
+++ b/app/services/data_migrations/backfill_confidential_data.rb
@@ -1,0 +1,27 @@
+module DataMigrations
+  class BackfillConfidentialData
+    TIMESTAMP = 20250428151006
+    MANUAL_RUN = false
+
+    def change
+      # There are only 29 of these in production, so it is safe to iterate over them
+      # See blazer query
+      # https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1152-no-confidential-answer-2025-references-with-feedback-provided/edit
+      references_query.find_each do |reference|
+        reference.update(audit_comment:, confidential: true)
+      end
+    end
+
+  private
+
+    def references_query
+      ApplicationReference
+        .where(confidential: nil, feedback_status: 'feedback_provided')
+        .joins(:application_form).where('application_form.recruitment_cycle_year': 2025)
+    end
+
+    def audit_comment
+      'Backfilling confidential data for references added in support, see trello ticket: https://trello.com/c/ncfBrX1Q'
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillConfidentialData',
   'DataMigrations::RemoveUnlockApplicationForEditingFeatureFlag',
   'DataMigrations::RemoveShowReferenceConfidentialityStatusFeatureFlag',
   'DataMigrations::AddRecruitmentCycleYearToPerformanceReports',

--- a/spec/services/data_migrations/backfill_confidential_data_spec.rb
+++ b/spec/services/data_migrations/backfill_confidential_data_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillConfidentialData do
+  subject(:data_migration) { described_class.new.change }
+
+  context 'references is not for a 2025 application form' do
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2024) }
+
+    it 'does not change the confidential status' do
+      reference = create(:application_reference, confidential: nil, feedback_status: 'feedback_provided', application_form:)
+      data_migration
+      expect(reference.reload.confidential).to be_nil
+    end
+  end
+
+  context 'reference is a status other than feedback_provided' do
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2025) }
+
+    it 'does not change the confidential status' do
+      feedback_status = %w[cancelled cancelled_at_end_of_cycle not_requested_yet feedback_requested feedback_refused email_bounced].sample
+      reference = create(:application_reference, confidential: nil, feedback_status:, application_form:)
+      data_migration
+      expect(reference.reload.confidential).to be_nil
+    end
+  end
+
+  context 'references has a true value for confidential' do
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2025) }
+
+    it 'does not change the confidential status' do
+      reference = create(:application_reference, confidential: false, feedback_status: 'feedback_provided', application_form:)
+      data_migration
+      expect(reference.reload.confidential).to be false
+    end
+  end
+
+  context 'reference is from 2025, feedback has been provided, and does not have a confidential status' do
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2025) }
+
+    it 'updates the confidential status to true' do
+      reference = create(:application_reference, confidential: nil, feedback_status: 'feedback_provided', application_form:)
+      data_migration
+      expect(reference.reload.confidential).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Context

There was a bug -- when reference feedback was added by a support user, there was no opportunity to indicate if the feedback should be confidential or not. The bug has been fixed, but there are currently 29 references that should have a value for confidential that do not. See blazer query https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1152-no-confidential-answer-2025-references-with-feedback-provided

Policy has advised that we should assume these are confidential / not shareable (confidential: true)

## Changes proposed in this pull request

Data migration and spec to backfill the data.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
