### PR TITLE
[788] Find a candidate new designs for application page

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.html.erb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.html.erb
@@ -1,41 +1,8 @@
-<h2 class="govuk-heading-l"><%= t('.title') %></h2>
-
-<% application_form.application_choices.each_with_index do |choice, index| %>
-  <h3 class="govuk-heading-m govuk-!-font-size-27"><%= t('.subtitle', counter: index + 1) %></h3>
-  <%= govuk_summary_list do |summary_list| %>
-
-    <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.subject') } %>
-      <% row.with_value { choice.course.subjects.pluck(:name).join(',') } %>
-    <% end %>
-
-    <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.location') } %>
-      <% row.with_value do %>
-        <p class='govuk-body'>
-          <%= course_address(choice) %>
-        </p>
-        <p class='govuk-body'>
-          <%= choice.course_option.site_postcode %>
-        </p>
-      <% end %>
-    <% end %>
-
-    <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.qualification') } %>
-      <% row.with_value { choice.course.qualifications_to_s } %>
-    <% end %>
-
-    <% summary_list.with_row do |row| %>
-      <% row.with_key { t('.funding_type') } %>
-      <% row.with_value { choice.course.funding_type.capitalize } %>
-    <% end %>
+<% application_choices.each_with_index do |choice, index| %>
+  <%= govuk_summary_card(title: t('.subtitle', counter: index + 1)) do |card| %>
+    <% card.with_summary_list(
+         actions: false,
+         rows: application_choice_rows(choice),
+       ) %>
   <% end %>
-
-  <h4 class="govuk-heading-m"><%= t('.personal_statement') %></h4>
-  <%= govuk_details(summary_text: 'Guidance given to candidates', classes: 'govuk-!-margin-bottom-4') do %>
-    <%= render 'candidate_interface/personal_statement/guidance' %>
-  <% end %>
-
-  <p class='govuk-body'><%= choice.personal_statement %></p>
 <% end %>

--- a/app/components/provider_interface/find_candidates/degrees_table_component.html.erb
+++ b/app/components/provider_interface/find_candidates/degrees_table_component.html.erb
@@ -1,0 +1,39 @@
+<%= govuk_table do |table| %>
+  <% table.with_caption(size: 'm', text: t('.caption', count: degree_rows.size)) %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: t('.degree_type')) %>
+      <% row.with_cell(text: t('.degree_subject')) %>
+      <% row.with_cell(text: t('.issued_by')) %>
+      <% row.with_cell(text: t('.year_range')) %>
+      <% row.with_cell(text: t('.grade')) %>
+    <% end %>
+  <% end %>
+  <% table.with_body do |body| %>
+    <% degree_rows.each do |degree| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: degree.degree_type, **cell_attributes(degree)) %>
+        <% row.with_cell(text: degree.degree_subject, **cell_attributes(degree)) %>
+        <% row.with_cell(text: degree.issued_by, **cell_attributes(degree)) %>
+        <% row.with_cell(text: degree.year_range, **cell_attributes(degree)) %>
+        <% row.with_cell(text: degree.grade, **cell_attributes(degree)) %>
+      <% end %>
+      <% if degree.enic_text.present? %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(colspan: 2, text: '') %>
+          <% row.with_cell(colspan: 3) do %>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+              <%= t('.comparability') %>
+              <span class="govuk-visually-hidden">
+                <%= t('.visually_hidden_enic_text', qualification: degree.degree_subject) %>
+              </span>
+            </p>
+            <p class="govuk-body">
+              <%= degree.enic_text %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/find_candidates/degrees_table_component.rb
+++ b/app/components/provider_interface/find_candidates/degrees_table_component.rb
@@ -1,0 +1,73 @@
+class ProviderInterface::FindCandidates::DegreesTableComponent < ViewComponent::Base
+  attr_accessor :application_form
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def degree_rows
+    degree_row = Struct.new(:degree_type, :degree_subject, :issued_by, :year_range, :grade, :enic_text)
+    degrees.map do |degree|
+      degree_row.new(
+        degree_type: degree_type(degree),
+        degree_subject: degree_subject(degree),
+        issued_by: issued_by(degree),
+        year_range: year_range(degree),
+        grade: grade(degree),
+        enic_text: enic_text(degree),
+      )
+    end
+  end
+
+  def degree_type(degree)
+    name = Hesa::DegreeType.find_by_name(degree.qualification_type)&.abbreviation || degree.qualification_type
+
+    if degree.grade&.include? 'honours'
+      "#{name} (Hons)"
+    else
+      name
+    end
+  end
+
+  def degree_subject(degree)
+    degree.subject
+  end
+
+  def issued_by(degree)
+    if degree.international?
+      "#{degree.institution_name}, #{COUNTRIES_AND_TERRITORIES[degree.institution_country]}"
+    else
+      degree.institution_name
+    end
+  end
+
+  def year_range(degree)
+    "#{degree.start_year} to #{degree.award_year}"
+  end
+
+  def grade(degree)
+    if degree.predicted_grade?
+      "Predicted: #{degree.grade}"
+    else
+      degree.grade
+    end
+  end
+
+  def enic_text(degree)
+    if degree.enic_reference.present? && degree.comparable_uk_degree.present?
+      degree_name = t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}")
+      "#{t('service_name.enic.short_name_with_naric')} statement #{degree.enic_reference} says this is comparable to a #{degree_name}"
+    end
+  end
+
+  def degrees
+    @degrees ||= application_form.degree_qualifications
+  end
+
+  def cell_attributes(row)
+    if row.enic_text.present?
+      { html_attributes: { class: 'qualifications-table__cell--no-bottom-border' } }
+    else
+      {}
+    end
+  end
+end

