### PR TITLE
Update editable_until method to use days instead of business_days

### DIFF
--- a/app/forms/support_interface/editable_until_form.rb
+++ b/app/forms/support_interface/editable_until_form.rb
@@ -36,7 +36,7 @@ module SupportInterface
     end
 
     def editable_until
-      Rails.configuration.x.sections.editable_window_days.business_days.from_now.end_of_day if editable_sections.present?
+      Rails.configuration.x.sections.editable_window_days.days.from_now.end_of_day if editable_sections.present?
     end
 
     def full_audit

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Unlocking non editable sections temporarily via support' do
   include DfESignInHelpers
   include CandidateHelper
+  include ActiveSupport::Testing::TimeHelpers
 
   scenario 'Unlocking some sections via support', :with_audited do
     given_i_am_a_support_user
@@ -105,7 +106,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
     @application_form.reload
     expect(@application_form.editable_sections).to contain_exactly('english_gcse', 'degrees')
     expect(@application_form.editable_until).to be_within(
-      Rails.configuration.x.sections.editable_window_days.business_days.from_now.to_f,
+      Rails.configuration.x.sections.editable_window_days.days.from_now.to_f,
     ).of(Time.zone.now)
   end
 
@@ -167,7 +168,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
 
   def when_the_editable_time_is_expired
     logout
-    advance_time_to(6.business_days.from_now)
+    advance_time_to(6.days.from_now)
     when_candidate_with_submitted_application_logged_in
   end
 

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Unlocking non editable sections temporarily via support' do
   include DfESignInHelpers
   include CandidateHelper
-  include ActiveSupport::Testing::TimeHelpers
 
   scenario 'Unlocking some sections via support', :with_audited do
     given_i_am_a_support_user
@@ -105,9 +104,9 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
   def and_the_application_is_now_updated_with_the_temporarily_editable_sections
     @application_form.reload
     expect(@application_form.editable_sections).to contain_exactly('english_gcse', 'degrees')
-    expect(@application_form.editable_until).to be_within(
-      Rails.configuration.x.sections.editable_window_days.days.from_now.to_f,
-    ).of(Time.zone.now)
+    expect(@application_form.editable_until.to_f).to be_within(0.1).of(
+      Rails.configuration.x.sections.editable_window_days.days.from_now.end_of_day.to_f,
+    )
   end
 
   def when_i_signout


### PR DESCRIPTION
## Context

When support make sections editable during one of the holidays (eg between 7 April and 21 April), the account should be locked again after 5 days but we found a bug in which the end date was much further in the future. This is because we were using BusinessTime to calculate the `editable_until`.

We should calculate 5 days, not business days when making sections editable again. Logic that makes allowance for holidays is only relevant for inactive.

## Changes proposed in this pull request

- Change `editable_until` to use `days` in lieu of `business_days`.

## Guidance to review

- Run the following spec: `spec/system/temporarily_editable_sections_spec.rb` 
- It's currently Tuesday and the `editable_until` date falls on a Sunday, which it previously would not have been able to due to `workday?` logic in `BusinessTime::BusinessDays`.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
