### PR TITLE
Course Recommender checks for Safeguarding and In Progress Applications

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -110,6 +110,10 @@ class ApplicationChoice < ApplicationRecord
     ApplicationStateChange::IN_PROGRESS_STATES.include? status.to_sym
   end
 
+  def self.in_progress
+    where(status: ApplicationStateChange::IN_PROGRESS_STATES)
+  end
+
   def application_unsuccessful?
     ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -81,6 +81,17 @@ class Candidate < ApplicationRecord
     end
   end
 
+  def self.with_safeguarding_concerns
+    safeguarding_on_application_forms = joins(:application_forms).where(application_forms: { safeguarding_issues_status: :has_safeguarding_issues_to_declare })
+    safeguarding_on_references = joins(application_forms: :application_references).where(application_references: { safeguarding_concerns_status: :has_safeguarding_concerns_to_declare })
+
+    with(
+      safeguarding_on_application_forms: safeguarding_on_application_forms,
+      safeguarding_on_references: safeguarding_on_references,
+    ).where(id: safeguarding_on_application_forms.select('candidates.id'))
+     .or(where(id: safeguarding_on_references.select('candidates.id')))
+  end
+
   def current_application
     application_form = application_forms.order(:created_at, :id).last
     application_form || if RecruitmentCycleTimetable.current_timetable.after_apply_deadline?

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -96,6 +96,14 @@ class Candidate < ApplicationRecord
     where.not(id: with_safeguarding_concerns)
   end
 
+  def safeguarding_concerns?
+    @has_safeguarding_concerns ||= begin
+      application_forms_with_safeguarding_concerns = application_forms.exists?(safeguarding_issues_status: :has_safeguarding_issues_to_declare)
+      application_references_with_safeguarding_concerns = application_references.exists?(safeguarding_concerns_status: :has_safeguarding_concerns_to_declare)
+      application_forms_with_safeguarding_concerns || application_references_with_safeguarding_concerns
+    end
+  end
+
   def current_application
     application_form = application_forms.order(:created_at, :id).last
     application_form || if RecruitmentCycleTimetable.current_timetable.after_apply_deadline?

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -92,6 +92,10 @@ class Candidate < ApplicationRecord
      .or(where(id: safeguarding_on_references.select('candidates.id')))
   end
 
+  def self.without_safeguarding_concerns
+    where.not(id: with_safeguarding_concerns)
+  end
+
   def current_application
     application_form = application_forms.order(:created_at, :id).last
     application_form || if RecruitmentCycleTimetable.current_timetable.after_apply_deadline?

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -12,12 +12,25 @@ class CandidateCoursesRecommender
   end
 
   def recommended_courses_url
-    find_url_with_query_params if recommended?
+    candidate_suitable_for_recommendation? && create_recommended_courses_url
   end
 
 private
 
   attr_reader :candidate, :locatable
+
+  def candidate_suitable_for_recommendation?
+    # Candidate does not have any safeguarding concerns on their applications
+    # Candidate does not have any safeguarding concerns on their references
+    !candidate.safeguarding_concerns?
+
+    # Candidate does not have any active applications
+    # Candidate does not already have QTS
+  end
+
+  def create_recommended_courses_url
+    find_url_with_query_params if recommended?
+  end
 
   def current_year
     @current_year ||= RecruitmentCycleTimetable.current_year

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -20,12 +20,18 @@ private
   attr_reader :candidate, :locatable
 
   def candidate_suitable_for_recommendation?
-    # Candidate does not have any safeguarding concerns on their applications
-    # Candidate does not have any safeguarding concerns on their references
-    !candidate.safeguarding_concerns?
+    conditions = [
+      # Candidate does not have any safeguarding concerns on their applications
+      # Candidate does not have any safeguarding concerns on their references
+      !candidate.safeguarding_concerns?,
 
-    # Candidate does not have any active applications
-    # Candidate does not already have QTS
+      # Candidate does not have any active applications
+      candidate.current_application.application_choices.in_progress.none?,
+
+      # Candidate does not already have QTS
+    ]
+
+    conditions.all?
   end
 
   def create_recommended_courses_url

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -125,6 +125,86 @@ RSpec.describe ApplicationChoice do
     end
   end
 