--- a/app/components/provider_interface/find_candidates/efl_qualification_card_component.html.erb
+++ b/app/components/provider_interface/find_candidates/efl_qualification_card_component.html.erb
@@ -1,0 +1,30 @@
+<p class="govuk-body">
+  <%= qualification_status %>
+</p>
+
+<% if english_proficiency.has_qualification? %>
+  <%= govuk_summary_list(actions: false) do |summary_list| %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t('.type_of_assessment')) %>
+      <% row.with_value(text: name) %>
+    <% end %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t('.year_completed')) %>
+      <% row.with_value(text: award_year) %>
+    <% end %>
+    <% if unique_reference_number %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: reference_number_title) %>
+        <% row.with_value(text: unique_reference_number) %>
+      <% end %>
+    <% end %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: grade_title) %>
+      <% row.with_value(text: grade) %>
+    <% end %>
+  <% end %>
+<% elsif english_proficiency.no_qualification? %>
+  <p class="govuk-body">
+    <%= no_qualification_details %>
+  </p>
+<% end %>

--- a/app/components/provider_interface/find_candidates/efl_qualification_card_component.rb
+++ b/app/components/provider_interface/find_candidates/efl_qualification_card_component.rb
@@ -1,0 +1,2 @@
+require_relative '../../shared/efl_qualification_card_component'
+class ProviderInterface::FindCandidates::EflQualificationCardComponent < EflQualificationCardComponent; end

--- a/app/components/provider_interface/find_candidates/experience_details_component.html.erb
+++ b/app/components/provider_interface/find_candidates/experience_details_component.html.erb
@@ -1,0 +1,41 @@
+<h3 class="govuk-heading-m" id="experience-details">
+  <%= title %>
+</h3>
+
+<% work_history_with_breaks.timeline.each do |item| %>
+  <section>
+    <% if explained_break?(item) %>
+      <h4 class="govuk-heading-s">
+        <%= t('.explained_break_title', formatted_duration: break_duration(item)) %>
+      </h4>
+      <p class="govuk-caption-m">
+        <%= item.reason %>
+      </p>
+    <% elsif unexplained_break?(item) %>
+      <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0 govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+        <h4 class="govuk-heading-s">
+          <%= t('.unexplained_break_title', formatted_duration: break_duration(item)) %>
+        </h4>
+      </div>
+    <% elsif work_or_volunteer_item?(item) %>
+      <h4 class="govuk-heading-s">
+        <%= "#{item.role} – #{working_pattern(item)}" %>
+      </h4>
+      <p class="govuk-!-margin-bottom-0 govuk-body">
+        <%= item.organisation %>
+      </p>
+      <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-0">
+        <%= work_or_volunteer_duration(item) %>
+      </p>
+      <% if item.relevant_skills? || item.working_with_children? %>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">
+          <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+            <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+          </svg>
+          <%= item.relevant_skills? ? t('.relevant_skills') : t('.worked_with_children') %>
+        </p>
+      <% end %>
+    <% end %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 govuk-!-margin-top-3">
+  </section>
+  <% end %>

--- a/app/components/provider_interface/find_candidates/experience_details_component.rb
+++ b/app/components/provider_interface/find_candidates/experience_details_component.rb
@@ -1,0 +1,61 @@
+class ProviderInterface::FindCandidates::ExperienceDetailsComponent < ViewComponent::Base
+  attr_accessor :application_form
+  include ViewHelper
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def title
+    if work_history? && unpaid_experience?
+      t('.title.details_work_and_unpaid')
+    elsif work_history?
+      t('.title.details_work')
+    elsif unpaid_experience?
+      t('.title.details_unpaid')
+    end
+  end
+
+  def working_pattern(item)
+    return item.working_pattern if item.is_a?(ApplicationVolunteeringExperience)
+
+    item.commitment.humanize
+  end
+
+  def work_history?
+    work_history_with_breaks.work_history.any?
+  end
+
+  def unpaid_experience?
+    work_history_with_breaks.unpaid_work.any?
+  end
+
+  def unexplained_break?(item)
+    item.is_a?(WorkHistoryWithBreaks::BreakPlaceholder)
+  end
+
+  def work_or_volunteer_item?(item)
+    item.is_a?(ApplicationWorkExperience) || item.is_a?(ApplicationVolunteeringExperience)
+  end
+
+  def explained_break?(item)
+    item.is_a?(ApplicationWorkHistoryBreak) && item.respond_to?(:reason)
+  end
+
+  def break_duration(explained_or_unexplained_break)
+    start_date = explained_or_unexplained_break.start_date.end_of_month
+    end_date = (explained_or_unexplained_break.end_date || Time.zone.now).beginning_of_month
+    number_of_months = ((end_date.year * 12) + end_date.month) - ((start_date.year * 12) + start_date.month)
+    format_months_to_years_and_months(number_of_months)
+  end
+
+  def work_or_volunteer_duration(work_or_volunteer_item)
+    start_date = work_or_volunteer_item.start_date.to_fs(:month_and_year)
+    end_date = work_or_volunteer_item.end_date.try(:to_fs, :month_and_year) || t('.present')
+
+    "#{start_date} – #{end_date}"
+  end
+
+  def work_history_with_breaks
+    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true)
+  end
+end

