### PR TITLE
[979 PR 2] Add dedicated question for having location preferences

### DIFF
--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -7,6 +7,12 @@ module CandidateInterface
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
         LocationPreferenceDecorator.new(location)
       end
+
+      @back_path = if @preference.training_locations_anywhere?
+                     new_candidate_interface_draft_preference_training_location_path(@preference)
+                   else
+                     candidate_interface_draft_preference_location_preferences_path(@preference)
+                   end
     end
 
     def update
@@ -15,7 +21,8 @@ module CandidateInterface
         params: request_params,
       )
 
-      if @preference_form.save
+      if @preference_form.valid?
+        @preference_form.save
         redirect_to candidate_interface_draft_preference_path(@preference)
       else
         @location_preferences = @preference.location_preferences

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -27,7 +27,7 @@ module CandidateInterface
 
       if @preference_form.save
         if @preference_form.preference.opt_in?
-          redirect_to candidate_interface_draft_preference_location_preferences_path(
+          redirect_to new_candidate_interface_draft_preference_training_location_path(
             @preference_form.preference,
           )
         else
@@ -48,7 +48,9 @@ module CandidateInterface
 
       if @preference_form.save
         if @preference.reload.opt_in?
-          redirect_to @back_path || candidate_interface_draft_preference_location_preferences_path(@preference)
+          redirect_to @back_path || new_candidate_interface_draft_preference_training_location_path(
+            @preference_form.preference,
+          )
         else
           flash[:success] = t('.opt_out_message')
           redirect_to candidate_interface_application_choices_path

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -12,6 +12,10 @@ module CandidateInterface
     def create
       ActiveRecord::Base.transaction do
         @preference.published!
+        if @preference.training_locations_anywhere?
+          @preference.update(dynamic_location_preferences: false)
+          @preference.location_preferences.destroy_all
+        end
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
       end
 

--- a/app/controllers/candidate_interface/training_locations_controller.rb
+++ b/app/controllers/candidate_interface/training_locations_controller.rb
@@ -10,8 +10,7 @@ module CandidateInterface
 
     def create
       @training_locations_form = TrainingLocationsForm.new(
-        { training_locations: form_params[:training_locations] },
-        preference: @preference,
+        { training_locations: form_params[:training_locations] }.merge(preference: @preference),
       )
 
       if @training_locations_form.valid?

--- a/app/controllers/candidate_interface/training_locations_controller.rb
+++ b/app/controllers/candidate_interface/training_locations_controller.rb
@@ -1,0 +1,63 @@
+module CandidateInterface
+  class TrainingLocationsController < CandidateInterfaceController
+    before_action :set_preference
+    before_action :set_back_path
+    before_action :set_submit_path, only: :new
+
+    def new
+      @training_locations_form = TrainingLocationsForm.build_from_preference(@preference)
+    end
+
+    def create
+      @training_locations_form = TrainingLocationsForm.new(
+        { training_locations: form_params[:training_locations] },
+        preference: @preference,
+      )
+
+      if @training_locations_form.valid?
+        @training_locations_form.save!
+        redirect_to @training_locations_form.next_step_path
+      else
+        set_submit_path
+        render :new
+      end
+    end
+
+    def form_params
+      params.fetch(:candidate_interface_training_locations_form, {}).permit(:training_locations)
+    end
+
+  private
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params[:draft_preference_id])
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
+    end
+
+    def set_back_path
+      @back_path = if return_to_review?
+                     candidate_interface_draft_preference_path(@preference)
+                   else
+                     edit_candidate_interface_pool_opt_in_path(@preference)
+                   end
+    end
+
+    def set_submit_path
+      @submit_path = if return_to_review?
+                       candidate_interface_draft_preference_training_locations_path(
+                         @preference,
+                         return_to: 'review',
+                       )
+                     else
+                       candidate_interface_draft_preference_training_locations_path(@preference)
+                     end
+    end
+
+    def return_to_review?
+      params[:return_to] == 'review'
+    end
+  end
+end

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -32,6 +32,7 @@ module CandidateInterface
       kwargs = {
         pool_status:,
         opt_out_reason: pool_status == 'opt_in' ? nil : opt_out_reason,
+        training_locations: pool_status == 'opt_out' ? nil : preference&.training_locations,
       }
 
       if preference.present?

