### PR TITLE
[902] bug candidate being blocked from applying but course sponsors visas

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -206,12 +206,7 @@ module CandidateInterface
     end
 
     def course_can_sponsor_visa?(application_choice)
-      (
-        application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?
-      ) ||
-        (
-          !application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?
-        )
+      application_choice.course.can_sponsor_skilled_worker_visa? || application_choice.course.can_sponsor_student_visa?
     end
 
     def status_row(application_choice)

--- a/app/validators/immigration_status_validator.rb
+++ b/app/validators/immigration_status_validator.rb
@@ -24,8 +24,8 @@ class ImmigrationStatusValidator < ActiveModel::EachValidator
   end
 
   def course_can_sponsor_visa?(application_choice)
-    (application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?) ||
-      (!application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?)
+    application_choice.course.can_sponsor_skilled_worker_visa? ||
+      application_choice.course.can_sponsor_student_visa?
   end
 
   def link_to_find


### PR DESCRIPTION
## Context

We discovered by testing the visa sponsorship deadlines that our logic for determining whether or not a course could sponsor a visa is not correct. As a result, we have been blocking applications with 'this course does not sponsor visas' when it actually does. 

## Changes proposed in this pull request

We were erroneously checking the funding type -- the validation for whether or not a course of a particular funding type can sponsor a particular visa type lives in Publish. We only need to check the values for `can_sponsor_skilled_worker_visa` and `can_sponsor_student_visa`.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
