### PR TITLE
FAC profile status banners

### DIFF
--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.html.erb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
+  <% notification_banner.with_heading(text: heading) %>
+  <p class="govuk-body"><%= text %></p>
+<% end %>

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.html.erb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
-  <% notification_banner.with_heading(text: heading) %>
+  <% notification_banner.with_heading(text: t('.heading', subject: invite.course.name, provider: invite.provider.name, count: @current_provider_user.providers.count)) %>
   <p class="govuk-body"><%= text %></p>
 <% end %>

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -21,7 +21,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
   end
 
   def text
-    if decision_pending_application_choice(invite)
+    if matching_application_choice(invite)
       I18n.t(
         'provider_interface.find_candidates.already_invited_candidate_banner_component.text_with_application',
         link: view_application_link(invite),
@@ -50,24 +50,16 @@ private
         candidate_id: @application_form.candidate_id,
       )
       .includes(:course, :provider)
-      .reject do |invite|
-        matching_application_choice(invite)&.application_unsuccessful?
-      end
   end
 
   def matching_application_choice(invite)
     @application_form.application_choices
-      .find { |choice| choice.course.code == invite.course.code }
-  end
-
-  def decision_pending_application_choice(invite)
-    @application_form.application_choices
-      .decision_pending
+      .visible_to_provider
       .find { |choice| choice.course.code == invite.course.code }
   end
 
   def view_application_link(invite)
-    choice = decision_pending_application_choice(invite)
+    choice = matching_application_choice(invite)
     return unless choice
 
     govuk_link_to(

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -1,0 +1,43 @@
+class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent < ViewComponent::Base
+  delegate :provider, to: :invite
+  delegate :course, to: :invite
+
+  def initialize(application_form:, current_provider_user:, show_provider_name:)
+    @application_form = application_form
+    @current_provider_user = current_provider_user
+    @show_provider_name = show_provider_name
+  end
+
+  def render?
+    invite.present?
+  end
+
+  def heading
+    key = @show_provider_name ? 'heading_with_provider' : 'heading_without_provider'
+    I18n.t("provider_interface.find_candidates.already_invited_candidate_banner_component.#{key}",
+           subject: course.name,
+           provider: provider.name)
+  end
+
+  def text
+    key = @show_provider_name ? 'text_with_provider' : 'text_without_provider'
+    I18n.t("provider_interface.find_candidates.already_invited_candidate_banner_component.#{key}",
+           subject: course.name_and_code,
+           provider: provider.name,
+           date: date)
+  end
+
+  def date
+    invite.created_at.to_fs(:govuk_date)
+  end
+
+private
+
+  def invite
+    @invite ||= Pool::Invite.find_by(
+      provider_id: @current_provider_user.provider_ids,
+      candidate_id: @application_form.candidate_id,
+      status: :published,
+    )
+  end
+end

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -8,8 +8,10 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
     @show_provider_name = show_provider_name
   end
 
+  # Displays if the candidate has already been invited to any of the providers they have access to
+  # We want to display a different banner (linking to the application) if the application_received_for_this_course? condition is true
   def render?
-    invite.present?
+    invite.present? && !application_received_for_this_course?
   end
 
   def heading
@@ -39,5 +41,11 @@ private
       candidate_id: @application_form.candidate_id,
       status: :published,
     )
+  end
+
+  def application_received_for_this_course?
+    @application_form.application_choices.any? do |choice|
+      choice.course.code == course.code
+    end
   end
 end

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -13,7 +13,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
   end
 
   def text
