### PR TITLE
FAC fix multiple subject to a course spacing

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.rb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.rb
@@ -28,7 +28,7 @@ private
   def course_subject(choice)
     {
       key: { text: t('.subject') },
-      value: { text: choice.course.subjects.pluck(:name).join(',') },
+      value: { text: choice.course.subjects.pluck(:name).join(', ') },
     }
   end
 

--- a/app/components/provider_interface/find_candidates/application_choices_component.rb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.rb
@@ -28,7 +28,7 @@ private
   def course_subject(choice)
     {
       key: { text: t('.subject') },
-      value: { text: choice.course.subjects.pluck(:name).join(', ') },
+      value: { text: choice.course.subjects.pluck(:name).to_sentence },
     }
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def then_i_am_redirected_to_view_that_candidate
-    save_and_open_page
     expect(page).to have_current_path(provider_interface_candidate_pool_candidate_path(@rejected_candidate), ignore_query: true)
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -39,7 +39,12 @@ RSpec.describe 'Providers views candidate pool list' do
       candidate: @rejected_candidate,
       submitted_at: 1.day.ago,
     )
-    create(:application_choice, :rejected, application_form: @rejected_candidate_form)
+    subjects = create_list(:subject, 2)
+    course = create(:course)
+    course.subjects << subjects
+    course_option = create(:course_option, course: course)
+
+    create(:application_choice, :rejected, application_form: @rejected_candidate_form, course_option: course_option)
 
     declined_candidate = create(:candidate)
     create(:candidate_preference, candidate: declined_candidate)
@@ -78,6 +83,7 @@ RSpec.describe 'Providers views candidate pool list' do
   end
 
   def then_i_am_redirected_to_view_that_candidate
+    save_and_open_page
     expect(page).to have_current_path(provider_interface_candidate_pool_candidate_path(@rejected_candidate), ignore_query: true)
   end
 


### PR DESCRIPTION
## Context

FAC - Previously when a provider viewed a candidate summary, there was no space between subjects if there were multiple subjects related to a course.

## Changes proposed in this pull request

- Add a space to the `.join(, )`.

## Guidance to review

Before:

![image](https://github.com/user-attachments/assets/71975149-97dd-493c-ac0e-e4e0b1d1b5a9)

After:

<img width="640" alt="Screenshot 2025-05-13 at 10 59 26" src="https://github.com/user-attachments/assets/93ccb2b2-bd40-4336-9228-54ae8896b147" />

- Log in as a provider and view a candidate with a `course_choice` whose `course` has multiple subjects.

Alternatively: 

- Use `save_and_open_page` in the spec to review the display of a candidate with a list of subjects associated with their `course`/`choice_choice`.

```ruby
  def then_i_am_redirected_to_view_that_candidate
    save_and_open_page
    expect(page).to have_current_path(provider_interface_candidate_pool_candidate_path(@rejected_candidate), ignore_query: true)
  end
```

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
