### PR TITLE
Update slack summary with invite counts

### DIFF
--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -10,21 +10,23 @@ class StatsSummary
 
       *Domestic applications :gb: :flag-ie:*
 
-      :#{mailbox_emoji(applications_submitted(today, domestic))}: #{pluralize(applications_submitted(today, domestic), 'application')} submitted | #{applications_submitted(this_day_last_year, domestic)} last cycle
-      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_made(today, domestic), 'offer')} made | #{offers_made(this_day_last_year, domestic)} last cycle
-      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_accepted(today, domestic), 'offer')} accepted | #{offers_accepted(this_day_last_year, domestic)} last cycle
-      :#{%w[man woman].sample}-gesturing-no: #{pluralize(rejections_issued(today, domestic), 'rejection')} issued | #{rejections_issued(this_day_last_year, domestic)} last cycle
-      :sleeping: #{pluralize(inactive_applications(today, domestic), 'application')} turned to inactive
-      :handshake: #{pluralize(candidates_recruited(today, domestic), 'candidate')} recruited | #{candidates_recruited(this_day_last_year, domestic)} last cycle
+      :#{mailbox_emoji(applications_submitted(today, domestic_application_forms))}: #{pluralize(applications_submitted(today, domestic_application_forms), 'application')} submitted | #{applications_submitted(this_day_last_year, domestic_application_forms)} last cycle
+      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_made(today, domestic_application_forms), 'offer')} made | #{offers_made(this_day_last_year, domestic_application_forms)} last cycle
+      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_accepted(today, domestic_application_forms), 'offer')} accepted | #{offers_accepted(this_day_last_year, domestic_application_forms)} last cycle
+      :#{%w[man woman].sample}-gesturing-no: #{pluralize(rejections_issued(today, domestic_application_forms), 'rejection')} issued | #{rejections_issued(this_day_last_year, domestic_application_forms)} last cycle
+      :sleeping: #{pluralize(inactive_applications(today, domestic_application_forms), 'application')} turned to inactive
+      :handshake: #{pluralize(candidates_recruited(today, domestic_application_forms), 'candidate')} recruited | #{candidates_recruited(this_day_last_year, domestic_application_forms)} last cycle
+      :incoming_envelope: #{pluralize(sent_invites(today, domestic_application_forms), 'invite')} sent | #{sent_invites(this_day_last_year, domestic_application_forms)} last cycle
 
       *International applications :earth_#{%w[africa americas asia].sample}:*
 
-      :#{mailbox_emoji(applications_submitted(today, international))}: #{pluralize(applications_submitted(today, international), 'application')} submitted | #{applications_submitted(this_day_last_year, international)} last cycle
-      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_made(today, international), 'offer')} made | #{offers_made(this_day_last_year, international)} last cycle
-      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_accepted(today, international), 'offer')} accepted | #{offers_accepted(this_day_last_year, international)} last cycle
-      :#{%w[man woman].sample}-gesturing-no: #{pluralize(rejections_issued(today, international), 'rejection')} issued | #{rejections_issued(this_day_last_year, international)} last cycle
-      :sleeping: #{pluralize(inactive_applications(today, international), 'application')} turned to inactive
-      :handshake: #{pluralize(candidates_recruited(today, international), 'candidate')} recruited | #{candidates_recruited(this_day_last_year, international)} last cycle
+      :#{mailbox_emoji(applications_submitted(today, international_application_forms))}: #{pluralize(applications_submitted(today, international_application_forms), 'application')} submitted | #{applications_submitted(this_day_last_year, international_application_forms)} last cycle
+      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_made(today, international_application_forms), 'offer')} made | #{offers_made(this_day_last_year, international_application_forms)} last cycle
+      :#{%w[man woman].sample}-tipping-hand: #{pluralize(offers_accepted(today, international_application_forms), 'offer')} accepted | #{offers_accepted(this_day_last_year, international_application_forms)} last cycle
+      :#{%w[man woman].sample}-gesturing-no: #{pluralize(rejections_issued(today, international_application_forms), 'rejection')} issued | #{rejections_issued(this_day_last_year, international_application_forms)} last cycle
+      :sleeping: #{pluralize(inactive_applications(today, international_application_forms), 'application')} turned to inactive
+      :handshake: #{pluralize(candidates_recruited(today, international_application_forms), 'candidate')} recruited | #{candidates_recruited(this_day_last_year, international_application_forms)} last cycle
+      :incoming_envelope: #{pluralize(sent_invites(today, international_application_forms), 'invite')} sent | #{sent_invites(this_day_last_year, international_application_forms)} last cycle
 
     MARKDOWN
   end
