### PR TITLE
Refactor the Pool::Candidate methods

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -215,10 +215,7 @@ module SupportInterface
     end
 
     def application_form_in_the_pool?
-      return false if candidate.submission_blocked? || candidate.account_locked?
-      return false if candidate.published_opt_in_preferences.blank?
-
-      Pool::Candidates.new(providers: []).curated_application_forms(ApplicationForm.where(id: application_form.id)).present?
+      CandidatePoolApplication.where(application_form_id: application_form.id).present?
     end
 
     attr_reader :application_form

--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -15,17 +15,14 @@ module ProviderInterface
 
         @pagy, @application_forms = pagy(
           Pool::Candidates.application_forms_for_provider(
-            providers: current_provider_user.providers,
             filters: @filter.applied_filters,
           ),
         )
       end
 
       def show
-        @application_form = Pool::Candidates.application_forms_for_provider(
-          providers: current_provider_user.providers,
-        )
-        .find_by(candidate_id: params.expect(:id))
+        @application_form = Pool::Candidates.application_forms_for_provider
+          .find_by(candidate_id: params.expect(:id))
 
         @candidate = @application_form.candidate
       end

--- a/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
@@ -64,9 +64,8 @@ module ProviderInterface
     private
 
       def set_candidate
-        @candidate ||= Pool::Candidates.application_forms_for_provider(
-          providers: current_provider_user.providers,
-        ).find_by(candidate_id: params.expect(:candidate_id)).candidate
+        @candidate ||= Pool::Candidates.application_forms_for_provider
+          .find_by(candidate_id: params.expect(:candidate_id)).candidate
       end
 
       def pool_invite_form_params

--- a/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
@@ -43,9 +43,8 @@ module ProviderInterface
       end
 
       def set_candidate
-        @candidate ||= Pool::Candidates.application_forms_for_provider(
-          providers: current_provider_user.providers,
-        ).find_by(candidate_id: params.expect(:candidate_id)).candidate
+        @candidate ||= Pool::Candidates.application_forms_for_provider
+         .find_by(candidate_id: params.expect(:candidate_id)).candidate
       end
 
       def invite

--- a/app/controllers/support_interface/find_candidates_controller.rb
+++ b/app/controllers/support_interface/find_candidates_controller.rb
@@ -7,7 +7,6 @@ module SupportInterface
 
       @pagy, @application_forms = pagy(
         Pool::Candidates.application_forms_for_provider(
-          providers: [],
           filters: @filter.applied_filters,
         ),
       )

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -15,10 +15,6 @@ class Pool::Candidates
       .distinct
   end
 
-  def self.application_forms_in_the_pool
-    new.application_forms_in_the_pool
-  end
-
   def application_forms_in_the_pool
     opted_in_candidates = Candidate.joins(:published_preferences).where(published_preferences: { pool_status: 'opt_in' }).select(:id)
 

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,53 +1,46 @@
 class Pool::Candidates
-  LOCATION_RADIUS = 30
-  attr_reader :providers, :filters
+  attr_reader :filters
 
-  def initialize(providers:, filters: {})
-    @providers = providers
+  def initialize(filters: {})
     @filters = filters
   end
 
-  def self.application_forms_for_provider(providers:, filters: {})
-    new(providers:, filters:).application_forms_for_provider
+  def self.application_forms_for_provider(filters: {})
+    new(filters:).application_forms_for_provider
   end
 
   def application_forms_for_provider
-    opted_in_candidates = Candidate.joins(:published_preferences).where(published_preferences: { pool_status: 'opt_in' }).select(:id)
-    dismissed_candidates = Candidate.joins(:pool_dismissals).where(pool_dismissals: { provider: providers }).select(:id)
-
     filtered_application_forms.joins(:candidate)
-      .where(candidate: { submission_blocked: false, account_locked: false })
-      .where(candidate: opted_in_candidates)
-      .where.not(candidate: dismissed_candidates)
       .order(order_by)
       .distinct
   end
 
   def self.application_forms_in_the_pool
-    new(providers: []).application_forms_in_the_pool
-  end
-
-  def self.application_forms_eligible_for_pool
-    new(providers: []).application_forms_eligible_for_pool
-  end
-
-  def application_forms_eligible_for_pool
-    filtered_application_forms.joins(:candidate)
-                              .where(candidates: { submission_blocked: false, account_locked: false })
-                              .distinct
+    new.application_forms_in_the_pool
   end
 
   def application_forms_in_the_pool
     opted_in_candidates = Candidate.joins(:published_preferences).where(published_preferences: { pool_status: 'opt_in' }).select(:id)
 