--- a/app/forms/candidate_interface/preferences_form.rb
+++ b/app/forms/candidate_interface/preferences_form.rb
@@ -3,6 +3,7 @@ class CandidateInterface::PreferencesForm
 
   attr_accessor :dynamic_location_preferences
   attr_reader :preference
+  validate :location_preferences_required
 
   def initialize(preference:, params: {})
     @preference = preference
@@ -19,6 +20,12 @@ class CandidateInterface::PreferencesForm
   end
 
   def save
-    preference.update!(dynamic_location_preferences:)
+    preference.update!(dynamic_location_preferences:) if valid?
+  end
+
+  def location_preferences_required
+    if @preference.location_preferences.blank?
+      errors.add(:base, :location_preferences_blank)
+    end
   end
 end

--- a/app/forms/candidate_interface/training_locations_form.rb
+++ b/app/forms/candidate_interface/training_locations_form.rb
@@ -1,0 +1,37 @@
+module CandidateInterface
+  class TrainingLocationsForm
+    include ActiveModel::Model
+    include Rails.application.routes.url_helpers
+
+    LOCATION_OPTIONS = %w[anywhere specific].freeze
+
+    attr_accessor :preference, :training_locations
+    validates :training_locations, inclusion: { in: LOCATION_OPTIONS }
+
+    def self.build_from_preference(preference)
+      new({ training_locations: preference.training_locations }, preference:)
+    end
+
+    def initialize(attributes = {}, preference:)
+      @preference = preference
+      super(attributes)
+    end
+
+    def save!
+      ActiveRecord::Base.transaction do
+        @preference.update!(training_locations:)
+        if @preference.reload.training_locations_specific? && @preference.location_preferences.empty?
+          LocationPreferences.add_default_location_preferences(preference: @preference)
+        end
+      end
+    end
+
+    def next_step_path
+      if @preference.training_locations_anywhere?
+        candidate_interface_draft_preference_path(@preference)
+      elsif @preference.training_locations_specific?
+        candidate_interface_draft_preference_location_preferences_path(@preference)
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/training_locations_form.rb
+++ b/app/forms/candidate_interface/training_locations_form.rb
@@ -9,28 +9,23 @@ module CandidateInterface
     validates :training_locations, inclusion: { in: LOCATION_OPTIONS }
 
     def self.build_from_preference(preference)
-      new({ training_locations: preference.training_locations }, preference:)
-    end
-
-    def initialize(attributes = {}, preference:)
-      @preference = preference
-      super(attributes)
+      new({ training_locations: preference.training_locations, preference: })
     end
 
     def save!
       ActiveRecord::Base.transaction do
-        @preference.update!(training_locations:)
-        if @preference.reload.training_locations_specific? && @preference.location_preferences.empty?
-          LocationPreferences.add_default_location_preferences(preference: @preference)
+        preference.update!(training_locations:)
+        if preference.reload.training_locations_specific? && preference.location_preferences.empty?
+          LocationPreferences.add_default_location_preferences(preference:)
         end
       end
     end
 
     def next_step_path
