### PR TITLE
Add copy link to find a candidate show page

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/shares_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/shares_controller.rb
@@ -1,0 +1,39 @@
+module ProviderInterface
+  module CandidatePool
+    class SharesController < ProviderInterfaceController
+      before_action :redirect_to_applications_unless_provider_opted_in
+      before_action :set_candidate
+      before_action :set_back_link
+
+      def show; end
+
+    private
+
+      def set_candidate
+        @application_form = Pool::Candidates.application_forms_for_provider
+          .find_by(candidate_id: params.expect(:candidate_id))
+
+        redirect_to provider_interface_applications_path if @application_form.nil?
+
+        @candidate = @application_form.candidate
+      end
+
+      def set_back_link
+        @back_link ||= if params[:return_to].present?
+                         provider_interface_candidate_pool_candidate_url(
+                           @candidate,
+                           return_to: params[:return_to],
+                         )
+                       else
+                         provider_interface_candidate_pool_candidate_url(@candidate)
+                       end
+      end
+
+      def redirect_to_applications_unless_provider_opted_in
+        invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
+
+        redirect_to provider_interface_applications_path if invites.blank?
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/candidate_pool/shares_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/shares_controller.rb
@@ -5,7 +5,9 @@ module ProviderInterface
       before_action :set_candidate
       before_action :set_back_link
 
-      def show; end
+      def show
+        @candidate_profile_link = provider_interface_candidate_pool_candidate_url(@candidate)
+      end
 
     private
 

--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -10,12 +10,14 @@ import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 // stimulus
 import { Application } from '@hotwired/stimulus'
 import LocationAutocompleteController from './controllers/location_autocomplete_controller'
+import CopyToClipboardController from './controllers/copy_to_clipboard_controller.js'
 import showMoreShowLess from './components/show-more-show-less'
 
 require.context('govuk-frontend/dist/govuk/assets')
 
 window.Stimulus = Application.start()
 window.Stimulus.register('location-autocomplete', LocationAutocompleteController)
+window.Stimulus.register('copy-to-clipboard', CopyToClipboardController)
 
 govUKFrontendInitAll()
 initWarnOnUnsavedChanges()

--- a/app/frontend/packs/controllers/copy_to_clipboard_controller.js
+++ b/app/frontend/packs/controllers/copy_to_clipboard_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['button', 'successTag']
+  static values = { text: String }
+
+  connect () {
+    // Feature works only for javascript enabled users
+    this.buttonTarget.style.display = 'inline'
+  }
+
+  call (event) {
+    event.preventDefault()
+
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
+
+    navigator.clipboard.writeText(this.textValue)
+    this.successTagTarget.hidden = false
+
+    this.timeout = setTimeout(() => {
+      this.successTagTarget.hidden = true
+    }, 5000)
+  }
+}

