### PR TITLE
Added worker to populate Find A Candidate table

### DIFF
--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -4,7 +4,7 @@ class FindACandidate::PopulatePoolWorker
   sidekiq_options queue: :default
 
   def perform
-    application_forms_eligible_for_pool = Pool::Candidates.application_forms_in_the_pool
+    application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool
                                             .select('application_forms.id as application_form_id, application_forms.candidate_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP')
 
     insert_all_from_eligible_sql = <<~SQL

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -1,0 +1,23 @@
+class FindACandidate::PopulatePoolWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default
+
+  def perform
+    application_forms_eligible_for_pool = Pool::Candidates.new(providers: [])
+                                                          .curated_application_forms
+                                                          .pluck(:id, :candidate_id)
+
+    candidate_application_insert_data = application_forms_eligible_for_pool.map do |application_form_id, candidate_id|
+      {
+        application_form_id: application_form_id,
+        candidate_id: candidate_id,
+      }
+    end
+
+    CandidatePoolApplication.transaction do
+      CandidatePoolApplication.delete_all
+      CandidatePoolApplication.insert_all(candidate_application_insert_data)
+    end
+  end
+end

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -4,8 +4,7 @@ class FindACandidate::PopulatePoolWorker
   sidekiq_options queue: :default
 
   def perform
-    application_forms_eligible_for_pool = Pool::Candidates.application_forms_in_the_pool                                              
-                                                          .curated_application_forms
+    application_forms_eligible_for_pool = Pool::Candidates.application_forms_in_the_pool
                                             .select('application_forms.id as application_form_id, application_forms.candidate_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP')
 
     insert_all_from_eligible_sql = <<~SQL

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -4,7 +4,7 @@ class FindACandidate::PopulatePoolWorker
   sidekiq_options queue: :default
 
   def perform
-    application_forms_eligible_for_pool = Pool::Candidates.new(providers: [])
+    application_forms_eligible_for_pool = Pool::Candidates.application_forms_in_the_pool                                              
                                                           .curated_application_forms
                                             .select('application_forms.id as application_form_id, application_forms.candidate_id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP')
 

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -14,6 +14,10 @@ class Clock
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true)
   end
 
+  every(15.minutes, 'FindACandidate::PopulatePoolWorker', skip_first_run: true) do
+    FindACandidate::PopulatePoolWorker.perform_async
+  end
+
   # Hourly jobs
 
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async }

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
   describe '#perform' do
     it 'creates CandidatePoolApplication records' do
       application_form = create(:application_form)
-      stub_curated_application_forms(application_form.id)
+      stub_application_forms_in_the_pool(application_form.id)
 
       expect {
         described_class.new.perform
@@ -16,7 +16,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'does not create duplicate CandidatePoolApplication records' do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
-      stub_curated_application_forms(application_form.id)
+      stub_application_forms_in_the_pool(application_form.id)
 
       expect {
         described_class.new.perform
@@ -26,7 +26,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'removes existing CandidatePoolApplication records before inserting new ones' do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
-      stub_curated_application_forms(ApplicationForm.none)
+      stub_application_forms_in_the_pool(ApplicationForm.none)
 
       expect {
         described_class.new.perform
@@ -37,7 +37,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       existing_application_in_pool = create(:application_form)
       new_application_for_pool = create(:application_form)
       create(:candidate_pool_application, application_form: existing_application_in_pool)
-      stub_curated_application_forms(new_application_for_pool.id)
+      stub_application_forms_in_the_pool(new_application_for_pool.id)
 
       expect {
         described_class.new.perform
@@ -49,8 +49,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
 private
 
-  def stub_curated_application_forms(application_form_ids)
-    pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form_ids))
-    allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+  def stub_application_forms_in_the_pool(application_form_ids)
+    allow(Pool::Candidates).to receive(:application_forms_in_the_pool).and_return(ApplicationForm.where(id: application_form_ids))
   end
 end

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
 
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.none)
       allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
 
       expect {

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe FindACandidate::PopulatePoolWorker do
+  describe '#perform' do
+    it 'creates CandidatePoolApplication records' do
+      application_form = create(:application_form)
+
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [application_form])
+      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+
+      expect {
+        described_class.new.perform
+      }.to change { CandidatePoolApplication.count }.from(0).to(1)
+
+      expect(CandidatePoolApplication.last.application_form).to eq(application_form)
+    end
+
+    it 'does not create duplicate CandidatePoolApplication records' do
+      application_form = create(:application_form)
+      create(:candidate_pool_application, application_form: application_form)
+
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [application_form])
+      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+
+      expect {
+        described_class.new.perform
+      }.not_to(change { CandidatePoolApplication.count })
+    end
+
+    it 'removes existing CandidatePoolApplication records before inserting new ones' do
+      application_form = create(:application_form)
+      create(:candidate_pool_application, application_form: application_form)
+
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [])
+      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+
+      expect {
+        described_class.new.perform
+      }.to change { CandidatePoolApplication.count }.from(1).to(0)
+    end
+
+    it 'removes existing and adds new CandidatePoolApplication records' do
+      existing_application_in_pool = create(:application_form)
+      new_application_for_pool = create(:application_form)
+      create(:candidate_pool_application, application_form: existing_application_in_pool)
+
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [new_application_for_pool])
+      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+
+      expect {
+        described_class.new.perform
+      }.not_to(change { CandidatePoolApplication.count })
+
+      expect(CandidatePoolApplication.last.application_form).to eq(new_application_for_pool)
+    end
+  end
+end

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 private
 
   def stub_application_forms_in_the_pool(application_form_ids)
