### PR TITLE
Ensure all TTA sign up opportunities are behind feature flag

### DIFF
--- a/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups/interruptions_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module AdviserSignUps
     class InterruptionsController < CandidateInterfaceController
+      before_action :render_404_if_adviser_sign_unavailable
+
       def show
         @adviser_interruption_form = CandidateInterface::AdviserInterruptionForm.new({ application_form:, proceed_to_request_adviser: params[:proceed_to_request_adviser] })
       end
@@ -32,6 +34,10 @@ module CandidateInterface
         params
           .fetch(:candidate_interface_adviser_interruption_form, {})
           .permit(:proceed_to_request_adviser)
+      end
+
+      def render_404_if_adviser_sign_unavailable
+        render_404 if FeatureFlag.inactive?(:adviser_sign_up)
       end
     end
   end

--- a/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
@@ -54,6 +54,7 @@ module CandidateInterface
     end
 
     def render_404_unless_available
+      render_404 if FeatureFlag.inactive?(:adviser_sign_up)
       render_404 unless application_form.eligible_to_sign_up_for_a_teaching_training_adviser?
     end
   end

--- a/app/views/candidate_interface/course_choices/go_to_find/new.html.erb
+++ b/app/views/candidate_interface/course_choices/go_to_find/new.html.erb
@@ -16,12 +16,14 @@
       <li>contact details</li>
     </ul>
 
-    <% if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? %>
-      <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_ups_path %> to help you understand your course options.</p>
-    <% elsif current_application.waiting_to_be_assigned_to_an_adviser? || current_application.already_assigned_to_an_adviser? %>
-      <p class="govuk-body">Your teacher training adviser can help you understand your course options.</p>
-    <% else %>
-      <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %> can help you understand your course options.</p>
+    <% if FeatureFlag.active?(:adviser_sign_up) %>
+      <% if current_application.eligible_to_sign_up_for_a_teaching_training_adviser? %>
+        <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_ups_path %> to help you understand your course options.</p>
+      <% elsif current_application.waiting_to_be_assigned_to_an_adviser? || current_application.already_assigned_to_an_adviser? %>
+        <p class="govuk-body">Your teacher training adviser can help you understand your course options.</p>
+      <% else %>
+        <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %> can help you understand your course options.</p>
+      <% end %>
     <% end %>
 
     <%= govuk_button_link_to t('application_form.begin_button'), find_url %>

--- a/app/views/candidate_interface/details/_adviser_call_to_action.html.erb
+++ b/app/views/candidate_interface/details/_adviser_call_to_action.html.erb
@@ -1,38 +1,39 @@
 <%# locals: (application_form:) %>
+<% if FeatureFlag.active?(:adviser_sign_up) %>
+  <% if application_form.eligible_to_sign_up_for_a_teaching_training_adviser? %>
+    <aside class="app-related" aria-labelledby="tta-title">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
+        <%= t('.available.heading') %>
+      </h2>
+      <p class="govuk-body-s govuk-!-margin-bottom-2">
+        <%= t('.available.text') %>
+      </p>
+      <p class="govuk-body-s">
+        <%= govuk_link_to(
+              t('.available.button_text'),
+              new_candidate_interface_adviser_sign_ups_path,
+            ) %>
+      </p>
+    </aside>
 
-<% if application_form.eligible_to_sign_up_for_a_teaching_training_adviser? %>
-  <aside class="app-related" aria-labelledby="tta-title">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
-      <%= t('.available.heading') %>
-    </h2>
-    <p class="govuk-body-s govuk-!-margin-bottom-2">
-      <%= t('.available.text') %>
-    </p>
-    <p class="govuk-body-s">
-      <%= govuk_link_to(
-            t('.available.button_text'),
-            new_candidate_interface_adviser_sign_ups_path,
-          ) %>
-    </p>
-  </aside>
+  <% elsif application_form.waiting_to_be_assigned_to_an_adviser? %>
+    <aside class="app-related" aria-labelledby="tta-title">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
+        <%= t('.waiting_to_be_assigned.heading') %>
+      </h2>
+      <p class="govuk-body-s">
+        <%= t('.waiting_to_be_assigned.text') %>
+      </p>
+    </aside>
 
