### PR TITLE
[906] Capture params when linking to course from Find

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -40,7 +40,7 @@ private
   end
 
   def request_authentication
-    redirect_to candidate_interface_create_account_or_sign_in_path(path: request.path)
+    redirect_to candidate_interface_create_account_or_sign_in_path(path: request.url)
   end
 
   def start_new_session_for(candidate:, id_token_hint: nil)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -147,5 +147,12 @@ RSpec.describe ApplicationHelper do
         expect(call).to be false
       end
     end
+
+    context 'when path is a full url with with valid path params' do
+      it 'returns true' do
+        url = candidate_interface_apply_from_find_url(providerCode: 'ABC', courseCode: '123')
+        expect(helper.valid_app_path(url)).to be true
+      end
+    end
   end
 end

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe 'OneLoginController' do
       expect(response).to redirect_to(candidate_interface_interstitial_path)
     end
 
+    context 'when there is a url in the origin' do
+      let(:path) { candidate_interface_apply_from_find_url(providerCode: 'ABC', courseCode: '123') }
+      let(:origin) { candidate_interface_account_path(path:) }
+
+      before do
+        Rails.application.env_config['omniauth.origin'] = origin
+      end
+
+      it 'includes path in redirect' do
+        candidate = create(:candidate)
+        create(:one_login_auth, candidate:, token: '123')
+
+        get auth_one_login_callback_path
+        expect(response).to redirect_to(candidate_interface_interstitial_path(path:))
+      end
+    end
+
     context 'when there is no omniauth_hash' do
       let(:omniauth_hash) { nil }
 

--- a/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
@@ -67,7 +67,7 @@ private
   def then_i_am_logged_out
     expect(page).to have_title 'Create a GOV.UK One Login or sign in'
     expect(page).to have_content 'You need a GOV.UK One Login to sign in to this service. You can create one if you do not already have one.'
-    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(path: '/candidate/application/choices')
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(path: 'http://www.example.com/candidate/application/choices')
   end
 
   def when_i_login_again

--- a/spec/system/candidate_interface/one_login_signup/candidate_signs_in_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_signs_in_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Candidate signs in' do
   def then_i_am_redirected_to_the_candidate_sign_in_path
     expect(page).to have_current_path(
       candidate_interface_create_account_or_sign_in_path(
-        path: '/candidate/application/details',
+        path: 'http://www.example.com/candidate/application/details',
       ),
     )
   end


### PR DESCRIPTION
## Context

We had a support ticket where a candidate had
- clicked on the Apply for this course button in Find
- Was directed to sign in to Apply using One Login
- Successfully signed in
- But saw a 'Page not found' error at the path `/candidate/apply`

Essentially, the params from the find like (providerCode, courseCode), were not appended to the path. 

## Changes proposed in this pull request

- Pass the whole url to the path param when redirecting. 
- Related specs

## Guidance to review

This has been deployed on qa, so it can be tested.
Make sure you are logged out of [Apply (QA)](https://qa.apply-for-teacher-training.service.gov.uk/candidate/details)
Go to [Find (QA)](https://qa.find-teacher-training-courses.service.gov.uk/)
Find a course and click 'Apply for this course'
Once redirected to Apply, go through the One Login process (either new or existing account)
When you are logged in, you should end up on the confirm selection page eg
 
<img width="758" alt="image" src="https://github.com/user-attachments/assets/83df0bb1-cec0-4bbc-b788-d40f5b2c29c2" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