--- a/app/frontend/packs/controllers/copy_to_clipboard_controller.js
+++ b/app/frontend/packs/controllers/copy_to_clipboard_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   connect () {
     // Feature works only for javascript enabled users
-    this.buttonTarget.style.display = 'inline'
+    this.buttonTarget.classList.remove('govuk-visually-hidden')
   }
 
   call (event) {

--- a/app/frontend/styles/_paragraph.scss
+++ b/app/frontend/styles/_paragraph.scss
@@ -1,0 +1,7 @@
+.align-self-center {
+  align-self: center;
+}
+
+.color-green {
+  color: govuk-colour("green");
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -72,6 +72,7 @@ $govuk-new-link-styles: true;
 @import "previews";
 @import "metadata";
 @import "components/tabs";
+@import "paragraph";
 
 // Override utilities
 @import "overrides";

--- a/app/frontend/styles/provider/_button.scss
+++ b/app/frontend/styles/provider/_button.scss
@@ -39,7 +39,3 @@ $app-button-inverted-hover-background-colour: govuk-tint(
   border-color: $govuk-focus-colour;
   box-shadow: inset 0 0 0 2px $govuk-focus-colour;
 }
-
-.hidden {
-  display: none;
-}

--- a/app/frontend/styles/provider/_button.scss
+++ b/app/frontend/styles/provider/_button.scss
@@ -39,3 +39,7 @@ $app-button-inverted-hover-background-colour: govuk-tint(
   border-color: $govuk-focus-colour;
   box-shadow: inset 0 0 0 2px $govuk-focus-colour;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -134,7 +134,7 @@ class NavigationItems
           items << {
             text: 'Find candidates',
             href: provider_interface_candidate_pool_root_path,
-            active: active?(current_controller, %w[candidates draft_invites invites not_seen]),
+            active: active?(current_controller, %w[candidates draft_invites invites not_seen shares]),
           }
         end
 

--- a/app/views/provider_interface/candidate_pool/candidates/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/show.html.erb
@@ -7,13 +7,24 @@
 
     <span class="govuk-caption-xl"><%= t('.candidate_number', candidate_id: @candidate.id) %></span>
     <h1 class="govuk-heading-xl"><%= @application_form.redacted_full_name %></h1>
-    <% if @policy.can_invite_candidates? %>
+
+    <div class='govuk-button-group'>
+      <% if @policy.can_invite_candidates? %>
+        <%= govuk_button_to(
+              t('.invite'),
+              new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate),
+              method: :get,
+            ) %>
+      <% end %>
+
       <%= govuk_button_to(
-            t('.invite'),
-            new_provider_interface_candidate_pool_candidate_draft_invite_path(@candidate),
-            method: :get,
-          ) %>
-    <% end %>
+        t('.share'),
+        provider_interface_candidate_pool_candidate_shares_path(@candidate),
+        params: { return_to: params[:return_to] },
+        secondary: true,
+        method: :get,
+      ) %>
+    </div>
 
     <h2 class="govuk-heading-l"><%= t('.right_to_work_and_study') %></h2>
 

--- a/app/views/provider_interface/candidate_pool/shares/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/shares/show.html.erb
@@ -9,12 +9,12 @@
     <h1 class="govuk-heading-xl"><%= @application_form.redacted_full_name %></h1>
 
     <p class='govuk-body'><%= t('.copy_and_paste_message') %></p>
-    <p class='govuk-body govuk-!-font-weight-bold'><%= @back_link %></p>
+    <p class='govuk-body govuk-!-font-weight-bold'><%= @candidate_profile_link %></p>
 
-    <div class='govuk-button-group' data-controller='copy-to-clipboard' data-copy-to-clipboard-text-value="<%= @back_link %>">
+    <div class='govuk-button-group' data-controller='copy-to-clipboard' data-copy-to-clipboard-text-value="<%= @candidate_profile_link %>">
       <%= govuk_button_to(
         t('.copy'),
-        class: 'hidden',
+        class: 'govuk-visually-hidden',
         data: {
           action: 'click->copy-to-clipboard#call',
           copy_to_clipboard_target: 'button',

--- a/app/views/provider_interface/candidate_pool/shares/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/shares/show.html.erb
@@ -1,0 +1,31 @@
+<% content_for :browser_title, t('.title') %>
+<% content_for :before_content, govuk_back_link_to(@back_link) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ServiceInformationBanner.new(namespace: :provider) %>
+
+    <span class="govuk-caption-xl"><%= t('.candidate_number', candidate_id: @candidate.id) %></span>
+    <h1 class="govuk-heading-xl"><%= @application_form.redacted_full_name %></h1>
+
+    <p class='govuk-body'><%= t('.copy_and_paste_message') %></p>
+    <p class='govuk-body govuk-!-font-weight-bold'><%= @back_link %></p>
+
+    <div class='govuk-button-group' data-controller='copy-to-clipboard' data-copy-to-clipboard-text-value="<%= @back_link %>">
+      <%= govuk_button_to(
+        t('.copy'),
+        class: 'hidden',
+        data: {
+          action: 'click->copy-to-clipboard#call',
+          copy_to_clipboard_target: 'button',
+        },
+        secondary: true,
+        method: :get,
+      ) %>
+
+      <p class='govuk-body align-self-center color-green' data-copy-to-clipboard-target='successTag' hidden>
+        <%= t('.copy_success') %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -65,6 +65,7 @@ en:
         show:
           title: Candidate details
           invite: Invite to apply
+          share: Share this candidate’s profile
           right_to_work_and_study: Right to work or study in the UK
           qualifications: Qualifications
           degree:
@@ -81,6 +82,13 @@ en:
           personal_statement_title: Personal statement
           safeguarding_title: Criminal record and professional misconduct
           application_choices_title: Applications submitted
+      shares:
+        show:
+          title: Share candidate
+          copy: Copy to clipboard
+          copy_success: Link copied to clipboard
+          candidate_number: "Candidate number:  %{candidate_id}"
+          copy_and_paste_message: Copy and paste this link to share this candidate’s profile with colleagues.
       draft_invites:
         new:
           title: Select a course to invite %{candidate_name} to apply to

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -85,7 +85,7 @@ en:
       shares:
         show:
           title: Share candidate
-          copy: Copy to clipboard
+          copy: Copy link to clipboard
           copy_success: Link copied to clipboard
           candidate_number: "Candidate number:  %{candidate_id}"
           copy_and_paste_message: Copy and paste this link to share this candidate’s profile with colleagues.

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -29,6 +29,7 @@ namespace :provider_interface, path: '/provider' do
     resources :not_seen, only: %i[index], path: 'not-seen'
     resources :invites, only: %i[index show], path: 'invited'
     resources :candidates, only: %i[index show], path: '/' do
+      resource :shares, only: %i[show], path: 'share'
       resources :draft_invites, path: 'invite' do
         resource :provider_invite_messages, only: %i[new create edit update], path: 'message'
         resource :publish_invite, only: %i[create], path: 'review'

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Provider shares candiate profile' do
 
     when_i_click('Share this candidate’s profile')
     then_i_am_redirected_to_the_share_page
-    when_i_click('Copy to clipboard')
+    when_i_click('Copy link to clipboard')
     then_i_can_see_success_message
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'Provider shares candiate profile' do
     host = Capybara.current_session.server.host
     port = Capybara.current_session.server.port
     expect(page).to have_content(
-      "http://#{host}:#{port}#{provider_interface_candidate_pool_candidate_path(@rejected_candidate, return_to: 'all')}",
+      "http://#{host}:#{port}#{provider_interface_candidate_pool_candidate_path(@rejected_candidate)}",
     )
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider shares candiate profile' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  let(:current_provider) { create(:provider) }
+
+  scenario 'View a candidate', :js do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_provider_user_exists
+    and_there_are_candidates_for_candidate_pool
+    and_provider_is_opted_in_to_candidate_pool
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_find_candidates_page
+    and_i_click_on_a_candidate
+    then_i_am_redirected_to_view_that_candidate
+
+    when_i_click('Share this candidate’s profile')
+    then_i_am_redirected_to_the_share_page
+    when_i_click('Copy to clipboard')
+    then_i_can_see_success_message
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_provider_user_exists
+    provider_user_exists_in_apply_database(provider_code: current_provider.code)
+  end
+
+  def and_there_are_candidates_for_candidate_pool
+    @rejected_candidate = create(:candidate)
+    create(:candidate_preference, candidate: @rejected_candidate)
+    @rejected_candidate_form = create(
+      :application_form,
+      :completed,
+      first_name: 'Rejected',
+      last_name: 'Candidate',
+      candidate: @rejected_candidate,
+      submitted_at: 1.day.ago,
+    )
+    create(:candidate_pool_application, application_form: @rejected_candidate_form)
+  end
+
+  def and_provider_is_opted_in_to_candidate_pool
+    create(:candidate_pool_provider_opt_in, provider: current_provider)
+  end
+
+  def when_i_visit_the_find_candidates_page
+    visit provider_interface_candidate_pool_root_path
+  end
+
+  def and_i_click_on_a_candidate
+    click_on @rejected_candidate.redacted_full_name_current_cycle
+  end
+
+  def then_i_am_redirected_to_view_that_candidate
+    expect(page).to have_current_path(provider_interface_candidate_pool_candidate_path(@rejected_candidate), ignore_query: true)
+  end
+
+  def when_i_click(button)
+    click_link_or_button button
+  end
+
+  def then_i_am_redirected_to_the_share_page
+    expect(page).to have_current_path(provider_interface_candidate_pool_candidate_shares_path(@rejected_candidate), ignore_query: true)
+
+    host = Capybara.current_session.server.host
+    port = Capybara.current_session.server.port
+    expect(page).to have_content(
+      "http://#{host}:#{port}#{provider_interface_candidate_pool_candidate_path(@rejected_candidate, return_to: 'all')}",
+    )
+  end
+
+  def then_i_can_see_success_message
+    expect(page).to have_content('Link copied to clipboard')
+  end
+end


### PR DESCRIPTION
## Context

We want to make it easier for provider users to share candidates from find a candidate.

This adds a share button on the show page that redirects to a page where you can copy the show link of a FAC candidate. This is meant to be shared with someone else.

If javascript is disabled the copy to clipboard button will not show.

The javascript is inspired by the [stimulus components](https://www.stimulus-components.com/docs/stimulus-clipboard/#mobile-menu) clipboard feature. I'm not convinced we should introduce a new library to just remove some javascript lines.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and click the link. Disable javascript, the button to copy the link should not appear.

![image](https://github.com/user-attachments/assets/29538338-1b67-4dbb-ad65-e2c412db9efe)


![image](https://github.com/user-attachments/assets/f65b54aa-d467-40c7-b4bf-953e9bf611d5)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