-    filtered_application_forms.joins(:candidate)
+    curated_application_forms.joins(:candidate)
       .where(candidate: { submission_blocked: false, account_locked: false })
       .where(candidate: opted_in_candidates)
       .distinct
   end
 
-  def curated_application_forms(application_forms_scope = ApplicationForm.current_cycle)
-    current_cycle_forms = application_forms_scope
+private
+
+  def filtered_application_forms
+    scope = ApplicationForm.where(id: CandidatePoolApplication.select(:application_form_id))
+    scope = filter_by_subject(scope)
+    scope = filter_by_study_mode(scope)
+    scope = filter_by_course_type(scope)
+    scope = filter_by_right_to_work_or_study(scope)
+    filter_by_distance(scope)
+  end
+
+  def curated_application_forms
+    current_cycle_forms = ApplicationForm.current_cycle
 
     # Subquery: To exclude forms with live applications (eg, being considered by the provider, or recruited / deferred)
     forms_with_live_applications = current_cycle_forms
@@ -80,17 +73,6 @@ class Pool::Candidates
       .where(id: forms_with_available_slots)
       .where.not(id: forms_with_live_applications.select('application_forms.id'))
       .where.not(id: forms_that_have_been_withdrawn_for_not_wanting_to_train.select('application_forms.id'))
-  end
-
-private
-
-  def filtered_application_forms
-    scope = curated_application_forms
-    scope = filter_by_subject(scope)
-    scope = filter_by_study_mode(scope)
-    scope = filter_by_course_type(scope)
-    scope = filter_by_right_to_work_or_study(scope)
-    filter_by_distance(scope)
   end
 
   def filter_by_distance(application_forms_scope)

--- a/app/workers/candidate/pool_eligible_application_form_worker.rb
+++ b/app/workers/candidate/pool_eligible_application_form_worker.rb
@@ -4,7 +4,7 @@ class Candidate::PoolEligibleApplicationFormWorker
   sidekiq_options queue: :low_priority
 
   def perform
-    application_forms = Pool::Candidates.application_forms_in_the_pool.select(:id)
+    application_forms = Pool::Candidates.new.application_forms_in_the_pool.select(:id)
 
     return if application_forms.blank?
 

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -97,9 +97,7 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
       it 'displays "Currently findable by providers" for the Find a Candidate opt-in status row' do
         candidate = create(:candidate)
         application_form = create(:application_form, candidate:)
-
-        create(:candidate_preference, candidate:)
-        create(:application_choice, status: :withdrawn, application_form:)
+        create(:candidate_pool_application, application_form: application_form)
 
         result = render_inline(described_class.new(application_form:))
 

--- a/spec/factories/candidate_pool_applications.rb
+++ b/spec/factories/candidate_pool_applications.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :candidate_pool_application do
+    application_form { association(:application_form) }
+    candidate { application_form.candidate }
+  end
+end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Pool::Candidates do
     end
   end
 
-  describe '.application_forms_in_the_pool' do
+  describe '#application_forms_in_the_pool' do
     it 'returns application_forms that should be in the candidate pool' do
       rejected_candidate = create(:candidate)
       create(:candidate_preference, candidate: rejected_candidate)
@@ -148,7 +148,7 @@ RSpec.describe Pool::Candidates do
       inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
       create(:application_choice, :inactive, application_form: inactive_candidate_form)
 
-      application_forms = described_class.application_forms_in_the_pool
+      application_forms = described_class.new.application_forms_in_the_pool
 
       expect(application_forms).to contain_exactly(
         rejected_candidate_form,
@@ -229,7 +229,7 @@ RSpec.describe Pool::Candidates do
         reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
       )
 
-      application_forms = described_class.application_forms_in_the_pool
+      application_forms = described_class.new.application_forms_in_the_pool
 
       expect(application_forms).to be_empty
     end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -4,113 +4,15 @@ RSpec.describe Pool::Candidates do
   describe '.application_forms_for_provider' do
     context 'tests base query without filters' do
       it 'returns application_forms that should be on candidate pool list' do
-        providers = [create(:provider)]
+        application_in_the_pool = create(:application_form)
+        create(:candidate_pool_application, application_form: application_in_the_pool)
+        _application_not_in_the_pool = create(:application_form)
 
