### PR TITLE
[910] Restrict the ability to send invites to only users who have the permission to make decisions

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     class CandidatesController < ProviderInterfaceController
       include Pagy::Backend
       before_action :redirect_to_applications_unless_provider_opted_in
+      before_action :set_policy
 
       def index
         @filter = ProviderInterface::CandidatePoolFilter.new(
@@ -28,6 +29,10 @@ module ProviderInterface
       end
 
     private
+
+      def set_policy
+        @policy = ProviderInterface::Policies::CandidatePoolInvitesPolicy.new(current_provider_user)
+      end
 
       def redirect_to_applications_unless_provider_opted_in
         invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)

--- a/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
@@ -1,32 +1,42 @@
 module ProviderInterface
   module CandidatePool
     class PublishInvitesController < ProviderInterfaceController
+      before_action :set_policy
       before_action :set_candidate
 
       def create
-        @pool_invite = PoolInviteForm.build_from_invite(
-          invite:,
-          current_provider_user:,
-        )
+        if @policy.can_invite_candidates?
 
-        if @pool_invite.valid?
-          invite.published!
-
-          flash[:success] = t(
-            '.success',
-            candidate: invite.candidate.redacted_full_name_current_cycle,
-            candidate_id: invite.candidate_id,
-            course: invite.course.name_code_and_course_provider,
+          @pool_invite = PoolInviteForm.build_from_invite(
+            invite:,
+            current_provider_user:,
           )
-          redirect_to provider_interface_candidate_pool_root_path
 
-          CandidateMailer.course_invite(invite).deliver_later
+          if @pool_invite.valid?
+            invite.published!
+
+            flash[:success] = t(
+              '.success',
+              candidate: invite.candidate.redacted_full_name_current_cycle,
+              candidate_id: invite.candidate_id,
+              course: invite.course.name_code_and_course_provider,
+            )
+            redirect_to provider_interface_candidate_pool_root_path
+
+            CandidateMailer.course_invite(invite).deliver_later
+          else
+            render '/provider_interface/candidate_pool/draft_invites/edit'
+          end
         else
-          render '/provider_interface/candidate_pool/draft_invites/edit'
+          redirect_to provider_interface_candidate_pool_candidates_path
         end
       end
 
     private
+
+      def set_policy
+        @policy = ProviderInterface::Policies::CandidatePoolInvitesPolicy.new(current_provider_user)
+      end
 
       def set_candidate
         @candidate ||= Pool::Candidates.application_forms_for_provider(

--- a/app/forms/provider_interface/pool_invite_form.rb
+++ b/app/forms/provider_interface/pool_invite_form.rb
@@ -52,11 +52,7 @@ module ProviderInterface
     end
 
     def providers
-      @providers ||= Provider.joins(:provider_permissions)
-                             .where(
-                               'provider_permissions.provider_user_id': current_provider_user.id,
-                               'provider_permissions.make_decisions': true,
-                             )
+      @providers ||= current_provider_user.providers_where_user_can_make_decisions
     end
 
     def course

--- a/app/forms/provider_interface/pool_invite_form.rb
+++ b/app/forms/provider_interface/pool_invite_form.rb
@@ -30,10 +30,12 @@ module ProviderInterface
       if id.present?
         invite = Pool::Invite.find_by(
           id:,
-          provider_id: providers.pluck(:id),
+          # It is possible that the permissions have changed, so we need to look at all the connected providers,
+          # not just the ones for which the user has permission to update
+          provider_id: current_provider_user.providers.pluck(:id),
         )
 
-        invite.update!(course_id:)
+        invite.update!(course:, provider: course.provider)
         invite
       else
         Pool::Invite.create!(

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -64,4 +64,13 @@ class ProviderUser < ApplicationRecord
   def can_manage_organisations?
     provider_permissions.exists?(manage_organisations: true)
   end
+
+  def providers_where_user_can_make_decisions
+    Provider
+      .joins(:provider_permissions)
+      .where(
+        'provider_permissions.provider_user_id': id,
+        'provider_permissions.make_decisions': true,
+      )
+  end
 end

--- a/app/services/provider_interface/policies/candidate_pool_invites_policy.rb
+++ b/app/services/provider_interface/policies/candidate_pool_invites_policy.rb
@@ -18,9 +18,7 @@ module ProviderInterface
     private
 
       def decision_making_providers
-        @decision_making_providers ||= Provider.joins(:provider_permissions)
-                                                .where('provider_permissions.provider_user_id': provider_user.id,
-                                                       'provider_permissions.make_decisions': true)
+        @decision_making_providers ||= provider_user.providers_where_user_can_make_decisions
       end
     end
   end

--- a/app/services/provider_interface/policies/candidate_pool_invites_policy.rb
+++ b/app/services/provider_interface/policies/candidate_pool_invites_policy.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  module Policies
+    class CandidatePoolInvitesPolicy
+      attr_reader :provider_user
+      def initialize(provider_user)
+        @provider_user = provider_user
+      end
+
+      def can_invite_candidates?
+        decision_making_providers.any?
+      end
+
+      def can_edit_invite?(invite)
+        invite.provider_id.in?(decision_making_providers.pluck(:id))
+      end
+      alias can_view_invite? can_edit_invite?
+
+    private
+
+      def decision_making_providers
+        @decision_making_providers ||= Provider.joins(:provider_permissions)
+                                                .where('provider_permissions.provider_user_id': provider_user.id,
+                                                       'provider_permissions.make_decisions': true)
+      end
+    end
+  end
+end

--- a/app/views/content/organisation_permissions.md
+++ b/app/views/content/organisation_permissions.md
@@ -12,7 +12,7 @@ These user permissions are not affected by organisation permissions.
 
 Users can be given permission to:
 
-- make offers and reject applications
+- send offers, invitations and rejections
 - view criminal record and professional misconduct information
 - view sex, disability and ethnicity information
 
@@ -20,8 +20,8 @@ These user permissions are affected by organisation permissions for courses run 
 
 For example, a user will only be able to make an offer if both:
 
-- the user has the user permission to make offers and reject applications
-- the user’s organisation has the organisation permission to make offers and reject applications for courses it runs with its partner organisation
+- the user has the user permission to send offers, invitations and rejections
+- the user’s organisation has the organisation permission to send offers, invitations and rejections for courses it runs with its partner organisation
 
 There are no organisation permissions for courses run without partner organisations. Users only need to have the appropriate user permissions.
 

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -7,7 +7,13 @@
 
     <span class="govuk-caption-xl"><%= t('.candidate_number', candidate_id: @candidate.id) %></span>
     <h1 class="govuk-heading-xl"><%= @application_form.redacted_full_name %></h1>
-    <%= govuk_button_to t('.invite'), new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate), method: :get %>
+    <% if @policy.can_invite_candidates? %>
+      <%= govuk_button_to(
+            t('.invite'),
+            new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate),
+            method: :get,
+          ) %>
+    <% end %>
 
     <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>
 

--- a/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
@@ -1,4 +1,7 @@
-<% content_for :browser_title, t('.title', candidate_name: @candidate.redacted_full_name_current_cycle) %>
+<% content_for :browser_title, title_with_error_prefix(
+  t('.title', candidate_name: @candidate.redacted_full_name_current_cycle),
+  @pool_invite.errors.any?,
+) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_candidate_pool_candidate_path(@candidate)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
@@ -1,4 +1,7 @@
-<% content_for :browser_title, t('.title', candidate_name: @candidate.redacted_full_name_current_cycle) %>
+<% content_for :browser_title, title_with_error_prefix(
+  t('.title', candidate_name: @candidate.redacted_full_name_current_cycle),
+  @pool_invite.errors.any?,
+) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_candidate_pool_candidate_path(@candidate)) %>
 
 <div class="govuk-grid-row">

