### PR TITLE
[861] Allow support users to add ENIC reference to degrees

### DIFF
--- a/app/controllers/support_interface/application_forms/degrees_controller.rb
+++ b/app/controllers/support_interface/application_forms/degrees_controller.rb
@@ -25,7 +25,18 @@ module SupportInterface
     private
 
       def edit_application_params
-        params.expect(support_interface_application_forms_edit_degree_form: %i[start_year award_year audit_comment])
+        params.expect(
+          support_interface_application_forms_edit_degree_form:
+            %i[
+              start_year
+              award_year
+              has_enic_reference
+              enic_reference
+              comparable_uk_degree
+              enic_reason
+              audit_comment
+            ],
+        )
       end
     end
   end

--- a/app/forms/support_interface/application_forms/edit_degree_form.rb
+++ b/app/forms/support_interface/application_forms/edit_degree_form.rb
@@ -4,14 +4,25 @@ module SupportInterface
       include ActiveModel::Model
 
       attr_reader :degree
-      attr_accessor :award_year, :start_year, :audit_comment
+      attr_accessor :award_year,
+                    :start_year,
+                    :has_enic_reference,
+                    :enic_reference,
+                    :comparable_uk_degree,
+                    :enic_reason,
+                    :audit_comment
 
       validates :start_year, presence: true
       validates :award_year, presence: true
+      validates :has_enic_reference, presence: true, if: -> { international? }
+      validates :enic_reference, :comparable_uk_degree, presence: true, if: -> { has_enic_reference == 'yes' }
+      validate :enic_reason_validation
       validates :audit_comment, presence: true
+
       validates_with SafeChoiceUpdateValidator
 
-      delegate :application_form, :subject, to: :degree
+      delegate :application_form, :subject, :international, to: :degree
+      alias international? international
 
       def initialize(degree)
         @degree = degree
@@ -19,15 +30,50 @@ module SupportInterface
         super(
           award_year: @degree.award_year,
           start_year: @degree.start_year,
+          has_enic_reference: @degree.enic_reference.present? ? 'yes' : 'no',
+          enic_reference: @degree.enic_reference,
+          comparable_uk_degree: @degree.comparable_uk_degree,
+          enic_reason: @degree.enic_reason,
         )
       end
 
+      def enic_reason_options
+        ApplicationQualification.enic_reasons.values.filter { |reason| reason != 'obtained' }
+      end
+
+      def comparable_degree_options
+        ApplicationQualification.comparable_uk_degrees.values
+      end
+
+      def enic_reason_validation
+        return unless international?
+        return if has_enic_reference == 'yes'
+        return if enic_reason.in? enic_reason_options
+
+        errors.add(:enic_reason, :blank)
+      end
+
       def save!
-        @degree.update!(
+        attributes = {
           start_year:,
           award_year:,
           audit_comment:,
-        )
+        }
+
+        if has_enic_reference == 'yes'
+          attributes.merge!(
+            enic_reference:,
+            comparable_uk_degree:,
+            enic_reason: 'obtained',
+          )
+        else
+          attributes.merge!(
+            enic_reference: nil,
+            comparable_uk_degree: nil,
+            enic_reason:,
+          )
+        end
+        @degree.update!(**attributes)
       end
     end
   end

--- a/app/views/support_interface/application_forms/degrees/edit.html.erb
+++ b/app/views/support_interface/application_forms/degrees/edit.html.erb
@@ -1,17 +1,59 @@
-<% content_for :browser_title, title_with_error_prefix('Edit GCSE', @degree_form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('.page_title', subject: @degree_form.subject.capitalize), @degree_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@degree_form.application_form)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_form, url: support_interface_application_form_update_degree_path do |f| %>
       <%= f.govuk_error_summary %>
+        <h1 class="govuk-heading-l">
+          <%= t('.page_title', subject: @degree_form.subject.capitalize) %>
+        </h1>
 