--- a/app/components/provider_interface/find_candidates/gcse_qualifications_table_component.html.erb
+++ b/app/components/provider_interface/find_candidates/gcse_qualifications_table_component.html.erb
@@ -1,0 +1,50 @@
+<%= govuk_table do |table| %>
+  <% table.with_caption(size: 'm', text: t('.caption')) %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: t('.type')) %>
+      <% row.with_cell(text: t('.subject')) %>
+      <% row.with_cell(text: t('.country')) %>
+      <% row.with_cell(text: t('.year_awarded'), numeric: true) %>
+      <% row.with_cell(text: t('.grades')) %>
+    <% end %>
+  <% end %>
+  <% table.with_body do |body| %>
+    <% gcse_rows.each do |gcse| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: gcse.qualification_type, **cell_attributes(gcse)) %>
+        <% row.with_cell(text: gcse.qualification_subject, **cell_attributes(gcse)) %>
+        <% if gcse.missing_text.present? %>
+          <% row.with_cell(colspan: 3) do %>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+              <%= gcse.missing_text[:heading] %>
+            </p>
+            <p class="govuk-body">
+              <%= gcse.missing_text[:text] %>
+            </p>
+          <% end %>
+        <% else %>
+          <% row.with_cell(text: gcse.country, **cell_attributes(gcse)) %>
+          <% row.with_cell(text: gcse.year_awarded, numeric: !gcse.year_awarded.to_i.zero?, **cell_attributes(gcse)) %>
+          <% row.with_cell(text: gcse.grades.join('<br>').html_safe, **cell_attributes(gcse)) %>
+        <% end %>
+      <% end %>
+      <% if gcse.enic_text.present? %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(colspan: 2, text: '') %>
+          <% row.with_cell(colspan: 3) do %>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+              <%= gcse.enic_text[:heading] %>
+              <span class="govuk-visually-hidden">
+                <%= t('.visually_hidden_text', qualification: gcse.qualification_subject) %>
+              </span>
+            </p>
+            <p class="govuk-body">
+              <%= gcse.enic_text[:text] %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/find_candidates/gcse_qualifications_table_component.rb
+++ b/app/components/provider_interface/find_candidates/gcse_qualifications_table_component.rb
@@ -1,0 +1,114 @@
+class ProviderInterface::FindCandidates::GcseQualificationsTableComponent < ViewComponent::Base
+  include ViewHelper
+  include GcseQualificationHelper
+
+  attr_accessor :application_form
+  delegate :maths_gcse, :english_gcse, :science_gcse, to: :application_form
+
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def gcse_rows
+    row = Struct.new(
+      :qualification_type,
+      :qualification_subject,
+      :country,
+      :year_awarded,
+      :grades,
+      :enic_text,
+      :missing_text,
+    )
+
+    [maths_gcse, english_gcse, science_gcse].map do |qualification|
+      next if qualification.blank?
+
+      row.new(
+        qualification_type: qualification_type(qualification),
+        qualification_subject: qualification_subject(qualification),
+        country: country(qualification),
+        year_awarded: year_awarded(qualification),
+        grades: grades(qualification),
+        enic_text: enic_text(qualification),
+        missing_text: missing_qualification_text(qualification),
+      )
+    end.compact
+  end
+
+  def qualification_type(qualification)
+    if qualification.other_uk_qualification_type.present?
+      qualification.other_uk_qualification_type
+    elsif qualification.non_uk_qualification_type.present?
+      qualification.non_uk_qualification_type
+    elsif qualification.currently_completing_qualification || qualification.missing_explanation.present?
+      t('.no_qualification_yet')
+    else
+      t('.gcse')
+    end
+  end
+
+  def qualification_subject(qualification)
+    if [ApplicationQualification::SCIENCE_SINGLE_AWARD,
+        ApplicationQualification::SCIENCE_DOUBLE_AWARD,
+        ApplicationQualification::SCIENCE_TRIPLE_AWARD].include? qualification.subject
+      t('.science')
+    else
+      qualification.subject.capitalize
+    end
+  end
+
+  def country(qualification)
+    if qualification.non_uk_qualification_type.present?
+      COUNTRIES_AND_TERRITORIES[qualification.institution_country]
+    else
+      t('.united_kingdom')
+    end
+  end
+
+  def year_awarded(qualification)
+    qualification.award_year.presence || t('.not_provided')
+  end
+
+  def grades(qualification)
+    if qualification.grade.present?
+      Array(qualification.grade)
+    elsif qualification.constituent_grades.present?
+      qualification.constituent_grades.map do |(subject, _details)|
+        ApplicationQualificationDecorator.new(qualification).grade_details.fetch(subject)
+      end
+    else
+      Array(t('.not_provided'))
+    end
+  end
+
+  def enic_text(qualification)
+    if qualification.enic_reference.present? && qualification.comparable_uk_qualification.present?
+      {
+        heading: t('.comparability'),
+        text: t('.comparability_enic_statement', reference: qualification.enic_reference, comparable: qualification.comparable_uk_qualification),
+      }
+    end
+  end
+
+  def missing_qualification_text(qualification)
+    if qualification.currently_completing_qualification
+      {
+        heading: t('.currently_studying_heading'),
+        text: qualification.not_completed_explanation || t('.no_additional_information_provided'),
+      }
+    elsif qualification.missing_explanation.present?
+      {
+        heading: t('.other_evidence_i_have_the_skills'),
+        text: qualification.missing_explanation,
+      }
+    end
+  end
+
+  def cell_attributes(row)
+    if row.enic_text.present?
+      { html_attributes: { class: 'qualifications-table__cell--no-bottom-border' } }
+    else
+      {}
+    end
+  end
+end

--- a/app/components/provider_interface/find_candidates/other_qualifications_component.html.erb
+++ b/app/components/provider_interface/find_candidates/other_qualifications_component.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_table(caption: t('.caption'), head:, rows:) %>

--- a/app/components/provider_interface/find_candidates/other_qualifications_component.rb
+++ b/app/components/provider_interface/find_candidates/other_qualifications_component.rb
@@ -1,0 +1,58 @@
+class ProviderInterface::FindCandidates::OtherQualificationsComponent < ViewComponent::Base
+  attr_accessor :application_form
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def head
+    [
+      t('.qualification'),
+      t('.subject'),
+      t('.country'),
+      { text: t('.year'), numeric: true },
+      t('.grade'),
+    ]
+  end
+
+  def rows
+    qualifications.map do |qualification|
+      [
+        qualification_type(qualification),
+        qualification_subject(qualification),
+        country(qualification),
+        { text: qualification.award_year, numeric: true },
+        grade(qualification),
+      ]
+    end
+  end
+
+private
+
+  def qualification_type(qualification)
+    qualification.other_uk_qualification_type.presence || qualification.non_uk_qualification_type
+  end
+
+  def qualification_subject(qualification)
+    qualification.subject&.titleize || t('.not_entered')
+  end
+
+  def country(qualification)
+    if qualification.international? || qualification.non_uk_qualification_type?
+      COUNTRIES_AND_TERRITORIES[qualification.institution_country]
+    else
+      t('.united_kingdom')
+    end
+  end
+
+  def grade(qualification)
+    if qualification.predicted_grade?
+      t('.predicted_grade', predicted_grade: qualification.grade)
+    else
+      qualification.grade.presence
+    end
+  end
+
+  def qualifications
+    @qualifications ||= application_form.application_qualifications.other
+  end
+end

