### PR TITLE
Allow provider to add a message to their invites 

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
@@ -60,7 +60,10 @@ module ProviderInterface
         )
 
         if @pool_invite.valid? && @pool_invite.save
-          redirect_to @back_path || provider_interface_candidate_pool_candidate_draft_invite_path(@candidate)
+          redirect_to @back_path || edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+            @candidate,
+            invite,
+          )
         else
           render :edit
         end
@@ -75,7 +78,7 @@ module ProviderInterface
 
       def pool_invite_form_params
         params.expect(
-          provider_interface_pool_invite_form: %i[course_id id status],
+          provider_interface_pool_invite_form: %i[course_id id status return_to],
         )
       end
 
@@ -104,12 +107,17 @@ module ProviderInterface
       end
 
       def set_back_path
-        if params[:return_to] == 'review'
+        if return_to_review?
           @back_path = provider_interface_candidate_pool_candidate_draft_invite_path(
             @candidate,
             invite,
           )
         end
+      end
+
+      def return_to_review?
+        params[:return_to] == 'review' ||
+          params.dig(:provider_interface_pool_invite_form, :return_to) == 'review'
       end
     end
   end

--- a/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/draft_invites_controller.rb
@@ -4,6 +4,7 @@ module ProviderInterface
       before_action :set_candidate
       before_action :redirect_if_invite_is_not_found, only: %i[show edit]
       before_action :set_policy
+      before_action :set_back_path, only: %i[edit update]
       before_action :redirect_if_candidate_cannot_send_invites
 
       def show
@@ -42,7 +43,10 @@ module ProviderInterface
 
         if @pool_invite.valid?
           invite = @pool_invite.save
-          redirect_to provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, invite)
+          redirect_to new_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+            @candidate,
+            invite,
+          )
         else
           render :new
         end
@@ -56,7 +60,7 @@ module ProviderInterface
         )
 
         if @pool_invite.valid? && @pool_invite.save
-          redirect_to provider_interface_candidate_pool_candidate_draft_invite_path(@candidate)
+          redirect_to @back_path || provider_interface_candidate_pool_candidate_draft_invite_path(@candidate)
         else
           render :edit
         end
@@ -96,6 +100,15 @@ module ProviderInterface
       def redirect_if_invite_is_not_found
         if invite.nil?
           redirect_to provider_interface_candidate_pool_candidate_path(@candidate)
+        end
+      end
+
+      def set_back_path
+        if params[:return_to] == 'review'
+          @back_path = provider_interface_candidate_pool_candidate_draft_invite_path(
+            @candidate,
+            invite,
+          )
         end
       end
     end

--- a/app/controllers/provider_interface/candidate_pool/provider_invite_messages_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/provider_invite_messages_controller.rb
@@ -1,0 +1,84 @@
+module ProviderInterface
+  module CandidatePool
+    class ProviderInviteMessagesController < ProviderInterfaceController
+      before_action :set_candidate
+      before_action :set_back_path, only: %i[edit]
+
+      def new
+        @pool_invite = PoolInviteMessageForm.new(invite:)
+        @course = invite.course
+      end
+
+      def edit
+        @pool_invite = PoolInviteMessageForm.new(
+          invite:,
+          invite_message_params: {
+            provider_message: invite.provider_message,
+            message_content: invite.message_content,
+          },
+        )
+        @course = invite.course
+      end
+
+      def create
+        @pool_invite = PoolInviteMessageForm.new(
+          invite:,
+          invite_message_params:,
+        )
+
+        if @pool_invite.valid?
+          @pool_invite.save
+          redirect_to provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, invite)
+        else
+          @course = invite.course
+          render :new
+        end
+      end
+
+      def update
+        @pool_invite = PoolInviteMessageForm.new(
+          invite:,
+          invite_message_params:,
+        )
+
+        if @pool_invite.valid?
+          @pool_invite.save
+          redirect_to provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, invite)
+        else
+          @course = invite.course
+          render :new
+        end
+      end
+
+    private
+
+      def set_candidate
+        @candidate ||= Pool::Candidates.application_forms_for_provider
+          .find_by(candidate_id: params.expect(:candidate_id)).candidate
+      end
+
+      def set_back_path
+        if params[:return_to] == 'review'
+          @back_path = provider_interface_candidate_pool_candidate_draft_invite_path(
+            @candidate,
+            invite,
+          )
+        end
+      end
+
+      def invite
+        @invite ||= Pool::Invite.find_by(
+          id: params.expect(:draft_invite_id),
+          provider_id: current_provider_user.provider_ids,
+          status: :draft,
+        )
+      end
+
+      def invite_message_params
+        params.expect(
+          provider_interface_pool_invite_message_form: %i[provider_message message_content],
+        )
+      end
+    end
+  end
+end

--- a/app/forms/provider_interface/pool_invite_form.rb
+++ b/app/forms/provider_interface/pool_invite_form.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class PoolInviteForm
     include ActiveModel::Model
 
-    attr_accessor :id, :course_id
+    attr_accessor :id, :course_id, :return_to
     attr_reader :current_provider_user, :candidate
 
     validates :course_id, presence: true