-      <%= f.govuk_fieldset legend: { text: "Edit #{@degree_form.subject.capitalize} degree details", size: 'l' } do %>
-        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' }, maxlength: 4, inputmode: 'numeric' %>
-        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, maxlength: 4, inputmode: 'numeric' %>
+        <%= f.govuk_text_field :start_year, label: { text: t('.start_year'), size: 'm' }, width: 20, maxlength: 4, inputmode: 'numeric' %>
+        <%= f.govuk_text_field :award_year, label: { text: t('.award_year'), size: 'm' }, width: 20, maxlength: 4, inputmode: 'numeric' %>
+        <% if @degree_form.international %>
+          <%= f.govuk_radio_buttons_fieldset(:has_enic_reference, legend: { text: t('.has_enic_reference'), size: 'm' }) do %>
+          <%= f.govuk_radio_button :has_enic_reference, 'yes', label: { text: 'Yes' } do %>
+            <%= f.govuk_text_field(
+                  :enic_reference,
+                  label: { text: t('.enic_reference'), size: 'm' },
+                  hint: { text: t('.enic_hint') },
+                  width: 20,
+                ) %>
+            <%= f.govuk_radio_buttons_fieldset(
+                  :comparable_uk_degree,
+                  legend: { text: t('.select_the_comparable_uk_degree'), size: 'm' },
+                  hint: { text: t('.comparable_uk_degree_hint') },
+                ) do %>
+              <% @degree_form.comparable_degree_options.each_with_index do |value, index| %>
+                <%= f.govuk_radio_button(
+                      :comparable_uk_degree,
+                      value,
+                      label: { text: t(".comparable_degrees.#{value}") },
+                      link_errors: index.zero?,
+                    ) %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <%= f.govuk_radio_button :has_enic_reference, 'no', label: { text: 'No' } do %>
+            <%= f.govuk_radio_buttons_fieldset(
+                  :enic_reason,
+                  legend: { text: t('.select_a_reason') },
+                ) do %>
+              <% @degree_form.enic_reason_options.each_with_index do |value, index| %>
+                <%= f.govuk_radio_button(
+                      :enic_reason,
+                      value,
+                      label: { text: t(".enic_reasons.#{value}") },
+                      link_errors: index.zero?,
+                    ) %>
+              <% end %>
+            <% end %>
+
+          <% end %>
+        <% end %>
       <% end %>
-
-        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_address_details_form.audit_comment.hint') } %>
+      <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_address_details_form.audit_comment.hint') } %>
 
       <%= f.govuk_submit 'Update details' %>
     <% end %>

--- a/config/locales/support_interface/application_forms/degrees.yml
+++ b/config/locales/support_interface/application_forms/degrees.yml
@@ -1,0 +1,26 @@
+en:
+  support_interface:
+    application_forms:
+      degrees:
+        edit:
+          page_title: Edit %{subject} degree details
+          start_year: Start year
+          award_year: Award year
+          enic_reference: UK ENIC reference number
+          enic_hint: For example ‘4000228363’
+          select_the_comparable_uk_degree: Select the comparable UK degree
+          comparable_uk_degree_hint: As shown on the statement
+          has_enic_reference: Does the candidate have an ENIC reference number?
+          comparable_degrees:
+            bachelor_ordinary_degree: Bachelor (Ordinary) degree
+            bachelor_honours_degree: Bachelor (Honours) degree
+            postgraduate_certificate_or_diploma: Postgraduate Certificate / Postgraduate Diploma
+            masters_degree: Master’s degree / Integrated Master’s degree
+            doctor_of_philosophy: Doctor of Philosophy degree
+            post_doctoral_award: Post Doctoral award
+          select_a_reason: Select a reason
+          enic_reasons:
+            waiting: I’m waiting for it to arrive
+            maybe: I will apply for one in the future
+            not_needed: I do not need a statement of comparability
+

--- a/config/locales/support_interface/application_forms/degrees.yml
+++ b/config/locales/support_interface/application_forms/degrees.yml
@@ -20,7 +20,7 @@ en:
             post_doctoral_award: Post Doctoral award
           select_a_reason: Select a reason
           enic_reasons:
-            waiting: I’m waiting for it to arrive
-            maybe: I will apply for one in the future
-            not_needed: I do not need a statement of comparability
+            waiting: Candidate is waiting for it to arrive
+            maybe: Candidate will apply for one in the future
+            not_needed: Candidate does not need a statement of comparability
 

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -261,6 +261,12 @@ en:
               blank: Award year cannot be blank
             start_year:
               blank: Start year cannot be blank
+            enic_reference:
+              blank: Enter an ENIC reference number
+            comparable_uk_degree:
+              blank: Select a comparable UK degree
+            enic_reason:
+              blank: Select a reason for not having an ENIC reference number
             audit_comment:
               blank: You must provide an audit comment
         support_interface/application_forms/edit_reference_feedback_form:

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -181,34 +181,9 @@ If you are asked to add an ENIC number to a qualification, you should first make
 
 For all international qualifications, you'll have to include an `institution_country`: https://github.com/DFE-Digital/apply-for-teacher-training/blob/78c9421d8582f63cfdec564b5c0677bfd787552c/config/initializers/countries_and_territories.rb
 
-***Degrees***
+***Non UK Degrees***
 
-It is most likely that you will only need to update the `enic_reference` and `comparable_uk_degree`, but you should look at the other relevant fields to make sure they also make sense
-
-Some notes about the required fields:
-
-- `enic_reference` This is a 10 digit number on the ENIC statement of comparability. It's call 'UK ENIC reference' on the statement.
-- `comparable_uk_degree` This is an enum, use one of these valid options https://github.com/DFE-Digital/apply-for-teacher-training/blob/7d61f9887494aae093ced34f587d5870528ba786/app/models/application_qualification.rb
-- `enic_reason` This will probably 'waiting'; should be updated to 'obtained'. See https://github.com/DFE-Digital/apply-for-teacher-training/blob/8fd1a3b8f31e69480927f491d833b39e3ccfb36c/app/models/application_qualification.rb#L63
-
-```ruby
-ApplicationQualification.find(QUALIFICATION_ID).update!(
-  enic_reference:,
-  comparable_uk_degree:,
-  audit_comment: ZENDESK_URL,
-  enic_reason:,
-
-  # Other things to check against the ENIC certificate
-  level: 'degree',
-  institution_name:,
-  institution_country:,
-  qualification_type: 'non_uk',
-  non_uk_qualification_type: nil, # not to be confused with the comparable_uk_degree. This can should be blank for degrees
-  award_year: AWARD_YEAR,
-  )
-````
-
-You may also be asked to remove ENIC / comparable_uk_degree information if the candidate has entered something like, 'awaiting response'. Just set the `enic_reference` and `comparable_uk_degree` to nil.
+Support users can update ENIC reference details on non-uk degrees directly.
 
 ***GCSEs***
 

--- a/spec/system/support_interface/editing_international_degree_spec.rb
+++ b/spec/system/support_interface/editing_international_degree_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'Editing degree' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits international degree', :with_audited do
+    given_i_am_a_support_user
+    and_an_application_exists_with_international_degree
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_degree
+    then_i_see_a_prepopulated_form
+
+    when_i_choose('Yes')
+    and_i_click('Update details')
+    then_i_see_the_error('Enter an ENIC reference number')
+    and_i_see_the_error('Select a comparable UK degree')
+
+    when_i_enter_an_enic_reference_number
+    and_i_choose('Bachelor (Ordinary) degree')
+    and_i_enter_an_audit_comment
+    and_i_click('Update details')
+    then_i_see_a_success_message
+    and_the_enic_reference_details_have_been_updated
+
+    when_i_click_the_change_link_next_to_the_first_degree
+    when_i_choose('No')
+    and_i_click('Update details')
+    then_i_see_the_error('Select a reason for not having an ENIC reference number')
+
+    when_i_choose('I will apply for one in the future')
+    and_i_enter_an_audit_comment
+    and_i_click('Update details')
+    then_i_see_a_success_message
+    and_the_enic_reason_has_been_updated
+  end
+
+private
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists_with_international_degree
+    @form = create(:completed_application_form)
+    @degree = create(
+      :non_uk_degree_qualification,
+      enic_reference: nil,
+      enic_reason: 'waiting',
+      comparable_uk_degree: nil,
+      application_form: @form,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_degree
+    within('[data-qa="degree-qualification"]') do
+      click_link_or_button 'Change'
+    end
+  end
+  alias_method :when_i_click_the_change_link_next_to_the_first_degree, :and_i_click_the_change_link_next_to_the_first_degree
+
+  def then_i_see_a_prepopulated_form
+    expect(page).to have_content("Edit #{@degree.subject.capitalize} degree")
+
+    expect(page).to have_content 'Does the candidate have an ENIC reference number?'
+  end
+
+  def when_i_choose(text)
+    choose text
+  end
+  alias_method :and_i_choose, :when_i_choose
+
+  def and_i_click(text)
+    click_on text
+  end
+
+  def then_i_see_the_error(text)
+    expect(page.title).to include 'Error:'
+    expect(page).to have_content 'There is a problem'
+    expect(page).to have_content(text).twice
+  end
+  alias_method :and_i_see_the_error, :then_i_see_the_error
+
+  def when_i_enter_an_enic_reference_number
+    fill_in 'UK ENIC reference number', with: '4000228363'
+  end
+
+  def and_i_select_a_comparable_uk_degree
+    choose 'Bachelor (Ordinary) degree'
+  end
+
+  def and_i_enter_an_audit_comment
+    fill_in 'Audit log comment', with: 'Audit log comment'
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content 'Success'
+    expect(page).to have_content 'Degree updated'
+  end
+
+  def and_the_enic_reference_details_have_been_updated
+    @degree.reload
+    expect(@degree.enic_reference).to eq '4000228363'
+    expect(@degree.enic_reason).to eq 'obtained'
+    expect(@degree.comparable_uk_degree).to eq 'bachelor_ordinary_degree'
+  end
+
+  def and_the_enic_reason_has_been_updated
+    @degree.reload
+    expect(@degree.enic_reference).to be_nil
+    expect(@degree.enic_reason).to eq 'maybe'
+    expect(@degree.comparable_uk_degree).to be_nil
+  end
+end

--- a/spec/system/support_interface/editing_international_degree_spec.rb
+++ b/spec/system/support_interface/editing_international_degree_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Editing degree' do
     and_i_click('Update details')
     then_i_see_the_error('Select a reason for not having an ENIC reference number')
 
-    when_i_choose('I will apply for one in the future')
+    when_i_choose('Candidate will apply for one in the future')
     and_i_enter_an_audit_comment
     and_i_click('Update details')
     then_i_see_a_success_message

--- a/spec/system/support_interface/editing_uk_degree_spec.rb
+++ b/spec/system/support_interface/editing_uk_degree_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Editing degree' do
   include DfESignInHelpers
 
-  scenario 'Support user edits degree', :with_audited do
+  scenario 'Support user edits uk degree', :with_audited do
     given_i_am_a_support_user
     and_an_application_exists
 
@@ -40,6 +40,8 @@ RSpec.describe 'Editing degree' do
   def then_i_see_a_prepopulated_form
     expect(page).to have_content('Edit Maths degree')
     expect(page).to have_css("input[value='1999']")
+
+    expect(page).to have_no_content 'Does the candidate have an ENIC reference number?'
   end
 
   def when_i_update_the_form


### PR DESCRIPTION
## Context

We repeatedly get support requests to add ENIC reference numbers to degrees. Support users are currently able to add ENIC details to GCSEs, but not to degrees. 

## Changes proposed in this pull request

This PR allows a support user to add, update, remove ENIC details from a degree. It DOES NOT include any other changes to degrees. 

https://github.com/user-attachments/assets/f078e9e4-0642-4429-a937-c545a16791f9

## Guidance to review

Sign into support and view a candidate with an international degree
You should be able to change the enic details as well as the start / award dates

Also view a candidate with a UK degree
You should only be able to change the start / award dates as usual.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
