### PR TITLE
Add New, Viewed and invited to FAC index page

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -25,7 +25,14 @@ module ProviderInterface
           .find_by(candidate_id: params.expect(:id))
         @candidate = @application_form&.candidate
 
-        redirect_to provider_interface_candidate_pool_root_path if @application_form.blank? || @candidate.blank?
+        if @application_form.blank? || @candidate.blank?
+          redirect_to provider_interface_candidate_pool_root_path
+        else
+          current_provider_user.pool_views.find_or_create_by(
+            application_form_id: @application_form.id,
+            recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+          )
+        end
       end
 
     private

--- a/app/helpers/find_a_candidate_helper.rb
+++ b/app/helpers/find_a_candidate_helper.rb
@@ -1,0 +1,22 @@
+module FindACandidateHelper
+  def candidate_status(application_form:, provider_user:)
+    viewed = provider_user.pool_views.find_by(
+      application_form: application_form,
+      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+    )
+
+    invited = Pool::Invite.published.find_by(
+      candidate_id: application_form.candidate_id,
+      provider_id: provider_user.provider_ids,
+      recruitment_cycle_year: RecruitmentCycleTimetable.current_year,
+    )
+
+    if invited
+      govuk_tag(text: 'Invited', colour: 'green')
+    elsif viewed
+      govuk_tag(text: 'Viewed', colour: 'grey')
+    else
+      govuk_tag(text: 'New')
+    end
+  end
+end

--- a/app/models/provider_pool_action.rb
+++ b/app/models/provider_pool_action.rb
@@ -1,0 +1,8 @@
+class ProviderPoolAction < ApplicationRecord
+  belongs_to :application_form
+  belongs_to :provider_user, foreign_key: :actioned_by_id
+
+  enum :status, {
+    viewed: 'viewed',
+  }, prefix: true
+end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -5,6 +5,7 @@ class ProviderUser < ApplicationRecord
   has_many :providers, through: :provider_permissions
   has_many :notes, dependent: :destroy
   has_many :pool_invites, class_name: 'Pool::Invite', foreign_key: 'invited_by_id'
+  has_many :pool_views, -> { status_viewed }, class_name: 'ProviderPoolAction', foreign_key: 'actioned_by_id'
   has_one :notification_preferences, class_name: 'ProviderUserNotificationPreferences'
   attr_accessor :impersonator
 

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -15,15 +15,16 @@
       <%= table.with_head do |head| %>
         <%= head.with_row do |row| %>
           <%= row.with_cell(text: t('.name')) %>
+          <%= row.with_cell(text: t('.status')) %>
           <% if @filter.applied_location_search? %>
-            <%= row.with_cell(text: t('.distance_from', origin: @filter.applied_filters[:location]), width: 'govuk-!-width-one-half') %>
+            <%= row.with_cell(text: t('.distance')) %>
           <% end %>
         <% end %>
       <% end %>
 
       <%= table.with_body do |body| %>
         <% @application_forms.each do |application_form| %>
-          <%= body.with_row do |row| %>
+          <%= body.with_row(html_attributes: { id: "candidate_#{application_form.candidate_id}" }) do |row| %>
             <%= row.with_cell do %>
             <%= govuk_link_to application_form.redacted_full_name, provider_interface_candidate_pool_candidate_path(application_form.candidate) %>
             <span class="govuk-body govuk-hint">(<%= application_form.candidate_id %>)</span>
@@ -38,6 +39,7 @@
                 <p class="govuk-body app-qualification__value--caption govuk-!-margin-bottom-1"><%= t('.no_degree') %></p>
               <% end %>
             <% end %>
+            <%= row.with_cell(text: candidate_status(application_form:, provider_user: current_provider_user)) %>
             <%= row.with_cell do %>
               <% if @filter.applied_location_search? %>
                 <% if application_form.site_distance == -1 %>

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -11,7 +11,8 @@ en:
             one: "%{count} candidate found"
             other: "%{count} candidates found"
           name: Name
-          distance_from: Distance from %{origin}
+          status: Status
+          distance: Distance
           no_degree: No degree
           miles:
             zero: "%{count} miles"

--- a/spec/factories/pool_invite.rb
+++ b/spec/factories/pool_invite.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     course factory: %i[course]
     recruitment_cycle_year { CycleTimetableHelper.current_year }
 
+    trait :published do
+      status { 'published' }
+    end
+
     trait :sent_to_candidate do
       sent_to_candidate_at { Time.current }
     end

