### PR TITLE
Remove visa sponsorship deadline feature flag from DB

### DIFF
--- a/app/services/data_migrations/remove_visa_sponsorship_deadline_feature_flag.rb
+++ b/app/services/data_migrations/remove_visa_sponsorship_deadline_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveVisaSponsorshipDeadlineFeatureFlag
+    TIMESTAMP = 20250521152819
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :early_application_deadlines_for_candidates_with_visa_sponsorship).destroy_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveVisaSponsorshipDeadlineFeatureFlag',
   'DataMigrations::DropShowSupportFindACandidateFeatureFlag',
   'DataMigrations::BackfillConfidentialData',
   'DataMigrations::RemoveUnlockApplicationForEditingFeatureFlag',

--- a/spec/services/data_migrations/remove_visa_sponsorship_deadline_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_visa_sponsorship_deadline_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveVisaSponsorshipDeadlineFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'early_application_deadlines_for_candidates_with_visa_sponsorship')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'show_support_find_a_candidate')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We don't need the visa sponsorship deadline anymore.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
