### PR TITLE
Check for both lower and upper case code matches during provider sync

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -630,7 +630,7 @@ module CandidateInterface
 
     def self.select_uk_degree_level(application_qualification)
       QUALIFICATION_LEVEL[
-        Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level.to_s
+        Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level.to_s,
       ]
     end
 

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -115,7 +115,7 @@ module TeacherTrainingPublicAPI
 
     def add_accredited_provider(course, accredited_body_code, recruitment_cycle_year)
       if accredited_body_code.present? && course.provider.code != accredited_body_code
-        accredited_provider = ::Provider.find_by(code: accredited_body_code) || ::Provider.find_by(code: accredited_body_code.upcase)
+        accredited_provider = ::Provider.find_by(code: accredited_body_code) || ::Provider.find_by(code: accredited_body_code.upcase) || ::Provider.find_by(code: accredited_body_code.downcase)
         accredited_provider = create_new_accredited_provider(accredited_body_code, recruitment_cycle_year) if accredited_provider.nil?
         course.accredited_provider = accredited_provider
         add_provider_relationship(course)

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -115,9 +115,8 @@ module TeacherTrainingPublicAPI
 
     def add_accredited_provider(course, accredited_body_code, recruitment_cycle_year)
       if accredited_body_code.present? && course.provider.code != accredited_body_code
-        accredited_provider = ::Provider.find_by(code: accredited_body_code)
+        accredited_provider = ::Provider.where('code ILIKE ?', accredited_body_code).first
         accredited_provider = create_new_accredited_provider(accredited_body_code, recruitment_cycle_year) if accredited_provider.nil?
-
         course.accredited_provider = accredited_provider
         add_provider_relationship(course)
       else

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -115,7 +115,7 @@ module TeacherTrainingPublicAPI
 
     def add_accredited_provider(course, accredited_body_code, recruitment_cycle_year)
       if accredited_body_code.present? && course.provider.code != accredited_body_code
-        accredited_provider = ::Provider.where('code ILIKE ?', accredited_body_code).first
+        accredited_provider =  ::Provider.find_by(code: accredited_body_code) || ::Provider.find_by(code: accredited_body_code.upcase)
         accredited_provider = create_new_accredited_provider(accredited_body_code, recruitment_cycle_year) if accredited_provider.nil?
         course.accredited_provider = accredited_provider
         add_provider_relationship(course)

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -115,7 +115,7 @@ module TeacherTrainingPublicAPI
 
     def add_accredited_provider(course, accredited_body_code, recruitment_cycle_year)
       if accredited_body_code.present? && course.provider.code != accredited_body_code
-        accredited_provider =  ::Provider.find_by(code: accredited_body_code) || ::Provider.find_by(code: accredited_body_code.upcase)
+        accredited_provider = ::Provider.find_by(code: accredited_body_code) || ::Provider.find_by(code: accredited_body_code.upcase)
         accredited_provider = create_new_accredited_provider(accredited_body_code, recruitment_cycle_year) if accredited_provider.nil?
         course.accredited_provider = accredited_provider
         add_provider_relationship(course)

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -38,7 +38,7 @@ module TeacherTrainingPublicAPI
     end
 
     def existing_provider
-      @existing_provider ||= ::Provider.find_by(code: @provider_from_api.code) || ::Provider.find_by(code: @provider_from_api.code.upcase)
+      @existing_provider ||= ::Provider.find_by(code: @provider_from_api.code) || ::Provider.find_by(code: @provider_from_api.code.upcase) || ::Provider.find_by(code: @provider_from_api.code.downcase)
     end
 
     def create_or_update_provider(attrs)

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -38,7 +38,7 @@ module TeacherTrainingPublicAPI
     end
 
     def existing_provider
-      @existing_provider ||= ::Provider.where('code ILIKE ?', @provider_from_api.code).first
+      @existing_provider ||= ::Provider.find_by(code: @provider_from_api.code) || ::Provider.find_by(code: @provider_from_api.code.upcase)
     end
 
     def create_or_update_provider(attrs)

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -38,7 +38,7 @@ module TeacherTrainingPublicAPI
     end
 
     def existing_provider
-      @existing_provider ||= ::Provider.find_by(code: @provider_from_api.code)
+      @existing_provider ||= ::Provider.where('code ILIKE ?', @provider_from_api.code).first
     end
 
     def create_or_update_provider(attrs)
@@ -50,7 +50,6 @@ module TeacherTrainingPublicAPI
         existing_provider
       else
         ::Provider.create!(attrs.merge(code: @provider_from_api.code))
-
       end
     end
   end

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Syncing providers', :sidekiq do
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
-          code: 'Abc', # Mixed case to verify case insensitivity
+          code: 'abc', # Lower case to verify case insensitivity
           name: 'ABC College',
         },
       ],

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Syncing providers', :sidekiq do
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
-          code: 'ABC',
+          code: 'Abc', # Mixed case to verify case insensitivity
           name: 'ABC College',
         },
       ],

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Sync courses', :sidekiq do
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
-          code: 'Abc', # Mixed case to verify case insensitivity
+          code: 'abc', # Lower case to verify case insensitivity
           name: 'ABC College',
         },
       ],

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Sync courses', :sidekiq do
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
-          code: 'ABC',
+          code: 'Abc', # Mixed case to verify case insensitivity
           name: 'ABC College',
         },
       ],
@@ -212,6 +212,7 @@ RSpec.describe 'Sync courses', :sidekiq do
 
   def and_it_updates_another
     course = Course.find_by(code: 'ABC1')
+    expect(course.provider.code).to eq('ABC')
     expect(course.name).to eql('Primary')
     expect(course.age_range).to eql('3 to 11')
     expect(course.withdrawn).to be false

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Sync courses', :sidekiq do
     stub_teacher_training_api_providers(
       specified_attributes: [
         {
-          code: 'abc', # Lower case to verify case insensitivity
+          code: 'aBc', # Mixed case to verify case insensitivity
           name: 'ABC College',
         },
       ],

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe 'Sync provider', :sidekiq do
     )
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
-                                               course_attributes: [{ accredited_body_code: 'ABC' }],
+                                               course_attributes: [{ accredited_body_code: 'AbC' }], # Mixed case to test case insensitivity
                                                site_code: 'D')
     stub_teacher_training_api_course_with_site(provider_code: 'DEF',
                                                course_code: 'DEF1',
-                                               course_attributes: [{ accredited_body_code: 'DEF' }],
+                                               course_attributes: [{ accredited_body_code: 'def' }], # Lower case to test case insensitivity
                                                site_code: 'E')
   end
 


### PR DESCRIPTION
## Context

If we sync a provider with a code like 6k6, and then Publish changes the code to 6K6, we create a duplicate the next time we sync. This bug was found through a support issue wherein duplicate providers existed and applications were made to the one in disuse.

## Changes proposed in this pull request

- Identified two places in which providers are created and altered the matching logic within create and update functions to use ~~a case insensitive SQL string `.where('code ILIKE ?', @provider.code` instead of the case sensitive `.find_by(code: @provider.code)`.~~ check for lower case OR upper case results. 
- The provider is then found if it exists regardless of case, or saved to the database in the case it was received from the Find API. 

## Guidance to review

- Please run the following tests which now use deliberately use mixed case letters when looking up providers in the database whose codes are saved in uppercase, e.g. `Abc` -> `ABC`. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