-    if invite.matching_application_choice(@application_form)
+    if invite.matching_application_choice
       I18n.t(
         'provider_interface.find_candidates.already_invited_candidate_banner_component.text_with_application',
         link: view_application_link(invite),
@@ -39,13 +39,13 @@ private
     @invites ||= Pool::Invite.published
       .where(
         provider_id: @current_provider_user.provider_ids,
-        candidate_id: @application_form.candidate_id,
+        application_form: @application_form,
       )
       .includes(:course, :provider)
   end
 
   def view_application_link(invite)
-    choice = invite.matching_application_choice(@application_form)
+    choice = invite.matching_application_choice
     return unless choice
 
     govuk_link_to(

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -14,12 +14,12 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
 
   def text
     if invite.matching_application_choice
-      I18n.t(
-        'provider_interface.find_candidates.already_invited_candidate_banner_component.text_with_application',
+      t(
+        'provider_interface.find_candidates.already_invited_candidate_banner_component.text_with_application_html',
         link: view_application_link(invite),
-      ).html_safe
+      )
     else
-      I18n.t(
+      t(
         'provider_interface.find_candidates.already_invited_candidate_banner_component.text',
         subject: invite.course.name_and_code,
         provider: invite.provider.name,
@@ -49,7 +49,7 @@ private
     return unless choice
 
     govuk_link_to(
-      I18n.t('provider_interface.find_candidates.already_invited_candidate_banner_component.view_application'),
+      t('provider_interface.find_candidates.already_invited_candidate_banner_component.view_application'),
       provider_interface_application_choice_path(choice),
     )
   end

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -13,7 +13,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
   end
 
   def text
-    if matching_application_choice(invite)
+    if invite.matching_application_choice(@application_form)
       I18n.t(
         'provider_interface.find_candidates.already_invited_candidate_banner_component.text_with_application',
         link: view_application_link(invite),
@@ -44,14 +44,8 @@ private
       .includes(:course, :provider)
   end
 
-  def matching_application_choice(invite)
-    @application_form.application_choices
-      .visible_to_provider
-      .find { |choice| choice.course.code == invite.course.code }
-  end
-
   def view_application_link(invite)
-    choice = matching_application_choice(invite)
+    choice = invite.matching_application_choice(@application_form)
     return unless choice
 
     govuk_link_to(

--- a/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_candidate_banner_component.rb
@@ -1,8 +1,7 @@
 class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent < ViewComponent::Base
-  def initialize(application_form:, current_provider_user:, show_provider_name:)
+  def initialize(application_form:, current_provider_user:)
     @application_form = application_form
     @current_provider_user = current_provider_user
-    @show_provider_name = show_provider_name
   end
 
   def render?
@@ -13,13 +12,6 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
     invites.first
   end
 
-  def heading
-    key = @show_provider_name ? 'heading_with_provider' : 'heading_without_provider'
-    I18n.t("provider_interface.find_candidates.already_invited_candidate_banner_component.#{key}",
-           subject: invite.course.name,
-           provider: invite.provider.name)
-  end
-
   def text
     if matching_application_choice(invite)
       I18n.t(
@@ -27,12 +19,12 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent 
         link: view_application_link(invite),
       ).html_safe
     else
-      key = @show_provider_name ? 'text_with_provider' : 'text_without_provider'
       I18n.t(
-        "provider_interface.find_candidates.already_invited_candidate_banner_component.#{key}",
+        'provider_interface.find_candidates.already_invited_candidate_banner_component.text',
         subject: invite.course.name_and_code,
         provider: invite.provider.name,
         date: date,
+        count: @current_provider_user.providers.count,
       )
     end
   end

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.html.erb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.html.erb
@@ -1,0 +1,9 @@
+<%= govuk_notification_banner(title_text: t('notification_banner.important')) do |banner| %>
+  <% banner.with_heading(text: heading) %>
+  <p class="govuk-body"><%= t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.intro') %></p>
+  <ul class="govuk-list govuk-list--bullet">
+    <% invite_details.each do |invite_text| %>
+      <li><%= invite_text %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.html.erb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |banner| %>
-  <% banner.with_heading(text: heading) %>
+  <% banner.with_heading(text: t('.heading')) %>
   <p class="govuk-body"><%= t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.intro') %></p>
   <ul class="govuk-list govuk-list--bullet">
     <% invite_details.each do |invite_text| %>

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -11,15 +11,15 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
   def invite_details
     invites.map do |invite|
       if invite.matching_application_choice
-        I18n.t(
-          'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text_with_application',
+        t(
+          'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text_with_application_html',
           course: invite.course.name_and_code,
           provider: invite.provider.name,
           date: invite.created_at.to_fs(:govuk_date),
           link: view_application_link(invite),
-        ).html_safe
+        )
       else
-        I18n.t(
+        t(
           'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text',
           course: invite.course.name_and_code,
           provider: invite.provider.name,
@@ -43,7 +43,7 @@ private
     choice = invite.matching_application_choice
     return unless choice
 
-    govuk_link_to(I18n.t(
+    govuk_link_to(t(
                     'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.view_application',
                   ), provider_interface_application_choice_path(choice))
   end

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -46,9 +46,9 @@ private
   end
 
   def matching_application_choice(invite)
-    @application_form.application_choices.find do |choice|
-      choice.course.code == invite.course.code
-    end
+    @application_form.application_choices
+      .visible_to_provider
+      .find { |choice| choice.course.code == invite.course.code }
   end
 
   def view_application_link(invite)

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -1,16 +1,11 @@
 class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent < ViewComponent::Base
-  def initialize(application_form:, current_provider_user:, show_provider_name:)
+  def initialize(application_form:, current_provider_user:)
     @application_form = application_form
     @current_provider_user = current_provider_user
-    @show_provider_name = show_provider_name
   end
 
   def render?
     invites.size > 1
-  end
-
-  def heading
-    I18n.t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.heading')
   end
 
   def invite_details
@@ -24,13 +19,12 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
           link: view_application_link(invite),
         ).html_safe
       else
-        key = @show_provider_name ? 'text_with_provider' : 'text_without_provider'
-
         I18n.t(
-          "provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.#{key}",
+          'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text',
           course: invite.course.name_and_code,
           provider: invite.provider.name,
           date: invite.created_at.to_fs(:govuk_date),
+          count: @current_provider_user.providers.count,
         )
       end
     end

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -55,6 +55,8 @@ private
     choice = matching_application_choice(invite)
     return unless choice
 
-    govuk_link_to('View application', provider_interface_application_choice_path(choice))
+    govuk_link_to(I18n.t(
+                    'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.view_application',
+                  ), provider_interface_application_choice_path(choice))
   end
 end

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -1,0 +1,44 @@
+class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent < ViewComponent::Base
+  def initialize(application_form:, current_provider_user:, show_provider_name:)
+    @application_form = application_form
+    @current_provider_user = current_provider_user
+    @show_provider_name = show_provider_name
+  end
+
+  def render?
+    invites.size > 1 && !application_received_for_any_invited_course?
+  end
+
+  def heading
+    I18n.t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.heading')
+  end
+
+  def invite_details
+    key = @show_provider_name ? 'text_with_provider' : 'text_without_provider'
+
+    invites.map do |invite|
+      I18n.t(
+        "provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.#{key}",
+        course: invite.course.name_and_code,
+        provider: invite.provider.name,
+        date: invite.created_at.to_fs(:govuk_date),
+      )
+    end
+  end
+
+private
+
+  def invites
+    @invites ||= Pool::Invite.published.where(
+      provider_id: @current_provider_user.provider_ids,
+      candidate_id: @application_form.candidate_id,
+    ).includes(:course, :provider)
+  end
+
+  def application_received_for_any_invited_course?
+    invited_course_codes = invites.map { |invite| invite.course.code }.compact.uniq
+    @application_form.application_choices.any? do |choice|
+      invited_course_codes.include?(choice.course.code)
+    end
+  end
+end

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -10,7 +10,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
 
   def invite_details
     invites.map do |invite|
-      if matching_application_choice(invite)
+      if invite.matching_application_choice(@application_form)
         I18n.t(
           'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text_with_application',
           course: invite.course.name_and_code,
@@ -39,14 +39,8 @@ private
     ).includes(:course, :provider)
   end
 
-  def matching_application_choice(invite)
-    @application_form.application_choices
-      .visible_to_provider
-      .find { |choice| choice.course.code == invite.course.code }
-  end
-
   def view_application_link(invite)
-    choice = matching_application_choice(invite)
+    choice = invite.matching_application_choice(@application_form)
     return unless choice
 
     govuk_link_to(I18n.t(

--- a/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
+++ b/app/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.rb
@@ -10,7 +10,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
 
   def invite_details
     invites.map do |invite|
-      if invite.matching_application_choice(@application_form)
+      if invite.matching_application_choice
         I18n.t(
           'provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.text_with_application',
           course: invite.course.name_and_code,
@@ -35,12 +35,12 @@ private
   def invites
     @invites ||= Pool::Invite.published.where(
       provider_id: @current_provider_user.provider_ids,
-      candidate_id: @application_form.candidate_id,
+      application_form: @application_form,
     ).includes(:course, :provider)
   end
 
   def view_application_link(invite)
-    choice = invite.matching_application_choice(@application_form)
+    choice = invite.matching_application_choice
     return unless choice
 
     govuk_link_to(I18n.t(

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -27,10 +27,10 @@ class Pool::Invite < ApplicationRecord
     sent_to_candidate_at.present?
   end
 
-  def matching_application_choice(form)
-    form.application_choices
+  def matching_application_choice
+    application_form.application_choices
       .visible_to_provider
-      .find { |choice| choice.course.code == course.code }
+      .find { |choice| choice.course == course }
   end
 
   def self.matching_application_choices_exists_sql

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -27,6 +27,12 @@ class Pool::Invite < ApplicationRecord
     sent_to_candidate_at.present?
   end
 
+  def matching_application_choice(form)
+    form.application_choices
+      .visible_to_provider
+      .find { |choice| choice.course.code == course.code }
+  end
+
   def self.matching_application_choices_exists_sql
     visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
                        .map { |app_state| ActiveRecord::Base.connection.quote(app_state.to_s) }

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -15,6 +15,9 @@
           ) %>
     <% end %>
 
+    <% more_than_one_provider = current_provider_user.providers.count > 1 %>
+    <%= render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(application_form: @application_form, current_provider_user:, show_provider_name: more_than_one_provider) %>
+
     <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>
 
     <%= render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form: @application_form) %>

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -15,17 +15,14 @@
           ) %>
     <% end %>
 
-    <% more_than_one_provider = current_provider_user.providers.count > 1 %>
     <%= render(ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
       application_form: @application_form,
       current_provider_user:,
-      show_provider_name: more_than_one_provider,
     )) %>
 
     <%= render(ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
       application_form: @application_form,
       current_provider_user:,
-      show_provider_name: more_than_one_provider,
     )) %>
 
     <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -16,7 +16,17 @@
     <% end %>
 
     <% more_than_one_provider = current_provider_user.providers.count > 1 %>
-    <%= render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(application_form: @application_form, current_provider_user:, show_provider_name: more_than_one_provider) %>
+    <%= render(ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
+      application_form: @application_form,
+      current_provider_user:,
+      show_provider_name: more_than_one_provider,
+    )) %>
+
+    <%= render(ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
+      application_form: @application_form,
+      current_provider_user:,
+      show_provider_name: more_than_one_provider,
+    )) %>
 
     <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>
 

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -2,9 +2,11 @@ en:
   provider_interface:
     find_candidates:
       already_invited_candidate_banner_component:
-        heading_with_provider: This candidate was invited to %{subject} at %{provider}.
-        heading_without_provider: This candidate was invited to %{subject}.
+        heading:
+          one: This candidate was invited to %{subject}.
+          other: This candidate was invited to %{subject} at %{provider}.
+        text:
+          one: This candidate was invited to %{subject} on %{date}. They have not applied yet.
+          other: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
         text_with_application: The candidate has submitted an application. %{link}
-        text_with_provider: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
-        text_without_provider: This candidate was invited to %{subject} on %{date}. They have not applied yet.
         view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -1,0 +1,8 @@
+en:
+  provider_interface:
+    find_candidates:
+      already_invited_candidate_banner_component:
+        heading_with_provider: "This candidate was invited to %{subject} at %{provider}."
+        heading_without_provider: "This candidate was invited to %{subject}."
+        text_with_provider: "This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet."
+        text_without_provider: "This candidate was invited to %{subject} on %{date}. They have not applied yet."

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -7,3 +7,4 @@ en:
         text_with_application: The candidate has submitted an application. %{link}
         text_with_provider: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
         text_without_provider: This candidate was invited to %{subject} on %{date}. They have not applied yet.
+        view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -2,7 +2,8 @@ en:
   provider_interface:
     find_candidates:
       already_invited_candidate_banner_component:
-        heading_with_provider: "This candidate was invited to %{subject} at %{provider}."
-        heading_without_provider: "This candidate was invited to %{subject}."
-        text_with_provider: "This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet."
-        text_without_provider: "This candidate was invited to %{subject} on %{date}. They have not applied yet."
+        heading_with_provider: This candidate was invited to %{subject} at %{provider}.
+        heading_without_provider: This candidate was invited to %{subject}.
+        text_with_application: The candidate has submitted an application. %{link}
+        text_with_provider: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
+        text_without_provider: This candidate was invited to %{subject} on %{date}. They have not applied yet.

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -3,10 +3,10 @@ en:
     find_candidates:
       already_invited_candidate_banner_component:
         heading:
-          one: This candidate was invited to %{subject}.
-          other: This candidate was invited to %{subject} at %{provider}.
+          one: This candidate was invited to %{subject}
+          other: This candidate was invited to %{subject} at %{provider}
         text:
           one: This candidate was invited to %{subject} on %{date}. They have not applied yet.
           other: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
-        text_with_application: The candidate has submitted an application. %{link}
+        text_with_application: This candidate has submitted an application. %{link}
         view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_candidate_banner_component.yml
@@ -8,5 +8,5 @@ en:
         text:
           one: This candidate was invited to %{subject} on %{date}. They have not applied yet.
           other: This candidate was invited to %{subject} at %{provider} on %{date}. They have not applied yet.
-        text_with_application: This candidate has submitted an application. %{link}
+        text_with_application_html: This candidate has submitted an application. %{link}
         view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
@@ -4,5 +4,6 @@ en:
       already_invited_to_multiple_courses_banner_component:
         heading: This candidate was invited to apply
         intro: "This candidate was invited to:"
+        text_with_application: "%{course} on %{date}. %{link}"
         text_with_provider: "%{course} at %{provider} on %{date}. They have not applied yet."
         text_without_provider: "%{course} on %{date}. They have not applied yet."

--- a/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
@@ -1,0 +1,8 @@
+en:
+  provider_interface:
+    find_candidates:
+      already_invited_to_multiple_courses_banner_component:
+        heading: This candidate was invited to apply
+        intro: "This candidate was invited to:"
+        text_with_provider: "%{course} at %{provider} on %{date}. They have not applied yet."
+        text_without_provider: "%{course} on %{date}. They have not applied yet."

--- a/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
@@ -7,3 +7,4 @@ en:
         text_with_application: "%{course} on %{date}. %{link}"
         text_with_provider: "%{course} at %{provider} on %{date}. They have not applied yet."
         text_without_provider: "%{course} on %{date}. They have not applied yet."
+        view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
@@ -4,7 +4,8 @@ en:
       already_invited_to_multiple_courses_banner_component:
         heading: This candidate was invited to apply
         intro: "This candidate was invited to:"
+        text:
+          one: "%{course} on %{date}. They have not applied yet."
+          other: "%{course} at %{provider} on %{date}. They have not applied yet."
         text_with_application: "%{course} on %{date}. %{link}"
-        text_with_provider: "%{course} at %{provider} on %{date}. They have not applied yet."
-        text_without_provider: "%{course} on %{date}. They have not applied yet."
         view_application: View application

--- a/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
+++ b/config/locales/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component.yml
@@ -7,5 +7,5 @@ en:
         text:
           one: "%{course} on %{date}. They have not applied yet."
           other: "%{course} at %{provider} on %{date}. They have not applied yet."
-        text_with_application: "%{course} on %{date}. %{link}"
+        text_with_application_html: "%{course} on %{date}. %{link}"
         view_application: View application

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
@@ -4,12 +4,12 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
     pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
     provider = pool_invite.provider
-    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    provider2 = FactoryBot.create(:provider)
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider, provider2])
 
     render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
       application_form: application_form,
       current_provider_user: current_provider_user,
-      show_provider_name: true,
     )
   end
 
@@ -23,15 +23,15 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
     render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
       application_form: application_form,
       current_provider_user: current_provider_user,
-      show_provider_name: false,
     )
   end
 
-  def fac_status_banner_where_candidate_has_applied
+  def fac_status_banner_for_single_invite_where_candidate_has_applied
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
     pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
     provider = pool_invite.provider
+    provider2 = FactoryBot.create(:provider)
     course = pool_invite.course
 
     FactoryBot.create(
@@ -41,35 +41,11 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
       provider_ids: [provider.id],
     )
 
-    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider, provider2])
 
     render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
       application_form: application_form,
       current_provider_user: current_provider_user,
-      show_provider_name: true,
-    )
-  end
-
-  def fac_status_banner_where_candidate_has_applied_without_provider_name
-    candidate = FactoryBot.create(:candidate)
-    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
-    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
-    provider = pool_invite.provider
-    course = pool_invite.course
-
-    FactoryBot.create(
-      :application_choice,
-      application_form: application_form,
-      course_option: FactoryBot.create(:course_option, course: course),
-      provider_ids: [provider.id],
-    )
-
-    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
-
-    render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
-      application_form: application_form,
-      current_provider_user: current_provider_user,
-      show_provider_name: false,
     )
   end
 end

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
@@ -1,0 +1,29 @@
+class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentPreview < ViewComponent::Preview
+  def with_provider_name
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    provider = pool_invite.provider
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
+      application_form:,
+      current_provider_user:,
+      show_provider_name: true,
+    )
+  end
+
+  def without_provider_name
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    provider = pool_invite.provider
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
+      application_form:,
+      current_provider_user:,
+      show_provider_name: false,
+    )
+  end
+end

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
@@ -1,5 +1,5 @@
 class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentPreview < ViewComponent::Preview