-      if @preference.training_locations_anywhere?
-        candidate_interface_draft_preference_path(@preference)
-      elsif @preference.training_locations_specific?
-        candidate_interface_draft_preference_location_preferences_path(@preference)
+      if preference.training_locations_anywhere?
+        candidate_interface_draft_preference_path(preference)
+      elsif preference.training_locations_specific?
+        candidate_interface_draft_preference_location_preferences_path(preference)
       end
     end
   end

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('.title') %>
-<% content_for :before_content, govuk_back_link(href: candidate_interface_draft_preference_location_preferences_path(@preference)) %>
+<% content_for :before_content, govuk_back_link(href: @back_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -17,33 +17,41 @@
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t('.preferred_locations') } %>
-        <% row.with_value do %>
-          <%= govuk_list do %>
-            <% if @location_preferences.blank? %>
-              <p class="govuk-body"><%= t('.no_location_preferences') %> </p>
-            <% else %>
+        <% row.with_key { t('.where_can_you_train') } %>
+        <% row.with_value { t(".#{@preference.training_locations}") } %>
+        <% row.with_action(
+             text: t('.change'),
+             href: new_candidate_interface_draft_preference_training_location_path(@preference, return_to: 'review'),
+             visually_hidden_text: t('.change_training_locations_visually_hidden'),
+           ) %>
+      <% end %>
+
+      <% if @preference.training_locations_specific? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.preferred_locations') } %>
+          <% row.with_value do %>
+            <%= govuk_list do %>
               <% @location_preferences.each do |location| %>
                 <%= tag.li t('.location', radius: location.within, location: location.decorated_name) %>
               <% end %>
             <% end %>
           <% end %>
+          <% row.with_action(
+            text: t('.change'),
+            href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+            visually_hidden_text: t('.change_location_preferences_hint'),
+          ) %>
         <% end %>
-        <% row.with_action(
-          text: t('.change'),
-          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
-          visually_hidden_text: t('.change_location_preferences_hint'),
-        ) %>
-      <% end %>
 
-      <% summary_list.with_row do |row| %>
-        <% row.with_key { t('.dynamic_locations') } %>
-        <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
-        <% row.with_action(
-          text: t('.change'),
-          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
-          visually_hidden_text: t('.change_dynamic_locations_hint'),
-        ) %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.dynamic_locations') } %>
+          <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
+          <% row.with_action(
+            text: t('.change'),
+            href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+            visually_hidden_text: t('.change_dynamic_locations_hint'),
+          ) %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -1,22 +1,19 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @preference_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@back_path || edit_candidate_interface_pool_opt_in_path(@preference)) %>
+<% content_for :before_content, govuk_back_link_to(@back_path || new_candidate_interface_draft_preference_training_location_path(@preference)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-    <p class="govuk-body"><%= t('.body') %></p>
-    <h2 class="govuk-heading-m"><%= t('.select_locations') %></h2>
-
     <%= form_with(
       model: @preference_form,
       url: candidate_interface_draft_preference_path(@preference.id),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+      <p class="govuk-body"><%= t('.body') %></p>
+      <h2 class="govuk-heading-m"><%= t('.select_locations') %></h2>
 
       <% if @location_preferences.blank? %>
-        <p class="govuk-body"><%= t('.no_location_preferences') %></p>
-
         <%= govuk_button_link_to(
           t('.add_location'),
           new_candidate_interface_draft_preference_location_preference_path(@preference),
@@ -32,7 +29,7 @@
           <% end %>
 
           <% table.with_body do |body| %>
-            <% @location_preferences.each_with_index do |location, index| %>
+            <% @location_preferences.each do |location| %>
               <% body.with_row do |row| %>
                 <%= row.with_cell(text: location.decorated_name) %>
 

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -17,33 +17,41 @@
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t('.preferred_locations') } %>
-        <% row.with_value do %>
-          <%= govuk_list do %>
-            <% if @location_preferences.blank? %>
-              <p class="govuk-body"><%= t('.no_location_preferences') %> </p>
-            <% else %>
+        <% row.with_key { t('.where_can_you_train') } %>
+        <% row.with_value { t(".#{@preference.training_locations}") } %>
+        <% row.with_action(
+           text: t('.change'),
+           href: new_candidate_interface_draft_preference_training_location_path(@preference),
+           visually_hidden_text: t('.change_training_locations_visually_hidden'),
+         ) %>
+      <% end %>
+
+      <% if @preference.training_locations_specific? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.preferred_locations') } %>
+          <% row.with_value do %>
+            <%= govuk_list do %>
               <% @location_preferences.each do |location| %>
                 <%= tag.li t('.location', radius: location.within, location: location.decorated_name) %>
               <% end %>
             <% end %>
           <% end %>
+          <% row.with_action(
+            text: t('.change'),
+            href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+            visually_hidden_text: t('.change_location_preferences_hint'),
+          ) %>
         <% end %>
-        <% row.with_action(
-          text: t('.change'),
-          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
-          visually_hidden_text: t('.change_location_preferences_hint'),
-        ) %>
-      <% end %>
 
-      <% summary_list.with_row do |row| %>
-        <% row.with_key { t('.dynamic_locations') } %>
-        <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
-        <% row.with_action(
-          text: t('.change'),
-          href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
-          visually_hidden_text: t('.change_dynamic_locations_hint'),
-        ) %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.dynamic_locations') } %>
+          <% row.with_value { @preference.dynamic_location_preferences? ? 'Yes' : 'No' } %>
+          <% row.with_action(
+            text: t('.change'),
+            href: candidate_interface_draft_preference_location_preferences_path(@preference, return_to: 'review'),
+            visually_hidden_text: t('.change_dynamic_locations_hint'),
+          ) %>
+        <% end %>
       <% end %>
     <% end %>
 
@@ -51,6 +59,5 @@
       t('.submit'),
       candidate_interface_draft_preference_publish_preferences_path(@preference),
     ) %>
-
   </div>
 </div>

--- a/app/views/candidate_interface/training_locations/new.html.erb
+++ b/app/views/candidate_interface/training_locations/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @training_locations_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@back_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @training_locations_form,
+          url: candidate_interface_draft_preference_training_locations_path(
+            @preference,
+            return_to: params[:return_to],
+          ),
+          method: :post,
+        ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: { text: t('.title'), size: 'l' }) do %>
+        <%= f.govuk_radio_button :training_locations, :anywhere, label: { text: t('.anywhere') }, link_errors: true %>
+        <%= f.govuk_radio_button :training_locations, :specific, label: { text: t('.specific') } %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -7,15 +7,19 @@ en:
       show:
         title: Check your application sharing preferences
         share_information: Do you want to make your application details visible to other training providers?