--- a/app/forms/provider_interface/pool_invite_message_form.rb
+++ b/app/forms/provider_interface/pool_invite_message_form.rb
@@ -1,23 +1,23 @@
 module ProviderInterface
   class PoolInviteMessageForm
     include ActiveModel::Model
+    include ActiveModel::Attributes
 
-    attr_accessor :provider_message, :message_content
-    attr_reader :invite
+    attribute :invite
+    attribute :provider_message, :boolean
+    attribute :message_content, :string
+    attribute :return_to, :string
 
-    validates :provider_message, presence: true
-    validates :message_content, presence: true, if: -> { provider_message == 'true' }
-    validates :message_content, word_count: { maximum: 200 }, if: -> { provider_message == 'true' }
+    validates :provider_message, inclusion: { in: [true, false] }
+    validates :message_content, presence: true, if: -> { provider_message == true }
+    validates :message_content, word_count: { maximum: 200 }, if: -> { provider_message == true }
 
-    def initialize(invite: nil, invite_message_params: {})
-      @invite = invite
-      super(invite_message_params)
-    end
+    delegate :persisted?, to: :invite
 
     def save
       invite.update!(
         provider_message:,
-        message_content: provider_message == 'false' ? nil : message_content,
+        message_content: provider_message == true ? message_content : nil,
       )
       invite
     end

--- a/app/forms/provider_interface/pool_invite_message_form.rb
+++ b/app/forms/provider_interface/pool_invite_message_form.rb
@@ -1,0 +1,25 @@
+module ProviderInterface
+  class PoolInviteMessageForm
+    include ActiveModel::Model
+
+    attr_accessor :provider_message, :message_content
+    attr_reader :invite
+
+    validates :provider_message, presence: true
+    validates :message_content, presence: true, if: -> { provider_message == 'true' }
+    validates :message_content, word_count: { maximum: 200 }, if: -> { provider_message == 'true' }
+
+    def initialize(invite: nil, invite_message_params: {})
+      @invite = invite
+      super(invite_message_params)
+    end
+
+    def save
+      invite.update!(
+        provider_message:,
+        message_content: provider_message == 'false' ? nil : message_content,
+      )
+      invite
+    end
+  end
+end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -522,9 +522,9 @@ class CandidateMailer < ApplicationMailer
     application_form = candidate.current_cycle_application_form
     @inviting_providers_count = pool_invites.pluck(:provider_id).uniq.size
     @single_provider_name = pool_invites.first.provider.name if @inviting_providers_count == 1
-    @invited_courses = pool_invites
-                         .map(&:course)
-                         .sort_by { |course| [course.provider.name, course.name_and_code] }
+    @invites = pool_invites.sort_by do |invite|
+      [invite.course.provider.name, invite.course.name_and_code]
+    end
 
     @preferences_url = candidate_preferences_link(candidate)
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -4,6 +4,7 @@ class ProviderUser < ApplicationRecord
   has_many :provider_permissions, dependent: :destroy
   has_many :providers, through: :provider_permissions
   has_many :notes, dependent: :destroy
+  has_many :pool_invites, class_name: 'Pool::Invite', foreign_key: 'invited_by_id'
   has_one :notification_preferences, class_name: 'ProviderUserNotificationPreferences'
   attr_accessor :impersonator
 

--- a/app/views/candidate_mailer/candidate_invites.text.erb
+++ b/app/views/candidate_mailer/candidate_invites.text.erb
@@ -1,3 +1,4 @@
+<%# If you update this, please update the preview template for provider invite message as well %>
 Dear <%= @application_form.first_name %>,
 
 <%= t('.body.invite_to_submit', count: @inviting_providers_count, provider_name: @single_provider_name) %>:

--- a/app/views/candidate_mailer/candidate_invites.text.erb
+++ b/app/views/candidate_mailer/candidate_invites.text.erb
@@ -19,8 +19,9 @@ Start date: <%= invite.course.start_date.to_fs(:short_month_and_year) %>
 
 [Review the full course details](<%= invite.course.find_url %>)
 
-<% if @invites.size > 1 && invite.message_content.present? %>
-  <%= invite.message_content %>
+<% if invite.message_content.present? %>
+## <%= invite.course.provider.name %> included this message:
+<%= invite.message_content %>
 <% end %>
 
 <% end %>
@@ -29,7 +30,3 @@ Start date: <%= invite.course.start_date.to_fs(:short_month_and_year) %>
 <%= t('.body.locations_not_suitable', count: @invites.size) %>, you can [update your preferences](<%= @preferences_url %>) to appear in more relevant searches.
 
 If you do not want to receive invitations like this, you can [stop providers from viewing your application details](<%= @preferences_url %>).
-
-<% if @invites.size == 1 && @invites.first.message_content.present? %>
-  <%= @invites.first.message_content %>
-<% end  %>

--- a/app/views/candidate_mailer/candidate_invites.text.erb
+++ b/app/views/candidate_mailer/candidate_invites.text.erb
@@ -2,25 +2,33 @@ Dear <%= @application_form.first_name %>,
 
 <%= t('.body.invite_to_submit', count: @inviting_providers_count, provider_name: @single_provider_name) %>:
 
