### PR TITLE
Fix FAC radius bug

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -630,7 +630,7 @@ module CandidateInterface
 
     def self.select_uk_degree_level(application_qualification)
       QUALIFICATION_LEVEL[
-        Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level.to_s
+        Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level.to_s,
       ]
     end
 

--- a/app/forms/candidate_interface/location_preferences_form.rb
+++ b/app/forms/candidate_interface/location_preferences_form.rb
@@ -73,7 +73,7 @@ private
   end
 
   def location
-    return if name == location_preference.name
+    return if location_preference.present? && location_preference.name == name
 
     if location_coordinates.nil?
       errors.add(:name, :invalid_location)

--- a/app/forms/candidate_interface/location_preferences_form.rb
+++ b/app/forms/candidate_interface/location_preferences_form.rb
@@ -30,13 +30,19 @@ class CandidateInterface::LocationPreferencesForm
     return if invalid?
 
     if location_preference.present?
-      location_preference.update(
-        within:,
-        name: name == location_preference.name ? name : suggested_location[:name],
-        latitude: location_coordinates&.latitude,
-        longitude: location_coordinates&.longitude,
-        provider_id: name == location_preference.name ? location_preference.provider_id : nil,
-      )
+      if name == location_preference.name
+        location_preference.update(
+          within:,
+        )
+      else
+        location_preference.update(
+          within:,
+          name: suggested_location[:name],
+          latitude: location_coordinates&.latitude,
+          longitude: location_coordinates&.longitude,
+          provider_id: name == location_preference.name ? location_preference.provider_id : nil,
+        )
+      end
     else
       preference.location_preferences.create(
         within:,
@@ -67,6 +73,8 @@ private
   end
 
   def location
+    return if name == location_preference.name
+
     if location_coordinates.nil?
       errors.add(:name, :invalid_location)
     end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -13,4 +13,9 @@ FactoryBot.define do
     region { 'north_west' }
     postcode { Faker::Address.postcode }
   end
+
+  trait :with_coordinates do
+    latitude { 51.5245592 }
+    longitude { -0.1340401 }
+  end
 end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -14,8 +14,15 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
   end
 
-  trait :with_coordinates do
+  trait :with_valid_coordinates do
     latitude { 51.5245592 }
-    longitude { -0.1340401 }
+    longitude { -0.1340401 } # London, UK
+    postcode { 'WC1E 6AE' }
+  end
+
+  trait :with_invalid_coordinates do
+    latitude { 41.5800945 }
+    longitude { -71.4774291 } # Massachusetts, US
+    postcode { 'Y6W 7XN' }
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -230,8 +230,8 @@ module CandidateHelper
     create(:course_option, site:, course: course3) unless CourseOption.find_by(site:, course: course3, study_mode: :full_time)
     create(:course_option, site:, course: course4) unless CourseOption.find_by(site:, course: course4, study_mode: :full_time)
 
-    site_with_coordinates = create(:site, :with_coordinates, provider: @provider)
-    create(:course_option, site: site_with_coordinates, course: course5) unless CourseOption.find_by(site: site_with_coordinates, course: course5, study_mode: :full_time)
+    site_with_invalid_coordinates = create(:site, :with_invalid_coordinates, provider: @provider)
+    create(:course_option, site: site_with_invalid_coordinates, course: course5) unless CourseOption.find_by(site: site_with_invalid_coordinates, course: course5, study_mode: :full_time)
   end
 
   def given_undergraduate_courses_exist

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -222,10 +222,16 @@ module CandidateHelper
     course4 =
       Course.find_by(code: '2392', provider: @provider) ||
       create(:course, :open, name: 'Biology', level: 'secondary', code: '2392', provider: @provider, start_date: Date.new(2020, 9, 1))
+    course5 =
+      Course.find_by(code: 'C998', provider: @provider) ||
+      create(:course, :teacher_degree_apprenticeship, :open, name: 'Mathematics (SEND)', level: 'primary', code: 'C998', provider: @provider, start_date: Date.new(2020, 9, 1))
     create(:course_option, site:, course:) unless CourseOption.find_by(site:, course:, study_mode: :full_time)
     create(:course_option, site:, course: course2) unless CourseOption.find_by(site:, course: course2, study_mode: :full_time)
     create(:course_option, site:, course: course3) unless CourseOption.find_by(site:, course: course3, study_mode: :full_time)
     create(:course_option, site:, course: course4) unless CourseOption.find_by(site:, course: course4, study_mode: :full_time)
+
+    site_with_coordinates = create(:site, :with_coordinates, provider: @provider)
+    create(:course_option, site: site_with_coordinates, course: course5) unless CourseOption.find_by(site: site_with_coordinates, course: course5, study_mode: :full_time)
   end
 
   def given_undergraduate_courses_exist

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -98,37 +98,13 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_application_choices_with_success_message
   end
 
-  scenario 'Candidate edits a dynamic location' do
-    given_i_am_signed_in
-    given_courses_exist
-    and_feature_flag_is_enabled
-    given_i_am_on_the_share_details_page
+  scenario 'Candidate edits radius on a dynamic location with invalid site data' do
+    given_i_am_a_candidate_who_has_opted_in_with_a_dynamic_location
+    and_i_have_a_location_preference_with_invalid_site_data_from_a_dynamic_location
+    and_i_navigate_to_update_my_preferences
 
-    when_i_click('Change your sharing and location settings')
-    then_i_am_redirected_to_opt_in_page
-
-    when_i_opt_in_to_find_a_candidate
-    and_i_click('Continue')
-    then_i_am_redirected_to_location_preferences(location_preferences)
-
-    when_i_check_dynamic_locations
-    and_i_click('Continue')
-    and_i_click('Submit preferences')
-    then_i_am_redirected_to_application_choices_with_success_message
-
-    when_i_click('Add application')
-    and_i_complete_the_flow_for_adding_a_choice
-    then_i_am_redirected_to_application_choices
-
-    when_i_click('Change your sharing and location settings')
-    and_i_click_the_relevant_change_link
-    then_i_see_my_location_preferences_page_including_the_dynamic_location
-
-    when_i_click_on_the_dynamic_location_change_link
-    and_i_change_the_distance
-    and_i_click('Update location')
-    then_i_see_my_location_preferences_page
-    and_the_distance_is_updated
+    when_i_update_the_radius_only
+    then_it_saves_successfully
   end
 
   scenario 'Candidate opts out of find a candidate' do
@@ -171,6 +147,25 @@ RSpec.describe 'Candidate adds preferences' do
     )
   end
 