-  def with_provider_name
+  def fac_status_banner_for_single_invite_not_applied_yet
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
     pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
@@ -7,13 +7,13 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
 
     render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
-      application_form:,
-      current_provider_user:,
+      application_form: application_form,
+      current_provider_user: current_provider_user,
       show_provider_name: true,
     )
   end
 
-  def without_provider_name
+  def fac_status_banner_for_single_invite_not_applied_yet_without_provider_name
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
     pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
@@ -21,8 +21,54 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
 
     render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
-      application_form:,
-      current_provider_user:,
+      application_form: application_form,
+      current_provider_user: current_provider_user,
+      show_provider_name: false,
+    )
+  end
+
+  def fac_status_banner_where_candidate_has_applied
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    provider = pool_invite.provider
+    course = pool_invite.course
+
+    FactoryBot.create(
+      :application_choice,
+      application_form: application_form,
+      course_option: FactoryBot.create(:course_option, course: course),
+      provider_ids: [provider.id],
+    )
+
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
+      application_form: application_form,
+      current_provider_user: current_provider_user,
+      show_provider_name: true,
+    )
+  end
+
+  def fac_status_banner_where_candidate_has_applied_without_provider_name
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    provider = pool_invite.provider
+    course = pool_invite.course
+
+    FactoryBot.create(
+      :application_choice,
+      application_form: application_form,
+      course_option: FactoryBot.create(:course_option, course: course),
+      provider_ids: [provider.id],
+    )
+
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent.new(
+      application_form: application_form,
+      current_provider_user: current_provider_user,
       show_provider_name: false,
     )
   end

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_candidate_banner_component_preview.rb
@@ -2,7 +2,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
   def fac_status_banner_for_single_invite_not_applied_yet
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
-    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:, application_form:)
     provider = pool_invite.provider
     provider2 = FactoryBot.create(:provider)
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider, provider2])
@@ -16,7 +16,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
   def fac_status_banner_for_single_invite_not_applied_yet_without_provider_name
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
-    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:, application_form:)
     provider = pool_invite.provider
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
 
