### PR TITLE
Personal statement truncate restore ellipsis

### DIFF
--- a/app/components/provider_interface/find_candidates/personal_statement_component.html.erb
+++ b/app/components/provider_interface/find_candidates/personal_statement_component.html.erb
@@ -11,7 +11,7 @@
   <%= govuk_link_to(
         t('.read_more'),
         '#',
-        class: 'app-show-more-show-less govuk-visually-hidden',
+        class: 'govuk-body app-show-more-show-less govuk-visually-hidden',
         data: {
           container: 'app-remaining-personal-statement',
           'section-container': 'personal-statement-section',

--- a/app/components/provider_interface/find_candidates/personal_statement_component.rb
+++ b/app/components/provider_interface/find_candidates/personal_statement_component.rb
@@ -15,10 +15,7 @@ class ProviderInterface::FindCandidates::PersonalStatementComponent < ViewCompon
   end
 
   def truncated_personal_statement
-    personal_statement.truncate_words(
-      MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT,
-      omission: ' ',
-    )
+    personal_statement.truncate_words(MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT)
   end
 
   def remaining_personal_statement_text


### PR DESCRIPTION
## Context

In research, a couple of providers initially thought they were looking at a very short personal statement rather than a truncated one, as they did not immediately spot the ‘read more’ link.

The users did see the link eventually, but it caused a moment of confusion. We would like to keep the truncating functionality as although most users wanted to read the personal statement in full, they would often do a lot of scrolling up and down looking at different things before they did so - showing the personal statement in full would make the page considerably longer and make this harder.

## Changes proposed in this pull request

To make the expandable text for conspicuous:
- Truncate the personal statement content with a trailing ellipsis
- Make the ‘Read more’ link the same size as the body text

<img width="514" alt="Screenshot 2025-07-02 at 09 34 07" src="https://github.com/user-attachments/assets/fe6c6f58-f20e-471b-9a12-a3769345cf4d" />

## Guidance to review

- This is a small update. It should be sufficient to check the diff for any improvements.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
