### PR TITLE
Make Candidate Pool Invite form use create and update method

### DIFF
--- a/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_with model: pool_invite, url: provider_interface_candidate_pool_candidate_draft_invites_path do |form| %>
-    <%= form.govuk_error_summary %>
+<%= form_with model: pool_invite, url:, method: do |form| %>
+  <%= form.govuk_error_summary %>
 
   <% if pool_invite.id.present? %>
     <%= form.hidden_field :id, value: pool_invite.id %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
@@ -6,6 +6,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render '/provider_interface/candidate_pool/draft_invites/form', pool_invite: @pool_invite, candidate: @candidate %>
+    <%= render(
+      'form',
+      pool_invite: @pool_invite,
+      candidate: @candidate,
+      url: provider_interface_candidate_pool_candidate_draft_invite_path,
+      method: :patch
+    ) %>
   </div>
 </div>

--- a/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
@@ -7,7 +7,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @pool_invite.available_courses.present? %>
-      <%= render 'form', pool_invite: @pool_invite, candidate: @candidate %>
+      <%= render(
+        'form',
+        pool_invite: @pool_invite,
+        candidate: @candidate,
+        url: provider_interface_candidate_pool_candidate_draft_invites_path,
+        method: :post
+      ) %>
     <% else %>
       <p class="govuk-body"><%= t('.no_available_courses') %> </p>
     <% end %>


### PR DESCRIPTION
## Context

Previously, only the create method of the draft_invites_controller was being hit by the form.

This commit changes the form to use the update method as well, when we update a draft pool invite.

The form works the same before as now. Because the form object would update or create based on the presence of id.

There is another way here, to just remove the `update` controller method and just use the `create`.  The form would work the same. The form object updates/creates based on the id param

https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/forms/provider_interface/pool_invite_form.rb#L30-L47

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
