### PR TITLE
[1017] Include publication styles in support where reports are also viewed

### DIFF
--- a/app/frontend/styles/application-support.scss
+++ b/app/frontend/styles/application-support.scss
@@ -3,6 +3,7 @@
 @import "components/paginated_filter";
 @import "components/checkbox_search_filter";
 @import "dfe-autocomplete/src/dfe-autocomplete";
+@import "application-publications";
 
 .app-data-set-documentation--datatype {
   margin: 0;


### PR DESCRIPTION
## Context

Styling was missing from reports when viewed in support (which is where draft reports are viewed now)

## Changes proposed in this pull request

| Before | After |
|------ | ------ |
| <img width="1258" alt="image" src="https://github.com/user-attachments/assets/95e700e5-6443-47d5-a656-0fc27229521d" /> | <img width="1328" alt="image" src="https://github.com/user-attachments/assets/ae43a24e-f093-4605-908d-c8f8471037ba" /> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