-        rejected_candidate = create(:candidate)
-        create(:candidate_preference, candidate: rejected_candidate)
-        rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
-        create(:application_choice, :rejected, application_form: rejected_candidate_form)
-
-        declined_candidate = create(:candidate)
-        create(:candidate_preference, candidate: declined_candidate)
-        declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
-        create(:application_choice, :declined, application_form: declined_candidate_form)
-
-        withdrawn_candidate = create(:candidate)
-        create(:candidate_preference, candidate: withdrawn_candidate)
-        withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
-        create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
-
-        conditions_not_met_candidate = create(:candidate)
-        create(:candidate_preference, candidate: conditions_not_met_candidate)
-        conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
-        create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
-
-        offer_withdrawn_candidate = create(:candidate)
-        create(:candidate_preference, candidate: offer_withdrawn_candidate)
-        offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
-        create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
-
-        inactive_candidate = create(:candidate)
-        create(:candidate_preference, candidate: inactive_candidate)
-        inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
-        create(:application_choice, :inactive, application_form: inactive_candidate_form)
-
-        application_forms = described_class.application_forms_for_provider(providers:, filters: {})
+        application_forms = described_class.application_forms_for_provider(filters: {})
 
         expect(application_forms).to contain_exactly(
-          rejected_candidate_form,
-          declined_candidate_form,
-          withdrawn_candidate_form,
-          conditions_not_met_candidate_form,
-          offer_withdrawn_candidate_form,
-          inactive_candidate_form,
+          application_in_the_pool,
         )
-      end
-
-      it 'does not returns application_forms that should not be on the candidate pool list' do
-        provider = create(:provider)
-        providers = [provider]
-
-        previous_year_form = create(:application_form, :completed, recruitment_cycle_year: previous_year)
-        create(:candidate_preference, candidate: previous_year_form.candidate)
-        create(:application_choice, :rejected, application_form: previous_year_form)
-
-        opt_out_candidate = create(:candidate)
-        create(:candidate_preference, pool_status: 'opt_out', candidate: opt_out_candidate)
-        opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
-        create(:application_choice, :rejected, application_form: opt_out_candidate_form)
-
-        dismissed_candidate = create(:candidate)
-        create(:candidate_preference, candidate: dismissed_candidate)
-        dismissed_candidate_form = create(:application_form, :completed, candidate: dismissed_candidate)
-        create(:application_choice, :rejected, application_form: dismissed_candidate_form)
-        create(:pool_dismissal, provider:, candidate: dismissed_candidate)
-
-        rejected_candidate = create(:candidate)
-        create(:candidate_preference, candidate: rejected_candidate)
-        rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
-        create(:application_choice, :rejected, application_form: rejected_candidate_form)
-        create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
-
-        declined_candidate = create(:candidate)
-        create(:candidate_preference, candidate: declined_candidate)
-        declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
-        create(:application_choice, :declined, application_form: declined_candidate_form)
-        create(:application_choice, :interviewing, application_form: declined_candidate_form)
-
-        withdrawn_candidate = create(:candidate)
-        create(:candidate_preference, candidate: withdrawn_candidate)
-        withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
-        create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
-        create(:application_choice, :offer, application_form: withdrawn_candidate_form)
-
-        conditions_not_met_candidate = create(:candidate)
-        create(:candidate_preference, candidate: conditions_not_met_candidate)
-        conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
-        create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
-        create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
-
-        offer_withdrawn_candidate = create(:candidate)
-        create(:candidate_preference, candidate: offer_withdrawn_candidate)
-        offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
-        create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
-        create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
-
-        inactive_candidate = create(:candidate)
-        create(:candidate_preference, candidate: inactive_candidate)
-        inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
-        create(:application_choice, :inactive, application_form: inactive_candidate_form)
-        create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
-
-        candidate_with_too_many_choices = create(:candidate)
-        create(:candidate_preference, candidate: candidate_with_too_many_choices)
-        candidate_with_too_many_choices_form = create(:application_form, :completed, candidate: candidate_with_too_many_choices)
-        create_list(:application_choice, 15, :offer_withdrawn, application_form: candidate_with_too_many_choices_form)
-
-        application_forms = described_class.application_forms_for_provider(providers:, filters: {})
-
-        expect(application_forms).to be_empty
       end
     end
 
@@ -152,7 +54,7 @@ RSpec.describe Pool::Candidates do
         visa_sponsorship_candidate_form = create_visa_sponsorship_candidate_form(part_time_tda_course_option)
 
         filters = { origin: manchester_coordinates }