-<% @invited_courses.each do |course| %>
-## <%= course.provider.name %> - <%= course.name_and_code %>
+<% @invites.each do |invite| %>
+## <%= invite.course.provider.name %> - <%= invite.course.name_and_code %>
 
-<% if course.fee_domestic.present? && course.fee_international.present? %>
-  <%= "Course fee: #{number_to_currency(course.fee_domestic)} for UK citizens; #{number_to_currency(course.fee_international)} for non-UK citizens" %>
-<% elsif course.fee_domestic.present? %>
-  <%= "Course fee: #{number_to_currency(course.fee_domestic)} for UK citizens" %>
-<% elsif course.fee_international.present? %>
-  <%= "Course fee: #{number_to_currency(course.fee_international)} for non-UK citizens" %>
+<% if invite.course.fee_domestic.present? && invite.course.fee_international.present? %>
+  <%= "Course fee: #{number_to_currency(invite.course.fee_domestic)} for UK citizens; #{number_to_currency(invite.course.fee_international)} for non-UK citizens" %>
+<% elsif invite.course.fee_domestic.present? %>
+  <%= "Course fee: #{number_to_currency(invite.course.fee_domestic)} for UK citizens" %>
+<% elsif invite.course.fee_international.present? %>
+  <%= "Course fee: #{number_to_currency(invite.course.fee_international)} for non-UK citizens" %>
 <% end %>
-Course length: <%= DisplayCourseLength.call(course_length: course.course_length) %>
-Age range: <%= course.age_range %>
-Qualification: <%= course.qualifications_to_s %>
-Start date: <%= course.start_date.to_fs(:short_month_and_year) %>
+Course length: <%= DisplayCourseLength.call(course_length: invite.course.course_length) %>
+Age range: <%= invite.course.age_range %>
+Qualification: <%= invite.course.qualifications_to_s %>
+Start date: <%= invite.course.start_date.to_fs(:short_month_and_year) %>
 
-[Review the full course details](<%= course.find_url %>)
+[Review the full course details](<%= invite.course.find_url %>)
+
+<% if @invites.size > 1 && invite.message_content.present? %>
+  <%= invite.message_content %>
+<% end  %>
 <% end %>
 
 
-<%= t('.body.locations_not_suitable', count: @invited_courses.size) %>, you can [update your preferences](<%= @preferences_url %>) to appear in more relevant searches.
+<%= t('.body.locations_not_suitable', count: @invites.size) %>, you can [update your preferences](<%= @preferences_url %>) to appear in more relevant searches.
 
 If you do not want to receive invitations like this, you can [stop providers from viewing your application details](<%= @preferences_url %>).
+
+<% if @invites.size == 1 && @invites.first.message_content.present? %>
+  <%= @invites.first.message_content %>
+<% end  %>

--- a/app/views/candidate_mailer/candidate_invites.text.erb
+++ b/app/views/candidate_mailer/candidate_invites.text.erb
@@ -21,7 +21,8 @@ Start date: <%= invite.course.start_date.to_fs(:short_month_and_year) %>
 
 <% if @invites.size > 1 && invite.message_content.present? %>
   <%= invite.message_content %>
-<% end  %>
+<% end %>
+
 <% end %>
 
 

--- a/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: pool_invite, url: provider_interface_candidate_pool_candidate_draft_invites_path do |form| %>
+<%= form_with model: pool_invite, url:, method: do |form| %>
     <%= form.govuk_error_summary %>
 
   <% if pool_invite.id.present? %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_with model: pool_invite, url:, method: do |form| %>
-    <%= form.govuk_error_summary %>
+  <%= form.govuk_error_summary %>
 
+  <%= form.hidden_field :return_to, value: params[:return_to] || pool_invite.return_to %>
   <% if pool_invite.id.present? %>
     <%= form.hidden_field :id, value: pool_invite.id %>
   <% end %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
@@ -6,6 +6,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render '/provider_interface/candidate_pool/draft_invites/form', pool_invite: @pool_invite, candidate: @candidate %>
+      <%= render(
+        '/provider_interface/candidate_pool/draft_invites/form',
+        pool_invite: @pool_invite,
+        candidate: @candidate,
+        url: provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, @pool_invite.id),
+        method: :patch,
+      ) %>
   </div>
 </div>

--- a/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/edit.html.erb
@@ -2,7 +2,12 @@
   t('.title', candidate_name: @candidate.redacted_full_name_current_cycle),
   @pool_invite.errors.any?,
 ) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_candidate_pool_candidate_path(@candidate)) %>
+<% content_for(
+  :before_content,
+  govuk_back_link_to(
+    @back_path || provider_interface_candidate_pool_candidate_path(@candidate),
+  ),
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
@@ -7,7 +7,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @pool_invite.available_courses.present? %>
-      <%= render 'form', pool_invite: @pool_invite, candidate: @candidate %>
+      <%= render(
+        'form',
+        pool_invite: @pool_invite,
+        candidate: @candidate,
+        url: provider_interface_candidate_pool_candidate_draft_invites_path,
+        method: :post
+      )
+      %>
     <% else %>
       <p class="govuk-body"><%= t('.no_available_courses') %> </p>
     <% end %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/new.html.erb
@@ -12,9 +12,8 @@
         pool_invite: @pool_invite,
         candidate: @candidate,
         url: provider_interface_candidate_pool_candidate_draft_invites_path,
-        method: :post
-      )
-      %>
+        method: :post,
+      ) %>
     <% else %>
       <p class="govuk-body"><%= t('.no_available_courses') %> </p>
     <% end %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('.title') %>