--- a/app/components/provider_interface/find_candidates/personal_statement_component.html.erb
+++ b/app/components/provider_interface/find_candidates/personal_statement_component.html.erb
@@ -1,0 +1,26 @@
+<% if show_full_personal_statement? %>
+  <%= simple_format(personal_statement, class: 'govuk-body') %>
+<% else %>
+  <span id="app-truncated-personal-statement">
+    <%= simple_format(truncated_personal_statement, class: 'govuk-body') %>
+  </span>
+  <span id="app-remaining-personal-statement" tabindex='-1' class='govuk-visually-hidden'>
+    <%= simple_format(remaining_personal_statement_text, class: 'govuk-body') %>
+  </span>
+
+  <%= govuk_link_to(
+        t('.read_more'),
+        '#',
+        class: 'app-show-more-show-less govuk-visually-hidden',
+        data: {
+          container: 'app-remaining-personal-statement',
+          'section-container': 'personal-statement-section',
+          'show-more': t('.read_more'),
+          'show-less': t('.read_less'),
+        },
+      ) %>
+
+  <noscript>
+    <%= simple_format(remaining_personal_statement_text, class: 'govuk-body') %>
+  </noscript>
+<% end %>

--- a/app/components/provider_interface/find_candidates/personal_statement_component.rb
+++ b/app/components/provider_interface/find_candidates/personal_statement_component.rb
@@ -1,0 +1,27 @@
+class ProviderInterface::FindCandidates::PersonalStatementComponent < ViewComponent::Base
+  MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT = 100
+  include ViewHelper
+
+  attr_reader :application_form
+  delegate :becoming_a_teacher, :further_information, to: :application_form
+  alias_attribute :personal_statement, :becoming_a_teacher
+
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def show_full_personal_statement?
+    personal_statement.to_s.split.size <= MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT
+  end
+
+  def truncated_personal_statement
+    personal_statement.truncate_words(
+      MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT,
+      omission: ' ',
+    )
+  end
+
+  def remaining_personal_statement_text
+    personal_statement[truncated_personal_statement.size..]
+  end
+end

--- a/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
@@ -1,8 +1,6 @@
-<h2 class="govuk-heading-m"><%= t('.title') %></h2>
-
 <%= govuk_summary_list do |summary_list| %>
   <% summary_list.with_row do |row| %>
-    <% row.with_key { t('.visa_sponsorhip') } %>
+    <% row.with_key { t('.visa_sponsorship') } %>
     <% row.with_value { visa_sponsorhip_value } %>
   <% end %>
 <% end %>

--- a/app/components/provider_interface/find_candidates/safeguarding_component.html.erb
+++ b/app/components/provider_interface/find_candidates/safeguarding_component.html.erb
@@ -1,5 +1,1 @@
-<section class="app-section summary-section govuk-!-padding-top-4">
-  <h2 class="govuk-heading-l"><%= t('.title') %></h2>
-
-  <%= render SummaryListComponent.new(rows: rows) %>
-</section>
+<%= render SummaryListComponent.new(rows:) %>

--- a/app/components/provider_interface/find_candidates/work_history_summary_component.html.erb
+++ b/app/components/provider_interface/find_candidates/work_history_summary_component.html.erb
@@ -1,0 +1,11 @@
+<%= govuk_summary_list(actions: false) do |summary_list| %>
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key(text: t('.do_you_have_work_history')) %>
+    <%= row.with_value(text: work_history_text) %>
+
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <%= row.with_key(text: t('.do_you_have_unpaid_experience')) %>
+    <%= row.with_value(text: unpaid_experience_text) %>
+  <% end %>
+<% end %>

--- a/app/components/provider_interface/find_candidates/work_history_summary_component.rb
+++ b/app/components/provider_interface/find_candidates/work_history_summary_component.rb
@@ -1,0 +1,31 @@
+class ProviderInterface::FindCandidates::WorkHistorySummaryComponent < ViewComponent::Base
+  attr_accessor :application_form
+  delegate :full_time_education?, to: :application_form
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def work_history_with_breaks
+    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true)
+  end
+
+  def work_history?
+    work_history_with_breaks.work_history.any?
+  end
+
+  def unpaid_experience?
+    work_history_with_breaks.unpaid_work.any?
+  end
+
+  def work_history_text
+    if !work_history? && full_time_education?
+      t('.full_time_education')
+    else
+      work_history? ? 'Yes' : 'No'
+    end
+  end
+
+  def unpaid_experience_text
+    unpaid_experience? ? 'Yes' : 'No'
+  end
+end

--- a/app/components/shared/work_history_and_unpaid_experience_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_component.html.erb
@@ -1,18 +1,15 @@
-<% if @find_candidates %>
-  <section class="app-section summary-section" data-qa="work-history-and-unpaid-experience">
-    <h2 class="govuk-heading-l" id="work-history">Work history and unpaid experience</h2>
-<% else %>
-  <section class="app-section govuk-!-width-two-thirds" data-qa="work-history-and-unpaid-experience">
-    <h3 class="govuk-heading-m" id="work-history">Work history and unpaid experience</h3>
-<% end %>
+<section class="app-section govuk-!-width-two-thirds" data-qa="work-history-and-unpaid-experience">
+  <h3 class="govuk-heading-m" id="work-history">Work history and unpaid experience</h3>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 
   <% if @details && subtitle %>
-      <h4 class="govuk-heading-s" id="work-history-subheader"><%= subtitle %></h4>
-    <% end %>
+    <h4 class="govuk-heading-s" id="work-history-subheader"><%= subtitle %></h4>
+  <% end %>
 
+  <% if @details %>
     <% history.each do |item| %>
       <%= render WorkHistoryAndUnpaidExperienceItemComponent.new(item:, editable: @editable) %>
+    <% end %>
   <% end %>
 </section>

--- a/app/components/shared/work_history_and_unpaid_experience_component.rb
+++ b/app/components/shared/work_history_and_unpaid_experience_component.rb
@@ -1,5 +1,5 @@
 class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
-  def initialize(application_form:, editable: false, application_choice: nil, details: true, find_candidates: false)
+  def initialize(application_form:, editable: false, application_choice: nil, details: true)
     @application_form = application_form
     @work_history_with_breaks ||= WorkHistoryWithBreaks.new(
       application_choice || application_form,
@@ -7,7 +7,6 @@ class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
     )
     @editable = editable
     @details = details
-    @find_candidates = find_candidates
   end
 
   def subtitle

--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -10,6 +10,7 @@ import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 // stimulus
 import { Application } from '@hotwired/stimulus'
 import LocationAutocompleteController from './controllers/location_autocomplete_controller'
+import showMoreShowLess from './components/show-more-show-less'
 
 require.context('govuk-frontend/dist/govuk/assets')
 
@@ -22,3 +23,4 @@ initAddFurtherConditions()
 checkboxSearchFilter('subject', 'Search for subject')
 filter()
 cookieBanners()
+showMoreShowLess()

--- a/app/frontend/packs/components/show-more-show-less.js
+++ b/app/frontend/packs/components/show-more-show-less.js
@@ -12,6 +12,7 @@ function ShowMoreShowLess () {
 
 ShowMoreShowLess.prototype.setShowMoreLinkListener = function (showMoreLink) {
   showMoreLink.addEventListener('click', this.expandContractTarget)
+  showMoreLink.classList.remove('govuk-visually-hidden')
 }
 
 ShowMoreShowLess.prototype.expandContractTarget = function (event) {
@@ -19,6 +20,7 @@ ShowMoreShowLess.prototype.expandContractTarget = function (event) {
 
   const link = event.target
   const container = document.getElementById(link.getAttribute('data-container'))
+  const sectionContainer = document.getElementById(link.getAttribute('data-section-container'))
   const lessText = link.getAttribute('data-show-less')
   const moreText = link.getAttribute('data-show-more')
   const isExpanded = link.getAttribute('aria-expanded')
@@ -27,11 +29,18 @@ ShowMoreShowLess.prototype.expandContractTarget = function (event) {
     container.classList.add('govuk-visually-hidden')
     link.text = moreText
     link.setAttribute('aria-expanded', false)
+    if (sectionContainer !== null) {
+      sectionContainer.scrollIntoView({ block: 'start' })
+    }
   } else {
     container.classList.remove('govuk-visually-hidden')
     link.text = lessText
-    container.focus()
     link.setAttribute('aria-expanded', true)
+    if (sectionContainer === null) {
+      container.scrollIntoView({ block: 'start' })
+    } else {
+      sectionContainer.scrollIntoView({ block: 'start' })
+    }
   }
 }
 

--- a/app/frontend/styles/_previews.scss
+++ b/app/frontend/styles/_previews.scss
@@ -1,0 +1,2 @@
+// Anything that is used in a preview needs to be added to the public folder
+@import "./provider/qualifications-table";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -69,6 +69,7 @@ $govuk-new-link-styles: true;
 @import "summary-card";
 @import "toc";
 @import "div";
+@import "previews";
 
 // Override utilities
 @import "overrides";

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -18,3 +18,4 @@
 @import "recruitment_performance_report";
 @import "withdrawal_reasons_report";
 @import "summary-list";
+@import "qualifications-table";

--- a/app/frontend/styles/provider/_qualifications-table.scss
+++ b/app/frontend/styles/provider/_qualifications-table.scss
@@ -1,0 +1,5 @@
+.qualifications-table {
+  &__cell--no-bottom-border {
+    border-bottom: none;
+  }
+}

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -5,47 +5,82 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render ServiceInformationBanner.new(namespace: :provider) %>
 
-    <h2 class="govuk-heading-m govuk-hint govuk-!-margin-bottom-0"><%= t('.candidate_number', candidate_id: @candidate.id) %></h2>
-    <h1 class="govuk-heading-l"><%= @application_form.redacted_full_name %></h1>
+    <span class="govuk-caption-xl"><%= t('.candidate_number', candidate_id: @candidate.id) %></span>
+    <h1 class="govuk-heading-xl"><%= @application_form.redacted_full_name %></h1>
     <%= govuk_button_to t('.invite'), new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate), method: :get %>
 
+    <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>
+
     <%= render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form: @application_form) %>
-    <%= render ProviderInterface::FindCandidates::ApplicationChoicesComponent.new(application_form: @application_form) %>
-    <%= render ProviderInterface::FindCandidates::SafeguardingComponent.new(application_form: @application_form, provider_user: current_provider_user) %>
-    <%= render WorkHistoryAndUnpaidExperienceComponent.new(application_form: @application_form, details: false, find_candidates: true) %>
   </div>
 
   <div class="govuk-grid-column-full">
-    <section class="app-section">
+    <section class="app-section" id="qualifications-section">
       <h2 class="govuk-heading-l" id="qualifications">
         <%= t('.qualifications') %>
       </h2>
 
       <% if @application_form.degrees? %>
-        <%= render DegreeQualificationCardsComponent.new(
-          @application_form.application_qualifications.degrees,
-          show_hesa_codes: false,
-          editable: false,
-        ) %>
+        <%= render ProviderInterface::FindCandidates::DegreesTableComponent.new(@application_form) %>
       <% else %>
-        <h3 class="govuk-heading-m" id="degrees">
-          <%= t('provider_interface.degree.heading') %>
+        <h3 class="govuk-heading-m" id="degrees-heading">
+          <%= t('.degree.heading') %>
         </h3>
-
         <p class="govuk-body">
-          <%= t('provider_interface.degree.teacher_degree_apprenticeship_message') %>
+          <%= t('.degree.teacher_degree_apprenticeship_message') %>
         </p>
       <% end %>
 
-      <%= render GcseQualificationCardsComponent.new(@application_form, editable: false) %>
+      <%= render ProviderInterface::FindCandidates::GcseQualificationsTableComponent.new(@application_form) %>
 
