### PR TITLE
Switch `.excluding` to `.where.not`

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -89,8 +89,8 @@ private
         status: %i[rejected declined withdrawn conditions_not_met offer_withdrawn inactive],
       })
       .where(id: forms_with_available_slots)
-      .excluding(forms_with_live_applications)
-      .excluding(forms_that_have_been_withdrawn_for_not_wanting_to_train)
+      .where.not(id: forms_with_live_applications.select('application_forms.id'))
+      .where.not(id: forms_that_have_been_withdrawn_for_not_wanting_to_train.select('application_forms.id'))
   end
 
   def filter_by_distance(application_forms_scope)


### PR DESCRIPTION
## Context

Excluding will execute the SQL on the query in the argument before passing the result to the main query causing multiple SQL queries to be executed. Where not passes the generated SQL to the main query and only executes 1 SQL statement.

## Changes proposed in this pull request

Switch `.excluding` to `.where.not`

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