-<% elsif application_form.waiting_to_be_assigned_to_an_adviser? %>
-  <aside class="app-related" aria-labelledby="tta-title">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
-      <%= t('.waiting_to_be_assigned.heading') %>
-    </h2>
-    <p class="govuk-body-s">
-      <%= t('.waiting_to_be_assigned.text') %>
-    </p>
-  </aside>
-
-<% elsif application_form.already_assigned_to_an_adviser? %>
-  <aside class="app-related" aria-labelledby="tta-title">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
-      <%= t('.already_assigned.heading') %>
-    </h2>
-    <p class="govuk-body-s govuk-!-margin-bottom-2">
-      <%= t('.already_assigned.text') %>
-    </p>
-  </aside>
+  <% elsif application_form.already_assigned_to_an_adviser? %>
+    <aside class="app-related" aria-labelledby="tta-title">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="tta-title">
+        <%= t('.already_assigned.heading') %>
+      </h2>
+      <p class="govuk-body-s govuk-!-margin-bottom-2">
+        <%= t('.already_assigned.text') %>
+      </p>
+    </aside>
+  <% end %>
 <% end %>

--- a/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
@@ -10,13 +10,14 @@
         <p class="govuk-body">You can give other evidence to show you have <%= capitalize_english(@subject) %> skills that are equal to a GCSE in <%= capitalize_english(@subject) %> at grade 4(C) or above.<p>
 
         <p class="govuk-body">Some training providers may let you do an equivalency test to show you have the required skills.</p>
-
-        <% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
-          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', new_candidate_interface_adviser_sign_ups_path, utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
-        <% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
-          <p class="govuk-body">Contact your teacher training adviser or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
-        <% else %>
-          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
+        <% if FeatureFlag.active?(:adviser_sign_up) %>
+          <% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
+            <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', new_candidate_interface_adviser_sign_ups_path, utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
+          <% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
+            <p class="govuk-body">Contact your teacher training adviser or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
+          <% else %>
+            <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
+          <% end %>
         <% end %>
 
         <%= f.govuk_text_area :missing_explanation, label: { text: "Give evidence of having #{capitalize_english(@subject)} skills at the required standard", size: 'm' }, rows: 4, max_words: 50 do %>

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -7,13 +7,14 @@
 </h1>
 
 <%= render 'guidance' %>
-
-<% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
-  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_ups_path) %>.</p>
-<% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
-  <p class="govuk-body">Ask your teacher training adviser for help with your personal statement.</p>
-<% else %>
-  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), current_application.phase) %>.</p>
+<% if FeatureFlag.active?(:adviser_sign_up) %>
+  <% if application_form.eligible_and_unassigned_a_teaching_training_adviser? %>
+    <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_ups_path) %>.</p>
+  <% elsif application_form.waiting_to_be_assigned_to_an_adviser? || application_form.already_assigned_to_an_adviser? %>
+    <p class="govuk-body">Ask your teacher training adviser for help with your personal statement.</p>
+  <% else %>
+    <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), current_application.phase) %>.</p>
+  <% end %>
 <% end %>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe 'Candidate becomes eligible for an adviser' do
   include CandidateHelper
 
-  it 'displays the adviser sign up CTA when eligible' do
+  it 'displays the adviser sign up CTA when eligible if Feature flag is activated' do
     given_i_am_signed_in_with_one_login
+    and_adviser_sign_up_feature_flag_is_activated
     and_enqueued_jobs_are_not_performed
     and_the_api_call_is_stubbed
     and_analytics_is_enabled
@@ -25,6 +26,10 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
 
   def and_analytics_is_enabled
     allow(DfE::Analytics).to receive(:enabled?).and_return(true)
+  end
+
+  def and_adviser_sign_up_feature_flag_is_activated
+    FeatureFlag.activate(:adviser_sign_up)
   end
 
   def and_i_visit_the_details_page


### PR DESCRIPTION
## Context

We want to disable TTA sign ups from the app as the feature has been _too_ popular. In order to do this, we need to make sure all the links to TTA sign up are behind the feature flag.

## Changes proposed in this pull request

Add feature flag checks before rendering certain content. 

## Guidance to review

Click around on the review app with / without the feature flag activated. Is everything as it should be?


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
