### PR TITLE
DO NOT REVIEW Only show TTA information in emails if feature flag activated

### DIFF
--- a/app/views/candidate_mailer/_application_rejected_get_help.text.erb
+++ b/app/views/candidate_mailer/_application_rejected_get_help.text.erb
@@ -1,6 +1,6 @@
 # Get help
 
-<% if @application_choice.application_form.adviser_status_assigned? %>
+<% if @application_choice.application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up) %>
 Your teacher training adviser can help you improve your application. They can support you with:
 
 * acting on any feedback
@@ -11,7 +11,7 @@ Your adviser has years of teaching experience and knows the application process 
 Contact your teacher training adviser to talk about your next steps.
 
 ## Contact our support team
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 A teacher training adviser can provide free support to help you improve your application. They can support you with:
 
 * acting on any feedback
@@ -20,6 +20,8 @@ A teacher training adviser can provide free support to help you improve your app
 All our advisers have years of teaching experience and know the application process inside and out.
 
 [Learn more about teacher training advisers](<%= t('get_into_teaching.url_get_an_adviser_start') %>).
+<% else %>
+## Contact our support team
 <% end %>
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
 <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
+++ b/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
@@ -1,6 +1,9 @@
 
 # Get help
+<% if FeatureFlag.active?(:adviser_sign_up) %>
+If you need support with your application, you can speak to a teacher training adviser.
+<% end %>
 
-If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -14,9 +14,9 @@ Courses fill up quickly at this time of year.
 
 If you have questions about your application, you can [get in touch with us on the phone or through live chat](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 
-<% if @application_form.adviser_status_assigned? %>
+<% if @application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up) %>
 You can also contact your teacher training adviser for support with writing your application.
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 You can also [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support to help you write a strong application.
 <% end %>
 

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -6,9 +6,9 @@ Dear <%= @application_form.first_name %>
 
 [Sign in to your account to submit your application](<%= application_choices_link %>).
 
-<% if @application_form.adviser_status_assigned? %>
+<% if @application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up) %>
 Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.
 <% end %>
 

--- a/app/views/candidate_mailer/new_cycle_has_started.text.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.text.erb
@@ -8,6 +8,7 @@ Courses can fill up quickly, so apply as soon as you are ready.
 
 [Sign in to your account to apply for courses](<%= sign_in_link %>).
 
+<% if FeatureFlag.active?(:adviser_sign_up) %>
 # Get a teacher training adviser
 
 A teacher training adviser can help you write a strong application.
@@ -15,6 +16,7 @@ A teacher training adviser can help you write a strong application.
 [Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase %>)
 
 All our advisers are experienced former teachers who provide free, one-to-one support and can help you with your personal statement and interview preparation.
+<% end %>
 
 # Get help
 

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -16,10 +16,12 @@ Contact <%= @provider_name %> if you have any questions. Let them know if you ca
 
 # Prepare for your interview
 
+<% if FeatureFlag.active?(:adviser_sign_up) %>
 Do you have a teacher training adviser yet? They can help you prepare for your interview.
 
 As former teachers, they can also offer insight into teacher training and teaching as a career.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'new_interview_offered', @application_form.phase %>)
+<% end %>
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -15,17 +15,20 @@ Some subjects and courses have bursaries of up to £29,000 and scholarships of u
 [Check if your subject has a bursary or scholarship](<%= email_link_with_utm_params t('get_into_teaching.url_scholarships_and_bursaries_funding_widget'), 'nudge_unsubmitted', @application_form.phase %>)
 
 # Get help
-<% if @application_form.adviser_status_assigned? %>
+<% if @application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up) %>
 Your teacher training adviser can help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.
 
 ## Contact our support team
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 A teacher training adviser could help with your application, if something is holding you back from submitting it. They can talk to you about teacher training and teaching as a career.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
+<% else %>
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
 <% end %>
 <%= t('get_into_teaching.opening_times') %>.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -5,17 +5,20 @@ You have not marked your personal statement as complete.
 [Sign in to your account to complete your teacher training application](<%= @personal_statement_link %>)
 
 # Get help with your personal statement
