### PR TITLE
Implement filter for invited candidates on provider index page

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -23,7 +23,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter << course_type_filter).concat(provider_locations_filters).compact
+      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter << course_type_filter << invited_candidates_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -47,7 +47,7 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: [], course_type: []).to_h)
+      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: [], course_type: [], invited_only: []).to_h)
     end
 
     def save_filter_state!
@@ -123,6 +123,21 @@ module ProviderInterface
             value: TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME,
             label: I18n.t('provider_interface.filters.course_type.teacher_degree_apprenticeship'),
             checked: applied_filters[:course_type]&.include?(TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME),
+          },
+        ],
+      }
+    end
+
+    def invited_candidates_filter
+      {
+        type: :checkboxes,
+        heading: I18n.t('provider_interface.filters.invited_candidates.heading'),
+        name: 'invited_only',
+        options: [
+          {
+            value: 'invited_only',
+            label: I18n.t('provider_interface.filters.invited_candidates.invited_only'),
+            checked: applied_filters[:invited_only]&.include?('invited_only'),
           },
         ],
       }

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -6,4 +6,6 @@ en:
         heading: 'Course type'
         postgraduate: 'Postgraduate courses'
         teacher_degree_apprenticeship: 'Undergraduate courses'
-
+      invited_candidates:
+        heading: Invited candidates
+        invited_only: Only show candidates who have been invited to apply

--- a/spec/factories/pool_invite.rb
+++ b/spec/factories/pool_invite.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     trait :sent_to_candidate do
       sent_to_candidate_at { Time.current }
+      published
     end
 
     trait :not_sent_to_candidate do

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Locations filter' do
-          expected_number_of_filters = 7
+          expected_number_of_filters = 8
           recruitment_cycle_index = 1
           providers_array_index = 3
           number_of_courses = 2
@@ -67,7 +67,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Providers filter' do
-          expected_number_of_filters = 7
+          expected_number_of_filters = 8
 
           expect(filter.filters.size).to eq(expected_number_of_filters)
           expect(headings).not_to include('Provider')
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       end
 
       it 'does include the course type filter' do
-        expect(filter.filters.size).to be(7)
+        expect(filter.filters.size).to be(8)
         expect(headings).to include('Course type')
       end
     end
@@ -93,11 +93,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           relevant_provider_labels = [provider1.sites.first.name_and_code, provider1.sites.last.name_and_code]
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][0][:value])
-          expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][1][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][0][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][1][:value])
 
-          expect(relevant_provider_labels).to include(filter.filters[6][:options][0][:label])
-          expect(relevant_provider_labels).to include(filter.filters[6][:options][1][:label])
+          expect(relevant_provider_labels).to include(filter.filters[7][:options][0][:label])
+          expect(relevant_provider_labels).to include(filter.filters[7][:options][1][:label])
         end
       end
 
@@ -115,8 +115,8 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           old_site_label = old_site.name_and_code
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(old_site_name_and_code).not_to include(filter.filters[6][:options][0][:value])
-          expect(old_site_label).not_to include(filter.filters[6][:options][0][:label])
+          expect(old_site_name_and_code).not_to include(filter.filters[7][:options][0][:value])
+          expect(old_site_label).not_to include(filter.filters[7][:options][0][:label])
         end
       end
     end
@@ -135,11 +135,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include("Locations for #{provider1.name}")
 
-        expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][0][:value])
-        expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][1][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][0][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][1][:value])
 
-        expect(relevant_provider_labels).to include(filter.filters[7][:options][0][:label])
-        expect(relevant_provider_labels).to include(filter.filters[7][:options][1][:label])
+        expect(relevant_provider_labels).to include(filter.filters[8][:options][0][:label])
+        expect(relevant_provider_labels).to include(filter.filters[8][:options][1][:label])
       end
     end
 

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -162,5 +162,37 @@ RSpec.describe FilterApplicationChoicesForProviders do
 
       expect(result).to eq([application_choices.last])
     end
+
+    context 'filter by invites' do
+      let(:application_form) { ApplicationForm.find_by(support_reference: 'XY6789') }
+      let(:candidate) { application_form.candidate }
+      let(:application_choice) { application_choices.find_by(application_form:) }
+      let(:course) { application_choice.current_course }
+
+      before { application_choices }
+
+      it 'returns invited candidate' do
+        create(:pool_invite, :sent_to_candidate, candidate:, course:, provider: course.provider)
+
+        result = described_class.call(application_choices:, filters: { invited_only: ['invited_only'] })
+        expect(result).to eq([application_choice])
+      end
+
+      it 'returns nothing when invite is not within years visible to providers' do
+        recruitment_cycle_year = RecruitmentCycleTimetable.years_visible_to_providers.min - 1
+        create(:pool_invite, :sent_to_candidate, candidate:, course:, provider: course.provider, recruitment_cycle_year:)
+
+        result = described_class.call(application_choices:, filters: { invited_only: ['invited_only'] })
+        expect(result).to eq([])
+      end
+
+      it 'when candidate has been invited to same provider, different course, returns invited candidate' do
+        course_for_invite = create(:course, provider: course.provider)
+        create(:pool_invite, :sent_to_candidate, candidate:, course: course_for_invite, provider: course_for_invite.provider)
+
+        result = described_class.call(application_choices:, filters: { invited_only: ['invited_only'] })
+        expect(result).to eq([application_choice])
+      end
+    end
   end
 end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -193,6 +193,14 @@ RSpec.describe FilterApplicationChoicesForProviders do
         result = described_class.call(application_choices:, filters: { invited_only: ['invited_only'] })
         expect(result).to eq([application_choice])
       end
+
+      it 'does not include candidates who have been invited to other providers' do
+        course_for_invite = create(:course)
+        create(:pool_invite, :sent_to_candidate, candidate:, course: course_for_invite, provider: course_for_invite.provider)
+
+        result = described_class.call(application_choices:, filters: { invited_only: ['invited_only'] })
+        expect(result).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

We want provider users to be able to filter applications by people who have received invites (to any course by the provider, it isn't exclusive to the specific course).

## Changes proposed in this pull request

https://github.com/user-attachments/assets/63305b27-836a-4546-861f-45a0a6c8f208

## Guidance to review

- On the review app, send some invites as a provider
- Login in as one of those candidates and submit an application to that provider (doesn't have to be the exact course)
- Back to the provider user, filter the main tab by only those who have received invites. 
You should see the application you have submitted

The filter is preserved like the others if you navigate away from the page. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
