### PR TITLE
Data migraiton to add application forms to pool invites

### DIFF
--- a/app/services/data_migrations/backfill_application_form_on_pool_invites.rb
+++ b/app/services/data_migrations/backfill_application_form_on_pool_invites.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class BackfillApplicationFormOnPoolInvites
+    TIMESTAMP = 20250630103024
+    MANUAL_RUN = false
+
+    def change
+      # There are currently about 1500 invites, so this will take no time at all. Tested locally with 1300
+      Pool::Invite.where(application_form: nil).includes(candidate: :application_forms).find_each do |invite|
+        invite.update(application_form: invite.candidate.current_application)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillApplicationFormOnPoolInvites',
   'DataMigrations::BackfillTrainingLocationsOnCandidatePreferences',
   'DataMigrations::BackfillRecruitmentCycleYearOnPoolInvites',
   'DataMigrations::DeleteSandboxOneLoginAccounts',

--- a/spec/services/data_migrations/backfill_application_form_on_pool_invites_spec.rb
+++ b/spec/services/data_migrations/backfill_application_form_on_pool_invites_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillApplicationFormOnPoolInvites do
+  it 'add application form to pool invites where one does not exist' do
+    application_form = create(:application_form)
+    invite_without_application = build(:pool_invite, application_form: nil, candidate: application_form.candidate, recruitment_cycle_year: application_form.recruitment_cycle_year)
+    invite_without_application.save(validate: false)
+
+    described_class.new.change
+
+    expect(invite_without_application.reload.application_form).to eq application_form
+  end
+end


### PR DESCRIPTION
## Context

Migration to backfill application form data to pool invites.

## Changes proposed in this pull request

There are about 1500 pool invites currently, so this will be a very quick job.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