--- a/spec/factories/provider_pool_action.rb
+++ b/spec/factories/provider_pool_action.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :provider_pool_action do
+    application_form factory: %i[application_form]
+    provider_user factory: %i[provider_user]
+    recruitment_cycle_year { RecruitmentCycleTimetable.current_year }
+
+    trait :viewed do
+      status { 'viewed' }
+    end
+  end
+end

--- a/spec/helpers/find_a_candidate_helper_spec.rb
+++ b/spec/helpers/find_a_candidate_helper_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe FindACandidateHelper do
+  let(:application_form) { create(:application_form) }
+  let(:provider_user) { create(:provider_user, :with_provider) }
+
+  describe '#candidate_status' do
+    context 'when candidate has been invited' do
+      it 'returns the invited tag' do
+        _invite = create(
+          :pool_invite,
+          :published,
+          candidate: application_form.candidate,
+          provider: provider_user.providers.first,
+        )
+        candidate_status = helper.candidate_status(
+          application_form:,
+          provider_user:,
+        )
+
+        expect(candidate_status).to eq(
+          '<strong class="govuk-tag govuk-tag--green">Invited</strong>',
+        )
+      end
+    end
+
+    context 'when candidate been viewed' do
+      it 'returns the viewed tag' do
+        _viewed_action = create(
+          :provider_pool_action,
+          :viewed,
+          application_form:,
+          provider_user:,
+        )
+        candidate_status = helper.candidate_status(
+          application_form:,
+          provider_user:,
+        )
+
+        expect(candidate_status).to eq(
+          '<strong class="govuk-tag govuk-tag--grey">Viewed</strong>',
+        )
+      end
+    end
+
+    context 'when candidate is new' do
+      it 'returns the new tag' do
+        candidate_status = helper.candidate_status(
+          application_form:,
+          provider_user:,
+        )
+
+        expect(candidate_status).to eq(
+          '<strong class="govuk-tag">New</strong>',
+        )
+      end
+    end
+
+    context 'when candidate has been viewed in the previous cycle' do
+      it 'returns the new tag' do
+        _viewed_action_previous_cycle = create(
+          :provider_pool_action,
+          :viewed,
+          application_form:,
+          provider_user:,
+          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        )
+        candidate_status = helper.candidate_status(
+          application_form:,
+          provider_user:,
+        )
+
+        expect(candidate_status).to eq(
+          '<strong class="govuk-tag">New</strong>',
+        )
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -14,10 +14,17 @@ RSpec.describe 'Providers views candidate pool details' do
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
+    then_i_see_the_rejected_candidate_as('New')
     and_i_click_on_a_candidate
 
     then_i_am_redirected_to_view_that_candidate
     and_i_can_view_their_details
+    when_i_click('Back')
+
+    then_i_am_redirected_to_find_a_candidate
+    then_i_see_the_rejected_candidate_as('Viewed')
+    when_the_rejected_candidate_exits_and_enters_the_pool_again
+    then_i_see_the_rejected_candidate_as('Viewed')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -72,6 +79,12 @@ RSpec.describe 'Providers views candidate pool details' do
     visit provider_interface_candidate_pool_root_path
   end
 
+  def then_i_see_the_rejected_candidate_as(status)
+    within("#candidate_#{@rejected_candidate.id}") do
+      expect(page).to have_content status
+    end
+  end
+
   def and_i_click_on_a_candidate
     click_on @rejected_candidate.redacted_full_name_current_cycle
   end
@@ -91,5 +104,18 @@ RSpec.describe 'Providers views candidate pool details' do
     expect(page).to have_content('Qualifications')
     expect(page).to have_content('A levels and other qualifications')
     expect(page).to have_content('Criminal record and professional misconduct')
+  end
+
+  def when_i_click(button)
+    click_link_or_button(button)
+  end
+
+  def then_i_am_redirected_to_find_a_candidate
+    expect(page).to have_current_path(provider_interface_candidate_pool_root_path)
+  end
+
+  def when_the_rejected_candidate_exits_and_enters_the_pool_again
+    CandidatePoolApplication.find_by(application_form: @rejected_candidate_form).delete
+    create(:candidate_pool_application, application_form: @rejected_candidate_form)
   end
 end


### PR DESCRIPTION
## Context

This commit adds these 3 statuses and the functionality to mark
candidates as viewed.

Initially all candidates would be New unless they've already been
invited.

Once the provider user lands on the show page of a candidate that
candidate will be marked as viewed. Through the ProviderPoolAction
table.

This is specific to a provide user.

The invited status is org wide. Meaning any provider user that invites a
candidate marks that candidate as invited.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Locally or on review app. View candidates, Log in as other provider users view candidates.
Invited status is org wide.


https://github.com/user-attachments/assets/08bd4202-abac-4bb5-b31b-7e9db5950fc0

 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
