### PR TITLE
[890] Bug: fix wrong application form associations being returned

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -22,8 +22,6 @@ module ProviderInterface
         @application_form = Pool::Candidates.application_forms_for_provider(
           providers: current_provider_user.providers,
         )
-        .select('*')
-        .includes(:application_choices)
         .find_by(candidate_id: params.expect(:id))
 
         @candidate = @application_form.candidate

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -89,8 +89,8 @@ private
         status: %i[rejected declined withdrawn conditions_not_met offer_withdrawn inactive],
       })
       .where(id: forms_with_available_slots)
-      .without(forms_with_live_applications)
-      .without(forms_that_have_been_withdrawn_for_not_wanting_to_train)
+      .excluding(forms_with_live_applications)
+      .excluding(forms_that_have_been_withdrawn_for_not_wanting_to_train)
   end
 
   def filter_by_distance(application_forms_scope)

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe Pool::Candidates do
         provider = create(:provider)
         providers = [provider]
 
+        previous_year_form = create(:application_form, :completed, recruitment_cycle_year: previous_year)
+        create(:candidate_preference, candidate: previous_year_form.candidate)
+        create(:application_choice, :rejected, application_form: previous_year_form)
+
         opt_out_candidate = create(:candidate)
         create(:candidate_preference, pool_status: 'opt_out', candidate: opt_out_candidate)
         opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)


### PR DESCRIPTION
## Context
When making changes to the individual application form view for find candidates, I experienced this rather odd bug, reproduced as follows: 

1. Login as a provider and click “Find Candidates”
2. Click on an anonymised name to view view the application form.
3. Not the CANDIDATE id in the url, and using the rails console, find the associated Application Form application_form_id = Candidate.find(:candidate_id).current_application.id
4. In support, view the application form (support/applications/:application_form_id).
5. Compare the data in the two views – the data that is directly from the application_form (personal statement, aka becoming\_a_teacher) matches. The data from associated records (eg, the submitted applications, qualifications) does not match.
6. Have a look at the application form with the same id as the candidate id (support/applications/:candidate_id). Note that the associated records match what is in the find-a-candidate view (eg, application choices, qualifications. But now the data from the application form itself is different.

## Changes proposed in this pull request

The thing that fixed it was removing the `select('*')` from the controller. I've also removed the selects from the query class for good measure. 

In addition, I've just added some sub queries and comments to make the query more readable and easier to edit / debug. 

## Guidance to review
Test it in the review app following the instructions above, but now you should see the same data for the application form in support as you do for the application form in find-candidates.

We have tested this against the sanitised production database locally and there weren't any notable performance issues. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