+        where_can_you_train: Where can you train?
+        specific: In specific locations
+        anywhere: Anywhere in England
+        change_training_locations_visually_hidden: where you would like to train
         preferred_locations: Preferred locations
         dynamic_locations: Add new course locations to my preferences when I apply to new courses
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
         no_location_preferences: You have no location preferences
-        change_share_information_hint: Change whether you want to share your application details
-        change_location_preferences_hint: Change your preferred locations
-        change_dynamic_locations_hint: Change updating your locations when you apply to a new course
+        change_share_information_hint: whether you want to share your application details
+        change_location_preferences_hint: your preferred locations
+        change_dynamic_locations_hint: updating your locations when you apply to a new course
     preferences:
       show: Check your application sharing preferences
       share_question: Do you want to share your application details with other training providers?
@@ -27,15 +31,19 @@ en:
       show:
         title: Check your application sharing preferences
         share_information: Do you want to make your application details visible to other training providers?
+        where_can_you_train: Where can you train?
+        specific: In specific locations
+        anywhere: Anywhere in England
+        change_training_locations_visually_hidden: where you would like to train
         preferred_locations: Preferred locations
         dynamic_locations: Add new course locations to my preferences when I apply to new courses
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
         no_location_preferences: You have no location preferences
-        change_share_information_hint: Change whether you want to share your application details
-        change_location_preferences_hint: Change your preferred locations
-        change_dynamic_locations_hint: Change updating your locations when you apply to a new course
+        change_share_information_hint: whether you want to share your application details
+        change_location_preferences_hint: your preferred locations
+        change_dynamic_locations_hint: updating your locations when you apply to a new course
     pool_opt_ins:
       new:
         title: Do you want to make your application details visible to other training providers?
@@ -67,7 +75,6 @@ en:
         remove: Remove
         add_another_location: Add another location
         add_location: Add a location
-        no_location_preferences: You have no location preferences. Providers will assume you can train anywhere in England.
         within: "%{within} miles"
       new:
         title: Add a location
@@ -90,13 +97,17 @@ en:
         candidate_interface/preferences_form:
           attributes:
             base:
