### PR TITLE
References bug support playbook guidance

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -48,6 +48,17 @@ If the request is from a referee (eg—an accidental refusal), use the “Undo r
 
 Candidates can cancel and reinstate references themselves, so this shouldn't typically be something the support dev handles.
 
+### Candidate cannot apply because of reference section incomplete
+
+There's an edge case where a candidate requests a new reference after they accept their offer, on the offer dashboard.
+If they withdraw after doing this. Their reference section would be incomplete and they would not be able to submit new applications.
+
+Please add your support ticket to this [ticket](https://trello.com/c/rIaPQ8C6/1039-bug-candidates-that-request-a-new-reference-on-their-offer-dashboard-and-withdraw-cannot-apply-again) and run this to fix it.
+
+```ruby
+ApplicationForm.find(id).update(references_completed: true, audit_comment: ZENDESK_URL)
+```
+
 ## Unlock Application Form Sections for Candidate Editing
 
 Occasionally, there might be a request to unlock certain sections of an application form, allowing the candidate to make edits. Ensure you receive confirmation from the policy team before proceeding.


### PR DESCRIPTION
## Context

There's an edge case where a candidate requests a new reference after they accept their offer, on the offer dashboard.
If they withdraw after doing this. Their reference section would be incomplete and they would not be able to submit new applications.

This adds some guidance to support playbook to fix it.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
