### PR TITLE
Migration to backfill recruitment cycle year on pool invites

### DIFF
--- a/app/services/data_migrations/backfill_recruitment_cycle_year_on_pool_invites.rb
+++ b/app/services/data_migrations/backfill_recruitment_cycle_year_on_pool_invites.rb
@@ -1,0 +1,18 @@
+module DataMigrations
+  class BackfillRecruitmentCycleYearOnPoolInvites
+    TIMESTAMP = 20250605151610
+    MANUAL_RUN = false
+
+    def change
+      Pool::Invite
+        .where(recruitment_cycle_year: nil)
+        .update_all(recruitment_cycle_year:)
+    end
+
+  private
+
+    def recruitment_cycle_year
+      @recruitment_cycle_year ||= RecruitmentCycleTimetable.current_year
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillRecruitmentCycleYearOnPoolInvites',
   'DataMigrations::DeleteSandboxOneLoginAccounts',
   'DataMigrations::RemoveVisaSponsorshipDeadlineFeatureFlag',
   'DataMigrations::DropShowSupportFindACandidateFeatureFlag',

--- a/spec/services/data_migrations/backfill_recruitment_cycle_year_on_pool_invites_spec.rb
+++ b/spec/services/data_migrations/backfill_recruitment_cycle_year_on_pool_invites_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillRecruitmentCycleYearOnPoolInvites do
+  it 'updates all pool invites without a recruitment cycle year' do
+    without_year = create(:pool_invite, recruitment_cycle_year: nil)
+    with_year = create(:pool_invite, recruitment_cycle_year: previous_year)
+
+    described_class.new.change
+
+    expect(without_year.reload.recruitment_cycle_year).to eq current_year
+    expect(with_year.reload.recruitment_cycle_year).to eq previous_year
+  end
+end


### PR DESCRIPTION
## Context

The invites are only relevant to the recruitment cycle in which they are sent. There is a large possibility that we’ll need to act on specific cohorts of invites, or scope invites to a particular year for various purposes.

For example:
- If we have an invite dashboard (for candidates or providers), it will need to be scoped to the current year
- At the end of the recruitment cycle, we’ll probably want to auto-dismiss the invites that haven’t been acted on.

## Changes proposed in this pull request

This is the data migration to backfill the recruitment cycle year data on al invites. Two related PRs have already been merged (one to create the column, one to add the data when creating new invites).

I'll do a 4th PR to make the recruitment cycle year a required field on the model. 

## Guidance to review

if you have any invites locally where the recruitment cycle year is nil, pull the branch and run the migrations. Check on the rails console. all the invites should have 2025 as a recruitment cycle year.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
