### PR TITLE
Add withdrawn and declined columns to manage data export

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -58,6 +58,8 @@ module ProviderInterface
           'Candidate ID' => application.application_form.candidate.public_id,
           'Support reference' => application.application_form.support_reference,
           'Offer accepted date' => application.accepted_at,
+          'Withdrawn date' => application.withdrawn_at,
+          'Declined date' => application.declined_at,
         }
       end
 

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Candidate ID' => application_choice.application_form.candidate.public_id,
         'Support reference' => application_choice.application_form.support_reference,
         'Offer accepted date' => application_choice.accepted_at,
+        'Withdrawn date' => application_choice.withdrawn_at,
+        'Declined date' => application_choice.declined_at,
       }
 
       expected.each do |key, expected_value|


### PR DESCRIPTION
## Context

A provider has requested the date of decline and withdraw.

This is a reasonable request seeing as we give the date or rejection and other status changes in this export already. We hope that adding this data will help Manage users analyse their recruitment performance data more efficiently to support the continuous improvement of their practices.

## Changes proposed in this pull request

- Add "Withdrawn date" column containing `application_choice.withdrawn_at`, if relevant
- Add "Declined date" column containing `application_choice.declined_at`, if relevant

## Guidance to review

- Log in as a provider user
- Visit the "Reports" tab
- Click on "Export application data"
- Use any filters that return results and download the CSV
- Review the columns and check that "Withdrawn at" and "Declined date" include date and times values for some of the results

<img width="303" alt="Screenshot 2025-04-29 at 14 34 21" src="https://github.com/user-attachments/assets/27f6de6c-5360-4913-9dbb-5ea0e0b7bce1" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
