### PR TITLE
Lb/977 improve visibility of withdrawal reasons in support console

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -13,6 +13,7 @@ module SupportInterface
       [
         application_number_row,
         status_row,
+        withdrawal_reasons_row,
         offer_made_at_row,
         course_candidate_applied_for_row,
         course_offered_by_provider_row,
@@ -43,6 +44,15 @@ module SupportInterface
         key: 'Status',
         value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice:)),
       }.merge(status_action_link)
+    end
+
+    def withdrawal_reasons_row
+      if application_choice.withdrawn?
+        {
+          key: t('.reasons_for_withdrawal'),
+          value: render(WithdrawalReasonsComponent.new(application_choice:)),
+        }
+      end
     end
 
     def offer_made_at_row

--- a/app/components/support_interface/withdrawal_reasons_component.rb
+++ b/app/components/support_interface/withdrawal_reasons_component.rb
@@ -1,0 +1,49 @@
+module SupportInterface
+  class WithdrawalReasonsComponent < ViewComponent::Base
+    OLD_REASONS_PATH = 'config/withdrawal_reasons.yml'.freeze
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def render?
+      @application_choice.withdrawn?
+    end
+
+    def call
+      govuk_list(reasons)
+    end
+
+  private
+
+    def reasons
+      # No reason given if withdrawn or declined by provider
+      if @application_choice.withdrawn_or_declined_for_candidate_by_provider?
+        [t('.withdrawn_by_provider_on_behalf_of_candidate')]
+      # New reason model
+      elsif @application_choice.published_withdrawal_reasons.present?
+        @application_choice.withdrawal_reasons.pluck(:reason, :comment).map do |reason, comment|
+          t(".reasons.#{reason.gsub('-', '_')}", comment:)
+        end
+      # Old reason model for backward compatibility
+      elsif @application_choice.structured_withdrawal_reasons.present?
+        @application_choice.structured_withdrawal_reasons.map do |reason_id|
+          find_reason_label(reason_id)
+        end.compact
+      # In the old model, reasons were optional
+      else
+        [t('.no_reason_given')]
+      end&.compact
+    end
+
+    def find_reason_label(reason_id)
+      old_reasons.find do |reason|
+        reason[:id] == reason_id
+      end&.fetch(:label, nil)
+    end
+
+    def old_reasons
+      YAML.load_file(OLD_REASONS_PATH)
+    end
+  end
+end

--- a/config/locales/components/support_interface/application_choice_component.yml
+++ b/config/locales/components/support_interface/application_choice_component.yml
@@ -1,0 +1,4 @@
+en:
+  support_interface:
+    application_choice_component:
+      reasons_for_withdrawal: Reasons for withdrawal

