### PR TITLE
Adds excluded_courses to course recommender

### DIFF
--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -146,20 +146,19 @@ private
 
   def excluded_courses
     # Does the Candidate have any submitted Applications?
-    return unless candidate.application_choices
-                           .joins(:application_form)
-                           .where(application_form: { recruitment_cycle_year: current_year })
-                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    return unless candidate.current_application.application_choices.visible_to_provider.any?
 
     # What Courses has the Candidate applied for?
     # course codes & provider codes
-    candidate.current_application.application_choices.visible_to_provider
-                       .joins(course_option: { course: :provider })
-                       .pluck('course.code', 'provider.code')
-                       .compact_blank
-                       .uniq
-                       .sort
-                       .map.with_index { |(course_code, provider_code), index| [index, { course_code: course_code, provider_code: provider_code }] }
+    candidate.current_application
+             .application_choices
+             .visible_to_provider
+             .joins(course_option: { course: :provider })
+             .pluck('course.code', 'provider.code')
+             .compact_blank
+             .uniq
+             .sort
+             .map.with_index { |(course_code, provider_code), index| [index, { course_code: course_code, provider_code: provider_code }] }
              .to_h
   end
 end

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -153,10 +153,7 @@ private
 
     # What Courses has the Candidate applied for?
     # course codes & provider codes
-    candidate.application_choices
-                       .joins(:application_form)
-                       .where(application_form: { recruitment_cycle_year: current_year })
-                       .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    candidate.current_application.application_choices.visible_to_provider
                        .joins(course_option: { course: :provider })
                        .pluck('course.code', 'provider.code')
                        .compact_blank

--- a/spec/services/candidate_courses_recommender_spec.rb
+++ b/spec/services/candidate_courses_recommender_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateCoursesRecommender do
   describe '.recommended_courses_url' do
     it 'returns nil when there is no recommendations' do
-      candidate = build(:candidate)
+      candidate = create(:candidate)
 
       expect(described_class.recommended_courses_url(candidate:)).to be_nil
     end


### PR DESCRIPTION
## Context

We don't want to recommend courses that a Candidate has already applied to in the past. 

## Changes proposed in this pull request

This param is populated with the courses that the Candidate has already applied to

## Guidance to review

- N/A
- Requires https://github.com/DFE-Digital/publish-teacher-training/pull/5365 to be fully integrated
    - This PR can be merged without the change on publish as we're not currently using this link

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
