### PR TITLE
Added invites field to hidden PII

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -26,3 +26,6 @@ shared:
     - email_address
   candidate_preferences:
     - candidate_id
+  pool_invites:
+    - application_form_id
+    - candidate_id


### PR DESCRIPTION
## Context

Fields are marked as PII fields in BQ

## Changes proposed in this pull request

- Added pool_invites.application_form_id and pool_invites.candidate_id to hidden_pii.yml
- 
## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
