### PR TITLE
Simplifies Audit Log creation for previews

### DIFF
--- a/spec/components/previews/provider_interface/activity_log_event_component_preview.rb
+++ b/spec/components/previews/provider_interface/activity_log_event_component_preview.rb
@@ -23,7 +23,7 @@ module ProviderInterface
     end
 
     def rejected_by_default_with_feedback
-      @activity_log_event = build_event_for_choice :rejected_by_default_with_feedback
+      @activity_log_event = build_event_for_choice :with_rejection_by_default_and_feedback
       render_component
     end
 
@@ -79,12 +79,8 @@ module ProviderInterface
 
   private
 
-    def build_event_for_choice(*args)
-      choice_args = [:application_choice].concat(args).push(id: ApplicationChoice.all.sample.id)
-      choice = FactoryBot.build(*choice_args)
-
-      audit_args = [:application_choice_audit].concat(args).push(application_choice: choice)
-      audit = FactoryBot.build(*audit_args)
+    def build_event_for_choice(trait)
+      audit = FactoryBot.create(:application_choice_audit, trait)
       ActivityLogEvent.new(audit:)
     end
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -408,7 +408,7 @@ FactoryBot.define do
       rejection_reasons_type { 'rejection_reason' }
       reject_by_default_feedback_sent_at { (rejected_at || Time.zone.now) + 1.second }
 
-      after(:create) do |choice, evaluator|
+      after(:create) do |choice, _evaluator|
         create(
           :application_choice_audit,
           :with_rejection_by_default_and_feedback,

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -408,11 +408,11 @@ FactoryBot.define do
       rejection_reasons_type { 'rejection_reason' }
       reject_by_default_feedback_sent_at { (rejected_at || Time.zone.now) + 1.second }
 
-      after(:create) do |_choice, evaluator|
+      after(:create) do |choice, evaluator|
         create(
           :application_choice_audit,
           :with_rejection_by_default_and_feedback,
-          application_choice: evaluator,
+          application_choice: choice,
         )
       end
     end

--- a/spec/factories/application_choice_audit.rb
+++ b/spec/factories/application_choice_audit.rb
@@ -14,7 +14,6 @@ FactoryBot.define do
     after(:build) do |audit, evaluator|
       audit.auditable_type = 'ApplicationChoice'
       audit.auditable_id = evaluator.application_choice.id
-      audit.auditable = evaluator.application_choice
       audit.associated = evaluator.application_choice.application_form
       audit.audited_changes = evaluator.changes
     end

--- a/spec/factories/application_choice_audit.rb
+++ b/spec/factories/application_choice_audit.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     after(:build) do |audit, evaluator|
       audit.auditable_type = 'ApplicationChoice'
       audit.auditable_id = evaluator.application_choice.id
+      audit.auditable = evaluator.application_choice
       audit.associated = evaluator.application_choice.application_form
       audit.audited_changes = evaluator.changes
     end
@@ -51,14 +52,10 @@ FactoryBot.define do
     end
 
     trait :with_rejection_by_default_and_feedback do
-      application_choice factory: %i[application_choice rejected_by_default]
+      application_choice factory: %i[application_choice rejected_by_default_with_feedback]
 
       changes do
         { 'reject_by_default_feedback_sent_at' => [nil, Time.zone.now.iso8601] }
-      end
-
-      after(:build) do |audit, _evaluator|
-        audit.auditable.rejected_by_default = true
       end
     end
 


### PR DESCRIPTION
## Context

When visiting the previews for these components, the application would throw a 500 error.

## Changes proposed in this pull request

Simplified the creation of factory data required to create audit component previews 

## Guidance to review

Check that all previews render from [`/rails/view_components/provider_interface/activity_log_event_component/`](https://apply-review-10730.test.teacherservices.cloud/rails/view_components/provider_interface/activity_log_event_component/)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
