### PR TITLE
Update the application invite notification banner so that it only displays for course matches

### DIFF
--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -16,7 +16,7 @@
 
 <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present || @application_choice.rejected? %>
 
-<%= render ProviderInterface::CandidateInvitedBannerComponent.new(application_form: @application_choice.application_form, current_provider_user:) %>
+<%= render ProviderInterface::CandidateInvitedBannerComponent.new(application_choice: @application_choice, current_provider_user:) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom">Application</h2>
 


### PR DESCRIPTION
## Context

[This PR ](https://trello.com/c/2iNZQTtU/1033-fac-application-invite-banners-in-applications-candidate-view) was intended to create a banner that only shows when the invite course and the application choice course are a match. This allows providers to see when an application has been received as likely the direct result of an invitation.

## Changes proposed in this pull request

- Add matching logic to the component 
- Update specs

https://github.com/user-attachments/assets/a78bbd62-7ab7-4ade-9363-f96ebcb0cd3a


## Guidance to review

- Log in as a provider and invite an applicant to some courses
- Log in as the candidate and submit an application to one of the invited courses
- Log back in as the provider and check that you see the banner only on the one where an application was made

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