+  describe '.in_progress' do
+    it 'returns nothing when there are no in progress choices' do
+      create(:application_choice, :rejected)
+
+      expect(described_class.in_progress).to be_empty
+    end
+
+    it 'returns all in progress statuses' do
+      # state: in_progress?
+      application_choice_expectations = [
+        {
+          application_choice: create(:application_choice, status: :withdrawn),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :unsubmitted),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :awaiting_provider_decision),
+          expected_to_be_in_progress: true,
+        },
+        {
+          application_choice: create(:application_choice, status: :inactive),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :interviewing),
+          expected_to_be_in_progress: true,
+        },
+        {
+          application_choice: create(:application_choice, status: :rejected),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :application_not_sent),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :offer),
+          expected_to_be_in_progress: true,
+        },
+        {
+          application_choice: create(:application_choice, status: :offer_withdrawn),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :declined),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :pending_conditions),
+          expected_to_be_in_progress: true,
+        },
+        {
+          application_choice: create(:application_choice, status: :conditions_not_met),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :recruited),
+          expected_to_be_in_progress: true,
+        },
+        {
+          application_choice: create(:application_choice, status: :cancelled),
+          expected_to_be_in_progress: false,
+        },
+        {
+          application_choice: create(:application_choice, status: :offer_deferred),
+          expected_to_be_in_progress: true,
+        },
+      ]
+
+      expected_application_choices = application_choice_expectations
+                                       .select { |application_choice_expectation| application_choice_expectation.fetch(:expected_to_be_in_progress) }
+                                       .map { |application_choice_expectation| application_choice_expectation.fetch(:application_choice) }
+
+      expect(described_class.in_progress).to match_array(expected_application_choices)
+    end
+  end
+
   describe '#decision_pending?' do
     it 'returns false for choices in states not requiring provider action' do
       (ApplicationStateChange.valid_states - ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES).each do |state|

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -189,6 +189,30 @@ RSpec.describe Candidate do
     end
   end
 
