### PR TITLE
Add FAC identifiers in support

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -184,13 +184,13 @@ module SupportInterface
       {
         key: 'Find a Candidate opt-in status',
         value: if application_form_in_the_pool?
-                 'Currently in the candidate pool'
+                 t('.findable')
                elsif candidate.published_opt_in_preferences.present?
-                 'Opted in (not currently in the candidate pool)'
+                 t('.opted_in')
                elsif candidate.published_preferences.last&.opt_out?
-                 'Opted Out'
+                 t('.opted_out')
                else
-                 'No status recorded'
+                 t('.no_status')
                end,
       }
     end

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -218,7 +218,7 @@ module SupportInterface
       return false if candidate.submission_blocked? || candidate.account_locked?
       return false if candidate.published_opt_in_preferences.blank?
 
-      Pool::Candidates.new(providers: []).application_forms_in_the_pool.exists?(id: application_form.id)
+      Pool::Candidates.new(providers: []).curated_application_forms(ApplicationForm.where(id: application_form.id)).present?
     end
 
     attr_reader :application_form

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -197,11 +197,12 @@ module SupportInterface
       return if candidate.published_opt_in_preferences.blank?
 
       location_preferences = candidate.published_preferences.last.location_preferences
+      decorated_preferences = location_preferences.map { |location| LocationPreferenceDecorator.new(location) }
 
       value =
         govuk_list do
-          location_preferences.map do |location|
-            tag.li t('.location', radius: location.within, location: location.name)
+          decorated_preferences.map do |location|
+            tag.li t('.location', radius: location.within, location: location.decorated_name)
           end.join.html_safe
         end
 

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -28,6 +28,8 @@ module SupportInterface
         editable_extension_row,
         one_login_account_row,
         unsubscribed_from_emails,
+        find_a_candidate_state_row,
+        find_a_candidate_location_preferences_row,
       ].compact
     end
 
@@ -176,6 +178,30 @@ module SupportInterface
 
     def subscribed_to_emails?
       candidate.subscribed_to_emails?
+    end
+
+    def find_a_candidate_state_row
+      {
+        key: 'Find a Candidate opt-in status',
+        value: if candidate.published_opt_in_preferences.present?
+                 'Opted in'
+               elsif candidate.published_preferences.last&.opt_out?
+                 'Opted Out'
+               else
+                 'No status recorded'
+               end,
+      }
+    end
+
+    def find_a_candidate_location_preferences_row
+      return if candidate.published_opt_in_preferences.blank?
+
+      location_preferences = candidate.published_preferences.last.location_preferences
+
+      {
+        key: 'Find a Candidate location preferences',
+        value: location_preferences.any? ? location_preferences.map(&:name).to_sentence : 'No location preferences recorded',
+      }
     end
 
     attr_reader :application_form

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -186,7 +186,7 @@ module SupportInterface
         value: if application_form_in_the_pool?
                  'Currently in the candidate pool'
                elsif candidate.published_opt_in_preferences.present?
