### PR TITLE
Final clean up of holidays

### DIFF
--- a/app/lib/production_recruitment_cycle_timetables_api/refresh_seed_data.rb
+++ b/app/lib/production_recruitment_cycle_timetables_api/refresh_seed_data.rb
@@ -4,10 +4,6 @@ module ProductionRecruitmentCycleTimetablesAPI
       timetables = client.fetch_all_recruitment_cycles.fetch('data')
       headers = timetables.first.keys
 
-      %w[christmas_holiday_range easter_holiday_range].each do |attribute|
-        headers.delete(attribute)
-      end
-
       CSV.open('config/initializers/cycle_timetables.csv', 'w', headers: true) do |csv|
         csv << headers
         timetables.each do |timetable|

--- a/app/presenters/publications/recruitment_cycle_timetables_presenter.rb
+++ b/app/presenters/publications/recruitment_cycle_timetables_presenter.rb
@@ -7,7 +7,7 @@ module Publications
     def call
       @timetables.map do |timetable|
         attributes = timetable.attributes
-        %w[id created_at christmas_holiday_range easter_holiday_range].each do |attribute|
+        %w[id created_at].each do |attribute|
           attributes.delete(attribute)
         end
 

--- a/spec/requests/publications/recruitment_cycle_timetables_spec.rb
+++ b/spec/requests/publications/recruitment_cycle_timetables_spec.rb
@@ -44,9 +44,6 @@ RSpec.describe 'RecruitmentCycleTimetables' do
       it 'does not return holiday ranges' do
         get('/publications/recruitment-cycle-timetables/current', params: { format: 'json' })
         expect(response).to have_http_status(:ok)
-
-        expect(data['christmas_holiday_range'].present?).to be false
-        expect(data['easter_holiday_range'].present?).to be false
       end
     end
 


### PR DESCRIPTION
## Context

A few mentions of the christmas and easter holidays were hanging about until the migration was complete. They can be deleted now.

## Changes proposed in this pull request

Just deleting some redundant references to the holiday ranges.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