+  describe '.without_safeguarding_concerns' do
+    it 'returns candidates without safeguarding concerns declared on their Application Form or References' do
+      candidate_with_safeguarding_concerns_on_application = create(:candidate)
+      _application_form_with_safeguarding_concerns = create(:application_form,
+                                                            candidate: candidate_with_safeguarding_concerns_on_application,
+                                                            safeguarding_issues_status: :has_safeguarding_issues_to_declare)
+
+      candidate_with_safeguarding_concerns_on_reference = create(:candidate)
+      application_form_with_reference = create(:application_form,
+                                               candidate: candidate_with_safeguarding_concerns_on_reference,
+                                               safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+      _reference_with_safeguarding_concerns = create(:reference,
+                                                     application_form: application_form_with_reference,
+                                                     safeguarding_concerns_status: :has_safeguarding_concerns_to_declare)
+
+      candidate_without_safeguarding_concerns = create(:candidate)
+      _application_form_without_safeguarding_concerns = create(:application_form,
+                                                               candidate: candidate_without_safeguarding_concerns,
+                                                               safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+
+      expect(described_class.without_safeguarding_concerns).to contain_exactly(candidate_without_safeguarding_concerns)
+    end
+  end
+
   describe '#current_application' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -213,6 +213,38 @@ RSpec.describe Candidate do
     end
   end
 
+  describe '#safeguarding_concerns?' do
+    it 'returns true if the candidate has safeguarding concerns declared on their Application Form' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate:, safeguarding_issues_status: :has_safeguarding_issues_to_declare)
+      _reference = create(:reference, application_form:, safeguarding_concerns_status: :no_safeguarding_concerns_to_declare)
+
+      expect(candidate.safeguarding_concerns?).to be true
+    end
+
+    it 'returns true if the candidate has safeguarding concerns declared on their References' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate:, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+      _reference = create(:reference, application_form:, safeguarding_concerns_status: :has_safeguarding_concerns_to_declare)
+
+      expect(candidate.safeguarding_concerns?).to be true
+    end
+
+    it 'returns false if the candidate has no safeguarding concerns declared on their Application Form or References' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate:, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+      _reference = create(:reference, application_form:, safeguarding_concerns_status: :no_safeguarding_concerns_to_declare)
+
+      expect(candidate.safeguarding_concerns?).to be false
+    end
+
+    it 'returns false if the candidate has no Application Forms or References' do
+      candidate = create(:candidate)
+
+      expect(candidate.safeguarding_concerns?).to be false
+    end
+  end
+
   describe '#current_application' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -154,6 +154,41 @@ RSpec.describe Candidate do
     end
   end
 
+  describe '.with_safeguarding_concerns' do
+    it 'returns candidates with safeguarding concerns declared on their Application Form' do
+      candidate_with_safeguarding_concerns = create(:candidate)
+      _application_form_with_safeguarding_concerns = create(:application_form,
+                                                            candidate: candidate_with_safeguarding_concerns,
+                                                            safeguarding_issues_status: :has_safeguarding_issues_to_declare)
+      candidate_without_safeguarding_concerns = create(:candidate)
+      _application_form_without_safeguarding_concerns = create(:application_form,
+                                                               candidate: candidate_without_safeguarding_concerns,
+                                                               safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+
+      expect(described_class.with_safeguarding_concerns).to contain_exactly(candidate_with_safeguarding_concerns)
+    end
+
+    it 'returns candidates with safeguarding concerns declared on their References' do
+      candidate_with_safeguarding_concerns = create(:candidate)
+      application_form = create(:application_form,
+                                candidate: candidate_with_safeguarding_concerns,
+                                safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+      _reference_with_safeguarding_concerns = create(:reference,
+                                                     application_form: application_form,
+                                                     safeguarding_concerns_status: :has_safeguarding_concerns_to_declare)
+
+      candidate_without_safeguarding_concerns = create(:candidate)
+      application_form_without_safeguarding_concerns = create(:application_form,
+                                                              candidate: candidate_without_safeguarding_concerns,
+                                                              safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+      _reference_without_safeguarding_concerns = create(:reference,
+                                                        application_form: application_form_without_safeguarding_concerns,
+                                                        safeguarding_concerns_status: :no_safeguarding_concerns_to_declare)
+
+      expect(described_class.with_safeguarding_concerns).to contain_exactly(candidate_with_safeguarding_concerns)
+    end
+  end
+
   describe '#current_application' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/services/candidate_courses_recommender_spec.rb
+++ b/spec/services/candidate_courses_recommender_spec.rb
@@ -6,10 +6,19 @@ RSpec.describe CandidateCoursesRecommender do
       stubbed_html_with_one_course
     end
 
-    it 'returns nil when there is no recommendations' do
+    it 'returns falsey when there is no recommendations' do
       candidate = create(:candidate)
 
-      expect(described_class.recommended_courses_url(candidate:)).to be_nil
+      expect(described_class.recommended_courses_url(candidate:)).to be_falsey
+    end
+
+    it 'returns falsey when the candidate has safeguarding concerns' do
+      candidate = create(:candidate)
+      _application_form = create(:application_form, candidate:, right_to_work_or_study: 'yes', personal_details_completed: true)
+
+      allow(candidate).to receive(:safeguarding_concerns?).and_return(true)
+
+      expect(described_class.recommended_courses_url(candidate:)).to be_falsey
     end
 
     describe "the 'can_sponsor_visa' parameter" do
@@ -23,7 +32,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -68,7 +77,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -174,7 +183,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -223,7 +232,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -271,7 +280,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -327,7 +336,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -353,7 +362,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           recommended_courses_url = described_class.recommended_courses_url(candidate:)
 
-          expect(recommended_courses_url).to be_nil
+          expect(recommended_courses_url).to be_falsey
         end
       end
 
@@ -455,7 +464,7 @@ RSpec.describe CandidateCoursesRecommender do
     end
 
     context 'number of courses found on the Find service' do
-      it 'returns nil when there are no courses found' do
+      it 'returns falsey when there are no courses found' do
         stubbed_html_with_no_courses
 
         candidate = create(:candidate)
@@ -465,7 +474,7 @@ RSpec.describe CandidateCoursesRecommender do
           candidate:,
         ).recommended_courses_url
 
-        expect(recommended_courses_url).to be_nil
+        expect(recommended_courses_url).to be_falsey
       end
 
       it 'returns a URL when the there is one course found' do
@@ -478,7 +487,7 @@ RSpec.describe CandidateCoursesRecommender do
           candidate:,
         ).recommended_courses_url
 
-        expect(recommended_courses_url).not_to be_nil
+        expect(recommended_courses_url).not_to be_falsey
       end
 
       it 'returns a URL when there are multiple courses found' do
@@ -491,7 +500,7 @@ RSpec.describe CandidateCoursesRecommender do
           candidate:,
         ).recommended_courses_url
 
-        expect(recommended_courses_url).not_to be_nil
+        expect(recommended_courses_url).not_to be_falsey
       end
     end
   end

--- a/spec/services/candidate_courses_recommender_spec.rb
+++ b/spec/services/candidate_courses_recommender_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe CandidateCoursesRecommender do
       expect(described_class.recommended_courses_url(candidate:)).to be_falsey
     end
 
+    it 'returns falsey when the candidate has application choices that are in progress' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate:, right_to_work_or_study: 'yes', personal_details_completed: true)
+      _in_progress_application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
+
+      expect(described_class.recommended_courses_url(candidate:)).to be_falsey
+    end
+
     describe "the 'can_sponsor_visa' parameter" do
       context 'when the Candidate has not completed their Personal Details' do
         it 'does not recommend courses' do
@@ -193,7 +201,7 @@ RSpec.describe CandidateCoursesRecommender do
           course_option = create(:course_option, course:)
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
-          _application_choices = create_list(:application_choice, 1, :awaiting_provider_decision, application_form:, course_option:)
+          _application_choices = create_list(:application_choice, 1, :rejected, application_form:, course_option:)
 
           uri = URI(described_class.recommended_courses_url(candidate:))
           query_parameters = Rack::Utils.parse_query(uri.query)