--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -3,7 +3,7 @@ en:
     view_applications_explanation: All users can view applications.
     question: Who can %{permission_description}?
     make_decisions:
-      description: Make offers and reject applications
+      description: Send offers, invitations and rejections
     view_safeguarding_information:
       description: View criminal convictions and professional misconduct
     view_diversity_information:

--- a/config/locales/provider_interface/user_permisssions.yml
+++ b/config/locales/provider_interface/user_permisssions.yml
@@ -1,7 +1,7 @@
 en:
   user_permissions:
     make_decisions:
-      description: Make offers and reject applications
+      description: Send offers, invitations and rejections
     view_safeguarding_information:
       description: View criminal convictions and professional misconduct
     view_diversity_information:

--- a/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_form_component_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsFormComponent do
 
   describe 'form group legends' do
     it 'renders the correct legend for make decisions' do
-      expect(render.css('legend')[0].text).to eq('Who can make offers and reject applications?')
+      expect(render.css('legend')[0].text).to eq('Who can send offers, invitations and rejections?')
     end
 
     it 'renders the correct legend for view safeguarding' do

--- a/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_review_card_component_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
     end
 
     it 'renders the names of the providers that have the make_decision permission' do
-      make_decision_row = row_with_key('Make offers and reject applications')
+      make_decision_row = row_with_key('Send offers, invitations and rejections')
       expect(entries_in_row(make_decision_row)).to contain_exactly(training_provider.name, ratifying_provider.name)
     end
 