-        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+        application_forms = described_class.application_forms_for_provider(filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
           manchester_candidate_form.id,
@@ -163,7 +65,7 @@ RSpec.describe Pool::Candidates do
 
         filters = { origin: manchester_coordinates, subject: [subject.id.to_s] }
 
-        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+        application_forms = described_class.application_forms_for_provider(filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
           part_time_candidate_form.id,
@@ -177,7 +79,7 @@ RSpec.describe Pool::Candidates do
           study_mode: ['part_time'],
         }
 
-        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+        application_forms = described_class.application_forms_for_provider(filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
           part_time_candidate_form.id,
@@ -191,7 +93,7 @@ RSpec.describe Pool::Candidates do
           course_type: ['TDA'],
         }
 
-        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+        application_forms = described_class.application_forms_for_provider(filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
           undergraduate_candidate_form.id,
@@ -205,100 +107,199 @@ RSpec.describe Pool::Candidates do
           visa_sponsorship: ['required'],
         }
 
-        application_forms = described_class.application_forms_for_provider(providers: [provider], filters:)
+        application_forms = described_class.application_forms_for_provider(filters:)
 
         expect(application_forms.map(&:id)).to contain_exactly(
           visa_sponsorship_candidate_form.id,
         )
       end
     end
-
-    def create_manchester_candidate_form(provider)
-      manchester_candidate = create(:candidate)
-      candidate_preference = create(:candidate_preference, candidate: manchester_candidate)
-      create(:candidate_location_preference, :manchester, candidate_preference:)
-      manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
-      course = create(:course, provider:)
-      course_option = create(
-        :course_option,
-        course: course,
-      )
-      create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
-
-      manchester_candidate_form
-    end
-
-    def create_subject_candidate_form(course_option)
-      # This candidate also doesn't have a location preference.
-      # They should still appear when searching by location
-      subject_candidate = create(:candidate)
-      _candidate_preference = create(:candidate_preference, candidate: subject_candidate)
-      subject_candidate_form = create(:application_form, :completed, candidate: subject_candidate)
-      create(:application_choice, :rejected, application_form: subject_candidate_form, course_option:)
-
-      subject_candidate_form
-    end
-
-    def create_part_time_candidate_form(course_option)
-      part_time_candidate = create(:candidate)
-      candidate_preference = create(:candidate_preference, candidate: part_time_candidate)
-      create(:candidate_location_preference, :manchester, candidate_preference:)
-      part_time_candidate_form = create(:application_form, :completed, candidate: part_time_candidate)
-      create(:application_choice, :rejected, application_form: part_time_candidate_form, course_option:)
-      part_time_candidate_form
-    end
-
-    def create_undergraduate_candidate_form(course_option)
-      undergraduate_candidate = create(:candidate)
-      candidate_preference = create(:candidate_preference, candidate: undergraduate_candidate)
-      create(:candidate_location_preference, :manchester, candidate_preference:)
-      undergraduate_candidate_form = create(
-        :application_form,
-        :completed,
-        candidate: undergraduate_candidate,
-      )
-      create(:application_choice, :declined, application_form: undergraduate_candidate_form, course_option:)
-      undergraduate_candidate_form
-    end
-
-    def create_visa_sponsorship_candidate_form(course_option)
-      visa_sponsorship_candidate = create(:candidate)
-      candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
-      create(:candidate_location_preference, :liverpool, candidate_preference:)
-      visa_sponsorship_candidate_form = create(
-        :application_form,
-        :completed,
-        candidate: visa_sponsorship_candidate,
-        right_to_work_or_study: :no,
-      )
-      create(:application_choice, :declined, application_form: visa_sponsorship_candidate_form, course_option:)
-
-      visa_sponsorship_candidate_form
-    end
   end
 
   describe '.application_forms_in_the_pool' do
     it 'returns application_forms that should be in the candidate pool' do
       rejected_candidate = create(:candidate)
-      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
       create(:candidate_preference, candidate: rejected_candidate)
+      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
       create(:application_choice, :rejected, application_form: rejected_candidate_form)
 
-      results = described_class.application_forms_in_the_pool
+      declined_candidate = create(:candidate)
+      create(:candidate_preference, candidate: declined_candidate)
+      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+      create(:application_choice, :declined, application_form: declined_candidate_form)
 
-      expect(results).to contain_exactly(rejected_candidate_form)
+      withdrawn_candidate = create(:candidate)
+      create(:candidate_preference, candidate: withdrawn_candidate)
+      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+
+      conditions_not_met_candidate = create(:candidate)
+      create(:candidate_preference, candidate: conditions_not_met_candidate)
+      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+
+      offer_withdrawn_candidate = create(:candidate)
+      create(:candidate_preference, candidate: offer_withdrawn_candidate)
+      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+
+      inactive_candidate = create(:candidate)
+      create(:candidate_preference, candidate: inactive_candidate)
+      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+      create(:application_choice, :inactive, application_form: inactive_candidate_form)
+
+      application_forms = described_class.application_forms_in_the_pool
+
+      expect(application_forms).to contain_exactly(
+        rejected_candidate_form,
+        declined_candidate_form,
+        withdrawn_candidate_form,
+        conditions_not_met_candidate_form,
+        offer_withdrawn_candidate_form,
+        inactive_candidate_form,
+      )
+    end
+
+    it 'does not returns application_forms that should not be on the candidate pool list' do
+      previous_year_form = create(:application_form, :completed, recruitment_cycle_year: previous_year)
+      create(:candidate_preference, candidate: previous_year_form.candidate)
+      create(:application_choice, :rejected, application_form: previous_year_form)
+
+      opt_out_candidate = create(:candidate)
+      create(:candidate_preference, pool_status: 'opt_out', candidate: opt_out_candidate)
+      opt_out_candidate_form = create(:application_form, :completed, candidate: opt_out_candidate)
+      create(:application_choice, :rejected, application_form: opt_out_candidate_form)
+
+      rejected_candidate = create(:candidate)
+      create(:candidate_preference, candidate: rejected_candidate)
+      rejected_candidate_form = create(:application_form, :completed, candidate: rejected_candidate)
+      create(:application_choice, :rejected, application_form: rejected_candidate_form)
+      create(:application_choice, :awaiting_provider_decision, application_form: rejected_candidate_form)
+
+      declined_candidate = create(:candidate)
+      create(:candidate_preference, candidate: declined_candidate)
+      declined_candidate_form = create(:application_form, :completed, candidate: declined_candidate)
+      create(:application_choice, :declined, application_form: declined_candidate_form)
+      create(:application_choice, :interviewing, application_form: declined_candidate_form)
+
+      withdrawn_candidate = create(:candidate)
+      create(:candidate_preference, candidate: withdrawn_candidate)
+      withdrawn_candidate_form = create(:application_form, :completed, candidate: withdrawn_candidate)
+      create(:application_choice, :withdrawn, application_form: withdrawn_candidate_form)
+      create(:application_choice, :offer, application_form: withdrawn_candidate_form)
+
+      conditions_not_met_candidate = create(:candidate)
+      create(:candidate_preference, candidate: conditions_not_met_candidate)
+      conditions_not_met_candidate_form = create(:application_form, :completed, candidate: conditions_not_met_candidate)
+      create(:application_choice, :conditions_not_met, application_form: conditions_not_met_candidate_form)
+      create(:application_choice, :pending_conditions, application_form: conditions_not_met_candidate_form)
+
+      offer_withdrawn_candidate = create(:candidate)
+      create(:candidate_preference, candidate: offer_withdrawn_candidate)
+      offer_withdrawn_candidate_form = create(:application_form, :completed, candidate: offer_withdrawn_candidate)
+      create(:application_choice, :offer_withdrawn, application_form: offer_withdrawn_candidate_form)
+      create(:application_choice, :recruited, application_form: offer_withdrawn_candidate_form)
+
+      inactive_candidate = create(:candidate)
+      create(:candidate_preference, candidate: inactive_candidate)
+      inactive_candidate_form = create(:application_form, :completed, candidate: inactive_candidate)
+      create(:application_choice, :inactive, application_form: inactive_candidate_form)
+      create(:application_choice, :offer_deferred, application_form: inactive_candidate_form)
+
+      candidate_with_too_many_choices = create(:candidate)
+      create(:candidate_preference, candidate: candidate_with_too_many_choices)
+      candidate_with_too_many_choices_form = create(:application_form, :completed, candidate: candidate_with_too_many_choices)
+      create_list(:application_choice, 15, :offer_withdrawn, application_form: candidate_with_too_many_choices_form)
+
+      no_longer_wants_to_train_candidate = create(:candidate)
+      create(:candidate_preference, candidate: no_longer_wants_to_train_candidate)
+      withdrawn_no_longer_wants_to_train_form = create(
+        :application_form,
+        :completed,
+        candidate: no_longer_wants_to_train_candidate,
+      )
+      withdrawn_choice = create(
+        :application_choice,
+        :withdrawn,
+        application_form: withdrawn_no_longer_wants_to_train_form,
+      )
+      create(
+        :withdrawal_reason,
+        application_choice: withdrawn_choice,
+        reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
+      )
+
+      application_forms = described_class.application_forms_in_the_pool
+
+      expect(application_forms).to be_empty
     end
   end
 
-  describe '.application_forms_eligible_for_pool' do
-    it 'returns application_forms that should be in the candidate pool' do
-      rejected_candidate_form = create(:application_form, :completed)
-      create(:application_choice, :rejected, application_form: rejected_candidate_form)
-      _accepted_application_form = create(:application_form, :with_accepted_offer)
+  def create_manchester_candidate_form(provider)
+    manchester_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: manchester_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
+    manchester_candidate_form = create(:application_form, :completed, candidate: manchester_candidate)
+    create(:candidate_pool_application, application_form: manchester_candidate_form)
+    course = create(:course, provider:)
+    course_option = create(
+      :course_option,
+      course: course,
+    )
+    create(:application_choice, :rejected, application_form: manchester_candidate_form, course_option:)
 
-      results = described_class.application_forms_eligible_for_pool
+    manchester_candidate_form
+  end
 
-      expect(results).to contain_exactly(rejected_candidate_form)
-    end
+  def create_subject_candidate_form(course_option)
+    # This candidate also doesn't have a location preference.
+    # They should still appear when searching by location
+    subject_candidate = create(:candidate)
+    _candidate_preference = create(:candidate_preference, candidate: subject_candidate)
+    subject_candidate_form = create(:application_form, :completed, candidate: subject_candidate)
+    create(:candidate_pool_application, application_form: subject_candidate_form)
+    create(:application_choice, :rejected, application_form: subject_candidate_form, course_option:)
+
+    subject_candidate_form
+  end
+
+  def create_part_time_candidate_form(course_option)
+    part_time_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: part_time_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
+    part_time_candidate_form = create(:application_form, :completed, candidate: part_time_candidate)
+    create(:candidate_pool_application, application_form: part_time_candidate_form)
+    create(:application_choice, :rejected, application_form: part_time_candidate_form, course_option:)
+    part_time_candidate_form
+  end
+
+  def create_undergraduate_candidate_form(course_option)
+    undergraduate_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: undergraduate_candidate)
+    create(:candidate_location_preference, :manchester, candidate_preference:)
+    undergraduate_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: undergraduate_candidate,
+    )
+    create(:candidate_pool_application, application_form: undergraduate_candidate_form)
+    create(:application_choice, :declined, application_form: undergraduate_candidate_form, course_option:)
+    undergraduate_candidate_form
+  end
+
+  def create_visa_sponsorship_candidate_form(course_option)
+    visa_sponsorship_candidate = create(:candidate)
+    candidate_preference = create(:candidate_preference, candidate: visa_sponsorship_candidate)
+    create(:candidate_location_preference, :liverpool, candidate_preference:)
+    visa_sponsorship_candidate_form = create(
+      :application_form,
+      :completed,
+      candidate: visa_sponsorship_candidate,
+      right_to_work_or_study: :no,
+    )
+    create(:candidate_pool_application, application_form: visa_sponsorship_candidate_form)
+    create(:application_choice, :declined, application_form: visa_sponsorship_candidate_form, course_option:)
+
+    visa_sponsorship_candidate_form
   end
 end