-<% content_for :before_content, govuk_back_link_to(edit_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, @pool_invite.id)) %>
+<% content_for :before_content, govuk_back_link_to(edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(@candidate, @pool_invite.id)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -38,8 +38,23 @@
           href: edit_provider_interface_candidate_pool_candidate_draft_invite_path(
             @candidate,
             @pool_invite.id,
+            return_to: 'review',
           ),
           visually_hidden_text: t('.visually_hidden_change_course'),
+        ) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t('.invitation_message') } %>
+        <% row.with_value { @invite.provider_message? ? @invite.message_content : t('.none') } %>
+        <% row.with_action(
+          text: t('.change'),
+          href: edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+            @candidate,
+            @pool_invite.id,
+            return_to: 'review',
+          ),
+          visually_hidden_text: t('.visually_hidden_change_invitation_message'),
         ) %>
       <% end %>
     <% end %>

--- a/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/draft_invites/show.html.erb
@@ -46,7 +46,7 @@
 
       <% summary_list.with_row do |row| %>
         <% row.with_key { t('.invitation_message') } %>
-        <% row.with_value { @invite.provider_message? ? @invite.message_content : t('.none') } %>
+        <% row.with_value { @invite.provider_message? ? simple_format(@invite.message_content) : t('.none') } %>
         <% row.with_action(
           text: t('.change'),
           href: edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: @pool_invite, url:, method: do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :provider_message, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' } do %>
+    <%= render 'invitation_email' %>
+
+    <%= f.govuk_radio_button :provider_message, true, label: { text: 'Yes' }, link_errors: true do %>
+      <%= render 'formatting_information' %>
+
+      <%= f.govuk_text_area(
+        :message_content,
+        label: { text: t('.enter_message') },
+        max_words: 200,
+      ) %>
+    <% end %>
+    <%= f.govuk_radio_button :provider_message, false, label: { text: 'No' } %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
@@ -6,11 +6,10 @@
     <%= render 'invitation_email' %>
 
     <%= f.govuk_radio_button :provider_message, true, label: { text: 'Yes' }, link_errors: true do %>
-      <%= render 'formatting_information' %>
-
       <%= f.govuk_text_area(
         :message_content,
-        label: { text: t('.enter_message') },
+        label: { text: t('.enter_message'), size: 's', class: 'govuk-!-margin-bottom-3' },
+        hint: -> { render 'formatting_information' },
         max_words: 200,
       ) %>
     <% end %>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_form.html.erb
@@ -1,6 +1,7 @@
-<%= form_with model: @pool_invite, url:, method: do |f| %>
+<%= form_with model: @pool_invite, url: do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%= f.hidden_field :return_to, value: params[:return_to] || @pool_invite.return_to %>
   <%= f.govuk_radio_buttons_fieldset :provider_message, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' } do %>
     <%= render 'invitation_email' %>
 

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_formatting_information.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_formatting_information.html.erb
@@ -1,0 +1,17 @@
+<%= govuk_details(summary_text: t('.help_with_format')) do %>
+  <h1 class='govuk-heading-m'><%= t('.title') %></h1>
+  <h2 class='govuk-heading-s'><%= t('.create_a_link_heading') %></h2>
+  <p class='govuk-body'><%= t('.link_is_made_up_of_two_parts') %></p>
+  <p class='govuk-body'><%= t('.link_format_warning') %></p>
+  <p class='govuk-body'><%= t('.link_instructions') %></p>
+  <p class='govuk-body'>
+    <%= t('.link_example_html', formatted_link: govuk_link_to('http://GOV.UK', 'http://gov.uk')) %>
+  </p>
+  <h2 class='govuk-heading-s'><%= t('.create_bullet_points_heading') %></h2>
+  <ul class='govuk-list govuk-list--bullet'>
+    <%= t('.bullet_point_guidance_html') %>
+  </ul>
+  <p class='govuk-body'><%= t('.for_example') %></p>
+  <p class='govuk-body'><%= t('.list_item_one') %></p>
+  <p class='govuk-body'><%= t('.list_item_two') %></p>
+<% end %>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
@@ -1,0 +1,37 @@
+<%= govuk_details(summary_text: 'View invitation email') do %>
+  <p class="govuk-body">Dear Fred,</p>
+
+  <p class="govuk-body">
+  <%= @course.provider.name %> have reviewed your application details and are inviting you to submit an application for:
+  </p>
+
+  <h3><%= @course.provider.name %> - <%= @course.name_and_code %></h3>
+
+  <%= govuk_list do %>
+    <% if @course.fee_domestic.present? && @course.fee_international.present? %>
+      <%= tag.li "Course fee: #{number_to_currency(@course.fee_domestic)} for UK citizens; #{number_to_currency(@course.fee_international)} for non-UK citizens", class: 'govuk-!-margin-bottom-0' %>
+    <% elsif @course.fee_domestic.present? %>
+      <%= tag.li "Course fee: #{number_to_currency(@course.fee_domestic)} for UK citizens", class: 'govuk-!-margin-bottom-0' %>
+    <% elsif @course.fee_international.present? %>
+      <%= tag.li "Course fee: #{number_to_currency(@course.fee_international)} for non-UK citizens", class: 'govuk-!-margin-bottom-0' %>
+    <% end %>
+    <%= tag.li "Course length: #{DisplayCourseLength.call(course_length: @course.course_length)}", class: 'govuk-!-margin-bottom-0' %>
+    <%= tag.li "Age range: #{@course.age_range}", class: 'govuk-!-margin-bottom-0' %>
+    <%= tag.li "Qualification: #{@course.qualifications_to_s}", class: 'govuk-!-margin-bottom-0' %>
+    <%= tag.li "Start date: #{@course.start_date.to_fs(:short_month_and_year)}", class: 'govuk-!-margin-bottom-0' %>
+  <% end %>
+
+  <p class="govuk-body">
+  <%= govuk_link_to('Review the full course details', @course.find_url) %>
+  </p>
+
+  <p class="govuk-body">
+  If this course is not in suitable location, you can <%= govuk_link_to 'update your preferences', '#' %> to appear in more relevant searches
+  </p>
+
+  <p class="govuk-body">
+  If you do not want to receive invitations like this, you can <%= govuk_link_to 'stop providers from viewing your application details', '#' %>.
+  </p>
+
+  <p class="govuk-body">[Your message goes here]</p>
+<% end %>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_details(summary_text: 'View invitation email') do %>
-  <p class="govuk-body">Dear Fred,</p>
+  <p class="govuk-body">Dear first name,</p>
 
   <p class="govuk-body">
   <%= @course.provider.name %> have reviewed your application details and are inviting you to submit an application for:
@@ -25,13 +25,6 @@
   <%= govuk_link_to('Review the full course details', @course.find_url) %>
   </p>
 
-  <p class="govuk-body">
-  If this course is not in suitable location, you can <%= govuk_link_to 'update your preferences', '#' %> to appear in more relevant searches
-  </p>
-
-  <p class="govuk-body">
-  If you do not want to receive invitations like this, you can <%= govuk_link_to 'stop providers from viewing your application details', '#' %>.
-  </p>
-
+  <p class="govuk-body govuk-!-margin-bottom-0"><%= @course.provider.name %> included this message:</p>
   <p class="govuk-body">[Your message goes here]</p>
 <% end %>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/edit.html.erb
@@ -18,7 +18,6 @@
         @candidate.id,
         @pool_invite.invite,
       ),