@@ -57,13 +59,17 @@ class StatsSummary
     applications_scope.where(application_choices: { inactive_at: period }).count
   end
 
+  def sent_invites(period, applications_scope)
+    Pool::Invite.where(candidate_id: applications_scope.select(:candidate_id), sent_to_candidate_at: period).count
+  end
+
 private
 
-  def international
+  def international_application_forms
     ApplicationForm.international.joins(:application_choices)
   end
 
-  def domestic
+  def domestic_application_forms
     ApplicationForm.domestic.joins(:application_choices)
   end
 

--- a/app/services/weekly_stats_summary.rb
+++ b/app/services/weekly_stats_summary.rb
@@ -18,6 +18,7 @@ class WeeklyStatsSummary
       :no_vote: #{pluralize(number_with_delimiter(rejections_issued(current_cycle_period, current_year, domestic)), 'total rejection')} issued | This point last cycle we had #{number_with_delimiter(rejections_issued(previous_cycle_period, previous_year, domestic))}
       :sleeping: #{pluralize(number_with_delimiter(inactive_applications(current_cycle_period, current_year, domestic)), 'application')} turned to inactive
       #{teacher} #{pluralize(number_with_delimiter(candidates_recruited(current_cycle_period, current_year, domestic)), 'total candidate')} recruited | This point last cycle we had #{number_with_delimiter(candidates_recruited(previous_cycle_period, previous_year, domestic))}
+      :incoming_envelope: #{pluralize(number_with_delimiter(sent_invites(current_cycle_period, current_year, domestic)), 'total invite')} sent | This point last cycle we had #{number_with_delimiter(sent_invites(previous_cycle_period, previous_year, domestic))}
 
       *International applications :earth_#{%w[africa americas asia].sample}:*
 
@@ -27,6 +28,7 @@ class WeeklyStatsSummary
       :no_vote: #{pluralize(number_with_delimiter(rejections_issued(current_cycle_period, current_year, international)), 'total rejection')} issued | This point last cycle we had #{number_with_delimiter(rejections_issued(previous_cycle_period, previous_year, international))}
       :sleeping: #{pluralize(number_with_delimiter(inactive_applications(current_cycle_period, current_year, international)), 'application')} turned to inactive
       #{teacher} #{pluralize(number_with_delimiter(candidates_recruited(current_cycle_period, current_year, international)), 'total candidate')} recruited | This point last cycle we had #{number_with_delimiter(candidates_recruited(previous_cycle_period, previous_year, international))}
+      :incoming_envelope: #{pluralize(number_with_delimiter(sent_invites(current_cycle_period, current_year, international)), 'total invite')} sent | This point last cycle we had #{number_with_delimiter(sent_invites(previous_cycle_period, previous_year, international))}
 
 
       _Please note these numbers are as of 11am and are not to be used for reporting purposes_
@@ -61,6 +63,11 @@ class WeeklyStatsSummary
 
   def inactive_applications(period, recruitment_cycle, applications_scope)
     applications_scope.where(application_choices: { inactive_at: period, current_recruitment_cycle_year: recruitment_cycle }).count