-      <%= render QualificationsTableComponent.new(
-        qualifications: @application_form.application_qualifications.other,
-        header: t('.a_level_header'),
-        subheader: t('.a_level_subheader', editable: false),
-      ) %>
+      <% if @application_form.application_qualifications.other.any? %>
+        <%= render ProviderInterface::FindCandidates::OtherQualificationsComponent.new(@application_form) %>
+      <% else %>
+        <h3 class="govuk-heading-m" id="gcses">
+          <%= t('.a_level_header') %>
+        </h3>
+        <p class="govuk-body">
+          <%= t('.no_other_qualifications') %>
+        </p>
+      <% end %>
 
-      <%= render EflQualificationCardComponent.new(@application_form) %>
+      <% if !@application_form.british_or_irish? && @application_form.english_proficiency.present? %>
+        <h3 class="govuk-heading-m" id='efl-qualification'>
+          <%= t('.english_as_a_foreign_language') %>
+        </h3>
+        <%= render ProviderInterface::FindCandidates::EflQualificationCardComponent.new(@application_form) %>
+      <% end %>
+
+    </section>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <section class='app-section' id='personal-statement-section'>
+      <h2 class="govuk-heading-l">
+        <span class="govuk-caption-l">
+          <%= t('.personal_statement_caption') %>
+        </span>
+        <%= t('.personal_statement_title') %>
+      </h2>
+      <%= render ProviderInterface::FindCandidates::PersonalStatementComponent.new(@application_form) %>
+    </section>
+    <section class="app-section" id="work-history-section">
+      <h2 class="govuk-heading-l" id="work-history">
+        <%= t('.work_history_and_unpaid_experience') %>
+      </h2>
+      <%= render ProviderInterface::FindCandidates::WorkHistorySummaryComponent.new(@application_form) %>
+      <%= render ProviderInterface::FindCandidates::ExperienceDetailsComponent.new(@application_form) %>
+    </section>
+    <section class="app-section" id="safeguarding-section">
+      <h2 class="govuk-heading-l">
+        <%= t('.safeguarding_title') %>
+      </h2>
+      <%= render ProviderInterface::FindCandidates::SafeguardingComponent.new(application_form: @application_form, provider_user: current_provider_user) %>
+    </section>
+    <section class="app-section" id="application-choices-section">
+      <h2 class="govuk-heading-l">
+        <%= t('.application_choices_title') %>
+      </h2>
+      <%= render ProviderInterface::FindCandidates::ApplicationChoicesComponent.new(application_form: @application_form) %>
     </section>
   </div>
 </div>

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -1,16 +1,77 @@
 en:
   provider_interface:
     find_candidates:
-      safeguarding_component:
-        title: Criminal record and professional misconduct
       right_to_work_component:
-        title: Right to work or study in the UK
-        visa_sponsorhip: Visa sponsorship
+        visa_sponsorship: Visa sponsorship
       application_choices_component:
-        title: Applications made
         subtitle: Application %{counter}
         subject: Subject
         location: Location
         qualification: Qualification
         funding_type: Funding type
-        personal_statement: Personal statement
+        date_submitted: Date submitted
+      personal_statement_component:
+        read_more: Read more
+        read_less: Read less
+      gcse_qualifications_table_component:
+        caption: GCSEs or equivalent
+        science: Science
+        united_kingdom: United Kingdom
+        type: Type
+        subject: Subject
+        country: Country
+        year_awarded: Year awarded
+        grades: Grades
+        candidate_does_not_have: Candidate does not have this qualification yet
+        details_of_qualification: Details of qualification currently studying for
+        not_provided: Not provided
+        other_evidence_i_have_the_skills: Other evidence I have the skills required
+        awarded: Awarded
+        grade: Grade
+        comparability: Comparability
+        comparability_enic_statement: UK ENIC or NARIC statement %{reference} says this is comparable to %{comparable}
+        not_added: Not added
+        currently_studying_heading: Currently studying to retake this qualification
+        no_additional_information_provided: No additional information provided
+        visually_hidden_text: statement for %{qualification}
+        no_qualification_yet: No qualification yet
+        gcse: GCSE
+      work_history_summary_component:
+        do_you_have_work_history: Do you have any work history?
+        do_you_have_unpaid_experience: Do you have any unpaid experience?
+      experience_details_component:
+        title:
+          details_work_and_unpaid: Details of work history and unpaid experience
+          details_work: Details of work history
+          details_unpaid: Details of unpaid experience
+        unexplained_break_title: Unexplained break (%{formatted_duration})
+        explained_break_title: Break (%{formatted_duration})
+        present: Present
+        relevant_skills: This role used skills relevant to teaching
+        worked_with_children: Worked with children
+      degrees_table_component:
+        caption:
+          one: Degree
+          other: Degrees
+        degree_type: Type
+        degree_subject: Subject
+        issued_by: Issued by
+        year_range: Years
+        grade: Grade
+        comparability: Comparability
+        visually_hidden_enic_text: statement for %{qualification}
+      other_qualifications_component:
+        caption: A levels and other qualifications
+        qualification: Type
+        subject: Subject
+        country: Country
+        year: Year awarded
+        grade: Grade
+        united_kingdom: United Kingdom
+        predicted_grade: "%{predicted_grade} (predicted)"
+        not_entered: Not entered
+      efl_qualification_card_component:
+        type_of_assessment: Type of assessment
+        year_completed: Year completed
+
+

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -21,10 +21,22 @@ en:
         show:
           title: Candidate details
           invite: Invite to apply
+          right_to_work_and_study: Right to work or study in the UK
           qualifications: Qualifications
+          degree:
+            heading: Degrees
+            teacher_degree_apprenticeship_message: A degree is not required for a teacher degree apprenticeship (TDA).
+          gcses_or_equivalent: GCSEs or equivalent
           a_level_header: A levels and other qualifications
-          a_level_subheader: Details of A levels and other qualifications
+          no_other_qualifications: No A levels or other qualifications
+          english_as_a_foreign_language: English as a foreign language
+          work_history_and_unpaid_experience: Work history and unpaid experience
           candidate_number: Candidate %{candidate_id}
+          personal_statement: Personal statement
+          personal_statement_caption: Most recent
+          personal_statement_title: Personal statement
+          safeguarding_title: Criminal record and professional misconduct
+          application_choices_title: Applications submitted
       draft_invites:
         new:
           title: Select a course to invite %{candidate_name} to apply to