-      method: :patch,
     ) %>
   </div>
 </div>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/edit.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :browser_title, title_with_error_prefix(
+  t('.title', candidate_name: @candidate.redacted_full_name_current_cycle),
+  @pool_invite.errors.any?,
+) %>
+<% content_for(
+  :before_content,
+  govuk_back_link_to(
+    @back_path || edit_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, @pool_invite.invite),
+  ),
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      'form',
+      pool_invite: @pool_invite,
+      url: provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate.id,
+        @pool_invite.invite,
+      ),
+      method: :patch,
+    ) %>
+  </div>
+</div>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/new.html.erb
@@ -13,7 +13,6 @@
         @candidate.id,
         @pool_invite.invite,
       ),
-      method: :post,
     ) %>
   </div>
 </div>

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/new.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, title_with_error_prefix(
+  t('.title', candidate_name: @candidate.redacted_full_name_current_cycle),
+  @pool_invite.errors.any?,
+) %>
+<% content_for :before_content, govuk_back_link_to(edit_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, @pool_invite.invite)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      'form',
+      pool_invite: @pool_invite,
+      url: provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate.id,
+        @pool_invite.invite,
+      ),
+      method: :post,
+    ) %>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -139,6 +139,29 @@
       "note": ""
     },
     {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "62e26a4d37b84dd77184bc5980c9bc70a9b59f1274745a6f4f2dfe23b7d605ec",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `Pool::Invite#find_by`",
+      "file": "app/controllers/provider_interface/candidate_pool/provider_invite_messages_controller.rb",
+      "line": 71,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "Pool::Invite.find_by(:id => params.expect(:draft_invite_id), :provider_id => current_provider_user.provider_ids, :status => :draft)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::CandidatePool::ProviderInviteMessagesController",
+        "method": "invite"
+      },
+      "user_input": "params.expect(:draft_invite_id)",
+      "confidence": "Weak",
+      "cwe_id": [
+        285
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "783f66b9e6119c7b65c794a57f29b291e256d49267c511bff375d031ef83ea96",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -139,29 +139,6 @@
       "note": ""
     },
     {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
-      "fingerprint": "62e26a4d37b84dd77184bc5980c9bc70a9b59f1274745a6f4f2dfe23b7d605ec",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `Pool::Invite#find_by`",
-      "file": "app/controllers/provider_interface/candidate_pool/provider_invite_messages_controller.rb",
-      "line": 71,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "Pool::Invite.find_by(:id => params.expect(:draft_invite_id), :provider_id => current_provider_user.provider_ids, :status => :draft)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::CandidatePool::ProviderInviteMessagesController",
-        "method": "invite"
-      },
-      "user_input": "params.expect(:draft_invite_id)",
-      "confidence": "Weak",
-      "cwe_id": [
-        285
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "783f66b9e6119c7b65c794a57f29b291e256d49267c511bff375d031ef83ea96",

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -103,7 +103,7 @@ en:
         provider_interface/pool_invite_message_form:
           attributes:
             provider_message:
-              blank: Select if you want to add your own message to the invitation email
+              inclusion: Select if you want to add your own message to the invitation email
             message_content:
               blank: You must enter an invitation message
               too_many_words: Invitation message must be %{maximum} words or less

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -48,13 +48,46 @@ en:
           course: Course
           visually_hidden_change_candidate: candidate
           visually_hidden_change_course: course
+          visually_hidden_change_invitation_message: invitation message
           send_invitation: Send invitation
           candidate_id: Candidate %{candidate_id}
+          invitation_message: Invitation message
+          none: None
         edit:
           title: Select a course to invite %{candidate_name} to apply to
         form:
           title: Select a course to invite %{candidate_name} to apply to
           continue: Continue
+      provider_invite_messages:
+        new:
+          title: Do you want to add your own message to the invitation email?
+        edit:
+          title: Do you want to add your own message to the invitation email?
+        form:
+          title: Do you want to add your own message to the invitation email?
+          enter_message: Enter your invitation message
+          invitation_email: View invitation email
+        formatting_information:
+          help_with_format: Help formatting your text
+          summary_text: Help formatting your text
+          title: How to format your text
+          create_a_link_heading: How to create a link
+          link_is_made_up_of_two_parts: >
+            Your link is made up of two parts, the link text which is what the reader will see, and the URL which is the
+            address the link will take them to.
+          link_format_warning: If you don't format the links properly, people will not be able to click on them.
+          link_instructions: >
+            Put square brackets [ ] around the link text and round brackets ( ) around the link URL. Make sure there are no
+            spaces between the brackets.
+          link_example_html: "For example: [http://GOV.UK](https://gov.uk/) will show as %{formatted_link}"
+          create_bullet_points_heading: How to create bullet points
+          bullet_point_guidance_html:
+            <li>use asterisks or hyphens to create a bullet point</li>
+            <li>make sure there is one space after the asterisk or hyphen</li>
+            <li>leave one empty line space before the bullet points start and one after</li>
+          for_example: "For example:"
+          list_item_one: "* list item 1"
+          list_item_two: "* list item 2"
       publish_invites:
         create:
           success: You have invited %{candidate} (%{candidate_id}) to apply to %{course}
@@ -67,3 +100,10 @@ en:
               blank: Select a course
               invalid: Course is not available
               already_invited: Select a different course. You have invited this person to the selected course already
+        provider_interface/pool_invite_message_form:
+          attributes:
+            provider_message:
+              blank: Select if you want to add your own message to the invitation email
+            message_content:
+              blank: You must enter an invitation message
+              too_many_words: Invitation message must be %{maximum} words or less

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -28,6 +28,7 @@ namespace :provider_interface, path: '/provider' do
   namespace :candidate_pool, path: 'find-candidates' do
     resources :candidates, only: %i[index show], path: '/' do
       resources :draft_invites, path: 'invite' do
+        resource :provider_invite_messages, only: %i[new create edit update], path: 'message'
         resource :publish_invite, only: %i[create], path: 'review'
       end
     end

--- a/spec/forms/provider_interface/pool_invite_message_form_spec.rb
+++ b/spec/forms/provider_interface/pool_invite_message_form_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe ProviderInterface::PoolInviteMessageForm, type: :model do
   subject(:form) do
     described_class.new(
       invite:,
-      invite_message_params:,
+      provider_message:,
+      message_content:,
     )
   end
 
   let(:invite) { create(:pool_invite) }
-  let(:invite_message_params) { { provider_message:, message_content: } }
   let(:provider_message) { 'true' }
   let(:message_content) { 'custom message' }
 
   describe '.validations' do
-    it { is_expected.to validate_presence_of(:provider_message) }
+    it { is_expected.to validate_inclusion_of(:provider_message).in_array([true, false]) }
 
     context 'provider_message is present but message is not' do
       let(:message_content) { nil }

--- a/spec/forms/provider_interface/pool_invite_message_form_spec.rb
+++ b/spec/forms/provider_interface/pool_invite_message_form_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::PoolInviteMessageForm, type: :model do
+  subject(:form) do
+    described_class.new(
+      invite:,
+      invite_message_params:,
+    )
+  end
+
+  let(:invite) { create(:pool_invite) }
+  let(:invite_message_params) { { provider_message:, message_content: } }
+  let(:provider_message) { 'true' }
+  let(:message_content) { 'custom message' }
+
+  describe '.validations' do
+    it { is_expected.to validate_presence_of(:provider_message) }
+
+    context 'provider_message is present but message is not' do
+      let(:message_content) { nil }
+
+      it 'returns message error' do
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:message_content]).to eq(['You must enter an invitation message'])
+      end
+    end
+
+    context 'provider_message is too long' do
+      let(:message_content) { 'long message ' * 101 }
+
+      it 'returns message error' do
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:message_content]).to eq(['Invitation message must be 200 words or less'])
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'when provider message is true' do
+      it 'adds message content to invite' do
+        expect { form.save }.to change { invite.provider_message }.from(nil).to(true)
+          .and change { invite.message_content }.from(nil).to(message_content)
+      end
+    end
+
+    context 'when provider message is false' do
+      let(:provider_message) { 'false' }
+
+      it 'does not add message content to invite' do
+        expect { form.save }.to change { invite.provider_message }.from(nil).to(false)
+          .and(not_change { invite.message_content })
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -569,6 +569,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate:,
       provider: provider,
       course: course,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
     CandidateMailer.candidate_invites(candidate, [invite])
