### PR TITLE
Randomly assigns confidential to test reference data

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -257,6 +257,7 @@ private
       safeguarding_concerns: ['', Faker::Lorem.sentence].sample,
       safeguarding_concerns_status: reference.safeguarding_concerns.blank? ? :no_safeguarding_concerns_to_declare : :has_safeguarding_concerns_to_declare,
       feedback: 'You are awesome',
+      confidential: [true, true, false].sample,
     )
 
     SubmitReference.new(


### PR DESCRIPTION
## Context

A vendor has requested that we set a value for confidential when creating test reference data via the API. 

## Changes proposed in this pull request

- Randomly assigns Confidential flag - there is a weighting towards a `true` value

## Guidance to review

- Generate test data through the API
- Check the confidential value of a Reference

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
