### PR TITLE
Push pii information about providers to BQ

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -467,6 +467,9 @@ shared:
     - id
     - last_signed_in_at
     - updated_at
+    - email_address
+    - first_name
+    - last_name
   provider_users_providers:
     - created_at
     - id
@@ -492,6 +495,7 @@ shared:
     - updated_at
     - vendor_id
     - selectable_school
+    - email_address
   reference_tokens:
     - application_reference_id
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -170,12 +170,8 @@
   :provider_user_notifications:
   - chase_provider_decision
   :provider_users:
-  - email_address
-  - first_name
-  - last_name
   - find_a_candidate_filters
   :providers:
-  - email_address
   - phone_number
   :one_login_auths:
   - token

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -12,6 +12,11 @@ shared:
     - email_address
   provider_users:
     - dfe_sign_in_uid
+    - email_address
+    - first_name
+    - last_name
+  providers:
+    - email_address
   validation_errors:
     - user_id
   emails:


### PR DESCRIPTION
## Context

Policy want a dashboard that will allow them to see who has previously started a teacher training course and allow them to contact the providers

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

A backfill rake task will be done after this is merged

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