-    allow(Pool::Candidates).to receive(:application_forms_in_the_pool).and_return(ApplicationForm.where(id: application_form_ids))
+    pool_candidates_double = instance_double(Pool::Candidates, application_forms_in_the_pool: ApplicationForm.where(id: application_form_ids))
+    allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
   end
 end

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'creates CandidatePoolApplication records' do
       application_form = create(:application_form)
 
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [application_form])
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
       allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
 
       expect {
@@ -19,7 +19,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
 
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [application_form])
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
       allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
 
       expect {
@@ -31,7 +31,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
 
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [])
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
       allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
 
       expect {
@@ -44,7 +44,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       new_application_for_pool = create(:application_form)
       create(:candidate_pool_application, application_form: existing_application_in_pool)
 
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: [new_application_for_pool])
+      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: new_application_for_pool.id))
       allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
 
       expect {

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
   describe '#perform' do
     it 'creates CandidatePoolApplication records' do
       application_form = create(:application_form)
-
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
-      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+      stub_curated_application_forms(application_form.id)
 
       expect {
         described_class.new.perform
@@ -18,9 +16,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'does not create duplicate CandidatePoolApplication records' do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
-
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form.id))
-      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+      stub_curated_application_forms(application_form.id)
 
       expect {
         described_class.new.perform
@@ -30,9 +26,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'removes existing CandidatePoolApplication records before inserting new ones' do
       application_form = create(:application_form)
       create(:candidate_pool_application, application_form: application_form)
-
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.none)
-      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+      stub_curated_application_forms(ApplicationForm.none)
 
       expect {
         described_class.new.perform
@@ -43,9 +37,7 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       existing_application_in_pool = create(:application_form)
       new_application_for_pool = create(:application_form)
       create(:candidate_pool_application, application_form: existing_application_in_pool)
-
-      pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: new_application_for_pool.id))
-      allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
+      stub_curated_application_forms(new_application_for_pool.id)
 
       expect {
         described_class.new.perform
@@ -53,5 +45,12 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
       expect(CandidatePoolApplication.last.application_form).to eq(new_application_for_pool)
     end
+  end
+
+private
+
+  def stub_curated_application_forms(application_form_ids)
+    pool_candidates_double = instance_double(Pool::Candidates, curated_application_forms: ApplicationForm.where(id: application_form_ids))
+    allow(Pool::Candidates).to receive(:new).and_return(pool_candidates_double)
   end
 end


### PR DESCRIPTION
## Context

We want to periodically populate the CandidatePoolApplication table with the most recent eligible Application Forms to appear in the Pool

## Changes proposed in this pull request

- Adds a worker to find all the eligible Application Forms and adds them to the CandidatePoolApplication table
- Worker set to run every 15 minutes

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
