### PR TITLE
Calling `erblint` has been changed to `erb_lint`

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -92,12 +92,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests: [rubocop, erblint, brakeman, yarn_lint]
+        tests: [rubocop, erb_lint, brakeman, yarn_lint]
         include:
           - tests: rubocop
             command: bundle exec rubocop --format clang --parallel
-          - tests: erblint
-            command: bundle exec rake erblint
+          - tests: erb_lint
+            command: bundle exec rake erb_lint
           - tests: brakeman
             command: bundle exec rake brakeman
           - tests: yarn_lint

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint-ruby: ## Run Rubocop
 
 .PHONY: lint-erb
 lint-erb: ## Run the ERB linter
-	docker-compose run --rm web /bin/sh -c "bundle exec rake erblint"
+	docker-compose run --rm web /bin/sh -c "bundle exec rake erb_lint"
 
 .PHONY: brakeman
 brakeman: ## Run Brakeman tests

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -42,8 +42,8 @@ task :rubocop do
 end
 
 desc 'Run ERB Lint'
-task :erblint do
-  sh 'bundle exec erblint --lint-all'
+task :erb_lint do
+  sh 'bundle exec erb_lint --lint-all'
 end
 
 desc 'Run Stylelint'
@@ -52,7 +52,7 @@ task :stylelint do
 end
 
 desc 'Run all the linters'
-task linting: %i[rubocop erblint stylelint]
+task linting: %i[rubocop erb_lint stylelint]
 
 desc 'Compile assets for testing'
 task :compile_assets do


### PR DESCRIPTION
## Context

The tool was updated in [v0.7 to consistently](https://github.com/Shopify/erb_lint/releases/tag/v0.7.0) use the name `erb_lint`

## Changes proposed in this pull request

Changes all references to `erblint` to `erb_lint` as per deprecation warning

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
