### PR TITLE
[979 - PR 3] Data migration for backfilling data on training locations column

### DIFF
--- a/app/services/data_migrations/backfill_training_locations_on_candidate_preferences.rb
+++ b/app/services/data_migrations/backfill_training_locations_on_candidate_preferences.rb
@@ -1,0 +1,23 @@
+module DataMigrations
+  class BackfillTrainingLocationsOnCandidatePreferences
+    TIMESTAMP = 20250609145824
+    MANUAL_RUN = false
+
+    def change
+      ActiveRecord::Base.transaction do
+        candidates_preferences
+          .joins(:location_preferences)
+          .distinct
+          .update_all(training_locations: 'specific')
+
+        candidates_preferences
+          .where.missing(:location_preferences)
+          .update_all(training_locations: 'anywhere')
+      end
+    end
+
+    def candidates_preferences
+      @candidates_preferences ||= CandidatePreference.published.opt_in.where(training_locations: nil)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillTrainingLocationsOnCandidatePreferences',
   'DataMigrations::BackfillRecruitmentCycleYearOnPoolInvites',
   'DataMigrations::DeleteSandboxOneLoginAccounts',
   'DataMigrations::RemoveVisaSponsorshipDeadlineFeatureFlag',

--- a/spec/services/data_migrations/backfill_training_locations_on_candidate_preferences_spec.rb
+++ b/spec/services/data_migrations/backfill_training_locations_on_candidate_preferences_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillTrainingLocationsOnCandidatePreferences do
+  describe '#.change' do
+    let(:published_no_locations_opt_in) do
+      create(
+        :candidate_preference,
+        :published,
+        :opt_in,
+        training_locations: nil,
+        location_preferences: [],
+      )
+    end
+    let(:published_with_locations_opt_in) do
+      create(
+        :candidate_preference,
+        :published,
+        :opt_in,
+        training_locations: nil,
+        location_preferences: [build(:candidate_location_preference)],
+      )
+    end
+
+    let(:published_with_locations_opt_out) do
+      create(
+        :candidate_preference,
+        :published,
+        :opt_out,
+        training_locations: nil,
+        location_preferences: [build(:candidate_location_preference)],
+      )
+    end
+    let(:unpublished_no_locations) do
+      create(
+        :candidate_preference,
+        :draft,
+        :opt_in,
+        training_locations: nil,
+        location_preferences: [],
+      )
+    end
+
+    let(:unpublished_with_locations) do
+      create(
+        :candidate_preference,
+        :draft,
+        :opt_in,
+        training_locations: nil,
+        location_preferences: [build(:candidate_location_preference)],
+      )
+    end
+
+    before do
+      published_no_locations_opt_in
+      published_with_locations_opt_in
+      published_with_locations_opt_out
+      unpublished_no_locations
+      unpublished_with_locations
+    end
+
+    it 'only updates published preferences that have opted in' do
+      described_class.new.change
+      expect(unpublished_no_locations.reload.training_locations).to be_nil
+      expect(unpublished_with_locations.reload.training_locations).to be_nil
+      expect(published_with_locations_opt_out.training_locations).to be_nil
+    end
+
+    it 'updates preferences without locations to "anywhere"' do
+      described_class.new.change
+      expect(published_no_locations_opt_in.reload.training_locations).to eq 'anywhere'
+    end
+
+    it 'updates preferences with locations to "specific"' do
+      described_class.new.change
+      expect(published_with_locations_opt_in.reload.training_locations).to eq 'specific'
+    end
+  end
+end


### PR DESCRIPTION
## Context

In order to add a dedicated question for candidates to indicate whether or not they wanted to train anywhere in England or only specific locations, we chose to add a column to the candidate preferences table. This is the third of three PRs. The first one add the column, the second one add the UI, and this one backfills the data.

After the data migration is run, [this blazer query](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1211-published-candidate-preferences-missing-training_location-answer) should be zero.

## Changes proposed in this pull request

The migration only makes changes to Candidates preferences that are 
1. published
2. opted in

If the preferences has associated location_preferences -> training_locations is 'specific'
If the preferences does not have associated location_preferences -> training_locations is 'anywhere'

## Guidance to review
The migration will alter about 8,750 records (or thereabouts). I do not believe this will have any significant impact on database performance, but if we are worried about it, we can always change it to be run manually and I can run it early Wednesday morning.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [x] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [x] does the code safely backfill existing records for consistency
