### PR TITLE
Break down add location preference caching logic to escape early if result is blank

### DIFF
--- a/app/services/location_suggestions.rb
+++ b/app/services/location_suggestions.rb
@@ -9,8 +9,14 @@ class LocationSuggestions
   def call
     return [] if query.blank?
 
-    Rails.cache.fetch(cache_key, expires_in: cache_expiration) do
-      fetch_suggestions
+    if Rails.cache.exist?(cache_key)
+      Rails.cache.read(cache_key)
+    else
+      suggestions = fetch_suggestions
+      return [] if suggestions.blank?
+
+      Rails.cache.write(cache_key, suggestions, expires_in: cache_expiration)
+      suggestions
     end
   end
 

--- a/spec/services/location_suggestions_spec.rb
+++ b/spec/services/location_suggestions_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe LocationSuggestions do
           hash_including(message: "Location suggestion failed for LocationSuggestions - #{query}, suggestions ignored (user experience unaffected)"),
         )
       end
+
+      it 'does not write anything to the cache' do
+        suggestions
+        expect(cache.exist?(suggestions_query.send(:cache_key))).to be false
+      end
     end
   end
 


### PR DESCRIPTION
## Context

When an API issue that affected the FAC add location preference search began to return errors, we noticed that empty arrays were being cached and returned to users who later searched the same terms.

Empty arrays resulting from errors should not be cached. Only valid searches, i.e. those that return results should be cached.

## Changes proposed in this pull request

- Refactor `Rails.cache.fetch` to a more explicit conditional statement which includes logic for escaping early if the search returns blank, in this case an empty array.

## Guidance to review

- Review the updated files, including the additional test added in the API returns nil results scenario.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