+  def given_i_am_a_candidate_who_has_opted_in_with_a_dynamic_location
+    given_i_am_signed_in
+    given_courses_exist
+    and_feature_flag_is_enabled
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_opt_in_page
+
+    when_i_opt_in_to_find_a_candidate
+    and_i_click('Continue')
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_check_dynamic_locations
+    and_i_click('Continue')
+    and_i_click('Submit preferences')
+    then_i_am_redirected_to_application_choices_with_success_message
+  end
+
   def and_i_opt_in_to_find_a_candidate
     choose 'Yes'
   end
@@ -184,6 +179,12 @@ RSpec.describe 'Candidate adds preferences' do
     click_link_or_button(button)
   end
   alias_method :and_i_click, :when_i_click
+
+  def and_i_navigate_to_update_my_preferences
+    when_i_click('Change your sharing and location settings')
+    and_i_click_the_relevant_change_link
+    then_i_see_my_location_preferences_page_including_the_dynamic_location
+  end
 
   def then_i_am_redirected_to_location_preferences(location_preferences)
     expect(page).to have_content('Location preferences')
@@ -338,14 +339,20 @@ RSpec.describe 'Candidate adds preferences' do
     all('a', text: 'Change').last.click
   end
 
-  def and_i_complete_the_flow_for_adding_a_choice
+  def and_i_have_a_location_preference_with_invalid_site_data_from_a_dynamic_location
+    when_i_click('Add application')
+    and_i_complete_the_flow_for_adding_a_choice_with_invalid_coordinates
+    then_i_am_redirected_to_application_choices
+  end
+
+  def and_i_complete_the_flow_for_adding_a_choice_with_invalid_coordinates
     choose 'Yes, I know where I want to apply'
     click_link_or_button('Continue')
 
     select 'Gorse SCITT (1N1)'
     click_link_or_button('Continue')
 
