### PR TITLE
Stop a reference from being destroyed if it has a safeguarding concerns

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -50,7 +50,6 @@ module SupportInterface
       t('support_interface.confidential_warning')
     end
 
-
   private
 
     def status_row

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -11,6 +11,7 @@ module SupportInterface
              :relationship_confirmation,
              :relationship_correction,
              :referee_type,
+             :safeguarding_concerns_status,
              to: :reference
 
     def initialize(reference:, reference_number:, editable:)
@@ -28,6 +29,7 @@ module SupportInterface
         email_address_row,
         relationship_row,
         feedback_row,
+        safeguarding_row,
         confidentiality_row,
         date_rows,
         sign_in_as_referee_row,
@@ -47,6 +49,7 @@ module SupportInterface
 
       t('support_interface.confidential_warning')
     end
+
 
   private
 
@@ -203,6 +206,13 @@ module SupportInterface
           visually_hidden_text: 'reference',
         },
       )
+    end
+
+    def safeguarding_row
+      {
+        key: 'Safeguarding concerns',
+        value: safeguarding_concerns_status&.humanize || 'No value',
+      }
     end
 
     def consent_row

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -21,12 +21,15 @@ module SupportInterface
     end
 
     def destroy
-      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(reference: @reference)
+      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(actor: current_support_user,
+                                                                          reference: @reference)
     end
 
     def confirm_destroy
-      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(delete_reference_params)
-      if @form.save(actor: current_support_user, reference: @reference)
+      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(delete_reference_params
+                                                                            .merge(actor: current_support_user,
+                                                                                   reference: @reference))
+      if @form.save
         flash[:success] = 'Reference deleted'
         redirect_to support_interface_application_form_path(@reference.application_form)
       else

--- a/app/forms/support_interface/application_forms/delete_reference_form.rb
+++ b/app/forms/support_interface/application_forms/delete_reference_form.rb
@@ -3,17 +3,20 @@ module SupportInterface
     class DeleteReferenceForm
       include ActiveModel::Model
 
-      attr_accessor :reference, :accept_guidance, :audit_comment_ticket, :application_form
+      attr_accessor :reference,
+                    :accept_guidance,
+                    :audit_comment_ticket,
+                    :actor
 
+      delegate :application_form, to: :reference
+
+      validates :actor, presence: true
       validates :accept_guidance, presence: true
       validates :audit_comment_ticket, presence: true
       validates_with ZendeskUrlValidator
       validates_with SafeChoiceUpdateValidator
 
-      def save(actor:, reference:)
-        @reference = reference
-        @application_form = reference.application_form
-
+      def save
         return false unless valid?
 
         SupportInterface::DeleteReference.new.call!(

--- a/app/forms/support_interface/application_forms/delete_reference_form.rb
+++ b/app/forms/support_interface/application_forms/delete_reference_form.rb
@@ -13,6 +13,7 @@ module SupportInterface
       validates :actor, presence: true
       validates :accept_guidance, presence: true
       validates :audit_comment_ticket, presence: true
+      validate :reference_has_no_safeguarding_concern
       validates_with ZendeskUrlValidator
       validates_with SafeChoiceUpdateValidator
 
@@ -24,6 +25,14 @@ module SupportInterface
           reference:,
           zendesk_url: audit_comment_ticket,
         )
+      end
+
+    private
+
+      def reference_has_no_safeguarding_concern
+        if reference.has_safeguarding_concerns_to_declare?
+          errors.add(:reference, 'Cannot delete reference with a safeguarding concern')
+        end
       end
     end
   end

--- a/app/views/support_interface/references/destroy.html.erb
+++ b/app/views/support_interface/references/destroy.html.erb
@@ -27,6 +27,10 @@
         key: 'Reference email address',
         value: @reference.email_address,
       },
+      {
+        key: 'Reference has safeguarding concerns',
+        value: @reference.has_safeguarding_concerns_to_declare? ? "Yes" : 'No concerns.',
+      }
       ])) %>
 
       <%= form_builder.govuk_text_field(

--- a/app/views/support_interface/references/destroy.html.erb
+++ b/app/views/support_interface/references/destroy.html.erb
@@ -29,8 +29,8 @@
       },
       {
         key: 'Reference has safeguarding concerns',
-        value: @reference.has_safeguarding_concerns_to_declare? ? "Yes" : 'No concerns.',
-      }
+        value: @reference.has_safeguarding_concerns_to_declare? ? 'Yes' : 'No concerns.',
+      },
       ])) %>
 
       <%= form_builder.govuk_text_field(

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -144,6 +144,10 @@ SET
         WHEN feedback IS NULL THEN NULL
         ELSE generate_lorem_ipsum('short')
         END,
+    safeguarding_concerns = CASE
+        WHEN safeguarding_concerns IS NULL THEN NULL
+        ELSE generate_lorem_ipsum('short')
+        END,
     name = concat('Application Reference_', id);
 
 -- SupportUser

--- a/spec/models/support_interface/application_forms/delete_reference_form_spec.rb
+++ b/spec/models/support_interface/application_forms/delete_reference_form_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe SupportInterface::ApplicationForms::DeleteReferenceForm do
     it { is_expected.to validate_presence_of(:actor) }
     it { is_expected.to validate_presence_of(:accept_guidance) }
     it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+
+    it 'is not valid if the reference has a safeguarding concern' do
+      reference = build(:reference, :has_safeguarding_concerns_to_declare)
+      form = described_class.new(reference:)
+
+      expect(form).not_to be_valid
+      expect(form.errors[:reference]).to include('Cannot delete reference with a safeguarding concern')
+    end
   end
 
   describe '#save' do

--- a/spec/models/support_interface/application_forms/delete_reference_form_spec.rb
+++ b/spec/models/support_interface/application_forms/delete_reference_form_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::DeleteReferenceForm do
+  subject { described_class.new({ reference: build(:reference) }) }
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:actor) }
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+  end
+
+  describe '#save' do
+    it 'returns false if the form is invalid' do
+      reference = build(:reference)
+      form = described_class.new(reference:)
+
+      expect(form.save).to be_falsey
+    end
+
+    it 'calls the DeleteReference service with the correct parameters' do
+      service_double = instance_double(SupportInterface::DeleteReference, call!: true)
+      allow(SupportInterface::DeleteReference).to receive(:new).and_return(service_double)
+
+      actor = build(:support_user)
+      reference = build(:reference)
+      zendesk_url = 'https://becomingateacher.zendesk.com/agent/tickets/123456'
+      form = described_class.new(
+        reference:,
+        accept_guidance: true,
+        audit_comment_ticket: zendesk_url,
+        actor: actor,
+      )
+
+      form.save
+
+      expect(service_double).to have_received(:call!)
+                                  .with(actor: actor, reference: reference, zendesk_url: zendesk_url)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We had a support request to reinstate a deleted Reference as the  original Reference had a safeguarding concern noted on it. 

## Changes proposed in this pull request

- Added validation to the DeleteReferenceForm in the Support Interface
- Added row to Delete Reference UI to show that the Reference has safeguarding concerns
- Added safeguarding status to Application Form UI in Support Interface

## Guidance to review

 - Create a Reference with a safeguarding concern
 - Attempt to destroy the Reference from the Support Interface

### Screenshot

**Delete Reference UI**
![image](https://github.com/user-attachments/assets/9e4ef38d-7c97-4c89-ac3e-3bb139d8b57d)

**Application Form UI**
![image](https://github.com/user-attachments/assets/34d96b37-8063-422c-898f-434a7302f9d0)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
