### PR TITLE
Ensure references are marked incomplete when adding

### DIFF
--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -53,7 +53,12 @@ module CandidateInterface
       end
 
       def set_references
-        @references = current_application.application_references.includes(:application_form)
+        @references = current_application
+                        .application_references.includes(:application_form)
+                        .order(
+                          Arel.sql('CASE WHEN (email_address IS NULL OR relationship IS NULL) THEN 0 ELSE 1 END ASC'),
+                          'created_at DESC',
+                        )
       end
 
       def set_destroy_backlink

--- a/app/forms/candidate_interface/reference/referee_name_form.rb
+++ b/app/forms/candidate_interface/reference/referee_name_form.rb
@@ -18,6 +18,7 @@ module CandidateInterface
           reference.update!(referee_type:, name:)
         else
           application_form.application_references.create!(name:, referee_type:)
+          application_form.update(references_completed: false)
         end
       end
     end

--- a/spec/system/candidate_interface/references/candidate_adds_references_after_completing_section_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_references_after_completing_section_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidates adds references after marking section complete' do
+  scenario 'section is set to incomplete' do
+    given_i_am_signed_in
+    and_i_have_completed_the_reference_section
+    when_i_add_a_an_incomplete_reference
+    then_the_section_is_marked_as_incomplete
+
+    when_i_try_to_complete_the_section
+    then_i_see_an_error
+  end
+
+private
+
+  def and_i_have_completed_the_reference_section
+    create_list(
+      :reference,
+      2,
+      :not_requested_yet,
+      application_form: @application_form,
+      referee_type: 'professional',
+    )
+    @application_form.update(references_completed: true)
+  end
+
+  def given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
+    @application_form = @current_candidate.current_application
+  end
+
+  def when_i_add_a_an_incomplete_reference
+    visit root_path
+    click_on 'Your details'
+    click_on 'References to be requested if you accept an offer'
+    click_on 'Add another reference'
+    choose 'Academic, such as a university tutor'
+    click_on 'Continue'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Reference 1'
+    click_on 'Save and continue'
+    # Now navigating away
+    click_on 'Your details'
+    click_on 'References to be requested if you accept an offer'
+  end
+
+  def then_the_section_is_marked_as_incomplete
+    expect(@application_form.reload.references_completed).to be false
+    expect(page).to have_content 'Reference 1'
+    expect(page).to have_content 'Enter email address'
+    expect(page).to have_content 'Enter how you know them and for how long'
+    completed_section = find_field('Yes, I have completed this section').checked?
+    expect(completed_section).to be false
+
+    not_completed_section = find_field('No, I’ll come back to it later').checked?
+    expect(not_completed_section).to be true
+  end
+
+  def when_i_try_to_complete_the_section
+    choose 'Yes, I have completed this section'
+    click_on 'Continue'
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content 'There is a problem'
+    expect(page).to have_content 'Enter all required fields for each reference added'
+    expect(page.title).to have_content 'Error:'
+  end
+end


### PR DESCRIPTION
## Context

A bug was identified:
If I add 2 references and mark the section as complete
when i add another reference, with in complete information
the reference is saved (as expected) with incomplete information
then the section is still marked as complete. (<-- this is the problem)

## Changes proposed in this pull request

At the point when we create a new reference (when they get to the name step), we will mark the section as incomplete.
Updated the ordering of the references so that those missing information are at the top of the list.

## Guidance to review

Either locally or in the review app
Enter 2 references for an applicant and mark the section as complete
Enter a third reference. Either completely, or navigating away from the form after completing the name field.
Return to the references section
The section should no longer be marked as complete.

https://github.com/user-attachments/assets/7af03985-5279-46af-9362-02dfe02a46ac


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
