### PR TITLE
Migrate provider user fac filters to provider_user_filters table

### DIFF
--- a/app/services/data_migrations/migrate_fac_filters_to_provider_user_filters.rb
+++ b/app/services/data_migrations/migrate_fac_filters_to_provider_user_filters.rb
@@ -1,0 +1,18 @@
+module DataMigrations
+  class MigrateFacFiltersToProviderUserFilters
+    TIMESTAMP = 20250625094620
+    MANUAL_RUN = true
+
+    def change
+      attributes = ProviderUser.where.not(find_a_candidate_filters: {}).map do |provider_user|
+        {
+          provider_user_id: provider_user.id,
+          kind: 'find_candidates_all',
+          filters: provider_user.find_a_candidate_filters,
+        }
+      end
+
+      ProviderUserFilter.insert_all(attributes)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillApplicationFormOnPoolInvites',
+  'DataMigrations::MigrateFacFiltersToProviderUserFilters',
   'DataMigrations::BackfillTrainingLocationsOnCandidatePreferences',
   'DataMigrations::BackfillRecruitmentCycleYearOnPoolInvites',
   'DataMigrations::DeleteSandboxOneLoginAccounts',

--- a/spec/services/data_migrations/migrate_fac_filters_to_provider_user_filters_spec.rb
+++ b/spec/services/data_migrations/migrate_fac_filters_to_provider_user_filters_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::MigrateFacFiltersToProviderUserFilters do
+  describe '#change' do
+    it 'migrates the filters from provider_user to provider_user_filters' do
+      location_filter = { 'location' => 'Manchester' }
+      user_with_filters_1 = create(
+        :provider_user,
+        find_a_candidate_filters: location_filter,
+      )
+
+      location_and_subject_filter = { 'location' => 'Manchester', 'subject_ids' => [1] }
+      user_with_filters_2 = create(
+        :provider_user,
+        find_a_candidate_filters: location_and_subject_filter,
+      )
+      _user_without_filters = create(:provider_user, find_a_candidate_filters: {})
+
+      expect { described_class.new.change }.to change { ProviderUserFilter.count }.from(0).to(2)
+        .and change { user_with_filters_1.provider_user_filters.find_candidates_all.last&.filters }.from(nil).to(location_filter)
+        .and change { user_with_filters_2.provider_user_filters.find_candidates_all.last&.filters }.from(nil).to(location_and_subject_filter)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to migrate the find a candidate filters from provider user table to their own table.

This will be ran manually to minimise the gap between switching to the new filters structure.

There will still be a gap where a provider user
might set a new filter but I think this would not be a problem. Worst case scenario they would lose that filter but once they apply it back they will always have that filter set for them.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