-    choose 'Mathematics (SEND) (C998)'
+    choose 'Mathematics (SEND) (C998)' # site purposely uses invalid coordinates
     click_link_or_button('Continue')
 
     click_link_or_button('Review application')
@@ -353,14 +360,25 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def and_i_click_the_relevant_change_link
-    all(:link, 'Change')[1].click
+    click_link('Change Change your preferred locations')
   end
 
   def when_i_click_on_the_dynamic_location_change_link
-    all(:link, 'Change')[2].click
+    click_link('Change Y6W 7XN')
+  end
+
+  def when_i_update_the_radius_only
+    when_i_click_on_the_dynamic_location_change_link
+    and_i_change_the_distance
+    and_i_click('Update location')
+    then_i_see_my_location_preferences_page
   end
 
   def and_i_change_the_distance
-    fill_in 'candidate-interface-location-preferences-form-within-field', with: '40'
+    fill_in 'Within', with: '40.0'
+  end
+
+  def then_it_saves_successfully
+    and_the_distance_is_updated
   end
 end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -96,6 +96,35 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_application_choices_with_success_message
   end
 
+  scenario 'Candidate edits a dynamic location' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+    # and_courses_exist
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_opt_in_page
+    when_i_click('Continue')
+    then_i_get_an_error('Select whether to make your application details visible to other training providers')
+
+    and_i_opt_in_to_find_a_candidate
+    when_i_click('Continue')
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_remove_all_locations
+    then_i_am_redirected_to_location_preferences_without_locations
+
+    when_i_check_dynamic_locations
+    when_i_click('Continue')
+    then_i_am_redirected_to_review_page_without_locations
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_application_choices_with_success_message
+
+    when_i_click('Add application')
+    # then_i_see_complete_flow_for_adding_a_choice
+  end
+
   scenario 'Candidate opts out of find a candidate' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
@@ -276,5 +305,20 @@ RSpec.describe 'Candidate adds preferences' do
 
   def when_i_click_change_on_the_last_location
     all('a', text: 'Change').last.click
+  end
+
+  def then_i_see_complete_flow_for_adding_a_choice
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button('Continue')
+    save_and_open_page
+
+    select 'Keele and North Staffordshire Teacher Education (24J)'
+    click_link_or_button('Continue')
+
+    choose 'Mathematics (QU1S)'
+    click_link_or_button('Continue')
+
+    click_link_or_button('Review application')
+    click_link_or_button('Confirm and submit application')
   end
 end


### PR DESCRIPTION
## Context

In some instances, users could not alter the radius distance on auto-created location preferences. This is caused by invalid postcodes synced from the Publish service having received geocode coordinates for locations outside of the UK. 

To resolve the issue within the scope of this bug, we have added a condition so that only new locations added by a user during an edit are geocoded. If the user simply wants to change the radius on an existing preference, we won't attempt to re-find the coordinates for that location.

This serves two purposes:
- Reducing API calls to Geocoder for all radius edits; 
- Reducing the error messages caused by the faulty coordinates until they can be corrected.

## Changes proposed in this pull request

- Add a condition so that geocode is only invoked if the `name` param does **not** match the existing `location_preference.name`.
- Add a test for editing the radius on dynamically created location preferences with invalid site data.

## Guidance to review

- Access the branch and generate some dynamic location preferences. Keele currently has coordinates outside of the UK. 
- After dynamically locating it as a location preference, attempt to change the radius.
- Verify that it can be successfully saved without error.
- Now return to the edit page and attempt to edit the location itself to another invalid value.
- Test that the error message does appear.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