--- a/spec/components/previews/provider_interface/find_candidates/degrees_table_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/degrees_table_component_preview.rb
@@ -1,0 +1,13 @@
+class ProviderInterface::FindCandidates::DegreesTableComponentPreview < ViewComponent::Preview
+  def degrees_table_for_find_candidate_view
+    application_form = FactoryBot.create(:application_form)
+    # UK degree
+    FactoryBot.create(:degree_qualification, predicted_grade: false, application_form:)
+    # International with ENIC
+    FactoryBot.create(:non_uk_degree_qualification, application_form:)
+    # International without ENIC
+    FactoryBot.create(:non_uk_degree_qualification, enic_reason: 'waiting', enic_reference: nil, application_form:)
+
+    render ProviderInterface::FindCandidates::DegreesTableComponent.new(application_form)
+  end
+end

--- a/spec/components/previews/provider_interface/find_candidates/gcse_qualifications_table_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/gcse_qualifications_table_component_preview.rb
@@ -1,0 +1,30 @@
+class ProviderInterface::FindCandidates::GcseQualificationsTableComponentPreview < ViewComponent::Preview
+  def non_standard_gcse_table_for_find_candidates
+    application_form = FactoryBot.build(:application_form)
+
+    # International with ENIC, science
+    FactoryBot.create(:gcse_qualification, :non_uk, subject: 'science', application_form:)
+
+    # Retaking GCSE
+    FactoryBot.create(:gcse_qualification, :missing_and_currently_completing, subject: 'maths', application_form:)
+
+    # Missing and not retaking, English, lots of text
+    FactoryBot.create(
+      :gcse_qualification,
+      :missing_and_not_currently_completing,
+      subject: 'english',
+      missing_explanation: Faker::Lorem.sentence(word_count: 200),
+      application_form:,
+    )
+
+    render ProviderInterface::FindCandidates::GcseQualificationsTableComponent.new(application_form)
+  end
+
+  def gcse_table_for_uk_find_candidates
+    application_form = FactoryBot.build(:application_form)
+    %w[maths english science].each do |gcse_subject|
+      FactoryBot.create(:gcse_qualification, subject: gcse_subject, application_form:)
+    end
+    render ProviderInterface::FindCandidates::GcseQualificationsTableComponent.new(application_form)
+  end
+end

--- a/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::ApplicationChoicesComponent, type: :component do
+  let(:application_form) { create(:application_form, :submitted) }
+
+  describe 'with draft and submitted applications' do
+    it 'only renders submitted applications' do
+      create(:application_choice, sent_to_provider_at: 1.day.ago, application_form:)
+      create(:application_choice, sent_to_provider_at: nil, application_form:)
+
+      rendered = render_inline(described_class.new(application_form:))
+
+      expect(rendered).to have_text 'Application 1'
+      expect(rendered).to have_no_text 'Application 2'
+    end
+  end
+
+  describe 'many submitted applications' do
+    it 'ordered by most recent sent' do
+      first_submission_date = 2.days.ago
+      create(:application_choice, sent_to_provider_at: first_submission_date, application_form:)
+
+      second_submission_date = 1.day.ago
+      create(:application_choice, sent_to_provider_at: second_submission_date, application_form:)
+
+      render_inline(described_class.new(application_form:))
+      first_card = page.find('div.govuk-summary-card', text: 'Application 1').text
+      second_card = page.find('div.govuk-summary-card', text: 'Application 2').text
+
+      expect(first_card).to have_content second_submission_date.to_fs(:govuk_date)
+      expect(second_card).to have_content first_submission_date.to_fs(:govuk_date)
+    end
+  end
+end

--- a/spec/components/provider_interface/find_candidates/degrees_table_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/degrees_table_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::DegreesTableComponent, type: :component do
+  describe 'additional enic text' do
+    let(:international_degree) do
+      create(:non_uk_degree_qualification, enic_reference: 4120228363, comparable_uk_degree: 'bachelor_ordinary_degree')
+    end
+
+    it 'renders additional enic text' do
+      application_form = international_degree.application_form
+
+      render_inline(described_class.new(application_form))
+      expect(page).to have_content "Comparability statement for #{international_degree.subject}"
+      expect(page).to have_content 'UK ENIC or NARIC statement 4120228363 says this is comparable to a Bachelor (Ordinary) degree'
+    end
+
+    it 'removes bottom border border between cells when enic text present' do
+      application_form = international_degree.application_form
+
+      render_inline(described_class.new(application_form))
+
+      expect(page).to have_css('.qualifications-table__cell--no-bottom-border')
+    end
+  end
+end

--- a/spec/components/provider_interface/find_candidates/efl_qualification_card_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/efl_qualification_card_component_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::EflQualificationCardComponent, type: :component do
+  context 'when the application_form has an English speaking nationality' do
+    it 'renders nothing' do
+      application_form = build_stubbed(:application_form, first_nationality: 'British')
+      render_inline(described_class.new(application_form))
+      expect(page.text).to eq ''
+    end
+  end
+
+  context 'when the application_form does not have an English speaking nationality' do
+    let(:application_form) { create(:application_form, first_nationality: 'French') }
+
+    context 'when the candidate has an EFL qualification' do
+      context 'which is an IELTS' do
+        it 'renders the expected output' do
+          create(:english_proficiency, :with_ielts_qualification, application_form:)
+          result = render_inline(described_class.new(application_form))
+
+          expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
+
+          expect(result.text).to include 'IELTS'
+          expect(result.text).to include '1999'
+          expect(result.text).to include 'Overall band score'
+          expect(result.text).to include '6.5'
+          expect(result.text).to include 'TRF number'
+          expect(result.text).to include '123456'
+        end
+      end
+
+      context 'which is a TOEFL' do
+        it 'renders the expected output' do
+          create(:english_proficiency, :with_toefl_qualification, application_form:)
+          result = render_inline(described_class.new(application_form))
+
+          expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
+
+          expect(result.text).to include 'TOEFL'
+          expect(result.text).to include '1999'
+          expect(result.text).to include 'Total score'
+          expect(result.text).to include '20'
+          expect(result.text).to include 'Registration number'
+          expect(result.text).to include '123456'
+        end
+      end
+
+      context 'which is an "Other" qualification' do
+        it 'renders the expected output' do
+          create(:english_proficiency, :with_other_efl_qualification, application_form:)
+          result = render_inline(described_class.new(application_form))
+
+          expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
+
+          expect(result.text).to include 'Cockney Rhyming Slang Proficiency Test'
+          expect(result.text).to include '2001'
+          expect(result.text).to include 'Score or grade'
+          expect(result.text).to include '20'
+        end
+      end
+    end
+
+    context 'when the candidate does not have an EFL qualification' do
+      it 'renders the expected output' do
+        create(
+          :english_proficiency,
+          :no_qualification,
+          application_form:,
+          no_qualification_details: 'Waiting for results',
+        )
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'Candidate has not done an English as a foreign language assessment yet.'
+        expect(result.text).to include 'Waiting for results'
+      end
+    end
+
+    context 'when the candidate declares they do not need an EFL qualification' do
+      it 'renders the expected output' do
+        create(:english_proficiency, :qualification_not_needed, application_form:)
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'Candidate said that English is not a foreign language to them'
+      end
+    end
+  end
+end