@@ -125,7 +125,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
 
     context 'when the provider user belongs to the training provider' do
       it 'renders the training provider name first' do
-        make_decision_row = row_with_key('Make offers and reject applications')
+        make_decision_row = row_with_key('Send offers, invitations and rejections')
         expect(entries_in_row(make_decision_row)).to eq([training_provider.name, ratifying_provider.name])
       end
     end
@@ -134,7 +134,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
       let(:provider_user) { build_stubbed(:provider_user, providers: [ratifying_provider]) }
 
       it 'renders the ratifying provider name first' do
-        make_decision_row = row_with_key('Make offers and reject applications')
+        make_decision_row = row_with_key('Send offers, invitations and rejections')
         expect(entries_in_row(make_decision_row)).to eq([ratifying_provider.name, training_provider.name])
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
       let(:provider_user) { build_stubbed(:provider_user, providers: [training_provider, ratifying_provider]) }
 
       it 'renders the training provider name first' do
-        make_decision_row = row_with_key('Make offers and reject applications')
+        make_decision_row = row_with_key('Send offers, invitations and rejections')
         expect(entries_in_row(make_decision_row)).to eq([training_provider.name, ratifying_provider.name])
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsReviewCardComponent do
       let(:provider_relationship_permission) { build_stubbed(:provider_relationship_permissions, :not_set_up_yet) }
 
       it 'displays not set up yet text' do
-        make_decision_row = row_with_key('Make offers and reject applications')
+        make_decision_row = row_with_key('Send offers, invitations and rejections')
         safeguarding_row = row_with_key('View criminal convictions and professional misconduct')
         diversity_row = row_with_key('View sex, disability and ethnicity information')
         expect(entries_in_row(make_decision_row)).to contain_exactly('Neither organisation can do this')

--- a/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
     it 'renders the details component' do
       expect(render.css('details > summary').text.squish).to eq('Check how user permissions are affected by organisation permissions')
       expect(render.css('details h2').map(&:text)).to contain_exactly(
-        'Make offers and reject applications',
+        'Send offers, invitations and rejections',
         'View criminal convictions and professional misconduct',
         'View sex, disability and ethnicity information',
       )

--- a/spec/components/provider_interface/user_card_component_spec.rb
+++ b/spec/components/provider_interface/user_card_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProviderInterface::UserCardComponent do
         'manage users',
         'manage organisation permissions',
         'manage interviews',
-        'make offers and reject applications',
+        'send offers, invitations and rejections',
         'view criminal convictions and professional misconduct',
         'view sex, disability and ethnicity information',
       ])

--- a/spec/components/provider_interface/user_permission_summary_component_spec.rb
+++ b/spec/components/provider_interface/user_permission_summary_component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
       end
 
       it 'displays the correct details for Make decisions' do
-        expect(row_text_selector(:make_decisions, render)).to include('Make offers and reject applications')
+        expect(row_text_selector(:make_decisions, render)).to include('Send offers, invitations and rejections')
         expect(row_text_selector(:make_decisions, render)).to include(y_n(permissions.make_decisions))
       end
 

--- a/spec/components/provider_interface/user_permissions_review_component_spec.rb
+++ b/spec/components/provider_interface/user_permissions_review_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProviderInterface::UserPermissionsReviewComponent do
     end
 
     it 'renders Yes in the row for a permission that is in the array' do
-      make_decisions_row = render.css('.govuk-summary-list__row').find { |row| row.text.include? 'Make offers and reject applications' }
+      make_decisions_row = render.css('.govuk-summary-list__row').find { |row| row.text.include? 'Send offers, invitations and rejections' }
       expect(make_decisions_row.css('.govuk-summary-list__value').text.squish).to eq('Yes')
     end
   end

