### PR TITLE
Use publication date to determine the current report

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -9,7 +9,8 @@ module Publications
     end
 
     def by_month
-      @report = MonthlyStatistics::MonthlyStatisticsReport.current_published_report_at(month)
+      @report = MonthlyStatistics::MonthlyStatisticsReport.find_by!(month:)
+
       render_report
     end
 
@@ -23,7 +24,7 @@ module Publications
     end
 
     def download
-      @report = MonthlyStatistics::MonthlyStatisticsReport.current_published_report_at(month)
+      @report = MonthlyStatistics::MonthlyStatisticsReport.find_by!(month:)
 
       return render 'errors/not_found', status: :not_found, formats: :html unless csv.exists?
 
@@ -58,7 +59,7 @@ module Publications
     end
 
     def month
-      Date.parse("#{params[:month]}-01")
+      params.expect(:month)
     rescue Date::Error
       raise ActiveRecord::RecordNotFound
     end

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -9,7 +9,7 @@ module Publications
     end
 
     def by_month
-      @report = MonthlyStatistics::MonthlyStatisticsReport.current_report_at(month)
+      @report = MonthlyStatistics::MonthlyStatisticsReport.current_published_report_at(month)
       render_report
     end
 
@@ -23,7 +23,7 @@ module Publications
     end
 
     def download
-      @report = MonthlyStatistics::MonthlyStatisticsReport.current_report_at(month)
+      @report = MonthlyStatistics::MonthlyStatisticsReport.current_published_report_at(month)
 
       return render 'errors/not_found', status: :not_found, formats: :html unless csv.exists?
 

--- a/app/views/publications/monthly_statistics/v2/show.html.erb
+++ b/app/views/publications/monthly_statistics/v2/show.html.erb
@@ -26,7 +26,7 @@
         <dd class="gem-c-metadata__definition"><%= @presenter.publication_date.to_fs(:govuk_date) %></dd>
 
         <% if @presenter.current_cycle? %>
-          <dt class="gem-c-metadata__term">Next update</dt>
+          <dt class="gem-c-metadata__term">Next planned update</dt>
           <dd class="gem-c-metadata__definition"><%= @presenter.next_publication_date.to_fs(:govuk_date) %></dd>
         <% end %>
       </dl>


### PR DESCRIPTION
## Context

We currently don't use the publication date to determine whether or not a report should be shown in the publicly available publications page. 

## Changes proposed in this pull request

This PR ensures that we only show reports if the publication date is in the past. This way, we can simply change the publication date on a single record to show it sooner / later. 

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
