### PR TITLE
[945] Bug: missing columns in Other qualification component

### DIFF
--- a/app/components/provider_interface/find_candidates/other_qualifications_component.rb
+++ b/app/components/provider_interface/find_candidates/other_qualifications_component.rb
@@ -29,7 +29,10 @@ class ProviderInterface::FindCandidates::OtherQualificationsComponent < ViewComp
 private
 
   def qualification_type(qualification)
-    qualification.other_uk_qualification_type.presence || qualification.non_uk_qualification_type
+    qualification.other_uk_qualification_type.presence ||
+      qualification.non_uk_qualification_type.presence ||
+      qualification.qualification_type ||
+      ''
   end
 
   def qualification_subject(qualification)
@@ -48,7 +51,7 @@ private
     if qualification.predicted_grade?
       t('.predicted_grade', predicted_grade: qualification.grade)
     else
-      qualification.grade.presence
+      qualification.grade.presence || ''
     end
   end
 

--- a/spec/components/previews/provider_interface/find_candidates/other_qualifications_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/other_qualifications_component_preview.rb
@@ -1,0 +1,16 @@
+class ProviderInterface::FindCandidates::OtherQualificationsComponentPreview < ViewComponent::Preview
+  def double_science_gcse
+    qualification = FactoryBot.create(
+      :other_qualification,
+      level: 'other',
+      qualification_type: 'GCSE',
+      subject: 'Double award Science (Double award)',
+      grade: 'CC',
+      award_year: 2007,
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+    )
+
+    render ProviderInterface::FindCandidates::OtherQualificationsComponent.new(qualification.application_form)
+  end
+end


### PR DESCRIPTION
## Context

Bug found where some columns in the other qualification component were nil. 

## Changes proposed in this pull request
There was a possibility of the 'type' and the 'grade' row equally nil. This change ensure they are at least an empty string, so we always have the same number of columns as headers.

| Before | After |
| ------- | ------- |
| <img width="1069" alt="image" src="https://github.com/user-attachments/assets/4cc59e12-33f0-4642-81e1-db2eae72e73a" /> | <img width="1096" alt="image" src="https://github.com/user-attachments/assets/58bbf632-a696-48a5-baa9-e661a27635f6" /> |


## Guidance to review

Have a look at the preview -- this replicates the problem as it was in production. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
