### PR TITLE
Replace bobheadxi with sticky PR comments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -302,15 +302,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - name: Start review-${{ github.event.pull_request.number }} Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          env: review-${{ github.event.pull_request.number }}
-          ref: ${{ github.head_ref }}
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -326,17 +317,19 @@ jobs:
           sha: ${{ needs.build.outputs.IMAGE_TAG }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
-      - name: Update review-${{ github.event.pull_request.number }} status
-        if: always()
-        uses: bobheadxi/deployments@v1
+      - name: Post sticky pull request comment
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          env: review-${{ github.event.pull_request.number }}
-          ref: ${{ github.head_ref }}
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.deploy_v2_review.outputs.deploy-url }}
+          header: review-app-v2
+          message: |
+            ### Review App Deployed
+
+            | Environment | URL |
+            | --- | --- |
+            | review-${{ github.event.pull_request.number }} | ${{ steps.deploy_v2_review.outputs.deploy-url }} |
+
+            The review app has been successfully deployed and is ready for testing.
 
   merge-dependabot:
     name: Merge dependabot

--- a/.github/workflows/delete-v2-review-app.yml
+++ b/.github/workflows/delete-v2-review-app.yml
@@ -63,36 +63,12 @@ jobs:
           storage-account-name: "${{ env.AZURE_RESOURCE_PREFIX }}${{ env.SERVICE_SHORT }}tfstate${{ env.CONFIG_SHORT }}sa"
           tf-state-file: ${{ env.TF_STATE_FILE }}
 
-      - name: Update ${{ env.DEPLOY_ENV }} status
-        if: always() && env.TF_STATE_EXISTS == 'true'
-        id: deactivate-env
-        uses: bobheadxi/deployments@v1
+      - name: Post sticky pull request comment
+        if: env.TF_STATE_EXISTS == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          env: ${{ env.DEPLOY_ENV }}
-          step: deactivate-env
-          token: ${{ secrets.GITHUB_TOKEN }}
-          desc: The deployment for ${{ env.DEPLOY_ENV }} has been removed.
+          header: review-app-v2
+          message: |
+            ### Review App Deleted
 
-      - uses: actions/github-script@v7
-        name: Remove environment entity
-        if: always() && (steps.deactivate-env.outcome == 'success')
-        with:
-          github-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-          script: |
-            const environment = process.env.DEPLOY_ENV || ''
-
-            if (environment) {
-              github.rest.repos.deleteAnEnvironment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                environment_name: environment
-              }).then(res => {
-                  console.log(`The environment ${environment} was removed successfully.`)
-              }).catch(err => {
-                  core.setFailed(err.message)
-              })
-            } else {
-              core.setFailed('An environment was not passed for deletion.')
-            }
-        env:
-          DEPLOY_ENV: ${{env.DEPLOY_ENV}}
+            The review app for PR #${{ github.event.pull_request.number }} has been successfully removed.


### PR DESCRIPTION
## Context

Replace the bobheadxi/deployments GitHub Action with marocchino/sticky-pull-request-comment across review app workflows. This simplifies deployment notifications by using sticky PR comments instead of managing GitHub deployment records.

Changes:
- Remove bobheadxi/deployments start/finish deployment tracking
- Add sticky PR comments for deployment success notifications
- Add sticky PR comments for review app deletion notifications
- Preserve GitHub environment cleanup where it was implemented
- Add pull-requests: write permission where missing

## Guidance to review

Comment attached in PR

## Things to check

- [x] Attach the PR to the Trello card
