### PR TITLE
Candidate pool seeds

### DIFF
--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -1,0 +1,52 @@
+class GenerateCandidatePoolData
+  def self.call
+    new.call
+  end
+
+  def call
+    return if HostingEnvironment.production?
+
+    CandidatePoolProviderOptIn.insert_all(
+      Provider.ids.map { |provider_id| { provider_id: } },
+    )
+
+    application_forms = Pool::Candidates.new.curated_application_forms
+
+    locations = [
+      { name: 'Manchester UK', coordinates: [53.4807593, -2.2426305] },
+      { name: 'London UK', coordinates: [51.5072178, -0.1275862] },
+      { name: 'Bristol UK', coordinates: [51.454513, -2.58791] },
+      { name: 'York UK', coordinates: [53.9614205, -1.0739108] },
+      { name: 'Liverpool UK', coordinates: [53.4083714, -2.9915726] },
+      { name: 'Birmingham UK', coordinates: [52.4822694, -1.8900078] },
+    ]
+    within_range = [10, 20, 30, 50, 100]
+
+    preference_attrs = application_forms.map do |form|
+      {
+        pool_status: 'opt_in',
+        status: 'published',
+        dynamic_location_preferences: true,
+        candidate_id: form.candidate_id,
+        training_locations: rand(100) < 20 ? 'anywhere' : 'specific', # 20% anywhere
+      }
+    end
+    CandidatePreference.insert_all(preference_attrs)
+
+    location_preference_attrs = CandidatePreference.all.map do |preference|
+      next if preference.training_locations.nil?
+
+      location = locations.sample
+      {
+        name: location[:name],
+        within: within_range.sample,
+        latitude: location[:coordinates].first,
+        longitude: location[:coordinates].last,
+        candidate_preference_id: preference.id,
+      }
+    end
+    CandidateLocationPreference.insert_all(location_preference_attrs)
+
+    FindACandidate::PopulatePoolWorker.perform_sync
+  end
+end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -44,6 +44,9 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
 
   puts 'Finding duplicate applications'
   UpdateDuplicateMatchesWorker.new.perform
+
+  puts 'Populate Candiate pool'
+  GenerateCandidatePoolData.call
 end
 
 desc 'Create undergraduate courses'

--- a/spec/services/generate_candidate_pool_data_spec.rb
+++ b/spec/services/generate_candidate_pool_data_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe GenerateCandidatePoolData do
+  describe '.call' do
+    it 'populated the candidate pool with dummy data' do
+      rejected_application_form = create(:application_form, :completed)
+      create(:application_choice, :rejected, application_form: rejected_application_form)
+      declined_application_form = create(:application_form, :completed)
+      create(:application_choice, :declined, application_form: declined_application_form)
+
+      expect { described_class.call }.to change(CandidatePreference, :count).from(0).to(2)
+        .and change(CandidatePoolProviderOptIn, :count).from(0).to(2)
+        .and change(CandidatePoolApplication, :count).from(0).to(2)
+    end
+
+    context 'when production' do
+      it 'does not create any records related to candidate pool' do
+        allow(HostingEnvironment).to receive(:production?).and_return(true)
+        rejected_application_form = create(:application_form, :completed)
+        create(:application_choice, :rejected, application_form: rejected_application_form)
+        declined_application_form = create(:application_form, :completed)
+        create(:application_choice, :declined, application_form: declined_application_form)
+
+        expect { described_class.call }.to not_change(CandidatePreference, :count)
+          .and not_change(CandidatePoolProviderOptIn, :count)
+          .and not_change(CandidatePoolApplication, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This adds dummy data for the candidate pool.

It opts all the providers in the feature and gets the candidates that
are eligible for the pool and adds candidate preferences for them.

Then runs the worker to create CandidatePoolApplication records

This should not run in production.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![image](https://github.com/user-attachments/assets/7d62d9af-b099-497c-9137-ccc1496e977a)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