@@ -595,6 +597,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate:,
       provider: provider,
       course: course_1,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
     invite_2 = FactoryBot.create(
@@ -602,6 +606,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate:,
       provider: provider,
       course: course_2,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
     CandidateMailer.candidate_invites(candidate, [invite_1, invite_2])
@@ -615,14 +621,25 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate: candidate,
       first_name: 'Fred',
     )
+    provider = FactoryBot.create(:provider)
 
-    pool_invites = FactoryBot.create_list(
+    invite_1 = FactoryBot.create(
       :pool_invite,
-      2,
       candidate:,
+      provider: provider,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
-    CandidateMailer.candidate_invites(candidate, pool_invites)
+    invite_2 = FactoryBot.create(
+      :pool_invite,
+      candidate:,
+      provider: provider,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
+    )
+
+    CandidateMailer.candidate_invites(candidate, [invite_1, invite_2])
   end
 
   def candidate_invites_multiple_providers
@@ -646,6 +663,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate:,
       provider: provider,
       course: course_1,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
     provider_1_invite_2 = FactoryBot.create(
@@ -653,6 +672,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       candidate:,
       provider: provider,
       course: course_2,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
     )
 
     other_invites = FactoryBot.create_list(

--- a/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Providers cannot send invites to candidates' do
     then_i_see_an_error('Course is not available')
 
     when_i_select_another_course
+    and_i_chose_not_to_add_invitation_message
     and_my_permissions_are_updated_again
     when_i_try_to_publish_the_invite
     then_i_see_an_error('Course is not available')
@@ -191,5 +192,14 @@ private
   def and_i_chose_not_to_add_invitation_message
     choose 'No'
     click_on 'Continue'
+  end
+
+  def then_i_am_redirected_to_message_page
+    expect(page).to have_current_path(
+      new_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate,
+        pool_invite,
+      ),
+    )
   end
 end

--- a/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Providers cannot send invites to candidates' do
     and_i_navigate_to_a_candidate
     and_i_click_the_invite_button
     and_i_select_a_course
+    and_i_chose_not_to_add_invitation_message
     and_then_my_permissions_are_updated
     when_i_try_to_publish_the_invite
     then_i_am_redirected_to_the_find_candidate_page
@@ -53,6 +54,7 @@ RSpec.describe 'Providers cannot send invites to candidates' do
     and_i_navigate_to_a_candidate
     and_i_click_the_invite_button
     and_i_select_a_course
+    and_i_chose_not_to_add_invitation_message
     and_then_my_permissions_are_updated_so_i_can_make_decisions_for_the_other_provider
     when_i_try_to_publish_the_invite
     then_i_see_an_error('Course is not available')
@@ -184,5 +186,10 @@ private
   def then_i_am_redirected_to_the_find_candidate_page
     expect(page).to have_content 'Candidates can choose to share their application details.'
     expect(page).to have_no_content 'Select a course to invite C***** C***** to apply to'
+  end
+
+  def and_i_chose_not_to_add_invitation_message
+    choose 'No'
+    click_on 'Continue'
   end
 end

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Providers invites candidates' do
     then_i_am_redirected_to_the_review_page(last_course, 'None')
 
     when_i_click('Change invitation message')
-    then_i_am_redirected_to_the_edit_message_page
+    then_i_am_redirected_to_the_edit_message_page_with_return_param
     when_i_choose_yes
     and_i_add_message_content
 
@@ -107,6 +107,9 @@ RSpec.describe 'Providers invites candidates' do
     then_i_get_an_error('Course is not available')
 
     when_i_select_a_course(last_course)
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_the_edit_message_page
     when_i_click('Continue')
 
     then_i_am_redirected_to_the_review_page(last_course)
@@ -282,12 +285,21 @@ RSpec.describe 'Providers invites candidates' do
     )
   end
 
-  def then_i_am_redirected_to_the_edit_message_page
+  def then_i_am_redirected_to_the_edit_message_page_with_return_param
     expect(page).to have_current_path(
       edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
         @candidate,
         pool_invite,
         return_to: 'review',
+      ),
+    )
+  end
+
+  def then_i_am_redirected_to_the_edit_message_page
+    expect(page).to have_current_path(
+      edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate,
+        pool_invite,
       ),
     )
   end

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe 'Providers invites candidates' do
   let(:first_course) { current_provider.courses.first }
   let(:second_course) { current_provider.courses.second }
   let(:last_course) { current_provider.courses.last }