-<% if @application_form.adviser_status_assigned?  %>
+<% if @application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up) %>
 Your teacher training adviser can help you understand what to put in your personal statement.
 
 ## Contact our support team
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 A teacher training adviser can help you understand what to put in your personal statement.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
+<% else %>
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
 <% end %>
 <%= t('get_into_teaching.opening_times') %>.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
@@ -20,17 +20,20 @@ In their reference, they will be asked:
 - whether they want you to be able to see their reference of if it is confidential
 
 # Get help
-<% if @application_form.adviser_status_assigned? %>
+<% if @application_form.adviser_status_assigned? && FeatureFlag.active?(:adviser_sign_up)%>
 Your teacher training adviser can give advice on references.
 
 ## Contact our support team
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
-<% else %>
+<% elsif FeatureFlag.active?(:adviser_sign_up) %>
 A teacher training adviser can give advice on references:
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
 
 Alternatively, call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
+<% else %>
+## Contact our support team
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
 <% end %>
 <%= t('get_into_teaching.opening_times') %>.
 

--- a/app/views/candidate_mailer/tailored_rejection_advice/_personal_statement_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_personal_statement_tailored_advice.text.erb
@@ -1,8 +1,11 @@
-<% if @application_choice.render_tailored_advice_section_headings? %>
+<% if FeatureFlag.active?(:adviser_sign_up) %>
+
+  <% if @application_choice.render_tailored_advice_section_headings? %>
 <%# Do not be tempted to indent this title. Have a look at the preview if you do. It will no longer be a heading. %>
 ## Improve your personal statement
-<% end %>
+  <% end %>
 
 A teacher training adviser can provide free support to help you improve your personal statement.
 
 [Learn more about teacher training advisers](<%= t('get_into_teaching.url_get_an_adviser_start') %>).
+<% end %>

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CandidateMailer do
   before do
     magic_link_stubbing(candidate)
     email_log_interceptor_stubbing
+    FeatureFlag.activate(:adviser_sign_up)
   end
 
   describe '.application_rejected' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
+  before { FeatureFlag.activate(:adviser_sign_up) }
 
   let(:email) { described_class.eoc_first_deadline_reminder(application_form) }
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
+  before { FeatureFlag.activate(:adviser_sign_up) }
 
   describe '.eoc_second_deadline_reminder', time: mid_cycle do
     let(:email) { described_class.eoc_second_deadline_reminder(application_form) }

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_interview_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_interview_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
+  before { FeatureFlag.activate(:adviser_sign_up) }
+
   describe '.new_interview' do
     let(:application_choice_with_interview) { build_stubbed(:application_choice, course_option:, application_form:) }
     let(:interview) do

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
+  before { FeatureFlag.activate(:adviser_sign_up) }
 
   describe '.nudge_unsubmitted' do
     let(:email) { described_class.nudge_unsubmitted(application_form) }

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_personal_statement_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
+  before { FeatureFlag.activate(:adviser_sign_up) }
 
   describe '.nudge_unsubmitted_with_incomplete_courses' do
     let(:email) { described_class.nudge_unsubmitted_with_incomplete_personal_statement(application_form) }

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
+  before { FeatureFlag.activate(:adviser_sign_up) }
 
   describe '.nudge_unsubmitted_with_incomplete_references' do
     context 'when the references section has not been completed' do


### PR DESCRIPTION
## Context

So far, the TTAs don't want us to disable the prompts from the emails, but this PR is a just in case they change their mind next week.

## Changes proposed in this pull request

Puts TTA prompts in emails behind the feature flag. 

## Guidance to review

View the previews of all the listed emails in the review app. The feature flag is deactivated, so you should not see any TTA information. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
