### PR TITLE
Update enic links to open in new tab

### DIFF
--- a/app/views/candidate_interface/degrees/degree/new_enic.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_enic.html.erb
@@ -9,7 +9,13 @@
     <h1 class="govuk-heading-l"><%= t('page_titles.degree_enic') %></h1>
 
     <p class="govuk-body"> <%= t('application_form.degree.enic_statement.apply_enic') %></p>
-    <p class="govuk-body"> <%= govuk_link_to(t('application_form.degree.enic_statement.enic_link'), t('service_name.enic.statement_of_comparability_url')) %></p>
+    <p class="govuk-body">
+      <%= govuk_link_to(
+            t('application_form.degree.enic_statement.enic_link'),
+            t('service_name.enic.statement_of_comparability_url'),
+            new_tab: true,
+          ) %>
+    </p>
     <p class="govuk-body"> <%= t('application_form.degree.enic_statement.percentage_text_html') %></p>
     <p class="govuk-body"> <%= t('application_form.degree.enic_statement.enic_cost') %></p>
 

--- a/app/views/candidate_interface/gcse/enic/_form.html.erb
+++ b/app/views/candidate_interface/gcse/enic/_form.html.erb
@@ -5,7 +5,13 @@
 </h1>
 
 <p class="govuk-body"><%= t('gcse_edit_enic.apply_enic') %></p>
-<p class="govuk-body"> <%= govuk_link_to(t('gcse_edit_enic.enic_link'), t('service_name.enic.statement_of_comparability_url')) %></p>
+<p class="govuk-body">
+  <%= govuk_link_to(
+        t('gcse_edit_enic.enic_link'),
+        t('service_name.enic.statement_of_comparability_url'),
+        new_tab: true,
+      ) %>
+</p>
 <p class="govuk-body"> <%= t('gcse_edit_enic.percentage_text_html') %></p>
 <p class="govuk-body"> <%= t('gcse_edit_enic.enic_cost') %></p>
 

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -96,7 +96,7 @@ en:
         review_label: Do you have a UK ENIC statement of comparability?
         change_action: UK ENIC statement
         apply_enic: Because you gained your qualifications outside of the UK, you should include a statement of comparability from UK European Network of Information Centres (UK ENIC) with your applications.
-        enic_link: Apply for a statement of comparability from UK ENIC (opens in new tab)
+        enic_link: Apply for a statement of comparability from UK ENIC
         obtained: Yes, I have a statement of comparability
         waiting: I'm waiting for it to arrive
         maybe: I will apply for one in the future

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -57,7 +57,7 @@ en:
   gcse_edit_enic:
     page_title: Show how your %{subject} qualification compares to a UK one
     apply_enic: Because you gained your qualifications outside of the UK, you should include a statement of comparability from UK European Network of Information Centres (UK ENIC) with your applications.
-    enic_link: Apply for a statement of comparability from UK ENIC (opens in new tab)
+    enic_link: Apply for a statement of comparability from UK ENIC
     obtained: Yes, I have a statement of comparability
     waiting: I'm waiting for it to arrive
     maybe: I will apply for one in the future


### PR DESCRIPTION
## Context

We added a link to the ENIC website and indicated that it should open in a new tab, but it didn't.

## Changes proposed in this pull request

- removed the 'opens in new tab' hard coded text from the translation files (degree and gcse)
- Added the `new_tab: true` parameter to the enic link on the gcse and degree pages. (the text "(opens in new tab)" is added automatically if the the arg is included) 


## Guidance to review

As a candidate
Add a degree or gcse from another country, click through to the point where you see the text about ENIC
Click on the enic link
It should open in a new tab


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
