### PR TITLE
[1030] fac remove a providers previously rejected candidates

### DIFF
--- a/app/models/candidate_pool_application.rb
+++ b/app/models/candidate_pool_application.rb
@@ -17,7 +17,7 @@ class CandidatePoolApplication < ApplicationRecord
     return scope if provider_user.blank?
 
     provider_ids = provider_user.providers.ids
-    rejected_application_ids = where('rejected_provider_ids @> ARRAY[?]::bigint[]', Array.wrap(provider_ids)).pluck(:application_form_id)
+    rejected_application_ids = where('rejected_provider_ids @> ARRAY[?]::bigint[]', Array.wrap(provider_ids)).select(:application_form_id)
 
     scope.where.not(application_form_id: rejected_application_ids)
   end

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -87,7 +87,7 @@ class Pool::Candidates
 private
 
   def filtered_application_forms
-    scope = CandidatePoolApplication.filtered_application_forms(filters)
+    scope = CandidatePoolApplication.filtered_application_forms(filters, provider_user)
     scope = filter_by_distance(scope)
     calculate_statuses(scope)
   end

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -7,7 +7,7 @@ class FindACandidate::PopulatePoolWorker
     application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool
 
     applications = application_forms_eligible_for_pool
-                     .joins(application_choices: { course_option: { course: %i[subjects provider] } })
+                     .joins(application_choices: { course_option: { course: :subjects } })
                      .where.not(application_choices: { status: 'unsubmitted' })
                      .select(
                        'application_forms.id AS application_form_id',
@@ -17,7 +17,7 @@ class FindACandidate::PopulatePoolWorker
                        "BOOL_OR(courses.program_type != 'TDA') AS course_type_postgraduate",
                        "BOOL_OR(courses.program_type = 'TDA') AS course_type_undergraduate",
                        'ARRAY_AGG(DISTINCT subjects.id) AS subject_ids',
-                       "COALESCE(ARRAY_AGG(DISTINCT providers.id) FILTER (WHERE application_choices.status = 'rejected'), '{}') AS rejected_provider_ids",
+                       "COALESCE(ARRAY_AGG(DISTINCT courses.provider_id) FILTER (WHERE application_choices.status = 'rejected'), '{}') AS rejected_provider_ids",
                        "MAX(CASE WHEN application_forms.right_to_work_or_study = 'no' OR (application_forms.right_to_work_or_study = 'yes' AND application_forms.immigration_status IN ('student_visa', 'skilled_worker_visa')) THEN 1 ELSE 0 END) = 1 AS needs_visa",
                        'CURRENT_TIMESTAMP as created_at',
                        'CURRENT_TIMESTAMP as updated_at',

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -7,7 +7,7 @@ class FindACandidate::PopulatePoolWorker
     application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool
 
     applications = application_forms_eligible_for_pool
-                     .joins(application_choices: { course_option: { course: :subjects } })
+                     .joins(application_choices: { course_option: { course: %i[subjects provider] } })
                      .where.not(application_choices: { status: 'unsubmitted' })
                      .select(
                        'application_forms.id AS application_form_id',
@@ -17,6 +17,7 @@ class FindACandidate::PopulatePoolWorker
                        "BOOL_OR(courses.program_type != 'TDA') AS course_type_postgraduate",
                        "BOOL_OR(courses.program_type = 'TDA') AS course_type_undergraduate",
                        'ARRAY_AGG(DISTINCT subjects.id) AS subject_ids',
+                       "COALESCE(ARRAY_AGG(DISTINCT providers.id) FILTER (WHERE application_choices.status = 'rejected'), '{}') AS rejected_provider_ids",
                        "MAX(CASE WHEN application_forms.right_to_work_or_study = 'no' OR (application_forms.right_to_work_or_study = 'yes' AND application_forms.immigration_status IN ('student_visa', 'skilled_worker_visa')) THEN 1 ELSE 0 END) = 1 AS needs_visa",
                        'CURRENT_TIMESTAMP as created_at',
                        'CURRENT_TIMESTAMP as updated_at',
@@ -32,6 +33,7 @@ class FindACandidate::PopulatePoolWorker
         course_type_postgraduate,
         course_type_undergraduate,
         subject_ids,
+        rejected_provider_ids,
         needs_visa,
         created_at,
         updated_at

--- a/spec/models/candidate_pool_application_spec.rb
+++ b/spec/models/candidate_pool_application_spec.rb
@@ -89,6 +89,21 @@ RSpec.describe CandidatePoolApplication do
       expect(application_forms.ids).to contain_exactly(
         visa_sponsorship_candidate_form.id,
       )
+
+      provider_user = create(:provider_user, :with_two_providers)
+      form_rejected_by_both_providers = create(:application_form)
+      form_rejected_by_one_provider = create(:application_form)
+      form_rejected_by_another_provider = create(:application_form)
+
+      create(:candidate_pool_application, application_form: form_rejected_by_both_providers, rejected_provider_ids: provider_user.provider_ids)
+      create(:candidate_pool_application, application_form: form_rejected_by_one_provider, rejected_provider_ids: [provider_user.providers.first.id])
+      create(:candidate_pool_application, application_form: form_rejected_by_another_provider, rejected_provider_ids: [create(:provider).id])
+
+      application_forms = described_class.filtered_application_forms({}, provider_user)
+
+      expect(application_forms.ids).to include(form_rejected_by_one_provider.id)
+      expect(application_forms.ids).to include(form_rejected_by_another_provider.id)
+      expect(application_forms.ids).not_to include(form_rejected_by_both_providers.id)
     end
   end
 end


### PR DESCRIPTION
## Context

Providers do not want to view and potentially invite candidates that they have already rejected. 

## Changes proposed in this pull request

- Update the PopulatePoolWorker to collect the IDs of those providers who have rejected a candidate in a pool
- when filtering the `CandidatePoolApplications`, remove those applications that have been rejected by all the providers for which the user has access.

## Guidance to review

You can test it on the review app or locally. 
- Have a look at the candidates in find a candidate
- Login as one of those candidates and submit an application to a provider user with access to.
- Login as that provider user, and reject the application
- Re-run the PopulatePoolWorker on the command line. 
- Refresh the candidates tab, and the rejected application will disappear. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