--- a/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
+++ b/spec/requests/provider_interface/candidate_pool/publish_invites_controller_spec.rb
@@ -26,9 +26,8 @@ RSpec.describe 'ProviderInterface::CandidatePool::PublishInvitesController' do
       candidate = create(:candidate)
       create(:candidate_preference, candidate:)
       application_form = create(:application_form, :completed, candidate:)
+      create(:candidate_pool_application, application_form:)
       course = create(:course, provider:, exposed_in_find: true)
-      course_option = create(:course_option, course: course)
-      create(:application_choice, :rejected, application_form:, course_option:)
 
       draft_invite = create(
         :pool_invite,
@@ -56,9 +55,8 @@ RSpec.describe 'ProviderInterface::CandidatePool::PublishInvitesController' do
         candidate = create(:candidate)
         create(:candidate_preference, candidate:)
         application_form = create(:application_form, :completed, candidate:)
+        create(:candidate_pool_application, application_form:)
         course = create(:course, provider:, exposed_in_find: true)
-        course_option = create(:course_option, course: course)
-        create(:application_choice, :rejected, application_form:, course_option:)
 
         draft_invite = create(
           :pool_invite,

--- a/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
@@ -91,7 +91,7 @@ private
       candidate: @candidate,
       submitted_at: 1.day.ago,
     )
-    create(:application_choice, :rejected, application_form: rejected_candidate_form)
+    create(:candidate_pool_application, application_form: rejected_candidate_form)
   end
 
   def given_provider_user_cannot_make_decisions_for_any_of_their_courses

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Providers invites candidates' do
       candidate: @candidate,
       submitted_at: 1.day.ago,
     )