--- a/config/locales/components/support_interface/withdrawal_reasons_component.yml
+++ b/config/locales/components/support_interface/withdrawal_reasons_component.yml
@@ -1,0 +1,41 @@
+en:
+  support_interface:
+    withdrawal_reasons_component:
+      withdrawn_by_provider_on_behalf_of_candidate: Withdrawn by provider on behalf of candidate
+      no_reason_given: No reason given
+      reasons:
+        applying_to_another_provider:
+          accepted_another_offer: "I am going to apply (or have applied) to a different training provider: I have accepted another offer"
+          seen_a_course_that_suits_me_better: "I am going to apply (or have applied) to a different training provider: I have seen a course that suits me better"
+          provider_has_not_replied_to_me: "I am going to apply (or have applied) to a different training provider: The training provider has not replied to me"
+          location_is_too_far_away: "I am going to apply (or have applied) to a different training provider: The location I’m expected to train at is too far away"
+          personal_circumstances_have_changed:
+            concerns_about_cost_of_doing_course: "I am going to apply (or have applied) to a different training provider because my personal circumstances have changed: I have concerns about the cost of doing the course"
+            concerns_about_having_enough_time_to_train: "I am going to apply (or have applied) to a different training provider, personal circumstances have changed: I have concerns that I will not have time to train"
+            concerns_about_training_with_a_disability_or_health_condition: "I am going to apply (or have applied) to a different training provider because my personal circumstances have changed: I have concerns about training with a disability or health condition"
+            other: "I am going to apply (or have applied) to a different training provider because my personal circumstances have changed: %{comment}"
+          course_no_longer_available: "I am going to apply (or have applied) to a different training provider: The course is not available anymore"
+          other: "I am going to apply (or have applied) to a different training provider: %{comment}"
+        change_or_update_application_with_this_provider:
+          update_my_application_correct_an_error_or_add_information: "I am going to change or update my application with this training provider: I want to update my application, for example correct an error or add information"
+          change_study_pattern: "I am going to change or update my application with this training provider: I want to change my study pattern, for example from full time to part time"
+          apply_for_a_different_subject_with_the_same_provider: "I am going to change or update my application with this training provider: I want to apply for a different subject with the same provider"
+          other: "I am going to change or update my application with this training provider: %{comment}"
+        apply_in_the_future:
+          personal_circumstances_have_changed:
+            concerns_about_cost_of_doing_course: "I plan to apply for teacher training in the future because my personal circumstances have changed: I have concerns about the cost of doing the course"
+            concerns_about_having_enough_time_to_train: "I plan to apply for teacher training in the future because my personal circumstances have changed: I have concerns that I will not have time to train "
+            concerns_about_training_with_a_disability_or_health_condition: "I plan to apply for teacher training in the future because my personal circumstances have changed: I have concerns about training with a disability or health condition "
+            other: "I plan to apply for teacher training in the future because my personal circumstances have changed: %{comment}"
+          gain_more_experience: "I plan to apply for teacher training in the future: I want to get more experience before I apply again"
+          improve_qualifications: "I plan to apply for teacher training in the future: I want to improve my qualifications before I apply again"
+          other: "I plan to apply for teacher training in the future: %{comment}"
+        do_not_want_to_train_anymore:
+          personal_circumstances_have_changed:
+            concerns_about_cost_of_doing_course: "I do not want to train to teach anymore because my personal circumstances have changed: I have concerns about the cost of doing the course"
+            concerns_about_having_enough_time_to_train: "I do not want to train to teach anymore because my personal circumstances have changed: I have concerns that I will not have time to train"
+            concerns_about_training_with_a_disability_or_health_condition: "I do not want to train to teach anymore because my personal circumstances have changed: I have concerns about training with a disability or health condition"
+            other: "I do not want to train to teach anymore because my personal circumstances have changed: %{comment}"
+          another_career_path_or_accepted_a_job_offer: "I do not want to train to teach anymore: I have decided on another career path or I have accepted a job offer"
+          other: "I do not want to train to teach anymore: %{comment}"
+        other: "Other: %{comment}"

--- a/spec/factories/withdrawal_reason.rb
+++ b/spec/factories/withdrawal_reason.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :withdrawal_reason, class: 'WithdrawalReason' do
     application_choice
-    reason { 'applying-to-another-provider.accepted_another-offer' }
+    reason { 'applying-to-another-provider.accepted-another-offer' }
 
     trait :published do
       status { 'published' }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -164,8 +164,8 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     unless ENV['TEST_ENV_NUMBER']
-      logger.info "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
-      logger.info "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
+      Rails.logger.info "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
+      Rails.logger.info "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
     end
   end
 


### PR DESCRIPTION
## Context

We want to surface the withdrawal reasons in the support view. 

## Changes proposed in this pull request

Added a row in the ApplicationChoice component for rendering the withdrawal reasons. 
It is backward compatible with the old reason structure. 
It also indicates if it has been withdrawn by the provider on behalf of the candidate.

## Guidance to review
Here are some candidates to look at on the review app
[Candidate withdrawn, current reasons](https://apply-review-10794.test.teacherservices.cloud/support/applications/71)
[Provider withdrew candidate on their request ](https://apply-review-10794.test.teacherservices.cloud/support/applications/53)
[Candidate withdrawn](https://apply-review-10794.test.teacherservices.cloud/support/applications/72), old reasons
[Candidate withdrawn, no reason](https://apply-review-10794.test.teacherservices.cloud/support/applications/74) (this was possible with the old reasons)

Also check that the row for withdrawal reasons is only visible if the application is withdrawn.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