@@ -29,7 +29,7 @@ class ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponentP
   def fac_status_banner_for_single_invite_where_candidate_has_applied
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
-    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:, application_form:)
     provider = pool_invite.provider
     provider2 = FactoryBot.create(:provider)
     course = pool_invite.course

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
@@ -8,8 +8,8 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
     course1 = Course.find_or_create_by!(code: 'COURSE1', provider:)
     course2 = Course.find_or_create_by!(code: 'COURSE2', provider:)
 
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course1)
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course2)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course1)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course2)
 
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider, provider2])
 
@@ -28,8 +28,8 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
     course3 = Course.find_by(code: 'COURSE3', provider:) || FactoryBot.create(:course, code: 'COURSE3', provider:)
     course4 = Course.find_by(code: 'COURSE4', provider:) || FactoryBot.create(:course, code: 'COURSE4', provider:)
 
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course3)
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course4)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course3)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course4)
 
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
 
@@ -48,8 +48,8 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
     course5 = Course.find_by(code: 'COURSE5', provider:) || FactoryBot.create(:course, code: 'COURSE5', provider:)
     course6 = Course.find_by(code: 'COURSE6', provider:) || FactoryBot.create(:course, code: 'COURSE6', provider:)
 
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course5)
-    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course6)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course5)
+    FactoryBot.create(:pool_invite, :published, candidate:, application_form:, provider:, course: course6)
 
     FactoryBot.create(
       :application_choice,

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
@@ -1,0 +1,42 @@
+class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponentPreview < ViewComponent::Preview
+  def with_provider_name
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+
+    provider = Provider.find_or_create_by!(code: 'PV001')
+    course1 = Course.find_or_create_by!(code: 'COURSE1', provider:)
+    course2 = Course.find_or_create_by!(code: 'COURSE2', provider:)
+
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course1)
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course2)
+
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
+      application_form:,
+      current_provider_user:,
+      show_provider_name: true,
+    )
+  end
+
+  def without_provider_name
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+
+    provider = Provider.find_or_create_by!(code: 'PV000')
+
+    course3 = Course.find_by(code: 'COURSE3', provider:) || FactoryBot.create(:course, code: 'COURSE3', provider:)
+    course4 = Course.find_by(code: 'COURSE4', provider:) || FactoryBot.create(:course, code: 'COURSE4', provider:)
+
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course3)
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course4)
+
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
+      application_form:,
+      current_provider_user:,
+      show_provider_name: false,
+    )
+  end
+end

--- a/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_preview.rb
@@ -1,25 +1,25 @@
 class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponentPreview < ViewComponent::Preview
-  def with_provider_name
+  def fac_status_banner_for_multiple_invite_with_provider_name
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
 
     provider = Provider.find_or_create_by!(code: 'PV001')
+    provider2 = Provider.find_or_create_by!(code: 'PV991')
     course1 = Course.find_or_create_by!(code: 'COURSE1', provider:)
     course2 = Course.find_or_create_by!(code: 'COURSE2', provider:)
 
     FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course1)
     FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course2)
 
-    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider, provider2])
 
     render ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
       application_form:,
       current_provider_user:,
-      show_provider_name: true,
     )
   end
 
-  def without_provider_name
+  def fac_status_banner_for_multiple_invite_without_provider_name
     candidate = FactoryBot.create(:candidate)
     application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
 
@@ -36,7 +36,33 @@ class ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerCo
     render ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
       application_form:,
       current_provider_user:,
-      show_provider_name: false,
+    )
+  end
+
+  def fac_status_banner_for_multiple_invite_where_candidate_has_applied
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
+
+    provider = Provider.find_or_create_by!(code: 'PV999')
+
+    course5 = Course.find_by(code: 'COURSE5', provider:) || FactoryBot.create(:course, code: 'COURSE5', provider:)
+    course6 = Course.find_by(code: 'COURSE6', provider:) || FactoryBot.create(:course, code: 'COURSE6', provider:)
+
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course5)
+    FactoryBot.create(:pool_invite, :published, candidate:, provider:, course: course6)
+
+    FactoryBot.create(
+      :application_choice,
+      application_form: application_form,
+      course_option: FactoryBot.create(:course_option, course: course5),
+      provider_ids: [provider.id],
+    )
+
+    current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
+
+    render ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent.new(
+      application_form:,
+      current_provider_user:,
     )
   end
 end

--- a/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
     let(:application_form) { create(:application_form, :completed, candidate:, submitted_at: 1.day.ago) }
     let(:pool_invite) { create(:pool_invite, :published, candidate:) }
     let(:provider) { pool_invite.provider }
+    let(:provider2) { create(:provider) }
     let(:course) { Course.find(pool_invite.course_id) }
     let(:date) { pool_invite.created_at.to_fs(:govuk_date) }
     let(:current_provider_user) { create(:provider_user, providers: [provider]) }
@@ -15,7 +16,20 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
-                                 show_provider_name: true,
+                               ))
+
+        expect(result.text).to include('Important')
+        expect(result.text).to include("This candidate was invited to #{course.name_and_code} on #{date}")
+      end
+    end
+
+    context 'when a published pool invite exists and the candidate has not applied to the same course and the provider user has access to more than one provider' do
+      let(:current_provider_user) { create(:provider_user, providers: [provider, provider2]) }
+
+      it 'renders the banner with provider name, course name and code saying they have not applied yet' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
                                ))
 
         expect(result.text).to include('Important')
@@ -23,13 +37,14 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
       end
     end
 
-    context 'when the candidate has already applied to the same course through the provider' do
-      before do
+    context 'when the candidate has applied to the same course through the provider and has a status visible to the provider' do
+      let!(:application_choice) do
         create(
           :application_choice,
           application_form: application_form,
-          course_option: create(:course_option, course: course),
+          course_option: create(:course_option, course:),
           provider_ids: [provider.id],
+          status: 'awaiting_provider_decision',
         )
       end
 
@@ -37,11 +52,33 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
-                                 show_provider_name: true,
                                ))
 
         expect(result.text).to include('The candidate has submitted an application.')
-        expect(result.text).to include('View application')
+        expect(result).to have_link('View application', href: "/provider/applications/#{application_choice.id}")
+      end
+    end
+
+    context 'when a published pool invite exists and the candidate has a corresponding choice with a status not visible to the provider' do
+      let!(:application_choice) do
+        create(
+          :application_choice,
+          application_form: application_form,
+          course_option: create(:course_option, course:),
+          provider_ids: [provider.id],
+          status: 'cancelled',
+        )
+      end
+
+      it 'renders the banner with course name and code saying they were invited on a given date and does not link to the application' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                               ))
+
+        expect(result.text).to include('Important')
+        expect(result.text).to include("This candidate was invited to #{course.name_and_code} on #{date}")
+        expect(result).to have_no_link('View application', href: "/provider/applications/#{application_choice.id}")
       end
     end
 
@@ -53,50 +90,24 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
-                                 show_provider_name: true,
                                ))
 
         expect(result.text).to be_blank
       end
     end
 
-    context 'when the candidate has more than one invite the candidate from the provider user`s institutions' do
+    context 'when the candidate has more than one invite from the provider user`s institutions' do
       before do
         create(:pool_invite, :published, candidate:, provider:)
       end
 
-      it 'does not render the banner' do
+      it 'does not render the banner (because multiple invites banner should render)' do
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
-                                 show_provider_name: true,
                                ))
 
         expect(result.text).to be_blank
-      end
-    end
-
-    context 'when show_provider_name is true' do
-      it 'includes the provider name in the banner text' do
-        result = render_inline(described_class.new(
-                                 application_form:,
-                                 current_provider_user:,
-                                 show_provider_name: true,
-                               ))
-
-        expect(result.text).to include(provider.name)
-      end
-    end
-
-    context 'when show_provider_name is false' do
-      it 'does not include the provider name in the banner text' do
-        result = render_inline(described_class.new(
-                                 application_form:,
-                                 current_provider_user:,
-                                 show_provider_name: false,
-                               ))
-
-        expect(result.text).not_to include(provider.name)
       end
     end
   end

--- a/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerC
                                  current_provider_user:,
                                ))
 
-        expect(result.text).to include('The candidate has submitted an application.')
+        expect(result.text).to include('This candidate has submitted an application')
         expect(result).to have_link('View application', href: "/provider/applications/#{application_choice.id}")
       end
     end

--- a/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/already_invited_candidate_banner_component_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedCandidateBannerComponent, type: :component do
+  describe '#render?' do
+    let(:candidate) { create(:candidate) }
+    let(:application_form) { create(:application_form, :completed, candidate:, submitted_at: 1.day.ago) }
+    let(:pool_invite) { create(:pool_invite, :published, candidate:) }
+    let(:provider) { pool_invite.provider }
+    let(:course) { Course.find(pool_invite.course_id) }
+    let(:date) { pool_invite.created_at.to_fs(:govuk_date) }
+
+    context 'when a published pool invite exists and the candidate has not applied to the same course' do
+      let(:current_provider_user) { create(:provider_user, providers: [provider]) }
+
+      it 'renders the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.text).to include('Important')
+        expect(result.text).to include("This candidate was invited to #{course.name_and_code} at #{provider.name} on #{date}")
+      end
+    end
+
+    context 'when the candidate has already applied to the same course through the provider' do
+      let(:current_provider_user) { create(:provider_user, providers: [provider]) }
+
+      before do
+        create(
+          :application_choice,
+          application_form: application_form,
+          course_option: create(:course_option, course: course),
+          provider_ids: [provider.id],
+        )
+      end
+
+      it 'does not render the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.to_html).to be_blank
+      end
+    end
+
+    context 'when no invite exists for the current provider user' do
+      let(:different_provider) { create(:provider) }
+      let(:current_provider_user) { create(:provider_user, providers: [different_provider]) }
+
+      it 'does not render the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.to_html).to be_blank
+      end
+    end
+
+    context 'when show_provider_name is true' do
+      let(:current_provider_user) { create(:provider_user, providers: [provider]) }
+
+      it 'includes the provider name in the banner text' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.text).to include(provider.name)
+      end
+    end
+
+    context 'when show_provider_name is false' do
+      let(:current_provider_user) { create(:provider_user, providers: [provider]) }
+
+      it 'does not include the provider name in the banner text' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: false,
+                               ))
+
+        expect(result.text).not_to include(provider.name)
+      end
+    end
+  end
+end

--- a/spec/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_spec.rb
@@ -18,18 +18,15 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCourse
     let(:course1) { invite1.course }
     let(:course2) { invite2.course }
 
-    # TODO: Context blocks for when the candidate has not yet been invited to one or either of the courses (displays "They have not applied yet")
-    # TODO: Context blocks for when the candidate has been invited to one or both of the courses (shows view application link(s))
-
     context 'when multiple invites exist' do