+  end
+
+  def sent_invites(period, recruitment_cycle, applications_scope)
+    application_form_candidate_ids = applications_scope.where(application_choices: { current_recruitment_cycle_year: recruitment_cycle }).select(:candidate_id)
+    Pool::Invite.where(candidate_id: application_form_candidate_ids, sent_to_candidate_at: period).count
   end
 
 private

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -164,8 +164,8 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     unless ENV['TEST_ENV_NUMBER']
-      logger.info "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
-      logger.info "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
+      Rails.logger.info "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
+      Rails.logger.info "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
     end
   end
 

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe StatsSummary do
     create(:application_choice, :accepted, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
     create(:application_choice, :accepted, application_form: create(:application_form, :minimum_info))
     create(:application_choice, :rejected_by_default, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
-    create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
-    create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+    inactive_domestic_choice = create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
+    inactive_international_choice = create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+
+    create_list(:pool_invite, 2, :sent_to_candidate, candidate: inactive_domestic_choice.candidate)
+    create_list(:pool_invite, 1, :sent_to_candidate, candidate: inactive_international_choice.candidate)
 
     travel_temporarily_to(this_day_last_cycle) do
       last_cycle_international_form = create(:application_form, :submitted, first_nationality: 'Vatican citizen')
@@ -21,6 +24,9 @@ RSpec.describe StatsSummary do
       create(:application_choice, :rejected, application_form: last_cycle_domestic_form)
       create(:application_choice, :rejected)
       create(:application_choice, :offered)
+
+      create_list(:pool_invite, 3, :sent_to_candidate, candidate: last_cycle_international_form.candidate)
+      create_list(:pool_invite, 2, :sent_to_candidate, candidate: last_cycle_domestic_form.candidate)
     end
 
     advance_time_by(1.hour)
@@ -28,18 +34,21 @@ RSpec.describe StatsSummary do
     output = described_class.new.as_slack_message
 
     expect(output).to match('10 candidate signups \\| 4 last cycle')
+
     expect(output).to match('5 applications submitted \\| 4 last cycle')
-    expect(output).to match('2 offers accepted \\| 1 last cycle')
-    expect(output).to match('1 candidate recruited \\| 1 last cycle')
     expect(output).to match('2 offers made \\| 2 last cycle')
+    expect(output).to match('2 offers accepted \\| 1 last cycle')
     expect(output).to match('2 rejections issued \\| 2 last cycle')
     expect(output).to match('1 application turned to inactive')
+    expect(output).to match('1 candidate recruited \\| 1 last cycle')
+    expect(output).to match('2 invites sent \\| 2 last cycle')
 
     expect(output).to match('4 applications submitted \\| 1 last cycle')
-    expect(output).to match('1 offer accepted \\| 0 last cycle')
-    expect(output).to match('0 candidates recruited \\| 0 last cycle')
     expect(output).to match('2 offers made \\| 1 last cycle')
+    expect(output).to match('1 offer accepted \\| 0 last cycle')
     expect(output).to match('1 rejection issued \\| 0 last cycle')
     expect(output).to match('1 application turned to inactive')
+    expect(output).to match('0 candidates recruited \\| 0 last cycle')
+    expect(output).to match('1 invite sent \\| 3 last cycle')
   end
 end

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -9,8 +9,11 @@ RSpec.describe WeeklyStatsSummary do
     create(:application_choice, :accepted, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
     create(:application_choice, :accepted, application_form: create(:application_form, :minimum_info))
     create(:application_choice, :rejected_by_default, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
-    create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
-    create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+    inactive_domestic_choice = create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
+    inactive_international_choice = create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+
+    create_list(:pool_invite, 2, :sent_to_candidate, candidate: inactive_domestic_choice.candidate)
+    create_list(:pool_invite, 1, :sent_to_candidate, candidate: inactive_international_choice.candidate)
 
     travel_temporarily_to(this_day_last_cycle) do
       last_cycle_international_form = create(:application_form, :submitted, first_nationality: 'Vatican citizen')
@@ -19,6 +22,9 @@ RSpec.describe WeeklyStatsSummary do
       create(:application_choice, :offered, application_form: last_cycle_international_form)
       create(:application_choice, :rejected, application_form: last_cycle_domestic_form)
       create(:application_choice, :rejected)
+
+      create_list(:pool_invite, 3, :sent_to_candidate, candidate: last_cycle_international_form.candidate)
+      create_list(:pool_invite, 2, :sent_to_candidate, candidate: last_cycle_domestic_form.candidate)
     end
 
     advance_time_by(1.hour)
@@ -26,18 +32,21 @@ RSpec.describe WeeklyStatsSummary do
     output = described_class.new.as_slack_message
 
     expect(output).to match('9 total candidate signups \\| This point last cycle we had 3')
+
     expect(output).to match('5 total applications submitted \\| This point last cycle we had 3')
-    expect(output).to match('1 total candidate recruited \\| This point last cycle we had 1')
     expect(output).to match('2 total offers made \\| This point last cycle we had 1')
     expect(output).to match('2 total offers accepted \\| This point last cycle we had 1')
     expect(output).to match('2 total rejections issued \\| This point last cycle we had 2')
     expect(output).to match('1 application turned to inactive')
+    expect(output).to match('1 total candidate recruited \\| This point last cycle we had 1')
+    expect(output).to match('2 total invites sent \\| This point last cycle we had 2')
 
     expect(output).to match('4 total applications submitted \\| This point last cycle we had 1')
-    expect(output).to match('0 total candidates recruited \\| This point last cycle we had 0')
     expect(output).to match('2 total offers made \\| This point last cycle we had 1')
     expect(output).to match('1 total offer accepted \\| This point last cycle we had 0')
     expect(output).to match('2 total rejections issued \\| This point last cycle we had 2')
     expect(output).to match('1 application turned to inactive')
+    expect(output).to match('0 total candidates recruited \\| This point last cycle we had 0')
+    expect(output).to match('1 total invite sent \\| This point last cycle we had 3')
   end
 end


### PR DESCRIPTION
## Context

We want to be able to see at a glance how many Invites have been sent to Candidates each day and a round up at the end of each week. 

## Changes proposed in this pull request

- Added invite counts to the Slack summary notifications

## Guidance to review

- N/A


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