--- a/spec/components/provider_interface/find_candidates/gcse_qualifications_table_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/gcse_qualifications_table_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::GcseQualificationsTableComponent, type: :component do
+  context 'when enic has been obtained' do
+    let(:international_gcse) do
+      create(:gcse_qualification, :non_uk, enic_reference: '4120228363', subject: 'maths')
+    end
+
+    it 'renders additional enic text' do
+      application_form = international_gcse.application_form
+
+      render_inline(described_class.new(application_form))
+      expect(page).to have_content 'Comparability statement for Maths'
+      expect(page).to have_content 'UK ENIC or NARIC statement 4120228363 says this is comparable to Between GCSE and GCSE AS Level'
+    end
+
+    it 'removes bottom border border between cells when enic text present' do
+      application_form = international_gcse.application_form
+
+      render_inline(described_class.new(application_form))
+      expect(page).to have_css('.qualifications-table__cell--no-bottom-border')
+    end
+  end
+end

--- a/spec/components/provider_interface/find_candidates/safeguarding_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/safeguarding_component_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ProviderInterface::FindCandidates::SafeguardingComponent, type: :
 
       render_inline(described_class.new(application_form:, provider_user:))
 
-      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
       expect(page).to have_css(
         'dt.govuk-summary-list__key',
         text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
@@ -27,7 +26,6 @@ RSpec.describe ProviderInterface::FindCandidates::SafeguardingComponent, type: :
 
       render_inline(described_class.new(application_form:, provider_user:))
 
-      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
       expect(page).to have_css(
         'dl.govuk-summary-list',
         text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
@@ -57,7 +55,6 @@ RSpec.describe ProviderInterface::FindCandidates::SafeguardingComponent, type: :
 
       render_inline(described_class.new(application_form:, provider_user:))
 
-      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
       expect(page).to have_css(
         'dt.govuk-summary-list__key',
         text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',
@@ -81,7 +78,6 @@ RSpec.describe ProviderInterface::FindCandidates::SafeguardingComponent, type: :
 
       render_inline(described_class.new(application_form:, provider_user:))
 
-      expect(page).to have_css 'h2', text: 'Criminal record and professional misconduct'
       expect(page).to have_css(
         'dl.govuk-summary-list',
         text: 'Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?',

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
         grade { %w[pass merit distinction].sample }
         institution_country { Faker::Address.country_code }
         enic_reference { '4000123456' }
+        enic_reason { 'obtained' }
         comparable_uk_qualification { 'Between GCSE and GCSE AS Level' }
       end
 
@@ -139,6 +140,7 @@ FactoryBot.define do
       start_year { Faker::Date.between(from: 5.years.ago, to: 3.years.ago).year }
       award_year { Faker::Date.between(from: 2.years.ago, to: 1.year.ago).year }
       enic_reference { '4000228363' }
+      enic_reason { 'obtained' }
       comparable_uk_degree { 'bachelor_ordinary_degree' }
 
       trait :adviser_sign_up_applicable do

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -1065,7 +1065,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
 
     describe 'non-uk degree' do
       let(:application_qualification) do
-        create(:non_uk_degree_qualification, id: 1)
+        create(:non_uk_degree_qualification, id: 1, enic_reason: nil)
       end
 
       context 'standard non uk degree' do

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -84,11 +84,13 @@ RSpec.describe 'Providers views candidate pool list' do
   def and_i_can_view_their_details
     expect(page).to have_content(@rejected_candidate.redacted_full_name_current_cycle)
     expect(page).to have_content('Right to work or study in the UK')
-    expect(page).to have_content('Applications made')
-    expect(page).to have_content('Personal statement')
+    expect(page).to have_content('Qualifications')
+    expect(page).to have_content('Applications submitted')
+    expect(page).to have_content('Most recent Personal statement')
     expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).to have_content('Work history and unpaid experience')
     expect(page).to have_content('Qualifications')
     expect(page).to have_content('A levels and other qualifications')
+    expect(page).to have_content('Criminal record and professional misconduct')
   end
 end


### PR DESCRIPTION
## Context

An outcome from UR. The order of the elements on the page should be reordered and designs have been updated.

In addition, the headings were not correct as we were re-using components that were not made to be used in this situation.  I have refactored a bit to heading structure of the page is in the `show.html.erb` file rather than abstracted to the components.

## Changes proposed in this pull request

In addition, the headings were not correct as we were re-using components that were not made to be used in this situation.  I have refactored a bit to heading structure of the page is in the `show.html.erb` file rather than abstracted to the components.

Also fixed some bugs -- we were showing providers all the applications choices, not just the ones that were submitted, for instance.

Video before changes

https://github.com/user-attachments/assets/8b09de0f-d39d-4b18-ae43-4060b88bbaa3

Video after change

https://github.com/user-attachments/assets/bf97baee-be1e-4ef5-9a03-41fb9b3065c3

## Guidance to review

Best to review commit-by-commit


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
