### PR TITLE
Add FAC opt in status filters to Support index

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -37,6 +37,8 @@ class ApplicationForm < ApplicationRecord
   has_many :application_work_history_breaks, as: :breakable
   has_many :emails
 
+  has_one :candidate_pool_application
+
   belongs_to :previous_application_form, class_name: 'ApplicationForm', optional: true, inverse_of: 'subsequent_application_form'
   has_one :subsequent_application_form, class_name: 'ApplicationForm', foreign_key: 'previous_application_form_id', inverse_of: 'previous_application_form'
   has_one :english_proficiency

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -37,14 +37,13 @@ module SupportInterface
       end
 
       if applied_filters[:opt_in_status]&.include?('findable')
-        application_forms = Pool::Candidates.new(providers: []).curated_application_forms
+        application_forms = Pool::Candidates.new(providers: []).curated_application_forms.joins(candidate: :published_opt_in_preferences)
+        .where(candidate: { submission_blocked: false, account_locked: false }) # change this to check the new table that will have been produced
       end
 
-      # Chain these statements to mirror the logic in application_summary_component, i.e. if not findable but opted in, show opted in.
       if applied_filters[:opt_in_status]&.include?('opt_in')
         application_forms = application_forms
-          .joins(candidate: :published_preferences)
-          .where(published_preferences: { pool_status: 'opt_in' })
+          .joins(candidate: :published_opt_in_preferences)
       end
 
       if applied_filters[:opt_in_status]&.include?('opt_out')

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -37,13 +37,13 @@ module SupportInterface
       end
 
       if applied_filters[:opt_in_status]&.include?('findable')
-        application_forms = Pool::Candidates.new(providers: []).curated_application_forms.joins(candidate: :published_opt_in_preferences)
-        .where(candidate: { submission_blocked: false, account_locked: false }) # change this to check the new table that will have been produced
+        application_forms = application_forms.joins(:candidate_pool_application)
       end
 
       if applied_filters[:opt_in_status]&.include?('opt_in')
         application_forms = application_forms
           .joins(candidate: :published_opt_in_preferences)
+          .where.missing(:candidate_pool_application)
       end
 
       if applied_filters[:opt_in_status]&.include?('opt_out')

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationForm do
   it { is_expected.to have_one(:subsequent_application_form).class_name('ApplicationForm').with_foreign_key('previous_application_form_id').inverse_of('previous_application_form') }
   it { is_expected.to have_one(:english_proficiency) }
   it { is_expected.to have_one :recruitment_cycle_timetable }
+  it { is_expected.to have_one :candidate_pool_application }
 
   it { is_expected.to have_many(:application_choices) }
   it { is_expected.to have_many(:course_options).through(:application_choices) }

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -1,13 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationsFilter do
-  let!(:application_choice_with_offer) do
+  let(:application_choice_with_offer) do
     primary = create(:subject, name: 'Primary', code: 'F0')
     course = create(:course, subjects: [primary])
     course_option = create(:course_option, course: course)
 
     create(:application_choice, :offered, :previous_year, course_option: course_option)
   end
+
+  let(:application_form_with_opt_out_status) do
+    candidate = create(:candidate)
+    application_form = create(:completed_application_form, candidate:)
+
+    create(:candidate_preference, pool_status: 'opt_out', status: 'published', candidate:)
+    create(:application_choice, application_form:)
+
+    application_form
+  end
+
   let!(:application_choice_with_interview) { create(:application_choice, :interviewing, application_form: create(:completed_application_form, first_nationality: 'British')) }
   let!(:application_choice_recruited) { create(:application_choice, :recruited) }
   let!(:international_application) { create(:completed_application_form, first_nationality: 'American') }
@@ -146,6 +157,15 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         [international_application],
         params: {
           nationality: ['true'],
+        },
+      )
+    end
+
+    it 'can filter by Find a Candidate opt-in status' do
+      verify_filtered_applications_for_params(
+        [application_form_with_opt_out_status],
+        params: {
+          opt_in_status: ['opt_out'],
         },
       )
     end


### PR DESCRIPTION
## Context

Now that FAC status is visible on individual applications in Support, we have now added the ability to filter applications according to the status:

- Findable by providers
- Opted in (not findable)
- Opted out

## Changes proposed in this pull request

- Add one association to the ApplicationForm, `has_one :candidate_pool_application` to permit `.joins` in queries
- Add three filters corresponding to the statuses

## Guidance to review

- Log in as a Support user and make sure local environment is running workers.
- Check that applications are in various states before filtering and checking accuracy of the filter.
- Check efficiency of ActiveRecord queries. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
