### PR TITLE
Rename ProviderUserFilter path column to kind

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -278,7 +278,7 @@
   :provider_user_filters:
   - id
   - provider_user_id
-  - path
+  - kind
   - pagination_page
   - filters
   - created_at

--- a/db/migrate/20250627104638_rename_path_column_provider_user_filters.rb
+++ b/db/migrate/20250627104638_rename_path_column_provider_user_filters.rb
@@ -1,0 +1,7 @@
+class RenamePathColumnProviderUserFilters < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      rename_column :provider_user_filters, :path, :kind
+    end
+  end
+end

--- a/db/migrate/20250627111652_index_to_kind_on_provider_user_filters.rb
+++ b/db/migrate/20250627111652_index_to_kind_on_provider_user_filters.rb
@@ -1,0 +1,7 @@
+class IndexToKindOnProviderUserFilters < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :provider_user_filters, :kind, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_27_102530) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_27_111652) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -836,11 +836,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_27_102530) do
 
   create_table "provider_user_filters", force: :cascade do |t|
     t.bigint "provider_user_id", null: false
-    t.string "path", null: false
+    t.string "kind", null: false
     t.integer "pagination_page"
     t.jsonb "filters", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["kind"], name: "index_provider_user_filters_on_kind"
     t.index ["provider_user_id"], name: "index_provider_user_filters_on_provider_user_id"
   end
 


### PR DESCRIPTION
## Context

We won't be storing the url path in the ProviderUserFilters table so we can rename this column to something more descriptive.

There are no records in production DB for this table so we can rename it the dumb way.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
