### PR TITLE
Show deadline banners at 20 days, not 15

### DIFF
--- a/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.rb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
           application_choice.unsubmitted? &&
           application_form.right_to_work_or_study == 'no' &&
           course.visa_sponsorship_application_deadline_at.present? &&
-          course.visa_sponsorship_application_deadline_at.between?(Time.zone.now, 15.days.from_now)
+          course.visa_sponsorship_application_deadline_at.between?(Time.zone.now, 20.days.from_now)
       end
 
       def count_down

--- a/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.rb
+++ b/app/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
                        .application_choices
                        .unsubmitted
                        .joins(:course)
-                       .where('courses.visa_sponsorship_application_deadline_at' => Time.zone.now..15.days.from_now)
+                       .where('courses.visa_sponsorship_application_deadline_at' => Time.zone.now..20.days.from_now)
                        .order('courses.visa_sponsorship_application_deadline_at')
       end
     end

--- a/spec/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_spec.rb
+++ b/spec/components/candidate_interface/sponsorship_application_deadlines/application_choice_banner_component_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::ApplicationC
       end
     end
 
-    context 'deadline 14 days from now' do
-      let(:visa_sponsorship_application_deadline_at) { 14.days.from_now + 2.hours }
+    context 'deadline 19 days from now' do
+      let(:visa_sponsorship_application_deadline_at) { 19.days.from_now + 2.hours }
 
-      it 'renders text for 14 days from now' do
+      it 'renders text for 19 days from now' do
         application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
         rendered = render_inline(described_class.new(application_choice:))
 
-        expect(rendered).to have_text('Submit this application soon. The deadline for applications that need visa sponsorship is in 14 days')
+        expect(rendered).to have_text('Submit this application soon. The deadline for applications that need visa sponsorship is in 19 days')
       end
     end
 
-    context 'deadline 15 days from now' do
+    context 'deadline 20 days from now' do
       let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
-      let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 15.days.from_now + 1.second)) }
+      let(:course_option) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 20.days.from_now + 1.second)) }
 
       it 'does not render component' do
         application_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)

--- a/spec/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_spec.rb
+++ b/spec/components/candidate_interface/sponsorship_application_deadlines/applications_dashboard_banner_component_spec.rb
@@ -39,20 +39,20 @@ RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::Applications
       end
     end
 
-    context 'when the deadline is between 2-14 days away' do
-      let(:visa_sponsorship_application_deadline_at) { 14.days.from_now + 2.hours }
+    context 'when the deadline is between 2-19 days away' do
+      let(:visa_sponsorship_application_deadline_at) { 19.days.from_now + 2.hours }
 
       it 'renders the text for one day' do
         rendered = render_inline(described_class.new(application_form:))
 
         expect(rendered).to have_text("Submit your application for #{course_option.course.name_and_code} at #{course_option.course.provider.name} soon")
-        expect(rendered).to have_text('The deadline for applications that need visa sponsorship is in 14 days')
+        expect(rendered).to have_text('The deadline for applications that need visa sponsorship is in 19 days')
         expect(rendered).to have_no_text(course_option_without_deadline.course.name_and_code)
       end
     end
 
-    context 'when the deadline is more than 14 days away' do
-      let(:visa_sponsorship_application_deadline_at) { 15.days.from_now + 2.hours }
+    context 'when the deadline is more than 20 days away' do
+      let(:visa_sponsorship_application_deadline_at) { 20.days.from_now + 2.hours }
 
       it 'does not render the component' do
         rendered = render_inline(described_class.new(application_form:))
@@ -75,14 +75,14 @@ RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::Applications
   context 'with multiple relevant applications' do
     let(:application_form) { create(:application_form, right_to_work_or_study: 'no') }
 
-    context 'with deadlines of today, 1 day from now, and between 2-14 days' do
+    context 'with deadlines of today, 1 day from now, and between 2-19 days' do
       let(:today) { 3.hours.from_now }
       let(:course_option_with_today) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: today)) }
-      let(:course_option_with_14_days_from_now) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 14.days.from_now + 2.hours)) }
+      let(:course_option_with_19_days_from_now) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 19.days.from_now + 2.hours)) }
       let(:course_option_with_one_day_from_now) { create(:course_option, course: create(:course, visa_sponsorship_application_deadline_at: 1.day.from_now + 2.hours)) }
 
       before do
-        [course_option_with_today, course_option_with_14_days_from_now, course_option_with_one_day_from_now].each do |course_option|
+        [course_option_with_today, course_option_with_19_days_from_now, course_option_with_one_day_from_now].each do |course_option|
           create(:application_choice, :unsubmitted, course_option:, application_form:)
         end
       end
@@ -98,7 +98,7 @@ RSpec.describe CandidateInterface::SponsorshipApplicationDeadlines::Applications
           "#{course_option_with_one_day_from_now.course.name_and_code} at #{course_option_with_one_day_from_now.course.provider.name} - deadline in 1 day",
         )
         expect(rendered).to have_text(
-          "#{course_option_with_14_days_from_now.course.name_and_code} at #{course_option_with_14_days_from_now.course.provider.name} - deadline in 14 day",
+          "#{course_option_with_19_days_from_now.course.name_and_code} at #{course_option_with_19_days_from_now.course.provider.name} - deadline in 19 day",
         )
       end
     end


### PR DESCRIPTION
## Context

There was a conflict between the design history and the requirements in the trello cards, so we were showing the banners starting at 15 instead of 20 days before the deadline. 

## Changes proposed in this pull request

Just changes the days we show the two banners from 15 to 20 days. 

## Guidance to review

NA


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
