### PR TITLE
[895] Add opt out reason field to candidate preferences form

### DIFF
--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -62,7 +62,7 @@ module CandidateInterface
 
     def request_params
       params.fetch(:candidate_interface_pool_opt_ins_form, {}).permit(
-        :pool_status,
+        :pool_status, :opt_out_reason
       )
     end
 

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -66,10 +66,6 @@ module CandidateInterface
         preference.published!
         current_candidate.published_preferences.where.not(id: preference.id).destroy_all
       end
-
-      # This will have no effect if the candidate has not been sent the email
-      exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
-      exp.convert(current_candidate, goal: :opt_out)
     end
   end
 end

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -3,7 +3,13 @@
 
   <%= f.govuk_radio_buttons_fieldset :pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' } do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
-    <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } %>
+    <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
+      <%= f.govuk_text_area(
+        :opt_out_reason,
+        label: { text: t('.reason_for_opting_out') },
+        max_words: 200,
+      ) %>
+    <% end %>
   <% end %>
 
   <%= f.govuk_submit %>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -96,7 +96,7 @@ en:
             pool_status:
               blank: Select whether to make your application details visible to other training providers
             opt_out_reason:
-              too_many_words: Enter a reason of %{maximum} words or fewer
+              too_many_words: Reason for not sharing your application details must be %{maximum} words or less
         candidate_interface/location_preferences_form:
           attributes:
             within:

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -54,6 +54,7 @@ en:
       form:
         title: Do you want to make your application details visible to other training providers?
         body: When you have no applications that are waiting for a decision from a provider, other providers will be able to see your application details and invite you to apply to their courses.
+        reason_for_opting_out: Why do you not want to share your application details with other providers? (Optional)
     location_preferences:
       index:
         title: Location preferences
@@ -94,6 +95,8 @@ en:
           attributes:
             pool_status:
               blank: Select whether to make your application details visible to other training providers
+            opt_out_reason:
+              too_many_words: Enter a reason of %{maximum} words or fewer
         candidate_interface/location_preferences_form:
           attributes:
             within:

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -118,6 +118,22 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_application_choices
   end
 
+  scenario 'Candidate opts out of find a candidate and gives a reason' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    visit new_candidate_interface_pool_opt_in_path
+    and_i_opt_out_to_find_a_candidate
+    and_i_enter_a_reason_with_too_many_words
+    when_i_click('Continue')
+    then_i_see_an_error
+
+    when_i_enter_a_reason_with_fewer_words
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_application_choices
+  end
+
   def given_i_am_signed_in
     given_i_am_signed_in_with_one_login
     @application = create(
@@ -173,6 +189,26 @@ RSpec.describe 'Candidate adds preferences' do
 
   def and_i_opt_out_to_find_a_candidate
     choose 'No'
+  end
+
+  def and_i_enter_a_reason_with_too_many_words
+    fill_in(
+      'Why do you not want to share your application details with other providers? (Optional)',
+      with: Faker::Lorem.sentence(word_count: 201),
+    )
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content 'There is a problem'
+    expect(page.title).to include 'Error:'
+    expect(page).to have_content('Enter a reason of 200 words or fewer').twice
+  end
+
+  def when_i_enter_a_reason_with_fewer_words
+    fill_in(
+      'Why do you not want to share your application details with other providers? (Optional)',
+      with: Faker::Lorem.sentence(word_count: 199),
+    )
   end
 
   def when_i_click(button)

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'Candidate adds preferences' do
   def then_i_see_an_error
     expect(page).to have_content 'There is a problem'
     expect(page.title).to include 'Error:'
-    expect(page).to have_content('Enter a reason of 200 words or fewer').twice
+    expect(page).to have_content('Reason for not sharing your application details must be 200 words or less').twice
   end
 
   def when_i_enter_a_reason_with_fewer_words

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe 'Candidate edits published preference' do
     and_the_candidate_preference_id_is_changed
   end
 
+  scenario 'Candidate adds a reason for opting out' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click_change_share_preference
+    and_i_choose_not_to_share_my_details
+    and_i_add_a_reason_for_opting_out
+
+    when_i_click('Continue')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+  end
+
   scenario 'Candidate edits location_preferences' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
@@ -82,6 +99,13 @@ RSpec.describe 'Candidate edits published preference' do
 
   def and_i_choose_not_to_share_my_details
     choose 'No'
+  end
+
+  def and_i_add_a_reason_for_opting_out
+    fill_in(
+      'Why do you not want to share your application details with other providers? (Optional)',
+      with: Faker::Lorem.sentence(word_count: 199),
+    )
   end
 
   def then_i_am_redirected_on_the_application_choices_page


### PR DESCRIPTION
## Context

We want to start collecting free text reasons for why people opt out of find a candidate.

## Changes proposed in this pull request

Adds an optional reason field which is exposed if a candidate selects 'No'. The field is limited to 200 words

https://github.com/user-attachments/assets/6bb38289-8f4b-4b69-8305-5b42ccf105e5


## Guidance to review

Test it out on the review app.
You don't see the reason anywhere because we only show the review page if you select yes. But you can see the opt out reason if you check the record on the command line. You can also check that it is set to nil if you select opt_in. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
