### PR TITLE
Add visually hidden change text to summary table for FAC

### DIFF
--- a/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
@@ -12,7 +12,11 @@
           <%= @candidate.redacted_full_name_current_cycle %>
           <p class="govuk-body govuk-hint"><%= t('.candidate_id', candidate_id: @candidate.id) %> </p>
         <% end %>
-        <% row.with_action(text: t('.change'), href: provider_interface_candidate_pool_root_path(@candidate)) %>
+        <% row.with_action(
+             text: t('.change'),
+             href: provider_interface_candidate_pool_root_path(@candidate),
+             visually_hidden_text: t('.visually_hidden_change_candidate'),
+           ) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
@@ -35,6 +39,7 @@
             @candidate,
             @pool_invite.id,
           ),
+          visually_hidden_text: t('.visually_hidden_change_course'),
         ) %>
       <% end %>
     <% end %>

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -46,6 +46,8 @@ en:
           candidate: Candidate
           change: Change
           course: Course
+          visually_hidden_change_candidate: candidate
+          visually_hidden_change_course: course
           send_invitation: Send invitation
           candidate_id: Candidate %{candidate_id}
         edit:

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Providers invites candidates' do
 
     then_i_am_redirected_to_the_review_page(first_course)
 
-    when_i_click_change_course
+    when_i_click('Change course')
     then_i_am_redirected_to_the_edit_page
 
     when_i_select_a_course(last_course)
@@ -144,12 +144,6 @@ RSpec.describe 'Providers invites candidates' do
       ignore_query: true,
     )
     expect(page).to have_content(course.name_code_and_course_provider)
-  end
-
-  def when_i_click_change_course
-    within '.govuk-summary-list__row:nth-of-type(2)' do
-      click_link_or_button 'Change'
-    end
   end
 
   def then_i_am_redirected_to_the_edit_page


### PR DESCRIPTION
## Context

We should have visually hidden text in summary tables to distinguish the change links for screen readers, etc. It also makes testing easier (yay).

## Changes proposed in this pull request

Added visually hidden change links to the summary table for reviewing an invite before sending it.

| Before | After |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/91d29229-e8f2-4afb-8d62-ca91e9f4721f) | ![image](https://github.com/user-attachments/assets/b8226ae3-779b-4b45-9a73-2fe3f52079b1) |


## Guidance to review
Inspect the html on the review page, you should see a visually hidden span with candidate / course respectively.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
