### PR TITLE
Sanitise email addresses for OneLoginAuths

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -149,10 +149,16 @@ SET
 -- SupportUser
 UPDATE "support_users"
 SET
-    email_address = concat('application_reference_', id, '@example.com'),
+    email_address = concat('support_user_', id, '@example.com'),
     first_name  = 'Support',
     last_name = concat('User', id),
     dfe_sign_in_uid = gen_random_uuid();
+
+-- OneLoginAuth
+UPDATE "one_login_auths"
+SET
+    email_address = concat('one_login_auth_', id, '@example.com'),
+    token = gen_random_uuid();
 
 -- VendorApiUser
 UPDATE "vendor_api_users"


### PR DESCRIPTION
## Context

Our OneLoginAuth records should have their email_address sanitised. 

## Changes proposed in this pull request

Sanitise the OneLoginAuth email address

## Guidance to review

- N/A


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
