### PR TITLE
Adding another missing preview related to end of cycle

### DIFF
--- a/spec/components/previews/candidate_interface/carried_over_content_component_preview.rb
+++ b/spec/components/previews/candidate_interface/carried_over_content_component_preview.rb
@@ -1,0 +1,25 @@
+module CandidateInterface
+  class CarriedOverContentComponentPreview < ViewComponent::Preview
+    def after_find_opens
+      application_form = FactoryBot.create(:application_form)
+      render AfterFindOpensComponent.new(application_form:)
+    end
+
+    def before_find_opens
+      application_form = FactoryBot.create(:application_form)
+      render BeforeFindOpensComponent.new(application_form:)
+    end
+  end
+
+  class AfterFindOpensComponent < CandidateInterface::CarriedOverContentComponent
+    def after_find_opens?
+      true
+    end
+  end
+
+  class BeforeFindOpensComponent < CandidateInterface::CarriedOverContentComponent
+    def after_find_opens?
+      false
+    end
+  end
+end


### PR DESCRIPTION
## Context

Just another missing component preview for end of cycle. Content that is shown on the application page before apply opens.

## Changes proposed in this pull request
Two versions of the component -- before / after find opens.

## Guidance to review

View the components in the review app

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
