### PR TITLE
Use reference actions policy to align editable logic

### DIFF
--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -11,7 +11,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: reference.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
-          <% if deletable?(reference) && reference_editable?(reference) %>
+          <% if deletable? && reference_editable?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= govuk_link_to confirm_destroy_path(reference), class: 'govuk-!-font-weight-bold' do %>
                 <%= t('application_form.references.delete_reference.action') %>

--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -11,7 +11,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: reference.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
-          <% if deletable? && reference_editable?(reference) %>
+          <% if deletable?(reference) && reference_editable?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= govuk_link_to confirm_destroy_path(reference), class: 'govuk-!-font-weight-bold' do %>
                 <%= t('application_form.references.delete_reference.action') %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -58,10 +58,8 @@ module CandidateInterface
       %w[Status]
     end
 
-    def deletable?(reference)
-      policy = ReferenceActionsPolicy.new(reference)
-
-      policy.editable? && policy.request_can_be_deleted?
+    def deletable?
+      @editable && @deletable
     end
 
   private

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -58,8 +58,10 @@ module CandidateInterface
       %w[Status]
     end
 
-    def deletable?
-      @editable && @deletable
+    def deletable?(reference)
+      policy = ReferenceActionsPolicy.new(reference)
+
+      policy.editable? && policy.request_can_be_deleted?
     end
 
   private
@@ -69,9 +71,9 @@ module CandidateInterface
     end
 
     def name_row(reference)
-      action = if reference.feedback_provided?
-                 {}
-               else
+      policy = ReferenceActionsPolicy.new(reference)
+
+      action = if policy.editable?
                  {
                    action: {
                      href: reference_edit_name_path(
@@ -83,6 +85,8 @@ module CandidateInterface
                      visually_hidden_text: "name for #{reference.name}",
                    },
                  }
+               else
+                 {}
                end
 
       {
@@ -98,15 +102,18 @@ module CandidateInterface
         return_to: return_to_params,
         step: reference_workflow_step,
       )
-      action = if reference.feedback_provided?
-                 {}
-               else
+
+      policy = ReferenceActionsPolicy.new(reference)
+
+      action = if policy.editable?
                  {
                    action: {
                      href: edit_email_path,
                      visually_hidden_text: "email address for #{reference.name}",
                    },
                  }
+               else
+                 {}
                end
 
       if reference.email_address?
@@ -129,15 +136,17 @@ module CandidateInterface
         return_to: return_to_params,
         step: reference_workflow_step,
       )
-      action = if reference.feedback_provided?
-                 {}
-               else
+      policy = ReferenceActionsPolicy.new(reference)
+
+      action = if policy.editable?
                  {
                    action: {
                      href: edit_relationship_path,
                      visually_hidden_text: "relationship for #{reference.name}",
                    },
                  }
+               else
+                 {}
                end
 
       if reference.relationship?
@@ -154,10 +163,10 @@ module CandidateInterface
     end
 
     def reference_type_row(reference)
+      policy = ReferenceActionsPolicy.new(reference)
+
       if reference.referee_type?
-        action = if reference.feedback_provided?
-                   {}
-                 else
+        action = if policy.editable?
                    {
                      action: {
                        href: reference_edit_type_path(
@@ -169,6 +178,8 @@ module CandidateInterface
                        visually_hidden_text: "reference type for #{reference.name}",
                      },
                    }
+                 else
+                   {}
                  end
 
         {

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -69,9 +69,7 @@ module CandidateInterface
     end
 
     def name_row(reference)
-      policy = ReferenceActionsPolicy.new(reference)
-
-      action = if policy.editable?
+      action = if reference_editable?(reference)
                  {
                    action: {
                      href: reference_edit_name_path(
@@ -101,9 +99,7 @@ module CandidateInterface
         step: reference_workflow_step,
       )
 
-      policy = ReferenceActionsPolicy.new(reference)
-
-      action = if policy.editable?
+      action = if reference_editable?(reference)
                  {
                    action: {
                      href: edit_email_path,
@@ -134,9 +130,8 @@ module CandidateInterface
         return_to: return_to_params,
         step: reference_workflow_step,
       )
-      policy = ReferenceActionsPolicy.new(reference)
 
-      action = if policy.editable?
+      action = if reference_editable?(reference)
                  {
                    action: {
                      href: edit_relationship_path,
@@ -161,10 +156,8 @@ module CandidateInterface
     end
 
     def reference_type_row(reference)
-      policy = ReferenceActionsPolicy.new(reference)
-
       if reference.referee_type?
-        action = if policy.editable?
+        action = if reference_editable?(reference)
                    {
                      action: {
                        href: reference_edit_type_path(
@@ -221,7 +214,7 @@ module CandidateInterface
     end
 
     def reference_editable?(reference)
-      !reference.duplicate?
+      !reference.duplicate? && reference.not_requested_yet?
     end
 
     def confirm_destroy_path(reference)

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_from_previous_cycle_spec.rb
@@ -129,6 +129,8 @@ RSpec.describe 'Candidate accepts an offer and updates references between cycles
       support_reference: '123A',
     )
 
+    @application_form.application_references.update_all(feedback_status: 'not_requested_yet')
+
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'DEF')
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -128,6 +128,8 @@ RSpec.describe 'Candidate accepts an offer' do
       recruitment_cycle_year: 2024,
     )
 
+    @application_form.application_references.update_all(feedback_status: 'not_requested_yet')
+
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'DEF')
 

--- a/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'References' do
   def then_i_still_have_a_reference_request_outstanding
     visit candidate_interface_references_review_path
     expect(page).to have_content('has already given a reference', count: 2)
-    expect(page).to have_content('Change reference type for', count: 1)
   end
 
   def and_i_can_add_more_reference_requests


### PR DESCRIPTION
## Context

We had an issue where in certain edge cases, change links appeared next to reference details on the "Your details" review page which did not lead anywhere and simply refreshed the page. This was due to change links erroneously being displayed when the reference had already been requested or feedback had already been received.

It has been clarified with Policy colleagues that references with "feedback_requested" should not be editable and therefore change links should not be displayed.

## Changes proposed in this pull request

- Use one private method in the references review component to show change links under two conditions:
If the reference is not rolled over from a previous cycle
If the status is "not_requested_yet"

- The section_policy methods `can_edit?` and `can_delete?` interact with this method for rendering the change/delete links in the `html.erb` component file. There will be a later piece of work to simplify and centralise the reference actions policy in due course.

## Guidance to review

- Log into Support and find a candidate with no submitted applications
- Make sure that all seeded references have a status of `not_requested_yet`
- Check that you are able to add, change, and delete references and the relevant reference guidance appears at the top of the page
- Log in as one of the providers the applicant has an application choice for and make an offer to the candidate
- Accept the offer as a candidate and check that you are able to change and delete all references on the accept offer page
- Complete accepting the offer and then withdraw it
- Go back to your details and view the references section: make sure that it shows uneditable references with no guidance text at the top

https://github.com/user-attachments/assets/f30bceea-8df2-4067-b905-4349281bc133

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency