### PR TITLE
Update course recommender to check for courses

### DIFF
--- a/spec/services/candidate_courses_recommender_spec.rb
+++ b/spec/services/candidate_courses_recommender_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe CandidateCoursesRecommender do
   describe '.recommended_courses_url' do
+    before do
+      stubbed_html_with_one_course
+    end
+
     it 'returns nil when there is no recommendations' do
       candidate = build(:candidate)
 
@@ -390,5 +394,82 @@ RSpec.describe CandidateCoursesRecommender do
         expect(query_parameters['location']).to eq('SW1A 1AA')
       end
     end
+
+    context 'number of courses found on the Find service' do
+      it 'returns nil when there are no courses found' do
+        stubbed_html_with_no_courses
+
+        candidate = create(:candidate)
+        _application_form = create(:application_form, candidate:, degrees_completed: true)
+
+        recommended_courses_url = described_class.new(
+          candidate:,
+        ).recommended_courses_url
+
+        expect(recommended_courses_url).to be_nil
+      end
+
+      it 'returns a URL when the there is one course found' do
+        stubbed_html_with_one_course
+
+        candidate = create(:candidate)
+        _application_form = create(:application_form, candidate:, degrees_completed: true)
+
+        recommended_courses_url = described_class.new(
+          candidate:,
+        ).recommended_courses_url
+
+        expect(recommended_courses_url).not_to be_nil
+      end
+
+      it 'returns a URL when there are multiple courses found' do
+        stubbed_html_with_courses
+
+        candidate = create(:candidate)
+        _application_form = create(:application_form, candidate:, degrees_completed: true)
+
+        recommended_courses_url = described_class.new(
+          candidate:,
+        ).recommended_courses_url
+
+        expect(recommended_courses_url).not_to be_nil
+      end
+    end
+  end
+
+private
+
+  def stubbed_html_with_no_courses
+    stubbed_request_with_body('No courses found')
+  end
+
+  def stubbed_html_with_one_course
+    stubbed_request_with_body('1 course found')
+  end
+
+  def stubbed_html_with_courses
+    stubbed_request_with_body('7,536 courses found')
+  end
+
+  def stubbed_request_with_body(course_count_text)
+    uri = URI.join(I18n.t('find_teacher_training.production_url'), 'results')
+
+    body = body_for_stub_with_text(course_count_text)
+
+    stub_request(:get, uri)
+      .with(query: hash_including({}))
+      .to_return(body: body)
+  end
+
+  def body_for_stub_with_text(course_count_text)
+    <<-HTML
+         <html>
+        <body>
+          <h1 class="govuk-heading-xl">
+              #{course_count_text}
+          </h1>
+        </body>
+        </html>
+    HTML
   end
 end


### PR DESCRIPTION
Recommender no hits the Find service to check that the link returns a number of Courses. If no Courses are found the recommender will not return a recommendation link

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
