### PR TITLE
Content updates for location preferences

### DIFF
--- a/app/views/candidate_interface/location_preferences/_form.html.erb
+++ b/app/views/candidate_interface/location_preferences/_form.html.erb
@@ -5,7 +5,7 @@
 
   <%= f.govuk_text_field(
     :within,
-    label: { text: t('.within'), size: 'm' },
+    label: { text: t('.within') },
     hint: { text: t('.enter_distance_in_miles'), hidden: true },
     class: 'govuk-!-width-one-quarter',
     suffix_text: t('.miles'),
@@ -16,7 +16,7 @@
   <div class="location-autocomplete-input">
     <%= f.govuk_text_field(
       :name,
-      label: { text: t('.name'), size: 'm' },
+      label: { text: t('.name') },
       data: {
         controller: 'location-autocomplete',
         location_autocomplete_path_value: candidate_interface_location_suggestions_path,

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -23,17 +23,17 @@
         <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border' }) do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
-              <%= row.with_cell(text: t('.location')) %>
               <%= row.with_cell(text: t('.distance_from_location')) %>
+              <%= row.with_cell(text: t('.location')) %>
             <% end %>
           <% end %>
 
           <% table.with_body do |body| %>
             <% @location_preferences.each do |location| %>
               <% body.with_row do |row| %>
-                <%= row.with_cell(text: location.decorated_name) %>
-
                 <%= row.with_cell(text: t('.within', within: location.within)) %>
+
+                <%= row.with_cell(text: location.decorated_name) %>
                 <%= row.with_cell do %>
                   <%= govuk_link_to(
                         t('.change'),

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -9,18 +9,20 @@
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= t('.title') %></h1>
       <p class="govuk-body"><%= t('.body') %></p>
-      <h2 class="govuk-heading-m"><%= t('.select_locations') %></h2>
 
       <% if @location_preferences.blank? %>
-          <%= govuk_button_link_to(
-            t('.add_location'),
-            new_candidate_interface_draft_preference_location_preference_path(@preference),
-            secondary: true,
-          ) %>
+        <p class="govuk-body"><%= t('.no_location_preferences') %></p>
+        <%= govuk_button_link_to(
+          t('.add_location'),
+          new_candidate_interface_draft_preference_location_preference_path(@preference),
+          secondary: true,
+        ) %>
       <% else %>
-        <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border' }) do |table| %>
+        <h2 class="govuk-heading-m"><%= t('.select_locations') %></h2>
+
+        <%= govuk_table(html_attributes: { class: 'app-table__row--no-bottom-border govuk-!-margin-bottom-0' }) do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>
               <%= row.with_cell(text: t('.distance_from_location')) %>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -40,7 +40,7 @@ en:
         change: Change
         submit: Submit preferences
         location: Within %{radius} miles of %{location}
-        no_location_preferences: You have no location preferences
+        no_location_preferences: You have not added any training areas
         change_share_information_hint: whether you want to share your application details
         change_location_preferences_hint: your preferred locations
         change_dynamic_locations_hint: updating your locations when you apply to a new course
@@ -74,16 +74,17 @@ en:
         update_location_preferences: Add the locations of courses you apply to
         remove: Remove
         add_another_location: Add an area
-        add_location: Add a location
+        add_location: Add an area
         within: "%{within} miles"
+        no_location_preferences: You have not added any training areas
       new:
-        title: Add a location
-        submit_text: Add location
+        title: Add an area where you can train
+        submit_text: Add area
       edit:
-        title: Change location preferences
-        submit_text: Update location
+        title: Update the area where you can train
+        submit_text: Update training area
       form:
-        within: Within
+        within: I can travel up to
         name: of city, town or postcode
         miles: miles
         enter_distance_in_miles: Enter distance in miles

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -65,15 +65,15 @@ en:
         reason_for_opting_out: Why do you not want to share your application details with other providers? (Optional)
     location_preferences:
       index:
-        title: Location preferences
-        body: Training providers will use the locations you enter here to search for candidates near their courses. You should add all areas that you can travel to for training.
-        select_locations: Add, change or remove preferred locations
-        location: Location
-        distance_from_location: Distance from location
+        title: Areas you can train in
+        body: Training providers will use the locations you enter here to search for candidates near their courses. You should add all locations that you can train in.
+        select_locations: Add, change or remove areas
+        location: from city, town, or postcode
+        distance_from_location: I can travel up to
         change: Change
         update_location_preferences: Add the locations of courses you apply to
         remove: Remove
-        add_another_location: Add another location
+        add_another_location: Add an area
         add_location: Add a location
         within: "%{within} miles"
       new:
@@ -122,5 +122,3 @@ en:
           attributes:
             dynamic_location_preferences:
               inclusion: Select if you want to add the locations of courses you apply to
-
-

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -6,12 +6,12 @@ en:
         success_opt_out: You are not sharing your application details with providers you have not applied to
       show:
         title: Check your application sharing preferences
-        share_information: Do you want to make your application details visible to other training providers?
+        share_information: Do you want to be invited to apply to similar courses?
         where_can_you_train: Where can you train?
         specific: In specific locations
         anywhere: Anywhere in England
         change_training_locations_visually_hidden: where you would like to train
-        preferred_locations: Preferred locations
+        preferred_locations: Areas you can train in
         dynamic_locations: Add the locations of courses you apply to
         change: Change
         submit: Submit preferences
@@ -89,9 +89,9 @@ en:
         miles: miles
         enter_distance_in_miles: Enter distance in miles
       show:
-        title: Do you want to remove this location?
-        location: Location
-        remove: Yes, remove location
+        title: Do you want to remove this training area?
+        location: Area
+        remove: Yes, remove training area
   activemodel:
     errors:
       models:

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -22,20 +22,20 @@ en:
         change_dynamic_locations_hint: updating your locations when you apply to a new course
     preferences:
       show: Check your application sharing preferences
-      share_question: Do you want to share your application details with other training providers?
-      preferred_locations: Preferred locations
-      update_my_locations: Add new locations to my preferences when I apply to new courses
+      share_question: Do you want to be invited to apply to similar courses?
+      preferred_locations: Areas you can train in
+      update_my_locations: Add the locations of courses you apply to
       change: Change
       submit: Submit preferences
     draft_preferences:
       show:
         title: Check your application sharing preferences
-        share_information: Do you want to make your application details visible to other training providers?
+        share_information: Do you want to be invited to apply to similar courses?
         where_can_you_train: Where can you train?
         specific: In specific locations
         anywhere: Anywhere in England
         change_training_locations_visually_hidden: where you would like to train
-        preferred_locations: Preferred locations
+        preferred_locations: Areas you can train in
         dynamic_locations: Add the locations of courses you apply to
         change: Change
         submit: Submit preferences
@@ -51,8 +51,8 @@ en:
         title: Do you want to make your application details visible to other training providers?
       show:
         title: Check your application sharing preferences
-        share_information: Do you want to share your application details with other training providers?
-        preferred_locations: Preferred locations
+        share_information: Do you want to be invited to apply to similar courses?
+        preferred_locations: Areas you can train in
         change: Change
         submit: Submit preferences
       create:
@@ -73,7 +73,7 @@ en:
         change: Change
         update_location_preferences: Add the locations of courses you apply to
         remove: Remove
-        add_another_location: Add an area
+        add_another_location: Add another area
         add_location: Add an area
         within: "%{within} miles"
         no_location_preferences: You have not added any training areas
@@ -85,7 +85,7 @@ en:
         submit_text: Update training area
       form:
         within: I can travel up to
-        name: of city, town or postcode
+        name: from city, town or postcode
         miles: miles
         enter_distance_in_miles: Enter distance in miles
       show:
@@ -114,7 +114,7 @@ en:
             within:
               blank: Enter a location radius
               greater_than_or_equal_to: The location radius must be 0 miles or more
-              not_a_number: Enter a number for location radius
+              not_a_number: Location radius must be a number
             name:
               blank: Enter a city, town or postcode
               invalid_location: City, town or postcode must be in the United Kingdom

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -57,14 +57,14 @@ RSpec.describe 'Candidate adds preferences' do
     when_i_click('Continue')
     then_i_am_redirected_to_location_preferences(location_preferences)
 
-    when_i_click('Add another location')
+    when_i_click('Add another area')
     and_i_input_a_location
-    when_i_click('Add location')
+    when_i_click('Add area')
     then_i_am_redirected_to_location_preferences(new_locations)
 
     when_i_click_change_on_the_last_location
     and_i_edit_a_location
-    when_i_click('Update location')
+    when_i_click('Update training area')
     then_i_am_redirected_to_location_preferences(updated_locations)
 
     when_i_click('Continue')
@@ -251,7 +251,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def then_i_am_redirected_to_location_preferences(location_preferences)
-    expect(page).to have_content('Location preferences')
+    expect(page).to have_content('Areas you can train in')
 
     location_preferences.each_with_index do |location, index|
       within ".govuk-table__body .govuk-table__row:nth-of-type(#{index + 1})" do
@@ -267,13 +267,13 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def then_i_am_redirected_to_location_preferences_without_locations
-    expect(page).to have_content('Location preferences')
+    expect(page).to have_content('Areas you can train in')
     expect(page).to have_content('You have no location preferences')
   end
 
   def then_i_see_my_location_preferences_page
-    expect(page).to have_content('Location preferences')
-    expect(page).to have_content('Training providers will use the locations you enter here to search for candidates near their courses. You should add all areas that you can travel to for training.')
+    expect(page).to have_content('Areas you can train in')
+    expect(page).to have_content('Training providers will use the locations you enter here to search for candidates near their courses. You should add all locations that you can train in.')
   end
 
   def then_i_see_my_location_preferences_page_including_the_dynamic_location
@@ -296,7 +296,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def then_i_am_redirected_to_opt_in
-    expect(page).to have_content('Do you want to make your application details visible to other training providers?')
+    expect(page).to have_content('Do you want to be invited to apply to similar courses?')
 
     yes_option = find_by_id('candidate-interface-pool-opt-ins-form-pool-status-opt-in-field')
     expect(yes_option).to be_checked
@@ -317,13 +317,13 @@ RSpec.describe 'Candidate adds preferences' do
 
     summary_list = [
       {
-        label: 'Do you want to make your application details visible to other training providers?',
+        label: 'Do you want to be invited to apply to similar courses?',
         value: 'Yes',
       },
       { label: 'Where can you train?',
         value: 'In specific locations' },
       {
-        label: 'Preferred locations',
+        label: 'Areas you can train in',
         value: locations,
       },
       {
@@ -383,13 +383,13 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def and_i_input_a_location
-    fill_in('Within', with: new_location[:within])
-    fill_in('of city, town or postcode', with: new_location[:name])
+    fill_in('I can travel up to', with: new_location[:within])
+    fill_in('from city, town or postcode', with: new_location[:name])
   end
 
   def and_i_edit_a_location
-    fill_in('Within', with: updated_location[:within])
-    fill_in('of city, town or postcode', with: updated_location[:name])
+    fill_in('I can travel up to', with: updated_location[:within])
+    fill_in('from city, town or postcode', with: updated_location[:name])
   end
 
   def and_feature_flag_is_enabled
@@ -445,12 +445,12 @@ RSpec.describe 'Candidate adds preferences' do
   def when_i_update_the_radius_only
     when_i_click_on_the_dynamic_location_change_link
     and_i_change_the_distance
-    and_i_click('Update location')
+    and_i_click('Update training area')
     then_i_see_my_location_preferences_page
   end
 
   def and_i_change_the_distance
-    fill_in 'Within', with: '40.0'
+    fill_in 'I can travel up to', with: '40.0'
   end
 
   def then_it_saves_successfully


### PR DESCRIPTION
## Context

In research there was some confusion over location preferences - some people did not understand how they related to courses they had been invited to, or how the radiuses related to the location.

## Changes proposed in this pull request

Changes to content which reframe 'location preferences' as ‘areas you can train in’, and 'distance from location' to 'how far you can travel to x location'.

Content changes affect the following pages and are reflected in the [prototype](https://apply-beta-prototype.herokuapp.com/candidate-pool/locations/areas).
- Candidate preferences review page
- Candidate preferences index
- Add a preference
- Edit a preference
- Remove a preference

https://github.com/user-attachments/assets/cf847ad7-3855-4b49-a0f9-4e8f5b98695c

## Guidance to review

- Please review the videos and page diff to check the content has been accurately updated without any unintended consequences.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
