### PR TITLE
Ensure candidates with student and skilled worker visas are not able to submit after deadline

### DIFF
--- a/app/validators/visa_sponsorship_application_deadline_passed_validator.rb
+++ b/app/validators/visa_sponsorship_application_deadline_passed_validator.rb
@@ -5,7 +5,7 @@ class VisaSponsorshipApplicationDeadlinePassedValidator < ActiveModel::EachValid
 
   def validate_each(record, attribute, application_choice)
     return unless FeatureFlag.active?(:early_application_deadlines_for_candidates_with_visa_sponsorship)
-    return unless application_choice.application_form.right_to_work_or_study == 'no'
+    return unless application_choice.application_form.requires_visa_sponsorship?
 
     deadline = application_choice.course.visa_sponsorship_application_deadline_at
     return if deadline.nil? || deadline.after?(Time.zone.now)

--- a/spec/system/candidate_interface/submitting/candidate_reviews_application_when_visa_deadline_has_passed_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_application_when_visa_deadline_has_passed_spec.rb
@@ -15,6 +15,26 @@ RSpec.describe 'Candidate review application when visa deadline has passed' do
     and_i_can_delete_my_application_choice
   end
 
+  scenario 'Candidate has a student visa', time: mid_cycle do
+    given_i_have_a_student_visa
+    given_have_a_draft_application_for_a_course_with_a_visa_sponsorship_application_deadline_in_the_past
+    and_i_am_signed_in
+
+    when_i_view_my_application_choice
+    then_i_see_the_warning_text
+    and_i_can_delete_my_application_choice
+  end
+
+  scenario 'Candidate has a skilled worker visa', time: mid_cycle do
+    given_i_have_a_skilled_worker_visa
+    given_have_a_draft_application_for_a_course_with_a_visa_sponsorship_application_deadline_in_the_past
+    and_i_am_signed_in
+
+    when_i_view_my_application_choice
+    then_i_see_the_warning_text
+    and_i_can_delete_my_application_choice
+  end
+
 private
 
   def given_have_a_draft_application_for_a_course_with_a_visa_sponsorship_application_deadline_in_the_past
@@ -25,6 +45,14 @@ private
 
   def given_i_require_visa_sponsorship
     @application_form = create(:application_form, :completed, :with_degree, right_to_work_or_study: 'no')
+  end
+
+  def given_i_have_a_student_visa
+    @application_form = create(:application_form, :completed, :with_degree, right_to_work_or_study: 'yes', immigration_status: 'student_visa')
+  end
+
+  def given_i_have_a_skilled_worker_visa
+    @application_form = create(:application_form, :completed, :with_degree, right_to_work_or_study: 'yes', immigration_status: 'skilled_worker_visa')
   end
 
   def and_i_am_signed_in


### PR DESCRIPTION
…

## Context

Just missed this bit out in my earlier PR about applying the visa deadlines to candidates who have skilled worker / or student visas. 

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="844" alt="image" src="https://github.com/user-attachments/assets/c681f61e-349c-4cdd-8a08-ce00dc39ebed" /> | <img width="828" alt="image" src="https://github.com/user-attachments/assets/fae78422-bdb8-43a0-b72f-638705709f85" /> |


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