-                 'Opted in (not in pool)'
+                 'Opted in (not currently in the candidate pool)'
                elsif candidate.published_preferences.last&.opt_out?
                  'Opted Out'
                else

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -184,7 +184,7 @@ module SupportInterface
       {
         key: 'Find a Candidate opt-in status',
         value: if candidate.published_opt_in_preferences.present?
-                 'Opted in'
+                 'Currently in the candidate pool'
                elsif candidate.published_preferences.last&.opt_out?
                  'Opted Out'
                else

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -198,9 +198,16 @@ module SupportInterface
 
       location_preferences = candidate.published_preferences.last.location_preferences
 
+      value =
+        govuk_list do
+          location_preferences.map do |location|
+            tag.li t('.location', radius: location.within, location: location.name)
+          end.join.html_safe
+        end
+
       {
         key: 'Find a Candidate location preferences',
-        value: location_preferences.any? ? location_preferences.map(&:name).to_sentence : 'No location preferences recorded',
+        value: location_preferences.any? ? value : 'No location preferences recorded',
       }
     end
 

--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
     def show
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
-        CandidateInterface::LocationPreferenceDecorator.new(location)
+        LocationPreferenceDecorator.new(location)
       end
     end
 

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
       end
 
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
-        CandidateInterface::LocationPreferenceDecorator.new(location)
+        LocationPreferenceDecorator.new(location)
       end
       @preference_form = PreferencesForm.build_from_preference(
         preference: @preference,

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
     def show
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
-        CandidateInterface::LocationPreferenceDecorator.new(location)
+        LocationPreferenceDecorator.new(location)
       end
     end
 

--- a/app/decorators/location_preference_decorator.rb
+++ b/app/decorators/location_preference_decorator.rb
@@ -1,4 +1,4 @@
-class CandidateInterface::LocationPreferenceDecorator < SimpleDelegator
+class LocationPreferenceDecorator < SimpleDelegator
   def decorated_name
     if provider.present?
       "#{name} (#{provider.name})"

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -46,8 +46,8 @@ class Pool::Candidates
       .distinct
   end
 
-  def curated_application_forms(application_forms_scope = ApplicationForm.all)
-    current_cycle_forms = application_forms_scope.current_cycle
+  def curated_application_forms(application_forms_scope = ApplicationForm.current_cycle)
+    current_cycle_forms = application_forms_scope
 
     # Subquery: To exclude forms with live applications (eg, being considered by the provider, or recruited / deferred)
     forms_with_live_applications = current_cycle_forms

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -46,19 +46,8 @@ class Pool::Candidates
       .distinct
   end
 
-private
-
-  def filtered_application_forms
-    scope = curated_application_forms
-    scope = filter_by_subject(scope)
-    scope = filter_by_study_mode(scope)
-    scope = filter_by_course_type(scope)
-    scope = filter_by_right_to_work_or_study(scope)
-    filter_by_distance(scope)
-  end
-
-  def curated_application_forms
-    current_cycle_forms = ApplicationForm.current_cycle
+  def curated_application_forms(application_forms_scope = ApplicationForm.all)
+    current_cycle_forms = application_forms_scope.current_cycle
 
     # Subquery: To exclude forms with live applications (eg, being considered by the provider, or recruited / deferred)
     forms_with_live_applications = current_cycle_forms
@@ -91,6 +80,17 @@ private
       .where(id: forms_with_available_slots)
       .where.not(id: forms_with_live_applications.select('application_forms.id'))
       .where.not(id: forms_that_have_been_withdrawn_for_not_wanting_to_train.select('application_forms.id'))
+  end
+
+private
+
+  def filtered_application_forms
+    scope = curated_application_forms
+    scope = filter_by_subject(scope)
+    scope = filter_by_study_mode(scope)
+    scope = filter_by_course_type(scope)
+    scope = filter_by_right_to_work_or_study(scope)
+    filter_by_distance(scope)
   end
 
   def filter_by_distance(application_forms_scope)

--- a/config/locales/support_interface/application_summary_component.yml
+++ b/config/locales/support_interface/application_summary_component.yml
@@ -1,4 +1,8 @@
 en:
   support_interface:
     application_summary_component:
+      findable: Currently findable by providers
+      opted_in: Opted in (not findable)
+      opted_out: Opted Out
+      no_status: No status recorded
       location: Within %{radius} miles of %{location}

--- a/config/locales/support_interface/application_summary_component.yml
+++ b/config/locales/support_interface/application_summary_component.yml
@@ -3,6 +3,6 @@ en:
     application_summary_component:
       findable: Currently findable by providers
       opted_in: Opted in (not findable)
-      opted_out: Opted Out
+      opted_out: Opted out
       no_status: No status recorded
       location: Within %{radius} miles of %{location}

--- a/config/locales/support_interface/application_summary_component.yml
+++ b/config/locales/support_interface/application_summary_component.yml
@@ -1,0 +1,4 @@
+en:
+  support_interface:
+    application_summary_component:
+      location: Within %{radius} miles of %{location}

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -77,5 +77,97 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
         expect(result.css('.govuk-summary-list__value').text).to include('No')
       end
     end
+
+    context 'when the candidate has opted into sharing application details with providers but still has pending decisions' do
+      it 'displays "Opted in (not findable)" for the Find a Candidate opt-in status row' do
+        candidate = create(:candidate)
+        application_form = create(:application_form, candidate:)
+
+        create(:candidate_preference, candidate:)
+        create(:application_choice, status: :awaiting_provider_decision, application_form:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate opt-in status')
+        expect(result.css('.govuk-summary-list__value').text).to include('Opted in (not findable)')
+      end
+    end
+
+    context 'when the candidate has opted into sharing application details with providers and has no active applications' do
+      it 'displays "Currently findable by providers" for the Find a Candidate opt-in status row' do
+        candidate = create(:candidate)
+        application_form = create(:application_form, candidate:)
+
+        create(:candidate_preference, candidate:)
+        create(:application_choice, status: :withdrawn, application_form:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate opt-in status')
+        expect(result.css('.govuk-summary-list__value').text).to include('Currently findable by providers')
+      end
+    end
+
+    context 'when the candidate has opted out of sharing application details with providers' do
+      it 'displays "Opted out" for the Find a Candidate opt-in status row' do
+        candidate = create(:candidate)
+        application_form = create(:application_form, candidate:)
+
+        create(:candidate_preference, pool_status: 'opt_out', candidate:)
+        create(:application_choice, status: :withdrawn, application_form:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate opt-in status')
+        expect(result.css('.govuk-summary-list__value').text).to include('Opted out')
+      end
+    end
+
+    context 'when the candidate has not yet submitted a decision for sharing application details with providers' do
+      it 'displays "No status recorded" for the Find a Candidate opt-in status row and the location preferences row does not display' do
+        candidate = create(:candidate)
+        application_form = create(:completed_application_form, candidate:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate opt-in status')
+        expect(result.css('.govuk-summary-list__value').text).to include('No status recorded')
+
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Find a Candidate location preferences')
+      end
+    end
+
+    context 'when the candidate has published location preferences' do
+      it 'displays the location preferences and selected radius in a list' do
+        candidate = create(:candidate)
+        application_form = create(:application_form, candidate:)
+        candidate_preference = create(:candidate_preference, candidate:)
+
+        create(:application_choice, status: :withdrawn, application_form:)
+        create(:candidate_location_preference, :manchester, candidate_preference:)
+        create(:candidate_location_preference, :liverpool, candidate_preference:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate location preferences')
+        expect(result.css('.govuk-summary-list__value').text).to include('Within 10.0 miles of Manchester')
+        expect(result.css('.govuk-summary-list__value').text).to include('Within 10.0 miles of Liverpool')
+      end
+    end
+
+    context 'when the candidate is opted in but has no location preferences' do
+      it 'displays "No location preferences recorded"' do
+        candidate = create(:candidate)
+        application_form = create(:application_form, candidate:)
+
+        create(:candidate_preference, candidate:)
+        create(:application_choice, status: :withdrawn, application_form:)
+
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Find a Candidate location preferences')
+        expect(result.css('.govuk-summary-list__value').text).to include('No location preferences recorded')
+      end
+    end
   end
 end

--- a/spec/decorators/candidate_interface/location_preference_decorator_spec.rb
+++ b/spec/decorators/candidate_interface/location_preference_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::LocationPreferenceDecorator do
+RSpec.describe LocationPreferenceDecorator do
   describe 'decorated_name' do
     context 'when provider is present' do
       it 'returns the provider in the name of the location preference' do


### PR DESCRIPTION
## Context

We’d like non-dev/data members of the team, and Support, to be able to identify candidate accounts based on criteria associated with the Find a candidate feature. This could help with future recruitment for User Research, or to troubleshoot insights/issues.

## Changes proposed in this pull request

- Add up to two rows to the application summary component: FAC opt-in status and a list of location preferences.
- Add a number of conditional statuses, including: "Currently findable by providers, "Opted in (not findable)", "Opted out", "No status recorded".

## Guidance to review

![Screenshot 2025-05-16 at 16 35 31](https://github.com/user-attachments/assets/a446e82b-9cdf-4e03-a059-65182a56fe2b)
![Screenshot 2025-05-16 at 16 34 20](https://github.com/user-attachments/assets/aa3ba9b9-18bc-438e-bdd5-d51afc7a9fd3)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