-              location_preferences_blank: Add location preferences
+              location_preferences_blank: Add an area you can train in
         candidate_interface/pool_opt_ins_form:
           attributes:
             pool_status:
               blank: Select whether to make your application details visible to other training providers
             opt_out_reason:
               too_many_words: Reason for not sharing your application details must be %{maximum} words or less
+        candidate_interface/training_locations_form:
+          attributes:
+            training_locations:
+              inclusion: Select where you can train
         candidate_interface/location_preferences_form:
           attributes:
             within:

--- a/config/locales/candidate_interface/training_locations.yml
+++ b/config/locales/candidate_interface/training_locations.yml
@@ -1,0 +1,7 @@
+en:
+  candidate_interface:
+    training_locations:
+      new:
+        title: Where can you train?
+        anywhere: Anywhere in England
+        specific: In specific locations

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -20,8 +20,9 @@ namespace :candidate_interface, path: '/candidate' do
 
   resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in'
   resources :draft_preferences, only: %i[show update], path: 'preferences' do
-    resource :publish_preferences, only: %i[show create], path: 'publish-preferences'
+    resources :training_locations, only: %i[new create], path: 'training-locations'
     resources :location_preferences, path: 'location-preferences'
+    resource :publish_preferences, only: %i[show create], path: 'publish-preferences'
   end
   resource :candidate_feature_launch_email, only: :show, path: 'feature-launch-email'
 

--- a/spec/factories/candidate_preference.rb
+++ b/spec/factories/candidate_preference.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     pool_status { 'opt_in' }
     dynamic_location_preferences { true }
     status { 'published' }
+    training_locations { 'specific' }
   end
 end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   after { FeatureFlag.deactivate(:candidate_preferences) }
 
-  scenario 'Candidate opts in to find a candidate' do
+  scenario 'Candidate opts in to find a candidate with specific locations' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
@@ -38,10 +38,21 @@ RSpec.describe 'Candidate adds preferences' do
     and_i_opt_in_to_find_a_candidate
     when_i_click('Continue')
 
+    then_i_am_redirected_to_training_locations
+    when_i_click('Back')
+
+    then_i_am_redirected_to_opt_in_page
+    when_i_click('Continue')
+    and_i_click('Continue')
+    then_i_get_an_error('Select where you can train')
+
+    and_i_select_specific_locations
+    when_i_click('Continue')
+
     then_i_am_redirected_to_location_preferences(location_preferences)
 
     when_i_click('Back')
-    then_i_am_redirected_to_opt_in
+    then_i_am_redirected_to_training_locations
 
     when_i_click('Continue')
     then_i_am_redirected_to_location_preferences(location_preferences)
@@ -71,7 +82,7 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_application_choices_with_success_message
   end
 
-  scenario 'Candidate opts in to find a candidate without any locations' do
+  scenario 'Candidate opts in to find a candidate for anywhere in England' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
@@ -84,13 +95,9 @@ RSpec.describe 'Candidate adds preferences' do
     and_i_opt_in_to_find_a_candidate
     when_i_click('Continue')
 
-    then_i_am_redirected_to_location_preferences(location_preferences)
-
-    when_i_remove_all_locations
-    then_i_am_redirected_to_location_preferences_without_locations
-
-    when_i_check_dynamic_locations
-    when_i_click('Continue')
+    then_i_am_redirected_to_training_locations
+    when_i_select_anywhere
+    and_i_click('Continue')
 
     then_i_am_redirected_to_review_page_without_locations
 
@@ -174,6 +181,8 @@ RSpec.describe 'Candidate adds preferences' do
 
     when_i_opt_in_to_find_a_candidate
     and_i_click('Continue')
+    and_i_select_specific_locations
+    and_i_click('Continue')
     then_i_am_redirected_to_location_preferences(location_preferences)
 
     when_i_check_dynamic_locations
@@ -186,6 +195,14 @@ RSpec.describe 'Candidate adds preferences' do
     choose 'Yes'
   end
   alias_method :when_i_opt_in_to_find_a_candidate, :and_i_opt_in_to_find_a_candidate