-    create(:application_choice, :rejected, application_form: rejected_candidate_form)
+    create(:candidate_pool_application, application_form: rejected_candidate_form)
   end
 
   def and_provider_is_opted_in_to_candidate_pool

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -39,12 +39,7 @@ RSpec.describe 'Providers views candidate pool details' do
       candidate: @rejected_candidate,
       submitted_at: 1.day.ago,
     )
-    subjects = create_list(:subject, 2)
-    course = create(:course)
-    course.subjects << subjects
-    course_option = create(:course_option, course: course)
-
-    create(:application_choice, :rejected, application_form: @rejected_candidate_form, course_option: course_option)
+    create(:candidate_pool_application, application_form: @rejected_candidate_form)
 
     declined_candidate = create(:candidate)
     create(:candidate_preference, candidate: declined_candidate)
@@ -56,9 +51,9 @@ RSpec.describe 'Providers views candidate pool details' do
       candidate: declined_candidate,
       submitted_at: Time.zone.today,
     )
-    create(:application_choice, :declined, application_form: @declined_candidate_form)
+    create(:candidate_pool_application, application_form: @declined_candidate_form)
 
-    previous_cycle_form = create(
+    _previous_cycle_form = create(
       :application_form,
       :completed,
       first_name: 'test',
@@ -67,7 +62,6 @@ RSpec.describe 'Providers views candidate pool details' do
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )
-    create(:application_choice, :declined, application_form: previous_cycle_form)
   end
 
   def and_provider_is_opted_in_to_candidate_pool

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Providers views candidate pool list' do
     set_rejected_candidate_form
     set_declined_candidate_form
     set_visa_sponsorship_candidate_form
-    set_withdrawn_no_longer_want_to_train_form
 
     allow(GoogleMapsAPI::Client).to receive(:new).and_return(client)
     allow(client).to receive(:autocomplete).and_return(api_response)
@@ -94,6 +93,7 @@ RSpec.describe 'Providers views candidate pool list' do
       candidate: declined_candidate,
       submitted_at: Time.zone.today,
     )
