### PR TITLE
Adjustments to the monthly stats report

### DIFF
--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -3,8 +3,8 @@ module Publications
     class MonthlyStatisticsReport < ApplicationRecord
       validates :statistics, :generation_date, :publication_date, :month, presence: true
 
-      scope :published, -> { where('publication_date <= ?', Time.zone.now) }
-      scope :drafts, -> { where('publication_date > ?', Time.zone.now) }
+      scope :published, -> { where('publication_date <= ?', Time.zone.today) }
+      scope :drafts, -> { where('publication_date > ?', Time.zone.today) }
 
       def month_to_date
         Date.parse("#{month}-01")

--- a/app/presenters/publications/v1/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v1/monthly_statistics_presenter.rb
@@ -9,7 +9,7 @@ module Publications
         @report = report
       end
 
-      delegate :publication_date, :statistics, :deferred_application_count, :month, to: :report
+      delegate :publication_date, :generation_date, :statistics, :deferred_application_count, :month, to: :report
 
       def next_cycle_name
         next_timetable.cycle_range_name

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -3,7 +3,7 @@ module Publications
     class MonthlyStatisticsPresenter
       attr_reader :statistics
       attr_accessor :report
-      delegate :publication_date, :month, :draft?, to: :report
+      delegate :publication_date, :generation_date, :month, :draft?, to: :report
 
       def initialize(report)
         @report = report

--- a/app/views/shared/publications/monthly_statistics/_v1.html.erb
+++ b/app/views/shared/publications/monthly_statistics/_v1.html.erb
@@ -12,6 +12,9 @@
   <div class="metadata-wrapper">
     <div class="govuk-grid-column-two-thirds metadata-column">
       <dl class="gem-c-metadata">
+        <dt class="gem-c-metadata__term">Generated</dt>
+        <dd class="gem-c-metadata__definition"><%= @presenter.generation_date.to_fs(:govuk_date) %></dd>
+
         <dt class="gem-c-metadata__term">Published</dt>
         <dd class="gem-c-metadata__definition"><%= @presenter.publication_date.to_fs(:govuk_date) %></dd>
 

--- a/app/views/shared/publications/monthly_statistics/_v2.html.erb
+++ b/app/views/shared/publications/monthly_statistics/_v2.html.erb
@@ -22,6 +22,9 @@
   <div class="metadata-wrapper">
     <div class="govuk-grid-column-two-thirds metadata-column">
       <dl class="gem-c-metadata">
+        <dt class="gem-c-metadata__term">Generated</dt>
+        <dd class="gem-c-metadata__definition"><%= @presenter.generation_date.to_fs(:govuk_date) %></dd>
+
         <dt class="gem-c-metadata__term">Published</dt>
         <dd class="gem-c-metadata__definition"><%= @presenter.publication_date.to_fs(:govuk_date) %></dd>
 
@@ -151,7 +154,6 @@
         teacher training is also not included except for TDA. Applications to train to teach in Further Education are
         also not included.</p>
     <% end %>
-    <p class="govuk-body">These statistics collect data up to and including the day before they were published.</p>
     <p class="govuk-body">There will be monthly updates throughout the recruitment cycle.</p>
   </div>
 </div>

--- a/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
+++ b/spec/models/publications/monthly_statistics/monthly_statistics_report_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
         published_report = create(
           :monthly_statistics_report,
           :v2,
-          publication_date: 1.day.ago,
+          publication_date: Time.zone.today,
           generation_date: 1.day.ago,
         )
 
@@ -43,7 +43,7 @@ RSpec.describe Publications::MonthlyStatistics::MonthlyStatisticsReport do
         create(
           :monthly_statistics_report,
           :v2,
-          publication_date: 1.day.ago,
+          publication_date: Time.zone.today,
           generation_date: 1.day.ago,
         )
         expect(described_class.drafts).to eq [draft_report]


### PR DESCRIPTION
## Context

We have some feedback from those reviewing the draft report. In addition, I found a small bug.

## Changes proposed in this pull request

- Content changes to the report to include generation date as well as publication date.
- Removal of a misleading line about the dates the report covers. 
- Change scopes to use Date objects instead of DateTime objects.
| Before | After | 
| ------ | ------ |
| <img width="701" alt="image" src="https://github.com/user-attachments/assets/a0f0dc1a-9cff-442f-8788-0bd75d16e078" /> | <img width="722" alt="image" src="https://github.com/user-attachments/assets/b56a4fd5-f354-4fca-9980-b1066240fca1" /> |

## Guidance to review

Locally, generate a report and check that both dates are visible.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
