### PR TITLE
[865] Update wording for interview availability

### DIFF
--- a/config/locales/candidate_interface/interview_preferences.yml
+++ b/config/locales/candidate_interface/interview_preferences.yml
@@ -9,7 +9,7 @@ en:
       any_preferences:
         key: Do you have any times you cannot be available for interviews?
       details:
-        key: Give details of your interview availability
+        key: Details of when you are not available for interview
 
   activemodel:
     errors:

--- a/spec/components/utility/interview_preferences_component_spec.rb
+++ b/spec/components/utility/interview_preferences_component_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe InterviewPreferencesComponent do
     it 'renders interview preferences' do
       application_form = instance_double(
         ApplicationForm,
-        interview_preferences: 'Fridays are best for me.',
+        interview_preferences: 'Fridays are no good for me.',
       )
       result = render_inline(described_class.new(application_form:))
       expect(result.text).to include('Do you have any times you cannot be available for interviews?Yes')
-      expect(result.text).to include('Give details of your interview availabilityFridays are best for me.')
+      expect(result.text).to include('Details of when you are not available for interviewFridays are no good for me.')
     end
   end
 end


### PR DESCRIPTION
## Context

A support request was raised related to the interview availability question. We updated the wording at some point to ask the candidate when they CANNOT attend interview, having originally asked them when the CAN attend. However, we never updated the wording on any of the components seen by providers or support. 

## Changes proposed in this pull request

| Before | After | 
| ------ | ------ |
| <img width="755" alt="image" src="https://github.com/user-attachments/assets/ee8b2982-8dd8-4049-b404-dcf770f2bf23" /> | <img width="779" alt="image" src="https://github.com/user-attachments/assets/90beca11-4c95-4ea6-80b2-02418de2623a" /> |


## Guidance to review
NA


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
