### PR TITLE
Reduce default test applications generated for providers

### DIFF
--- a/app/controllers/support_interface/provider_test_data_controller.rb
+++ b/app/controllers/support_interface/provider_test_data_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ProviderTestDataController < SupportInterfaceController
     before_action :check_this_is_sandbox
 
-    DEFAULT_APPLICATION_COUNT = 100
+    DEFAULT_APPLICATION_COUNT = 50
     DEFAULT_COURSES_COUNT = 1
 
     def create

--- a/spec/requests/support_interface/provider_test_data_controller_spec.rb
+++ b/spec/requests/support_interface/provider_test_data_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SupportInterface::ProviderTestDataController do
       it 'enqueues a generation test data job' do
         expect(GenerateTestApplicationsForCourses)
           .to have_received(:perform_async)
-          .exactly(100).times
+          .exactly(50).times
       end
     end
 


### PR DESCRIPTION
## Context

[This support ticket](https://trello.com/c/Q4eQrLwS/750-generate-test-applications-on-sandbox) presents an issue wherein test data cannot be generated for a provider. The following error is raised:

`Parameter is invalid (cannot be greater than number of available courses): courses_per_application` 

It is raised if `course_ids.count < courses_per_application`. Only 1 course is given to an application by default, so this suggests that within a given iteration a course is not available.

**Test in review and local environments:**

The service works as expected in the review and test environments.

✅ In review app:
- `courses_number = Course.joins(:provider).where(providers: { id: 17 }).count` 
=> 97
- `GenerateTestApplicationsForProvider.new(provider: provider, courses_per_application: 1, count: 50).call`
=> 50
- `GenerateTestApplicationsForProvider.new(provider: provider, courses_per_application: 1, count: 100).call`
=> 100

✅  In local environment: 
- `courses_number = Course.joins(:provider).where(providers: { id: 1 }).count` 
=> 52
- `GenerateTestApplicationsForProvider.new(provider: provider, courses_per_application: 1, count: 50).call`
=> 50
- `GenerateTestApplicationsForProvider.new(provider: provider, courses_per_application: 1, count: 100).call`
=> 100

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
