### PR TITLE
Add conditional rendering of sandbox feature and yml file

### DIFF
--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,11 +1,11 @@
 <%= render 'provider_navigation', title: 'Applications' %>
-  <% if HostingEnvironment.sandbox_mode? && @provider.courses.open.current_cycle.any? %>
+  <% if HostingEnvironment.sandbox_mode? && @provider.courses.current_cycle.open.any? %>
     <%= render SandboxFeatureComponent.new(
       description: t('.description'),
     ) do %>
       <%= govuk_button_to t('.generate'), support_interface_provider_test_data_path(@provider), class: 'govuk-!-margin-bottom-0' %>
     <% end %>
-  <% elsif HostingEnvironment.sandbox_mode? && @provider.courses.open.current_cycle.empty? %>
+  <% elsif HostingEnvironment.sandbox_mode? && @provider.courses.current_cycle.open.empty? %>
     <%= render SandboxFeatureComponent.new(
       description: t('.cannot_generate', provider: @provider.name_and_code),
     ) %>

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,11 +1,15 @@
 <%= render 'provider_navigation', title: 'Applications' %>
-<% if HostingEnvironment.sandbox_mode? && @provider.courses.open.any? %>
-  <%= render SandboxFeatureComponent.new(
-    description: 'This task generates 100 new applications for the current provider, with one course choice per application.',
-  ) do %>
-    <%= govuk_button_to 'Generate test applications', support_interface_provider_test_data_path(@provider), class: 'govuk-!-margin-bottom-0' %>
+  <% if HostingEnvironment.sandbox_mode? && @provider.courses.open.current_cycle.any? %>
+    <%= render SandboxFeatureComponent.new(
+      description: t('.description'),
+    ) do %>
+      <%= govuk_button_to t('.generate'), support_interface_provider_test_data_path(@provider), class: 'govuk-!-margin-bottom-0' %>
+    <% end %>
+  <% elsif HostingEnvironment.sandbox_mode? && @provider.courses.open.current_cycle.empty? %>
+    <%= render SandboxFeatureComponent.new(
+      description: t('.cannot_generate', provider: @provider.name_and_code),
+    ) %>
   <% end %>
-<% end %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @pagy) do %>
   <%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @application_forms) %>

--- a/config/locales/support_interface/applications.yml
+++ b/config/locales/support_interface/applications.yml
@@ -1,0 +1,7 @@
+en:
+  support_interface:
+    providers:
+      applications:
+        description: This task generates 100 new applications for the current provider, with one course choice per application.
+        generate: Generate test applications
+        cannot_generate: Before we can generate test data, %{provider} needs at least one course published to Sandbox that is open for applications in the current cycle.

--- a/config/locales/support_interface/applications.yml
+++ b/config/locales/support_interface/applications.yml
@@ -4,4 +4,4 @@ en:
       applications:
         description: This task generates 100 new applications for the current provider, with one course choice per application.
         generate: Generate test applications
-        cannot_generate: Before we can generate test data, %{provider} needs at least one course published to Sandbox that is open for applications in the current cycle.
+        cannot_generate: Before we can generate test data, %{provider} needs at least one published course in the current cycle.

--- a/spec/system/support_interface/generate_test_data_for_provider_spec.rb
+++ b/spec/system/support_interface/generate_test_data_for_provider_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Generate test data for provider via support', :sandbox, sidekiq:
 
     when_i_visit_the_support_provider_applications_page
     then_i_will_not_see_the_generate_test_data_button
+    and_i_see_guidance_text
 
     when_the_provider_has_courses_open
     and_i_visit_the_support_provider_applications_page
@@ -33,6 +34,10 @@ RSpec.describe 'Generate test data for provider via support', :sandbox, sidekiq:
 
   def then_i_will_not_see_the_generate_test_data_button
     expect(page).to have_no_button 'Generate test applications'
+  end
+
+  def and_i_see_guidance_text
+    expect(page).to have_content `Before we can generate test data, #{@provider.name_and_code} needs at least one course published to Sandbox that is open for applications in the current cycle.`
   end
 
   def when_the_provider_has_courses_open

--- a/spec/system/support_interface/generate_test_data_for_provider_spec.rb
+++ b/spec/system/support_interface/generate_test_data_for_provider_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Generate test data for provider via support', :sandbox, sidekiq:
   end
 
   def and_i_see_guidance_text
-    expect(page).to have_content `Before we can generate test data, #{@provider.name_and_code} needs at least one course published to Sandbox that is open for applications in the current cycle.`
+    expect(page).to have_content `Before we can generate test data, #{@provider.name_and_code} needs at least one course published in the current cycle.`
   end
 
   def when_the_provider_has_courses_open


### PR DESCRIPTION
## Context

When requested, Support users generate test data for Providers in Sandbox. When the Provider does not have any courses published and open in the current cycle, the Support user will see a generic error.

If the Provider does not have any courses published and open in the current cycle, the Support user should see text prompting them to ask the Provider to publish courses before test data can be generated. The button should also be hidden until this condition is met.

## Changes proposed in this pull request

- Expand conditional rendering logic for the generate test data sandbox component that hides the button and shows guidance text if the condition is not met.

## Guidance to review

- Log in as a support user and navigate to the providers tab.
- Temporarily remove the sandbox environment condition in the rendering logic in `app/views/support_interface/providers/applications.html.erb`.
- Search a provider without courses published and open in the current cycle. 
- Review the new text.
- Search a provider with courses published and open in the current cycle.
- Make sure the original text and button are displayed.

<img width="1150" alt="Screenshot 2025-05-30 at 11 28 13" src="https://github.com/user-attachments/assets/ab1df6ef-7e21-48df-88da-0196e364d318" />

<img width="1148" alt="Screenshot 2025-05-30 at 11 25 54" src="https://github.com/user-attachments/assets/805b33fe-32fc-466e-a849-795c334674f9" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
