### PR TITLE
Remove one login accounts on sandbox

### DIFF
--- a/app/services/data_migrations/delete_sandbox_one_login_accounts.rb
+++ b/app/services/data_migrations/delete_sandbox_one_login_accounts.rb
@@ -1,0 +1,19 @@
+module DataMigrations
+  class DeleteSandboxOneLoginAccounts
+    TIMESTAMP = 20250604115710
+    MANUAL_RUN = true
+
+    def change
+      if HostingEnvironment.sandbox_mode?
+        ActiveRecord::Base.transaction do
+          OneLoginAuth.delete_all
+          Session.delete_all
+          AccountRecoveryRequest.delete_all
+          Candidate.where(
+            account_recovery_status: %w[recovered dismissed],
+          ).update_all(account_recovery_status: 'not_started')
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DeleteSandboxOneLoginAccounts',
   'DataMigrations::RemoveVisaSponsorshipDeadlineFeatureFlag',
   'DataMigrations::DropShowSupportFindACandidateFeatureFlag',
   'DataMigrations::BackfillConfidentialData',

--- a/spec/services/data_migrations/delete_sandbox_one_login_accounts_spec.rb
+++ b/spec/services/data_migrations/delete_sandbox_one_login_accounts_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DeleteSandboxOneLoginAccounts do
+  let(:recovered_candidate) { create(:candidate, account_recovery_status: 'recovered') }
+  let(:dismissed_candidate) { create(:candidate, account_recovery_status: 'dismissed') }
+  let!(:one_login_auth) { create(:one_login_auth, candidate: recovered_candidate) }
+  let(:account_recovery_request) { create(:account_recovery_request, candidate: recovered_candidate) }
+  let!(:account_recovery_request_code) { create(:account_recovery_request_code, account_recovery_request:) }
+  let!(:session) { create(:session, candidate: recovered_candidate) }
+
+  describe '#change' do
+    it 'deletes one login accounts in sandbox' do
+      allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(true)
+
+      expect { described_class.new.change }.to change { OneLoginAuth.count }.from(1).to(0)
+      .and change { Session.count }.from(1).to(0)
+      .and change { AccountRecoveryRequest.count }.from(1).to(0)
+      .and change { AccountRecoveryRequestCode.count }.from(1).to(0)
+      .and change { recovered_candidate.reload.account_recovery_status }.from('recovered').to('not_started')
+      .and change { dismissed_candidate.reload.account_recovery_status }.from('dismissed').to('not_started')
+    end
+
+    it 'does not deletes one login accounts in production' do
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+
+      expect { described_class.new.change }.not_to(change { OneLoginAuth.count })
+      expect { described_class.new.change }.not_to(change { Session.count })
+      expect { described_class.new.change }.not_to(change { AccountRecoveryRequest.count })
+      expect { described_class.new.change }.not_to(change { AccountRecoveryRequestCode.count })
+      expect { described_class.new.change }.not_to(change { recovered_candidate.reload.account_recovery_status })
+      expect { described_class.new.change }.not_to(change { dismissed_candidate.reload.account_recovery_status })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Our sandbox env is using the production env of one login. This was because the testing integration env one login has required an extra step to login. There was a pop-up that required you to input a separate account and password from your one login.

This is not the case anymore and we have created quite a few fraud alerts in one login because of the sandbox accounts created

We will switch sandbox to use the testing intgration env of one login, similar to what QA uses. Part of doing that we need to wipe the one login accounts on sandbox.

This commit adds a data migration to do that. We will run it manually.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
