### PR TITLE
Use application_not_sent instaed of cancelled in preview

### DIFF
--- a/spec/components/previews/candidate_interface/carry_over_between_cycles_component_preview.rb
+++ b/spec/components/previews/candidate_interface/carry_over_between_cycles_component_preview.rb
@@ -5,7 +5,7 @@ module CandidateInterface
         :application_form,
         recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
       )
-      FactoryBot.create(:application_choice, status: 'cancelled', application_form:)
+      FactoryBot.create(:application_choice, status: 'application_not_sent', application_form:)
       render CarryOverBetweenCyclesComponent.new(application_form:)
     end
 


### PR DESCRIPTION
## Context

## Changes proposed in this pull request

Corrected the status used in a preview -- when we 'cancel' the applications at the end of cycle, the status becomes 'application_not_sent', NOT 'cancelled'. I know, confusing, right? 'Cancelled' is not used as a status anywhere. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
