### PR TITLE
Add teacher success user to Candidate API 

### DIFF
--- a/app/controllers/concerns/service_api_user_authentication.rb
+++ b/app/controllers/concerns/service_api_user_authentication.rb
@@ -19,7 +19,13 @@ module ServiceAPIUserAuthentication
   def authorized?
     authenticate_with_http_token do |token|
       @authenticating_token = AuthenticationToken.find_by_hashed_token(user_type: 'ServiceAPIUser', raw_token: token)
-      @authenticating_token.present? && @authenticating_token.user_id == ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize).id
+      return false if @authenticating_token.nil?
+
+      if ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize, id: @authenticating_token.user_id)
+        @authenticating_token.touch(:used_at)
+        return true
+      end
+      false
     end
   end
 

--- a/app/models/service_api_user.rb
+++ b/app/models/service_api_user.rb
@@ -14,6 +14,7 @@ class ServiceAPIUser < ActiveHash::Base
     { id: 2, name: 'DfE TAD', authorized_api: 'DataAPI' },
     { id: 3, name: 'DfE Register', authorized_api: 'RegisterAPI' },
     { id: 4, name: 'DfE Candidate', authorized_api: 'CandidateAPI' },
+    { id: 5, name: 'DfE Teacher Success', authorized_api: 'CandidateAPI' },
   ]
 
   def self.test_data_user
@@ -30,6 +31,10 @@ class ServiceAPIUser < ActiveHash::Base
 
   def self.candidate_user
     find(4)
+  end
+
+  def self.teacher_success_user
+    find(5)
   end
 
   # Fix a bug in ActiveHash that causes the user_type in a AuthenticationToken to

--- a/spec/requests/candidate_api/get_candidate_spec.rb
+++ b/spec/requests/candidate_api/get_candidate_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe 'GET /candidate-api/:versions/candidates/:candidate_id' do
         expect(response).to have_http_status(:success)
       end
 
+      it 'allows access to the API for Teacher Success users' do
+        candidate = create(:candidate)
+        candidate_id_param = "C#{candidate.id}"
+
+        get_api_request "/candidate-api/#{version}/candidates/#{candidate_id_param}", token: teacher_success_api_token
+
+        expect(response).to have_http_status(:success)
+      end
+
       it 'conforms to the API spec' do
         candidate = create(:candidate)
         candidate_id_param = "C#{candidate.id}"

--- a/spec/support/candidate_api/candidate_api_spec_helper.rb
+++ b/spec/support/candidate_api/candidate_api_spec_helper.rb
@@ -13,6 +13,10 @@ module CandidateAPISpecHelper
     @candidate_api_token = ServiceAPIUser.candidate_user.create_magic_link_token!
   end
 
+  def teacher_success_api_token
+    @teacher_success_api_token = ServiceAPIUser.teacher_success_user.create_magic_link_token!
+  end
+
   def parsed_response
     JSON.parse(response.body)
   end


### PR DESCRIPTION
## Context

The Teacher Success team would like to access our Candidate API for their own development work. We have added a `teacher_success_user` to the `ServiceApiUser` class prior to generating a token in Sandbox.

## Changes proposed in this pull request

- Add `teacher_success_user` to the `ServiceApiUser` class with access to the Candidate API. 
- Add tests for this user to the existing request spec.
- Refactor the `ServiceAPIUserAuthentication.authorized?` method to verify the user id and update the `last_used_at` field when an authenticated http request is made.

## Guidance to review

- Run and review: `spec/requests/candidate_api/get_candidate_spec.rb`.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