+    create(:candidate_pool_application, application_form: @declined_candidate_form)
     create(:application_choice, :declined, application_form: @declined_candidate_form)
 
     previous_cycle_form = create(
@@ -118,6 +118,7 @@ RSpec.describe 'Providers views candidate pool list' do
       candidate: rejected_candidate,
       submitted_at: 1.day.ago,
     )
+    create(:candidate_pool_application, application_form: @rejected_candidate_form)
     course_option = create(
       :course_option,
       course: create(:course, provider: current_provider),
@@ -141,6 +142,7 @@ RSpec.describe 'Providers views candidate pool list' do
       submitted_at: 6.hours.ago,
       right_to_work_or_study: :no,
     )
+    create(:candidate_pool_application, application_form: @visa_sponsorship_form)
     course_option = create(
       :course_option,
       course: create(:course, provider: current_provider),
@@ -150,32 +152,6 @@ RSpec.describe 'Providers views candidate pool list' do
       :rejected,
       application_form: @visa_sponsorship_form,
       course_option:,
-    )
-  end
-
-  def set_withdrawn_no_longer_want_to_train_form
-    no_longer_wants_to_train_candidate = create(:candidate)
-    create(:candidate_preference, candidate: no_longer_wants_to_train_candidate)
-    @withdrawn_no_longer_wants_to_train_form = create(
-      :application_form,
-      :completed,
-      candidate: no_longer_wants_to_train_candidate,
-      submitted_at: 3.hours.ago,
-    )
-    course_option = create(
-      :course_option,
-      course: create(:course, provider: current_provider),
-    )
-    withdrawn_choice = create(
-      :application_choice,
-      :withdrawn,
-      application_form: @withdrawn_no_longer_wants_to_train_form,
-      course_option:,
-    )
-    create(
-      :withdrawal_reason,
-      application_choice: withdrawn_choice,
-      reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
     )
   end
 