+
+  def and_i_select_specific_locations
+    choose 'In specific locations'
+  end
+
+  def when_i_select_anywhere
+    choose 'Anywhere in England'
+  end
 
   def and_i_opt_out_to_find_a_candidate
     choose 'No'
@@ -287,6 +304,8 @@ RSpec.describe 'Candidate adds preferences' do
         label: 'Do you want to make your application details visible to other training providers?',
         value: 'Yes',
       },
+      { label: 'Where can you train?',
+        value: 'In specific locations' },
       {
         label: 'Preferred locations',
         value: locations,
@@ -307,7 +326,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   def then_i_am_redirected_to_review_page_without_locations
     expect(page).to have_content('Check your application sharing preferences')
-    expect(page).to have_content('You have no location preferences')
+    expect(page).to have_content('Anywhere in England')
   end
 
   def and_the_dynamic_locations_is_checked
@@ -371,6 +390,10 @@ RSpec.describe 'Candidate adds preferences' do
     expect(page).to have_content('Do you want to make your application details visible to other training providers?')
   end
 
+  def then_i_am_redirected_to_training_locations
+    expect(page).to have_content 'Where can you train?'
+  end
+
   def when_i_click_change_on_the_last_location
     all('a', text: 'Change').last.click
   end
@@ -396,7 +419,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def and_i_click_the_relevant_change_link
-    click_link('Change Change your preferred locations')
+    click_link('Change your preferred locations')
   end
 
   def when_i_click_on_the_dynamic_location_change_link

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe 'Candidate edits published preference' do
     and_the_candidate_preference_id_is_changed
   end
 
+  scenario 'Candidate edits training locations' do
+    given_i_am_signed_in
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    and_i_click('Change where you would like to train')
+    then_i_am_redirected_to_the_training_locations_page
+
+    when_i_select_anywhere_in_england
+    and_i_click('Continue')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+    and_there_are_no_location_preferences
+  end
+
   def given_i_am_signed_in
     given_i_am_signed_in_with_one_login
     @application = create(
@@ -70,6 +89,7 @@ RSpec.describe 'Candidate edits published preference' do
       :candidate_preference,
       candidate: @current_candidate,
       status: 'published',
+      training_locations: 'specific',
     )
     _location_preferences = create(
       :candidate_location_preference,
@@ -88,9 +108,14 @@ RSpec.describe 'Candidate edits published preference' do
   def when_i_click(button)
     click_link_or_button(button)
   end
+  alias_method :and_i_click, :when_i_click
 
   def then_i_am_redirected_to_preference_review_page
     expect(page).to have_content('Check your application sharing preferences')
+  end
+
+  def then_i_am_redirected_to_the_training_locations_page
+    expect(page).to have_content('Where can you train?')
   end
 
   def when_i_click_change_share_preference
@@ -116,8 +141,16 @@ RSpec.describe 'Candidate edits published preference' do
     @current_candidate.published_preferences.last != @existing_candidate_preference
   end
 
+  def and_there_are_no_location_preferences
+    expect(@current_candidate.published_preferences.last.location_preferences).to eq []
+  end
+
   def when_i_click_dynamic_locations
     all('a', text: 'Change').last.click
+  end
+
+  def when_i_select_anywhere_in_england
+    choose 'Anywhere in England'
   end
 
   def and_i_untick_dynamic_locations


### PR DESCRIPTION
## Context

We are adding a step in the UI flow for candidate preferences where we ask specifically if the candidates wants to add specific locations or just study anywhere. 

This will be done in three PRs. The first for adding the `training_locations` column enum has already been merged in. This second (the largest one) is for the UI. There will be a third for backfilling the data. To see the whole thing, have a look at this [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10809).

## Changes proposed in this pull request

https://github.com/user-attachments/assets/6ca5b456-a913-461c-b3d6-00402928516f

## Guidance to review

Test it out locally or on the review app. 
- when you choose 'anywhere', any previously added locations are destroyed.
- when you choose 'specific', you are required to add locations

Check back links and navigation from the review screen. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
