### PR TITLE
Level 3 headings used for each submitted Application

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.html.erb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.html.erb
@@ -1,5 +1,5 @@
 <% application_choices.each_with_index do |choice, index| %>
-  <%= govuk_summary_card(title: t('.subtitle', counter: index + 1)) do |card| %>
+  <%= govuk_summary_card(title: t('.subtitle', counter: index + 1), heading_level: 3) do |card| %>
     <% card.with_summary_list(
          actions: false,
          rows: application_choice_rows(choice),

--- a/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
@@ -31,4 +31,16 @@ RSpec.describe ProviderInterface::FindCandidates::ApplicationChoicesComponent, t
       expect(second_card).to have_content first_submission_date.to_fs(:govuk_date)
     end
   end
+
+  describe 'heading structures' do
+    it 'uses H3 tags for each Application heading' do
+      create(:application_choice, sent_to_provider_at: 1.day.ago, application_form:)
+      create(:application_choice, sent_to_provider_at: 1.day.ago, application_form:)
+
+      rendered = render_inline(described_class.new(application_form:))
+
+      expect(rendered).to have_css('h3', text: 'Application 1')
+      expect(rendered).to have_css('h3', text: 'Application 2')
+    end
+  end
 end

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Providers views candidate pool list' do
+RSpec.describe 'Providers views candidate pool details' do
   include CourseOptionHelpers
   include DfESignInHelpers
 


### PR DESCRIPTION
## Context

The heading hierarchy of this page was incorrect as the "Applications submitted" title is an <h2> and then each application had <h2> titles. 

## Changes proposed in this pull request

- Changes from `<h2>` to `<h3>` heading for each submitted application

## Guidance to review

No visual change

![image](https://github.com/user-attachments/assets/7252cd8f-1157-4f20-a307-21835ff08fc7)
![Screenshot 2025-05-12 at 15 41 55](https://github.com/user-attachments/assets/e6858764-4eb2-44a0-b7cd-4d1a2faf50ad)