+  let(:message_content) { 'message_content' }
 
-  scenario 'Invite candidate and edit course' do
+  scenario 'Invite candidate and edit invite' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_provider_has_courses(3)
@@ -27,12 +28,26 @@ RSpec.describe 'Providers invites candidates' do
     when_i_select_a_course(first_course)
     when_i_click('Continue')
 
-    then_i_am_redirected_to_the_review_page(first_course)
+    then_i_am_redirected_to_message_page
+    when_i_click('Continue')
+    then_i_get_an_error('Select if you want to add your own message to the invitation email')
+    when_i_choose_no
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_the_review_page(first_course, 'None')
 
     when_i_click('Change course')
     then_i_am_redirected_to_the_edit_page
 
     when_i_select_a_course(last_course)
+    when_i_click('Continue')
+    then_i_am_redirected_to_the_review_page(last_course, 'None')
+
+    when_i_click('Change invitation message')
+    then_i_am_redirected_to_the_edit_message_page
+    when_i_choose_yes
+    and_i_add_message_content
+
     when_i_click('Continue')
     then_i_am_redirected_to_the_review_page(last_course)
 
@@ -55,6 +70,11 @@ RSpec.describe 'Providers invites candidates' do
     when_i_select_a_course_from_dropdown(first_course)
     when_i_click('Continue')
 