--- a/spec/forms/provider_interface/pool_invite_form_spec.rb
+++ b/spec/forms/provider_interface/pool_invite_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProviderInterface::PoolInviteForm, type: :model do
     )
   end
 
-  let(:current_provider_user) { create(:provider_user, :with_provider) }
+  let(:current_provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
   let(:provider) { current_provider_user.providers.first }
   let(:candidate) { create(:candidate) }
   let(:course) { create(:course, :open, provider:) }

--- a/spec/mailers/provider_mailer/provider_mailer_organisation_permissions_set_up_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_organisation_permissions_set_up_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderMailer do
       'University of Croydon set up organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon set up organisation permissions for courses you run with them',
-      'make offers' => /Make offers and reject applications:\s+- University of Purley/,
+      'make offers' => /Send offers, invitations and rejections:\s+- University of Purley/,
       'view safeguarding' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
       'view diversity' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
       'link to manage organisation permissions' => '/provider/organisation-settings/organisations/123/organisation-permissions',

--- a/spec/mailers/provider_mailer/provider_mailer_organisation_permissions_updated_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_organisation_permissions_updated_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderMailer do
       'University of Croydon changed organisation permissions - manage teacher training applications',
       'salutation' => 'Dear Johny English',
       'heading' => 'University of Croydon changed organisation permissions for courses you run with them',
-      'make offers' => /Make offers and reject applications:\s+- University of Purley/,
+      'make offers' => /Send offers, invitations and rejections:\s+- University of Purley/,
       'view safeguarding' => /View criminal convictions and professional misconduct:\s+- University of Purley\s+- University of Croydon/,
       'view diversity' => /View sex, disability and ethnicity information:\s+- University of Purley\s+- University of Croydon/,
       'link to manage organisation permissions' => '/provider/organisation-settings/organisations/123/organisation-permissions',

--- a/spec/mailers/provider_mailer/provider_mailer_permissions_granted_by_support_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_permissions_granted_by_support_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProviderMailer do
       'You have been added to Hogwarts University - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
       'heading' => 'You have been added to Hogwarts University. You can now manage their teacher training applications.',
-      'make decisions' => 'make offers and reject application',
+      'make decisions' => 'send offers, invitations and rejections',
       'view diversity' => 'view sex, disability and ethnicity information',
       'dsi info' => 'If you do not have a DfE Sign-in account, you should have received an email with instructions from dfe.signin@education.gov.uk.',
       'footer' => 'Get help, report a problem or give feedback',

--- a/spec/mailers/provider_mailer/provider_mailer_permissions_granted_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_permissions_granted_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProviderMailer do
       'Jane Doe added you to Hogwarts University - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
       'heading' => 'Jane Doe added you to Hogwarts University. You can now manage their applications.',
-      'make decisions' => 'make offers and reject application',
+      'make decisions' => 'send offers, invitations and rejections',
       'view safeguarding' => 'view criminal convictions and professional misconduct',
       'view diversity' => 'view sex, disability and ethnicity information',
       'dsi info' => 'If you do not have a DfE Sign-in account, you should have received an email with instructions from dfe.signin@education.gov.uk.',

--- a/spec/mailers/provider_mailer/provider_mailer_permissions_updated_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_permissions_updated_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ProviderMailer do
         'Your permissions have been updated for Hogwarts University - manage teacher training applications',
         'salutation' => 'Dear Princess Fiona',
         'heading' => 'Your permissions have been updated for Hogwarts University.',
-        'make decisions' => 'make offers and reject application',
+        'make decisions' => 'send offers, invitations and rejections',
         'view safeguarding' => 'view criminal convictions and professional misconduct',
         'link to applications' => 'http://localhost:3000/provider/applications',
         'footer' => 'Get help, report a problem or give feedback',

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -166,4 +166,17 @@ RSpec.describe ProviderUser do
       expect(loaded_user.impersonator).to eq(support_user)
     end
   end
+
+  describe '#provieders_where_user_can_make_descisions' do
+    it 'only returns providers for where a user has permission to make decisions' do
+      provider_user = create(:provider_user)
+      provider_without_permissions = create(:provider)
+      provider_with_permissions = create(:provider)
+      create(:provider_permissions, provider_user:, provider: provider_without_permissions, make_decisions: false)
+      create(:provider_permissions, provider_user:, provider: provider_with_permissions, make_decisions: true)
+
+      result = provider_user.providers_where_user_can_make_decisions
+      expect(result).to contain_exactly(provider_with_permissions)
+    end
+  end
 end

--- a/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
+++ b/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'ProviderInterface::CandidatePool::PublishInvitesController' do
   describe 'POST /provider/find-candidates/:candidate_id/invite/:draft_invite_id/review' do
-    let!(:provider_user) { create(:provider_user, :with_provider, dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+    let!(:provider_user) { create(:provider_user, :with_provider, :with_make_decisions, dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
     let(:provider) { provider_user.providers.first }
 
     before do

--- a/spec/services/provider_interface/policies/candidate_pool_invites_policy_spec.rb
+++ b/spec/services/provider_interface/policies/candidate_pool_invites_policy_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::Policies::CandidatePoolInvitesPolicy do
+  let(:providers) { create_list(:provider, 3) }
+  let(:provider_user) { create(:provider_user, providers:) }
+
+  describe '#can_invite_candidates?' do
+    context 'when make_decision is set to true for some providers' do
+      it 'returns true' do
+        provider_user.provider_permissions.first.update(make_decisions: true)
+
+        expect(described_class.new(provider_user).can_invite_candidates?).to be true
+      end
+    end
+
+    context 'when user has multiple providers, none with make_decision set to true' do
+      it 'returns false' do
+        provider_user.provider_permissions.update_all(make_decisions: false)
+
+        expect(described_class.new(provider_user).can_invite_candidates?).to be false
+      end
+    end
+
+    context 'when user has multiple providers, all with make_decision set to true' do
+      it 'returns true' do
+        provider_user.provider_permissions.update_all(make_decisions: true)
+
+        expect(described_class.new(provider_user).can_invite_candidates?).to be true
+      end
+    end
+  end
+
+  describe '#can_edit_invite?' do
+    let(:course) { create(:course, :open, provider: providers.first) }
+    let(:invite) { create(:pool_invite, course:, invited_by: provider_user, provider: course.provider) }
+
+    context 'invite is for a provider the user has permissions to make decisions for' do
+      it 'returns true' do
+        provider_user.provider_permissions.where(provider: course.provider).first.update(make_decisions: true)
+
+        expect(described_class.new(provider_user).can_edit_invite?(invite)).to be true
+      end
+    end
+
+    context 'invite is for a provider the user does NOT have permission to make decisions for' do
+      it 'returns false' do
+        provider_user.provider_permissions.where(provider: course.provider).first.update(make_decisions: false)
+
+        expect(described_class.new(provider_user).can_edit_invite?(invite)).to be false
+      end
+    end
+  end
+end

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -19,6 +19,7 @@ module DfESignInHelpers
   end
 
   alias and_i_sign_in_to_the_provider_interface provider_signs_in_using_dfe_sign_in
+  alias when_i_sign_in_to_the_provider_interface provider_signs_in_using_dfe_sign_in
 
   def support_user_signs_in_using_dfe_sign_in
     visit support_interface_sign_in_path

--- a/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe 'Providers cannot send invites to candidates' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  before do
+    given_i_am_a_provider_user_with_dfe_sign_in_with_many_providers
+    and_those_providers_have_courses_for_the_pool
+    and_there_are_candidates_for_candidate_pool
+  end
+
+  scenario 'User cannot make decisions views the find candidates page' do
+    given_provider_user_cannot_make_decisions_for_any_of_their_courses
+    when_i_sign_in_to_the_provider_interface
+    and_i_navigate_to_a_candidate
+    then_i_do_not_see_the_invite_button
+
+    when_i_visit_the_invite_page_directly
+    then_i_am_redirected_to_the_find_candidate_page
+  end
+
+  scenario 'User can make decisions for one of its providers' do
+    given_provider_user_can_make_decisions_for_just_one_of_its_providers
+    when_i_sign_in_to_the_provider_interface
+    and_i_navigate_to_a_candidate
+    and_i_click_the_invite_button
+    then_i_only_see_courses_that_i_have_permission_to_make_decisions_form
+  end
+
+  scenario 'User cannot edit an invite unless they can make decisions' do
+    given_provider_user_can_make_decisions_for_just_one_of_its_providers
+    and_an_invite_exists_for_the_other_provider
+    when_i_sign_in_to_the_provider_interface
+    and_i_directly_visit_the_edit_page
+    then_i_am_redirected_to_the_find_candidate_page
+  end
+
+private
+
+  def given_i_am_a_provider_user_with_dfe_sign_in_with_many_providers
+    @provider_user = provider_user_exists_in_apply_database
+    user_exists_in_dfe_sign_in(
+      email_address: @provider_user.email_address,
+      dfe_sign_in_uid: @provider_user.dfe_sign_in_uid,
+    )
+  end
+
+  def and_those_providers_have_courses_for_the_pool
+    @provider_user.providers.each do |provider|
+      create_list(:course, 3, :open, provider:)
+      create(:candidate_pool_provider_opt_in, provider:)
+    end
+  end
+
+  def and_there_are_candidates_for_candidate_pool
+    @candidate = create(:candidate)
+    create(:candidate_preference, candidate: @candidate)
+    rejected_candidate_form = create(
+      :application_form,
+      :completed,
+      first_name: 'Candidate',
+      last_name: 'Candidate',
+      candidate: @candidate,
+      submitted_at: 1.day.ago,
+    )
+    create(:application_choice, :rejected, application_form: rejected_candidate_form)
+  end
+
+  def given_provider_user_cannot_make_decisions_for_any_of_their_courses
+    @provider_user.provider_permissions.update_all(make_decisions: false)
+  end
+
+  def given_provider_user_can_make_decisions_for_just_one_of_its_providers
+    @provider_user.provider_permissions.update_all(make_decisions: false)
+    @can_make_decisions_provider = @provider_user.providers.first
+    @cannot_make_decisions_provider = @provider_user.providers.second
+
+    @provider_user.provider_permissions.where(provider: @can_make_decisions_provider).update(make_decisions: true)
+    @provider_user.provider_permissions.where(provider: @cannot_make_decisions_provider).update(make_decisions: false)
+  end
+
+  def and_an_invite_exists_for_the_other_provider
+    @invite = create(
+      :pool_invite,
+      provider: @cannot_make_decisions_provider,
+      course: @cannot_make_decisions_provider.courses.first,
+    )
+  end
+
+  def and_i_directly_visit_the_edit_page
+    visit provider_interface_candidate_pool_candidate_draft_invite_path(candidate_id: @candidate.id, id: @invite.id)
+  end
+
+  def and_i_navigate_to_a_candidate
+    click_on 'Find candidates'
+    click_on @candidate.redacted_full_name_current_cycle
+  end
+
+  def and_i_click_the_invite_button
+    click_on 'Invite to apply'
+  end
+
+  def then_i_only_see_courses_that_i_have_permission_to_make_decisions_form
+    @can_make_decisions_provider.courses.open.each do |course|
+      expect(page).to have_content(course.name_code_and_course_provider)
+    end
+
+    @cannot_make_decisions_provider.courses.open.each do |course|
+      expect(page).to have_no_content(course.name_code_and_course_provider)
+    end
+  end
+
+  def then_i_do_not_see_the_invite_button
+    expect(page).to have_content "Candidate #{@candidate.id}"
+    expect(page).to have_no_content 'Invite to apply'
+  end
+
+  def when_i_visit_the_invite_page_directly
+    visit new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate)
+  end
+
+  def then_i_am_redirected_to_the_find_candidate_page
+    expect(page).to have_content 'Candidates can choose to share their application details.'
+    expect(page).to have_no_content 'Select a course to invite C***** C***** to apply to'
+  end
+end

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -94,7 +94,8 @@ RSpec.describe 'Providers invites candidates' do
   end
 
   def and_provider_user_exists
-    provider_user_exists_in_apply_database(provider_code: current_provider.code)
+    provider_user = provider_user_exists_in_apply_database(provider_code: current_provider.code)
+    provider_user.provider_permissions.update_all(make_decisions: true)
   end
 
   def and_provider_has_courses(courses_number)

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -170,6 +170,8 @@ RSpec.describe 'Providers invites candidates' do
 
   def then_i_get_an_error(message)
     expect(page).to have_content(message)
+    expect(page).to have_content('There is a problem')
+    expect(page.title).to include('Error:')
   end
 
   def when_i_select_a_course_from_dropdown(course)

--- a/spec/system/provider_interface/edit_user_permissions_spec.rb
+++ b/spec/system/provider_interface/edit_user_permissions_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'User permissions' do
     expect(page).to have_field('Manage users', checked: true)
     expect(page).to have_field('Manage organisation permissions', checked: false)
     expect(page).to have_field('Manage interviews', checked: false)
-    expect(page).to have_field('Make offers and reject applications', checked: true)
+    expect(page).to have_field('Send offers, invitations and rejections', checked: true)
     expect(page).to have_field('View criminal convictions and professional misconduct', checked: true)
     expect(page).to have_field('View sex, disability and ethnicity information', checked: false)
   end
@@ -92,7 +92,7 @@ RSpec.describe 'User permissions' do
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews Yes')
-    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Send offers, invitations and rejections Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
   end
@@ -115,7 +115,7 @@ RSpec.describe 'User permissions' do
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
-    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Send offers, invitations and rejections Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information Yes')
   end

--- a/spec/system/provider_interface/invite_user_spec.rb
+++ b/spec/system/provider_interface/invite_user_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Provider user invitation' do
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users Yes')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
-    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Send offers, invitations and rejections No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information Yes')
   end

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Provider edits organisation permissions' do
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions
-    expect(page).to have_content("Make offers and reject applications #{@ratifying_provider.name} #{@training_provider.name}")
+    expect(page).to have_content("Send offers, invitations and rejections #{@ratifying_provider.name} #{@training_provider.name}")
   end
 
   def and_my_organisation_is_able_to_make_decisions

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Setting up organisation permissions' do
   end
 
   def then_i_see_the_error_message
-    expect(page).to have_content('Select who can make offers and reject applications')
+    expect(page).to have_content('Select who can send offers, invitations and rejections')
   end
 
   def when_i_complete_the_permissions_details

--- a/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_views_their_own_user_permissions_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'User permissions page' do
       expect(element_text(selector: '.govuk-summary-list__key', index: 0)).to eq('Manage users')
       expect(element_text(selector: '.govuk-summary-list__key', index: 1)).to eq('Manage organisation permissions')
       expect(element_text(selector: '.govuk-summary-list__key', index: 2)).to eq('Manage interviews')
-      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Make offers and reject applications')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Send offers, invitations and rejections')
       expect(element_text(selector: '.govuk-summary-list__key', index: 4)).to eq('View criminal convictions and professional misconduct')
       expect(element_text(selector: '.govuk-summary-list__key', index: 5)).to eq('View sex, disability and ethnicity information')
     end
@@ -57,7 +57,7 @@ RSpec.describe 'User permissions page' do
       expect(element_text(selector: '.govuk-summary-list__key', index: 0)).to eq('Manage users')
       expect(element_text(selector: '.govuk-summary-list__key', index: 1)).to eq('Manage organisation permissions')
       expect(element_text(selector: '.govuk-summary-list__key', index: 2)).to eq('Manage interviews')
-      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Make offers and reject applications')
+      expect(element_text(selector: '.govuk-summary-list__key', index: 3)).to eq('Send offers, invitations and rejections')
       expect(element_text(selector: '.govuk-summary-list__key', index: 4)).to eq('View criminal convictions and professional misconduct')
       expect(element_text(selector: '.govuk-summary-list__key', index: 5)).to eq('View sex, disability and ethnicity information')
     end

--- a/spec/system/provider_interface/view_organisation_users_spec.rb
+++ b/spec/system/provider_interface/view_organisation_users_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Organisation users' do
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
-    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Send offers, invitations and rejections No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
     expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
   end

--- a/spec/system/support_interface/managing_provider_permissions_spec.rb
+++ b/spec/system/support_interface/managing_provider_permissions_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Managing provider-provider permissions via support' do
   end
 
   def then_i_see_an_error
-    expect(page).to have_content 'Select who can make offers and reject applications'
+    expect(page).to have_content 'Select who can send offers, invitations and rejections'
   end
 
   def when_i_set_valid_relationships


### PR DESCRIPTION
## Context

Provider users should only be able to send invitation if they already have permission to 'make decisions'

## Changes proposed in this pull request

- Only show the invite button if the user is able to make decisions for at least one of the providers
- Include only those courses for which the user can make decisions in the invite list
- Redirect to the find a candidate page if the user does not have permission to make decisions
- Extra bonus: added the error prefix to the page titles. 

https://github.com/user-attachments/assets/61d54b5a-63f1-4556-b2ab-e63a0ff7debf


## Guidance to review

change permissions on a user and see how it effects their ability to invite candidates


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
