### PR TITLE
Fix institution_country bug

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -154,7 +154,7 @@ module CandidateInterface
       {
         qualification_type:,
         subject:,
-        institution_country:,
+        institution_country: qualification_type == OtherQualificationTypeForm::NON_UK_TYPE ? institution_country : 'GB',
         predicted_grade:,
         grade: grade.presence,
         other_uk_qualification_type:,

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe 'Entering their other qualifications', :mid_cycle do
     then_i_see_the_your_details_page
   end
 
+  scenario 'Candidate changes a non-uk qualification to other uk qualification' do
+    given_i_am_signed_in_with_one_login
+    and_i_visit_the_site
+    and_i_already_have_a_non_uk_qualification_saved
+
+    when_i_visit_a_levels_and_other_qualifications
+    and_i_click_change_qualification_type
+    and_i_change_it_to_scottish_advanced_higher
+    and_i_click_continue
+    and_i_click_save_and_continue
+    then_i_see_the_revised_qualification_with_institution_country_set_to_gb
+  end
+
   def and_i_visit_the_site
     visit candidate_interface_details_path
   end
@@ -377,5 +390,33 @@ RSpec.describe 'Entering their other qualifications', :mid_cycle do
     within '.govuk-heading-xl' do
       expect(page).to have_content 'Your details'
     end
+  end
+
+  def and_i_already_have_a_non_uk_qualification_saved
+    application_form = current_candidate.current_application
+    application_form.application_qualifications << create(:other_qualification, :non_uk, institution_country: 'ES', non_uk_qualification_type: 'Titulo de bachiller')
+    application_form.save
+  end
+
+  def when_i_visit_a_levels_and_other_qualifications
+    visit candidate_interface_review_other_qualifications_path
+  end
+
+  def and_i_click_change_qualification_type
+    click_link_or_button 'Change qualification for Titulo de bachiller'
+  end
+
+  def and_i_change_it_to_scottish_advanced_higher
+    choose 'Other UK qualification'
+    fill_in 'Qualification name', with: 'Scottish Advanced Higher', match: :first
+  end
+
+  def and_i_click_save_and_continue
+    click_link_or_button 'Save and continue'
+  end
+
+  def then_i_see_the_revised_qualification_with_institution_country_set_to_gb
+    expect(page).to have_content 'Scottish Advanced Higher'
+    expect(page).to have_content 'GB'
   end
 end


### PR DESCRIPTION
## Context

When a candidate attempted to update a non-UK qualification to other UK qualification, the institution country did not update to `GB`.

## Changes proposed in this pull request

- In the "Other qualification details form", Add logic to `attributes_for_persistence` so that the relevant country is persisted if the type is `NON_UK`, otherwise set it to `GB`.

## Guidance to review

https://github.com/user-attachments/assets/a3d2d715-1c3a-4d50-b96d-23803ca90259

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