+    then_i_am_redirected_to_message_page
+    when_i_choose_yes
+    and_i_add_message_content
+    when_i_click('Continue')
+
     then_i_am_redirected_to_the_review_page(first_course)
 
     when_i_click('Send invitation')
@@ -73,6 +93,11 @@ RSpec.describe 'Providers invites candidates' do
     when_i_click('Invite to apply')
 
     when_i_select_a_course(first_course)
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_message_page
+    when_i_choose_yes
+    and_i_add_message_content
     when_i_click('Continue')
 
     then_i_am_redirected_to_the_review_page(first_course)
@@ -104,6 +129,11 @@ RSpec.describe 'Providers invites candidates' do
     when_i_select_a_course(first_course)
     when_i_click('Continue')
 
+    then_i_am_redirected_to_message_page
+    when_i_choose_yes
+    and_i_add_message_content
+    when_i_click('Continue')
+
     then_i_am_redirected_to_the_review_page(first_course)
     when_the_invite_has_been_sent_already(first_course)
 
@@ -114,6 +144,11 @@ RSpec.describe 'Providers invites candidates' do
     when_i_select_a_course(second_course)
     when_i_click('Continue')
 
+    then_i_am_redirected_to_message_page
+    when_i_choose_yes
+    and_i_add_message_content
+    when_i_click('Continue')
+
     then_i_am_redirected_to_the_review_page(second_course)
     when_the_invite_has_been_sent_already(second_course)
 
@@ -122,6 +157,11 @@ RSpec.describe 'Providers invites candidates' do
 
     when_i_click('Invite to apply')
     when_i_select_a_course(last_course)
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_message_page
+    when_i_choose_yes
+    and_i_add_message_content
     when_i_click('Continue')
 
     then_i_am_redirected_to_the_review_page(last_course)
@@ -177,19 +217,16 @@ RSpec.describe 'Providers invites candidates' do
     choose course.name_code_and_course_provider
   end
 
-  def then_i_am_redirected_to_the_review_page(course)
-    pool_invite = Pool::Invite.where(provider_id: current_provider.id).last
-
+  def then_i_am_redirected_to_the_review_page(course, message = message_content)
     expect(page).to have_current_path(
       provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, pool_invite.id),
       ignore_query: true,
     )
     expect(page).to have_content(course.name_code_and_course_provider)
+    expect(page).to have_content(message)
   end
 
   def then_i_am_redirected_to_the_edit_page
-    pool_invite = Pool::Invite.where(provider_id: current_provider.id).last
-
     expect(page).to have_current_path(
       edit_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate, pool_invite.id),
       ignore_query: true,
@@ -234,5 +271,40 @@ RSpec.describe 'Providers invites candidates' do
       provider_interface_candidate_pool_candidate_path(@candidate),
       ignore_query: true,
     )
+  end
+
+  def then_i_am_redirected_to_message_page
+    expect(page).to have_current_path(
+      new_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate,
+        pool_invite,
+      ),
+    )
+  end
+
+  def then_i_am_redirected_to_the_edit_message_page
+    expect(page).to have_current_path(
+      edit_provider_interface_candidate_pool_candidate_draft_invite_provider_invite_messages_path(
+        @candidate,
+        pool_invite,
+        return_to: 'review',
+      ),
+    )
+  end
+
+  def pool_invite
+    Pool::Invite.where(provider_id: current_provider.id).last
+  end
+
+  def when_i_choose_yes
+    choose 'Yes'
+  end
+
+  def when_i_choose_no
+    choose 'No'
+  end
+
+  def and_i_add_message_content
+    fill_in 'Enter your invitation message', with: :message_content
   end
 end


### PR DESCRIPTION
## Context

This allows the provider user to add a custom message to their email invite sent to the candidate.

Please review by commit.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/212b13cb-7a1c-4d4e-b776-6a9f0145135c

If you want to test this on review please invite these candidates:


Candidate ids in the candidate pool. If you use thse ids the invite email will be in your inbox.
77 - Lori
35 - David




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