-      it 'renders the banner' do
+      it 'renders the banner with both course names' do
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
                                  show_provider_name: false,
                                ))
 
-        expect(result.text).to include(I18n.t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.heading'))
+        expect(result.text).to include('This candidate was invited to apply')
         expect(result.text).to include(course1.name_and_code)
         expect(result.text).to include(course2.name_and_code)
       end
@@ -45,12 +42,12 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCourse
                                  show_provider_name: true,
                                ))
 
-        expect(result.to_html).to be_blank
+        expect(result.text).to be_blank
       end
     end
 
     context 'when show_provider_name is false' do
-      it 'renders banner text without the provider name' do
+      it 'renders invite details without provider name' do
         result = render_inline(described_class.new(
                                  application_form:,
                                  current_provider_user:,
@@ -62,7 +59,42 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCourse
       end
     end
 
-    context 'when no matching invites for the current provider user exist' do
+    context 'when show_provider_name is true' do
+      it 'renders invite details with provider name' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.text).to include(provider.name)
+        expect(result.text).to include(course1.name_and_code)
+      end
+    end
+
+    context 'when an invite matches an application choice' do
+      before do
+        create(
+          :application_choice,
+          application_form: application_form,
+          course_option: create(:course_option, course: course1),
+          provider_ids: [provider.id],
+        )
+      end
+
+      it 'renders link to view application for that course' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.text).to include(course1.name_and_code)
+        expect(result.text).to include('View application')
+      end
+    end
+
+    context 'when no invites belong to the current provider user`s providers' do
       let(:other_provider) { create(:provider) }
       let(:current_provider_user) { create(:provider_user, providers: [other_provider]) }
 
@@ -73,7 +105,7 @@ RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCourse
                                  show_provider_name: true,
                                ))
 
-        expect(result.to_html).to be_blank
+        expect(result.text).to be_blank
       end
     end
   end

--- a/spec/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::AlreadyInvitedToMultipleCoursesBannerComponent, type: :component do
+  describe '#render?' do
+    let(:candidate) { create(:candidate) }
+    let(:application_form) { create(:application_form, candidate:, submitted_at: 1.day.ago) }
+    let(:provider) { create(:provider) }
+    let(:current_provider_user) { create(:provider_user, providers: [provider]) }
+
+    let!(:invite1) do
+      create(:pool_invite, :published, candidate:, provider:, created_at: 2.days.ago)
+    end
+
+    let!(:invite2) do
+      create(:pool_invite, :published, candidate:, provider:, created_at: 1.day.ago)
+    end
+
+    let(:course1) { invite1.course }
+    let(:course2) { invite2.course }
+
+    # TODO: Context blocks for when the candidate has not yet been invited to one or either of the courses (displays "They have not applied yet")
+    # TODO: Context blocks for when the candidate has been invited to one or both of the courses (shows view application link(s))
+
+    context 'when multiple invites exist' do
+      it 'renders the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: false,
+                               ))
+
+        expect(result.text).to include(I18n.t('provider_interface.find_candidates.already_invited_to_multiple_courses_banner_component.heading'))
+        expect(result.text).to include(course1.name_and_code)
+        expect(result.text).to include(course2.name_and_code)
+      end
+    end
+
+    context 'when only one invite exists' do
+      before { invite2.destroy }
+
+      it 'does not render the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.to_html).to be_blank
+      end
+    end
+
+    context 'when show_provider_name is false' do
+      it 'renders banner text without the provider name' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: false,
+                               ))
+
+        expect(result.text).to include(course1.name_and_code)
+        expect(result.text).not_to include(provider.name)
+      end
+    end
+
+    context 'when no matching invites for the current provider user exist' do
+      let(:other_provider) { create(:provider) }
+      let(:current_provider_user) { create(:provider_user, providers: [other_provider]) }
+
+      it 'does not render the banner' do
+        result = render_inline(described_class.new(
+                                 application_form:,
+                                 current_provider_user:,
+                                 show_provider_name: true,
+                               ))
+
+        expect(result.to_html).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Providers have told us that it is hard to keep track of candidates they have already invited to apply, which means they could waste time reviewing profiles they’ve already make a decision on, worry about accidentally inviting them again, and are unable to track the success of any invitations they’ve sent.

## Changes proposed in this pull request

Add a banner to the top of the profile page when viewing a candidate your organisation has already invited to a course/courses.

### Previews:
https://apply-review-10890.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/already_invited_to_multiple_courses_banner_component

https://apply-review-10890.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/already_invited_candidate_banner_component

### Invited, application received clips

_One invite with application submitted_

https://github.com/user-attachments/assets/d1273e1e-5605-4353-b408-33a194b638d8

_Multiple invites with a mix of statuses (no action/received/received and withdrawn)_

https://github.com/user-attachments/assets/b8dcd752-ddbd-4100-b995-1b5d785428db

## Guidance to review

- Log in as a provider and invite candidates to courses to see singular and plural "They have not applied yet" banners
- Log in as the candidate and submit an application for one of the invited courses and return to the provider view to see the "View application" banner and check that it links through as expected

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
