### PR TITLE
[968] Add missing previews for carry over components

### DIFF
--- a/app/frontend/styles/application-candidate.scss
+++ b/app/frontend/styles/application-candidate.scss
@@ -1,5 +1,4 @@
 @import "application";
 @import "candidate/all";
-@import "components/tabs";
 @import "components/show_more_show_less";
 @import "dfe-autocomplete/src/dfe-autocomplete";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -71,6 +71,7 @@ $govuk-new-link-styles: true;
 @import "div";
 @import "previews";
 @import "metadata";
+@import "components/tabs";
 
 // Override utilities
 @import "overrides";

--- a/spec/components/previews/candidate_interface/carry_over_between_cycles_component_preview.rb
+++ b/spec/components/previews/candidate_interface/carry_over_between_cycles_component_preview.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class CarryOverBetweenCyclesComponentPreview < ViewComponent::Preview
+    def with_application_choices
+      application_form = FactoryBot.create(
+        :application_form,
+        recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+      )
+      FactoryBot.create(:application_choice, status: 'cancelled', application_form:)
+      render CarryOverBetweenCyclesComponent.new(application_form:)
+    end
+
+    def without_application_choices
+      recruitment_cycle_year = RecruitmentCycleTimetable.previous_year
+      render CarryOverBetweenCyclesComponent.new(
+        application_form: FactoryBot.build_stubbed(:application_form, recruitment_cycle_year:),
+      )
+    end
+  end
+end

--- a/spec/components/previews/candidate_interface/carry_over_mid_cycle_component_preview.rb
+++ b/spec/components/previews/candidate_interface/carry_over_mid_cycle_component_preview.rb
@@ -1,0 +1,17 @@
+module CandidateInterface
+  class CarryOverMidCycleComponentPreview < ViewComponent::Preview
+    def application_from_many_years_ago
+      recruitment_cycle_year = RecruitmentCycleTimetable.current_year - 3
+      render CandidateInterface::CarryOverMidCycleComponent.new(
+        application_form: FactoryBot.build_stubbed(:application_form, recruitment_cycle_year:),
+      )
+    end
+
+    def application_from_previous_year
+      recruitment_cycle_year = RecruitmentCycleTimetable.current_year - 1
+      render CandidateInterface::CarryOverMidCycleComponent.new(
+        application_form: FactoryBot.build_stubbed(:application_form, recruitment_cycle_year:),
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

In doing some planning for the end of cycle, I identified a few missing previews that will help get the content reviewed.

## Changes proposed in this pull request

Previews for the various carry over screens

## Guidance to review

View previews on the review app:
- [Carry over mid cycle, application many years ago](https://apply-review-10768.test.teacherservices.cloud/rails/view_components/candidate_interface/carry_over_mid_cycle_component/application_from_many_years_ago)
- [Carry over mid cycle, application last year](https://apply-review-10768.test.teacherservices.cloud/rails/view_components/candidate_interface/carry_over_mid_cycle_component/application_from_previous_year)
- [Carry over between cycles, with application choices](https://apply-review-10768.test.teacherservices.cloud/rails/view_components/candidate_interface/carry_over_between_cycles_component/with_application_choices)
- [Carry over between cycles without application choices](https://apply-review-10768.test.teacherservices.cloud/rails/view_components/candidate_interface/carry_over_between_cycles_component/without_application_choices)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
