### PR TITLE
Fix race condition on pool invite form

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
@@ -1,9 +1,10 @@
 module ProviderInterface
   module CandidatePool
     class DraftInvitesController < ProviderInterfaceController
+      before_action :set_candidate
+      before_action :redirect_if_invite_is_not_found, only: %i[show edit]
       before_action :set_policy
       before_action :redirect_if_candidate_cannot_send_invites
-      before_action :set_candidate
 
       def show
         if @policy.can_view_invite?(invite)
@@ -89,6 +90,12 @@ module ProviderInterface
       def redirect_if_candidate_cannot_send_invites
         unless @policy.can_invite_candidates?
           redirect_to provider_interface_candidate_pool_candidates_path
+        end
+      end
+
+      def redirect_if_invite_is_not_found
+        if invite.nil?
+          redirect_to provider_interface_candidate_pool_candidate_path(@candidate)
         end
       end
     end

--- a/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/publish_invites_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     class PublishInvitesController < ProviderInterfaceController
       before_action :set_policy
       before_action :set_candidate
+      before_action :redirect_if_invite_is_not_found
 
       def create
         if @policy.can_invite_candidates?
@@ -53,6 +54,12 @@ module ProviderInterface
           provider_id: current_provider_user.provider_ids,
           status: :draft,
         )
+      end
+
+      def redirect_if_invite_is_not_found
+        if invite.nil?
+          redirect_to provider_interface_candidate_pool_candidate_path(@candidate)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

There is an edge case when 2 provider users can invite the same
candidate to apply for a course in a short amount of time.

This causes an issue because the pool invite status changes from draft
to published. The second provider user would get an error because we
can't find the invite.

This commit fixes this by redirecting the second provider user to the
candidate show page, where they can start inviting the candidate again,
If they choose the same course they will see an error.

We need to redirect the user because they are trying to update a
pool_invite that is published. We need to stop this, so we redirect the
user back to the candidate show page

Sentry https://dfe-teacher-services.sentry.io/issues/6607645525/?alert_rule_id=853774&alert_type=issue&notification_uuid=7e76de00-1738-4a8b-ae2b-447e5e45166f&project=1765973&referrer=slack

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/0a6fe28c-6740-49cf-adc1-6dd9f14c3a31



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
