### PR TITLE
Remove apostrophe from FAC filter

### DIFF
--- a/app/components/provider_interface/find_candidates/filters_component.html.erb
+++ b/app/components/provider_interface/find_candidates/filters_component.html.erb
@@ -133,7 +133,7 @@
 
             <div class="govuk-form-group filter-group">
               <h3 class="govuk-heading-m">
-                <%= t('.candidate_visa_requirements') %>
+                <%= t('.visa_sponsorship') %>
               </h3>
               <%= f.govuk_collection_check_boxes(
                 :visa_sponsorship,

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -74,11 +74,10 @@ en:
         remove_location_hint: Remove candidate location preference filter
         study_mode: Study type
         course_type: Course type
-        visa_sponsorship: Candidate’s visa requirements
+        visa_sponsorship: Candidate visa requirements
         subjects_applied_to: Subjects previously applied to
         candidate_location_preference: Candidate location preferences
         candidate_course_preferences: Candidate course preferences
-        candidate_visa_requirements: Candidate’s visa requirements
         apply_filters: Apply filters
       other_qualifications_component:
         caption: A levels and other qualifications


### PR DESCRIPTION
## Context

We don't need to say Candidate’s visa requirements. We can remove the apostrophe

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![Screenshot from 2025-05-20 16-51-18](https://github.com/user-attachments/assets/4d949b61-8b9d-4f4c-9ed7-fe59c2c86243)
![Screenshot from 2025-05-20 16-51-09](https://github.com/user-attachments/assets/d9b69671-cb09-4726-9973-7e0a454cd0c6)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
