### PR TITLE
Added UTM params to Course Recommendation links

### DIFF
--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -35,7 +35,7 @@ private
   end
 
   def create_recommended_courses_url
-    find_url_with_query_params if recommended?
+    find_url_with_query_params_and_utm if recommended?
   end
 
   def current_year
@@ -66,9 +66,20 @@ private
     end
   end
 
-  def find_url_with_query_params
-    uri = URI("#{find_url}results")
-    uri.query = query_parameters.to_query
+  def find_url_with_query_params_and_utm
+    utm_params = {
+      utm_source: :apply,
+      utm_medium: :courses_recommender,
+    }
+
+    find_url_with_query_params(utm_params)
+  end
+
+  def find_url_with_query_params(additional_params = {})
+    uri = URI.join(find_url, 'results')
+    uri.query = query_parameters
+                  .with_defaults(additional_params)
+                  .to_query
     uri.to_s
   end
 

--- a/spec/services/candidate_courses_recommender_spec.rb
+++ b/spec/services/candidate_courses_recommender_spec.rb
@@ -416,6 +416,27 @@ RSpec.describe CandidateCoursesRecommender do
       end
     end
 
+    describe 'UTM parameters' do
+      it 'adds UTM parameters to the URL' do
+        right_to_work_or_study = 'no'
+        personal_details_completed = false
+
+        candidate = create(:candidate)
+        application_form = create(:application_form,
+                                  application_choices: [],
+                                  candidate:,
+                                  right_to_work_or_study:,
+                                  personal_details_completed:)
+        _application_choices = create(:application_choice, :rejected, application_form:)
+
+        uri = URI(described_class.recommended_courses_url(candidate:))
+        query_parameters = Rack::Utils.parse_query(uri.query)
+
+        expect(query_parameters['utm_source']).to eq('apply')
+        expect(query_parameters['utm_medium']).to eq('courses_recommender')
+      end
+    end
+
     context 'a mixture of scenarios' do
       it 'sets the parameters to the correct values' do
         right_to_work_or_study = 'no'


### PR DESCRIPTION
## Context

We want to be able to track how often these links are used by a Candidate. 

## Changes proposed in this pull request

- Added UTM params to Course Recommendation link

## Guidance to review

- N/A
- Based off of #10930 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