@@ -200,8 +176,6 @@ RSpec.describe 'Providers views candidate pool list' do
     expected_candidates.each do |candidate_text|
       expect(candidates).to have_text(candidate_text)
     end
-
-    expect(page).to have_no_text(candidate_name(@withdrawn_no_longer_wants_to_train_form))
   end
 
   def then_i_am_redirected_to_the_applications_page

--- a/spec/system/support_interface/find_a_candidate_spec.rb
+++ b/spec/system/support_interface/find_a_candidate_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Support user views candidate pool list' do
     set_rejected_candidate_form
     set_declined_candidate_form
     set_visa_sponsorship_candidate_form
-    set_withdrawn_no_longer_want_to_train_form
   end
 
   scenario 'View candidates' do
@@ -44,9 +43,9 @@ RSpec.describe 'Support user views candidate pool list' do
       candidate: declined_candidate,
       submitted_at: Time.zone.today,
     )
-    create(:application_choice, :declined, application_form: @declined_candidate_form)
+    create(:candidate_pool_application, application_form: @declined_candidate_form)
 
-    previous_cycle_form = create(
+    _previous_cycle_form = create(
       :application_form,
       :completed,
       first_name: 'test',
@@ -55,7 +54,6 @@ RSpec.describe 'Support user views candidate pool list' do
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )
-    create(:application_choice, :declined, application_form: previous_cycle_form)
   end
 
   def set_rejected_candidate_form
@@ -68,16 +66,7 @@ RSpec.describe 'Support user views candidate pool list' do
       candidate: rejected_candidate,
       submitted_at: 1.day.ago,
     )
-    course_option = create(
-      :course_option,
-      course: create(:course, provider: current_provider),
-    )
-    create(
-      :application_choice,
-      :rejected,
-      application_form: @rejected_candidate_form,
-      course_option:,
-    )
+    create(:candidate_pool_application, application_form: @rejected_candidate_form)
   end
 
   def set_visa_sponsorship_candidate_form
@@ -91,42 +80,7 @@ RSpec.describe 'Support user views candidate pool list' do
       submitted_at: 6.hours.ago,
       right_to_work_or_study: :no,
     )
-    course_option = create(
-      :course_option,
-      course: create(:course, provider: current_provider),
-    )
-    create(
-      :application_choice,
-      :rejected,
-      application_form: @visa_sponsorship_form,
-      course_option:,
-    )
-  end
-
-  def set_withdrawn_no_longer_want_to_train_form
-    no_longer_wants_to_train_candidate = create(:candidate)
-    create(:candidate_preference, candidate: no_longer_wants_to_train_candidate)
-    @withdrawn_no_longer_wants_to_train_form = create(
-      :application_form,
-      :completed,
-      candidate: no_longer_wants_to_train_candidate,
-      submitted_at: 3.hours.ago,
-    )
-    course_option = create(
-      :course_option,
-      course: create(:course, provider: current_provider),
-    )
-    withdrawn_choice = create(
-      :application_choice,
-      :withdrawn,
-      application_form: @withdrawn_no_longer_wants_to_train_form,
-      course_option:,
-    )
-    create(
-      :withdrawal_reason,
-      application_choice: withdrawn_choice,
-      reason: 'do-not-want-to-train-anymore.personal-circumstances-have-changed',
-    )
+    create(:candidate_pool_application, application_form: @visa_sponsorship_form)
   end
 
   def then_i_expect_to_see_eligible_candidates_order_by_application_form_submitted_at
@@ -141,8 +95,6 @@ RSpec.describe 'Support user views candidate pool list' do
     expected_candidates.each do |candidate_text|
       expect(candidates).to have_text(candidate_text)
     end
-
-    expect(page).to have_no_text(candidate_name(@withdrawn_no_longer_wants_to_train_form))
   end
 
   def and_find_candidates_is_not_in_my_navigation


### PR DESCRIPTION
## Context

This PR changes the Pool::Candidate to use the CandidatePoolApplication table as the source of truth for checking who is in the candidate pool.

`application_forms_for_provider` - Checks the table/cache
`application_forms_in_the_pool` - Constructs the candidate pool doing live queries on our tables.

Please review by commit.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and filter find a candidate.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