@@ -210,9 +218,9 @@ RSpec.describe CandidateCoursesRecommender do
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
           _application_choices = [
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: fee_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: salary_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: apprenticeship_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: fee_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: salary_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: apprenticeship_course_option),
           ]
 
           uri = URI(described_class.recommended_courses_url(candidate:))
@@ -241,7 +249,7 @@ RSpec.describe CandidateCoursesRecommender do
           course_option = create(:course_option, study_mode: :full_time)
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
-          _application_choices = create_list(:application_choice, 1, :awaiting_provider_decision, application_form:, course_option:)
+          _application_choices = create_list(:application_choice, 1, :rejected, application_form:, course_option:)
 
           uri = URI(described_class.recommended_courses_url(candidate:))
           query_parameters = Rack::Utils.parse_query(uri.query)
@@ -258,9 +266,9 @@ RSpec.describe CandidateCoursesRecommender do
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
           _application_choices = [
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: full_time_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: part_time_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: other_full_time_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: full_time_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: part_time_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: other_full_time_course_option),
           ]
 
           uri = URI(described_class.recommended_courses_url(candidate:))
@@ -291,7 +299,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
-          _application_choices = create_list(:application_choice, 1, :awaiting_provider_decision, application_form:, course_option:)
+          _application_choices = create_list(:application_choice, 1, :rejected, application_form:, course_option:)
 
           uri = URI(described_class.recommended_courses_url(candidate:))
           query_parameters = Rack::Utils.parse_query(uri.query)
@@ -316,9 +324,9 @@ RSpec.describe CandidateCoursesRecommender do
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
           _application_choices = [
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: a1_subject_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: b2_subject_course_option),
-            create(:application_choice, :awaiting_provider_decision, application_form:, course_option: mixed_subject_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: a1_subject_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: b2_subject_course_option),
+            create(:application_choice, :rejected, application_form:, course_option: mixed_subject_course_option),
           ]
 
           uri = URI(described_class.recommended_courses_url(candidate:))
@@ -373,7 +381,7 @@ RSpec.describe CandidateCoursesRecommender do
 
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
-          _application_choices = create_list(:application_choice, 1, :awaiting_provider_decision, application_form:, course_option:)
+          _application_choices = create_list(:application_choice, 1, :rejected, application_form:, course_option:)
 
           uri = URI(described_class.recommended_courses_url(candidate:))
           query_parameters = Rack::Utils.parse_query(uri.query)
@@ -393,8 +401,8 @@ RSpec.describe CandidateCoursesRecommender do
 
           candidate = create(:candidate)
           application_form = create(:application_form, candidate: candidate, application_choices: [])
-          _application_choice_1 = create(:application_choice, :awaiting_provider_decision, application_form:, course_option: course_option_1)
-          _application_choice_2 = create(:application_choice, :awaiting_provider_decision, application_form:, course_option: course_option_2)
+          _application_choice_1 = create(:application_choice, :rejected, application_form:, course_option: course_option_1)
+          _application_choice_2 = create(:application_choice, :rejected, application_form:, course_option: course_option_2)
 
           uri = URI(described_class.recommended_courses_url(candidate:))
           query_parameters = Rack::Utils.parse_query(uri.query)
@@ -420,7 +428,7 @@ RSpec.describe CandidateCoursesRecommender do
                                   candidate:,
                                   right_to_work_or_study:,
                                   personal_details_completed:)
-        _application_choices = create(:application_choice, :awaiting_provider_decision, application_form:, course_option:)
+        _application_choices = create(:application_choice, :rejected, application_form:, course_option:)
 
         uri = URI(described_class.recommended_courses_url(candidate:))
         query_parameters = Rack::Utils.parse_query(uri.query)
@@ -447,7 +455,7 @@ RSpec.describe CandidateCoursesRecommender do
                                   candidate:,
                                   right_to_work_or_study:,
                                   personal_details_completed:)
-        _application_choices = create(:application_choice, :awaiting_provider_decision, application_form:, course_option:)
+        _application_choices = create(:application_choice, :rejected, application_form:, course_option:)
 
         uri = URI(described_class.recommended_courses_url(candidate:, locatable:))
         query_parameters = Rack::Utils.parse_query(uri.query)


### PR DESCRIPTION
## Context

We do not want to recommend courses to Candidates that have safeguarding concerns either on their Application or on any of their References. 

We also don't want to recommend courses to any Candidate that has any in progress applications. 

## Changes proposed in this pull request

- Added safeguarding scopes and methods to Candidate model
- Added in progress scope to Application Choices
- Updated Course Recommender with exclusions

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
