### PR TITLE
Scope the candidate preferences to the filtered candidates

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -74,19 +74,25 @@ private
   def filter_by_distance(application_forms_scope)
     return application_forms_scope unless active_location_filter?
 
+    candidate_ids = application_forms_scope.select(:candidate_id)
     origin = filters.fetch(:origin)
 
-    candidate_preferences_anywhere = CandidatePreference.where(pool_status: 'opt_in', status: 'published')
+    candidate_preferences_anywhere = CandidatePreference
+                                       .where(candidate_id: candidate_ids, pool_status: 'opt_in', status: 'published')
                                        .where.missing(:location_preferences)
                                        .select('candidate_preferences.candidate_id as candidate_id', '-1 as distance')
 
     candidate_location_preferences_near_origin = CandidateLocationPreference
                                                    .joins(:candidate_preference)
-                                                   .where(candidate_preferences: { pool_status: 'opt_in', status: 'published' })
+                                                   .where(candidate_preferences: {
+                                                     pool_status: 'opt_in',
+                                                     status: 'published',
+                                                     candidate_id: candidate_ids,
+                                                   })
                                                    .near(origin, :within)
                                                    .select('candidate_preferences.candidate_id as candidate_id')
 
-    candidates_near_origin = Candidate.with(
+    candidates_near_origin = Candidate.where(id: candidate_ids).with(
       candidate_preferences_anywhere: candidate_preferences_anywhere,
       candidate_location_preferences_near_origin: candidate_location_preferences_near_origin,
     )


### PR DESCRIPTION
## Context

Previously, we would search in all candidate location preferences before serving the results for find a candidate.

This meant that we would call `.near` on more records that we needed.

This commit limits the distance calculations the geocoder needs to do to only the candidates that are filtered, only their candidate location preferences. Not all candidate location preferences

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This has some significant improvements. From 90 ms to 23ms. I imagine as we get more candidate preferences the improvements would be more substatial.

Before https://explain.dalibo.com/plan/26fd2bh3e1423599
After https://explain.dalibo.com/plan/gg4674fec2f10h9f




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
