### PR TITLE
Hide support find a candidate menu item behind feature flag

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -50,7 +50,7 @@ class NavigationItems
 
     def for_support_primary_nav(current_support_user, current_controller)
       if current_support_user
-        [
+        items = [
           {
             text: 'Candidates',
             href: support_interface_applications_path,
@@ -76,12 +76,17 @@ class NavigationItems
             href: support_interface_docs_path,
             active: active?(current_controller, %w[docs]),
           },
-          {
+        ]
+
+        if FeatureFlag.active?(:show_support_find_a_candidate)
+          items << {
             text: 'Find a candidate',
             href: support_interface_find_candidates_path,
             active: active?(current_controller, %w[find_candidates]),
-          },
-        ]
+          }
+        end
+
+        items
       else
         []
       end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:early_application_deadlines_for_candidates_with_visa_sponsorship, 'Implement alternative deadlines for candidates requiring visa sponsorships', 'Apply team'],
     [:candidate_preferences, 'Allow candidates to add their preferences for providers to find them', 'Apply team'],
+    [:show_support_find_a_candidate, 'Allow support to see the find a candidate pages', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

Using the location filter in production from support created the app to stop working. 

## Changes proposed in this pull request

Just hides the navigation so people don't use this. We can still get to the route so we can do some controlled testing.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
