### PR TITLE
Report should show actual next publication date if it exists

### DIFF
--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -4,6 +4,7 @@ module Publications
       validates :statistics, :generation_date, :publication_date, :month, presence: true
 
       scope :published, -> { where('publication_date <= ?', Time.zone.now) }
+      scope :drafts, -> { where('publication_date > ?', Time.zone.now) }
 
       def month_to_date
         Date.parse("#{month}-01")

--- a/app/presenters/publications/v1/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v1/monthly_statistics_presenter.rb
@@ -43,7 +43,17 @@ module Publications
         next_timetable.recruitment_cycle_year
       end
 
-      delegate :next_publication_date, to: :MonthlyStatisticsTimetable
+      def next_publication_date
+        if next_report_to_be_published.present?
+          next_report_to_be_published.publication_date
+        else
+          MonthlyStatisticsTimetable.next_publication_date
+        end
+      end
+
+      def next_report_to_be_published
+        @next_report_to_be_published ||= Publications::MonthlyStatistics::MonthlyStatisticsReport.drafts.order(:publication_date).first
+      end
 
       def current_reporting_period
         "#{report_timetable.apply_opens_at.to_fs(:govuk_date)} to #{report.generation_date.to_fs(:govuk_date)}"

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -84,10 +84,20 @@ module Publications
         report_timetable.current_year?
       end
 
-      delegate :next_publication_date, to: :MonthlyStatisticsTimetable
-
       def previous_year
         previous_timetable.recruitment_cycle_year
+      end
+
+      def next_publication_date
+        if next_report_to_be_published.present?
+          next_report_to_be_published.publication_date
+        else
+          MonthlyStatisticsTimetable.next_publication_date
+        end
+      end
+
+      def next_report_to_be_published
+        @next_report_to_be_published ||= Publications::MonthlyStatistics::MonthlyStatisticsReport.drafts.order(:publication_date).first
       end
 
       def next_year

--- a/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
+++ b/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
         expect(described_class.published).to eq [published_report]
       end
     end
+
+    describe '.drafts' do
+      it 'returns only reports with publication dates in the future' do
+        draft_report = create(
+          :monthly_statistics_report,
+          :v2,
+          publication_date: 1.day.from_now,
+          generation_date: 1.day.ago,
+        )
+
+        create(
+          :monthly_statistics_report,
+          :v2,
+          publication_date: 1.day.ago,
+          generation_date: 1.day.ago,
+        )
+        expect(described_class.drafts).to eq [draft_report]
+      end
+    end
   end
 
   describe '#draft?' do

--- a/spec/presenters/publications/v1/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v1/monthly_statistics_presenter_spec.rb
@@ -90,4 +90,22 @@ RSpec.describe Publications::V1::MonthlyStatisticsPresenter do
       expect(presenter.current_reporting_period).to eq '12 October 2021 to 22 November 2021'
     end
   end
+
+  describe '#next_publication_date' do
+    context 'when there is a draft report' do
+      it 'returns the publication date of that report' do
+        publication_date = 1.day.from_now
+        create(:monthly_statistics_report, :v2, publication_date:)
+        expect(presenter.next_publication_date.to_date).to eq publication_date.to_date
+      end
+    end
+
+    context 'when there is no draft report' do
+      it 'returns the projected publication date' do
+        travel_temporarily_to(Date.new(2021, 12, 21)) do
+          expect(presenter.next_publication_date).to eq(Date.new(2021, 12, 27))
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
@@ -250,4 +250,22 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#next_publication_date' do
+    context 'when there is a draft report' do
+      it 'returns the publication date of that report' do
+        publication_date = 1.day.from_now
+        create(:monthly_statistics_report, :v2, publication_date:)
+        expect(presenter.next_publication_date.to_date).to eq publication_date.to_date
+      end
+    end
+
+    context 'when there is no draft report' do
+      it 'returns the projected publication date' do
+        travel_temporarily_to(Date.new(2021, 12, 21)) do
+          expect(presenter.next_publication_date).to eq(Date.new(2021, 12, 27))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are delaying the publication of a report, so we want to render the actual next publication date on the latest report instead of the predicted one.

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="1003" alt="image" src="https://github.com/user-attachments/assets/a398fa75-5e64-4283-8bfd-f241279b12d9" /> | <img width="1042" alt="image" src="https://github.com/user-attachments/assets/b1586a07-314d-47f8-a508-f75235006e57" /> |


## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
