### PR TITLE
Fix flakey test

### DIFF
--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe 'Managing support users' do
 
   def and_there_are_other_support_users_in_the_db
     SupportUser.create(email_address: 'isignedinyesterday@msn.com', last_signed_in_at: Time.zone.yesterday, dfe_sign_in_uid: 'Y')
+    SupportUser.find_by(email_address: 'user@apply-support.com')
+          .update!(last_signed_in_at: Time.zone.now.beginning_of_day)
     SupportUser.create(email_address: 'isignedintoday@msn.com', last_signed_in_at: Time.zone.now, dfe_sign_in_uid: 'TD')
     SupportUser.create(email_address: 'isignedintomorrow@msn.com', last_signed_in_at: Time.zone.tomorrow, dfe_sign_in_uid: 'TM')
   end


### PR DESCRIPTION
## Context

The scenario at line 26 in `spec/system/support_interface/managing_support_users_spec.rb` aims to test the sorting of support users by last login time (ascending). It is producing flakey results due to a reliance on `Time.zone.now` for a user who comes later in the ordered list than the current support user. 

## Changes proposed in this pull request

I'm troubleshooting to see if I can reduce flakiness by giving a more precise login time to the current support user that allows it to place second in the sorted list (between `Time.zone.yesterday` and `Time.zone.now`) by more than a variable number of milliseconds at spec runtime.

## Guidance to review

- Please review small fix and check that you agree the addition would lead to reduced flakiness.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
