### PR TITLE
Candidate funding type preference

### DIFF
--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -8,11 +8,8 @@ module CandidateInterface
         LocationPreferenceDecorator.new(location)
       end
 
-      @back_path = if @preference.training_locations_anywhere?
-                     new_candidate_interface_draft_preference_training_location_path(@preference)
-                   else
-                     new_candidate_interface_draft_preference_dynamic_location_preference_path(@preference)
-                   end
+      @back_path = LocationPreferencesRequiredForm.new(preference: @preference)
+        .back_path
     end
 
     def update

--- a/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
@@ -20,7 +20,7 @@ module CandidateInterface
 
       if @dynamic_location_preferences_form.valid?
         @dynamic_location_preferences_form.save
-        redirect_to candidate_interface_draft_preference_path(@preference)
+        redirect_to @dynamic_location_preferences_form.next_path(return_to: params[:return_to])
       else
         set_back_path
         render :new

--- a/app/controllers/candidate_interface/funding_type_preferences_controller.rb
+++ b/app/controllers/candidate_interface/funding_type_preferences_controller.rb
@@ -1,0 +1,53 @@
+module CandidateInterface
+  class FundingTypePreferencesController < CandidateInterfaceController
+    before_action :set_preference
+    before_action :redirect_to_root_path_if_flag_is_inactive
+    before_action :set_back_path
+
+    def new
+      @funding_type_preference_form = FundingTypePreferenceForm.new(
+        {
+          funding_type: @preference.funding_type,
+          preference: @preference,
+        },
+      )
+    end
+
+    def create
+      @funding_type_preference_form = FundingTypePreferenceForm.new(
+        funding_type: funding_type_params[:funding_type],
+        preference: @preference,
+      )
+
+      if @funding_type_preference_form.valid?
+        @funding_type_preference_form.save!
+        redirect_to candidate_interface_draft_preference_path(@preference)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def funding_type_params
+      params.fetch(:candidate_interface_funding_type_preference_form, {}).permit(:funding_type)
+    end
+
+    def set_preference
+      @preference = current_candidate.preferences.find_by(id: params.expect(:draft_preference_id))
+
+      if @preference.blank?
+        redirect_to candidate_interface_application_choices_path
+      end
+    end
+
+    def redirect_to_root_path_if_flag_is_inactive
+      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
+    end
+
+    def set_back_path
+      @back_path = FundingTypePreferenceForm.new({ preference: @preference })
+        .back_path(return_to: params[:return_to])
+    end
+  end
+end

--- a/app/controllers/candidate_interface/training_locations_controller.rb
+++ b/app/controllers/candidate_interface/training_locations_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
 
       if @training_locations_form.valid?
         @training_locations_form.save!
-        redirect_to @training_locations_form.next_step_path
+        redirect_to @training_locations_form.next_step_path(return_to: params[:return_to])
       else
         set_submit_path
         render :new

--- a/app/forms/candidate_interface/dynamic_location_preferences_form.rb
+++ b/app/forms/candidate_interface/dynamic_location_preferences_form.rb
@@ -1,6 +1,7 @@
 class CandidateInterface::DynamicLocationPreferencesForm
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include Rails.application.routes.url_helpers
 
   attribute :dynamic_location_preferences, :boolean
   attribute :preference
@@ -9,5 +10,15 @@ class CandidateInterface::DynamicLocationPreferencesForm
 
   def save
     preference.update!(dynamic_location_preferences:) if valid?
+  end
+
+  def next_path(return_to: nil)
+    return candidate_interface_draft_preference_path(preference) if return_to == 'review'
+
+    if preference.applied_only_to_salaried_courses?
+      new_candidate_interface_draft_preference_funding_type_preference_path(preference)
+    else
+      candidate_interface_draft_preference_path(preference)
+    end
   end
 end

--- a/app/forms/candidate_interface/funding_type_preference_form.rb
+++ b/app/forms/candidate_interface/funding_type_preference_form.rb
@@ -1,0 +1,28 @@
+module CandidateInterface
+  class FundingTypePreferenceForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include Rails.application.routes.url_helpers
+
+    FUNDING_TYPE_OPTIONS = %w[fee salary].freeze
+
+    attribute :funding_type, :string
+    attribute :preference
+
+    validates :funding_type, inclusion: { in: FUNDING_TYPE_OPTIONS }
+
+    def save!
+      preference.update!(funding_type:) if valid?
+    end
+
+    def back_path(return_to: nil)
+      if return_to == 'review'
+        candidate_interface_draft_preference_path(preference)
+      elsif preference.training_locations_anywhere?
+        new_candidate_interface_draft_preference_training_location_path(preference)
+      else
+        new_candidate_interface_draft_preference_dynamic_location_preference_path(preference)
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/location_preferences_required_form.rb
+++ b/app/forms/candidate_interface/location_preferences_required_form.rb
@@ -1,6 +1,7 @@
 class CandidateInterface::LocationPreferencesRequiredForm
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include Rails.application.routes.url_helpers
 
   attribute :preference
   validate :location_preferences_required
@@ -8,6 +9,16 @@ class CandidateInterface::LocationPreferencesRequiredForm
   def location_preferences_required
     if preference.location_preferences.blank?
       errors.add(:base, :location_preferences_blank)
+    end
+  end
+
+  def back_path
+    if preference.funding_type.present?
+      new_candidate_interface_draft_preference_funding_type_preference_path(preference)
+    elsif preference.training_locations_anywhere?
+      new_candidate_interface_draft_preference_training_location_path(preference)
+    else
+      new_candidate_interface_draft_preference_dynamic_location_preference_path(preference)
     end
   end
 end

--- a/app/forms/candidate_interface/location_preferences_required_form.rb
+++ b/app/forms/candidate_interface/location_preferences_required_form.rb
@@ -13,7 +13,7 @@ class CandidateInterface::LocationPreferencesRequiredForm
   end
 
   def back_path
-    if preference.funding_type.present?
+    if preference.funding_type.present? || preference.applied_only_to_salaried_courses?
       new_candidate_interface_draft_preference_funding_type_preference_path(preference)
     elsif preference.training_locations_anywhere?
       new_candidate_interface_draft_preference_training_location_path(preference)

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -33,6 +33,7 @@ module CandidateInterface
         pool_status:,
         opt_out_reason: pool_status == 'opt_in' ? nil : opt_out_reason,
         training_locations: pool_status == 'opt_out' ? nil : preference&.training_locations,
+        funding_type: pool_status == 'opt_out' ? nil : preference&.funding_type,
       }
 
       if preference.present?

--- a/app/forms/candidate_interface/training_locations_form.rb
+++ b/app/forms/candidate_interface/training_locations_form.rb
@@ -21,8 +21,14 @@ module CandidateInterface
       end
     end
 
-    def next_step_path
-      if preference.training_locations_anywhere?
+    def next_step_path(return_to: nil)
+      if return_to == 'review' && preference.training_locations_anywhere?
+        return candidate_interface_draft_preference_path(preference)
+      end
+
+      if preference.applied_only_to_salaried_courses? && preference.training_locations_anywhere?
+        new_candidate_interface_draft_preference_funding_type_preference_path(preference)
+      elsif preference.training_locations_anywhere?
         candidate_interface_draft_preference_path(preference)
       elsif preference.training_locations_specific?
         candidate_interface_draft_preference_location_preferences_path(preference)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -176,6 +176,12 @@ class Candidate < ApplicationRecord
     application_forms.current_cycle.last
   end
 
+  def applied_only_to_salaried_courses?
+    current_cycle_application_form.courses.all? do |course|
+      course.salary? || course.apprenticeship?
+    end
+  end
+
 private
 
   def downcase_email

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -17,6 +17,13 @@ class CandidatePreference < ApplicationRecord
     specific: 'specific',
   }, prefix: true
 
+  enum :funding_type, {
+    fee: 'fee',
+    salary: 'salary',
+  }, prefix: true
+
+  delegate :applied_only_to_salaried_courses?, to: :candidate
+
   def create_draft_dup
     dup_record = dup
     dup_record.status = 'draft'

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -14,6 +14,7 @@ class CandidateInterface::ChoicesControllerMatcher
     'candidate_interface/training_locations',
     'candidate_interface/location_preferences',
     'candidate_interface/publish_preferences',
+    'candidate_interface/funding_type',
   ].freeze
 
   def self.choices_controller?(current_application:, controller_path:, request:)

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -53,6 +53,34 @@
           ) %>
         <% end %>
       <% end %>
+
+      <% if @preference.funding_type.present? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.funding_type') } %>
+          <% row.with_value { @preference.funding_type == 'fee' ? 'Yes' : 'No' } %>
+          <% row.with_action(
+            text: t('.change'),
+            href: new_candidate_interface_draft_preference_funding_type_preference_path(
+              @preference,
+              return_to: 'review',
+            ),
+            visually_hidden_text: t('.change_funding_type'),
+          ) %>
+        <% end %>
+      <% elsif @preference.applied_only_to_salaried_courses? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.funding_type') } %>
+          <% row.with_value do %>
+            <%= govuk_link_to(
+              t('.select_funding_type'),
+              new_candidate_interface_draft_preference_funding_type_preference_path(
+                @preference,
+                return_to: 'review',
+              ),
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%= govuk_button_to(

--- a/app/views/candidate_interface/funding_type_preferences/new.html.erb
+++ b/app/views/candidate_interface/funding_type_preferences/new.html.erb
@@ -20,8 +20,8 @@
           <%= t(
             '.funding_information_html',
             link: govuk_link_to(
-              'scholarships and bursaries that are available',
-              'https://getintoteaching.education.gov.uk/funding-and-support',
+              t('.funding_information'),
+              t('get_into_teaching.url_funding_and_support'),
               new_tab: true,
             ),
           ) %>

--- a/app/views/candidate_interface/funding_type_preferences/new.html.erb
+++ b/app/views/candidate_interface/funding_type_preferences/new.html.erb
@@ -1,0 +1,37 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @funding_type_preference_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@back_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @funding_type_preference_form,
+          url: candidate_interface_draft_preference_funding_type_preferences_path(
+            @preference,
+            return_to: params[:return_to],
+          ),
+          method: :post,
+        ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: { text: t('.title'), size: 'l' }) do %>
+        <%= govuk_warning_text(text: t('.warning')) %>
+
+        <p class='govuk-body'>
+          <%= t(
+            '.funding_information_html',
+            link: govuk_link_to(
+              'scholarships and bursaries that are available',
+              'https://getintoteaching.education.gov.uk/funding-and-support',
+              new_tab: true,
+            ),
+          ) %>
+        </p>
+
+        <%= f.govuk_radio_button :funding_type, :fee, label: { text: t('.fee') }, link_errors: true %>
+        <%= f.govuk_radio_button :funding_type, :salary, label: { text: t('.salary') } %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -21,7 +21,7 @@
         <% row.with_value { t(".#{@preference.training_locations}") } %>
         <% row.with_action(
            text: t('.change'),
-           href: new_candidate_interface_draft_preference_training_location_path(@preference),
+           href: new_candidate_interface_draft_preference_training_location_path(@preference, return_to: 'review'),
            visually_hidden_text: t('.change_training_locations_visually_hidden'),
          ) %>
       <% end %>
@@ -51,6 +51,34 @@
             href: new_candidate_interface_draft_preference_dynamic_location_preference_path(@preference, return_to: 'review'),
             visually_hidden_text: t('.change_dynamic_locations_hint'),
           ) %>
+        <% end %>
+      <% end %>
+
+      <% if @preference.funding_type.present? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.funding_type') } %>
+          <% row.with_value { @preference.funding_type == 'fee' ? 'Yes' : 'No' } %>
+          <% row.with_action(
+            text: t('.change'),
+            href: new_candidate_interface_draft_preference_funding_type_preference_path(
+              @preference,
+              return_to: 'review',
+            ),
+            visually_hidden_text: t('.change_funding_type'),
+          ) %>
+        <% end %>
+      <% elsif @preference.applied_only_to_salaried_courses? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t('.funding_type') } %>
+          <% row.with_value do %>
+            <%= govuk_link_to(
+              t('.select_funding_type'),
+              new_candidate_interface_draft_preference_funding_type_preference_path(
+                @preference,
+                return_to: 'review',
+              ),
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -105,7 +105,7 @@ en:
         funding_information_html: Find out more about funding your training and the %{link}
         fee: Yes, I would apply to a fee-funded course
         salary: No, I am only interested in salaried or apprenticeship routes into teaching
-        link: https://getintoteaching.education.gov.uk/funding-and-support scholarships and bursaries that are available (opens in new tab)
+        funding_information: scholarships and bursaries that are available
   activemodel:
     errors:
       models:

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -19,7 +19,10 @@ en:
         no_location_preferences: You have no location preferences
         change_share_information_hint: whether you want to share your application details
         change_location_preferences_hint: your preferred locations
-        change_dynamic_locations_hint: updating your locations when you apply to a new course
+        change_dynamic_locations_hint: your locations when you apply to a new course
+        select_funding_type: Select whether you would consider fee-funded courses
+        funding_type: Would you consider fee-funded courses?
+        change_funding_type: whether you would consider fee-funded courses
     preferences:
       show: Check your application sharing preferences
       share_question: Do you want to be invited to apply to similar courses?
@@ -43,7 +46,10 @@ en:
         no_location_preferences: You have not added any training areas
         change_share_information_hint: whether you want to share your application details
         change_location_preferences_hint: your preferred locations
-        change_dynamic_locations_hint: updating your locations when you apply to a new course
+        change_dynamic_locations_hint: your locations when you apply to a new course
+        funding_type: Would you consider fee-funded courses?
+        change_funding_type: whether you would consider fee-funded courses
+        select_funding_type: Select whether you would consider fee-funded courses
     pool_opt_ins:
       new:
         title: Do you want to make your application details visible to other training providers?
@@ -92,6 +98,14 @@ en:
         title: Do you want to remove this training area?
         location: Area
         remove: Yes, remove training area
+    funding_type_preferences:
+      new:
+        title: Would you consider fee-funded courses?
+        warning: Salaried courses are in high demand and fill up quickly. You are unlikely to be invited to apply to a salaried course.
+        funding_information_html: Find out more about funding your training and the %{link}
+        fee: Yes, I would apply to a fee-funded course
+        salary: No, I am only interested in salaried or apprenticeship routes into teaching
+        link: https://getintoteaching.education.gov.uk/funding-and-support scholarships and bursaries that are available (opens in new tab)
   activemodel:
     errors:
       models:
@@ -123,3 +137,7 @@ en:
           attributes:
             dynamic_location_preferences:
               inclusion: Select if you want to add the locations of courses you apply to
+        candidate_interface/funding_type_preference_form:
+          attributes:
+            funding_type:
+              inclusion: Select if you would consider a fee-funded course

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -23,6 +23,7 @@ namespace :candidate_interface, path: '/candidate' do
     resources :training_locations, only: %i[new create], path: 'training-locations'
     resources :location_preferences, path: 'location-preferences'
     resources :dynamic_location_preferences, only: %i[new create], path: 'dynamic-location-preferences'
+    resources :funding_type_preferences, only: %i[new create], path: 'funding-type'
     resource :publish_preferences, only: %i[show create], path: 'publish-preferences'
   end
   resource :candidate_feature_launch_email, only: :show, path: 'feature-launch-email'

--- a/spec/factories/candidate_preference.rb
+++ b/spec/factories/candidate_preference.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     dynamic_location_preferences { true }
     status { 'published' }
     training_locations { 'specific' }
+    funding_type { 'fee' }
   end
 
   trait :anywhere_in_england do

--- a/spec/forms/candidate_interface/dynamic_location_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/dynamic_location_preferences_form_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+module CandidateInterface
+  RSpec.describe CandidateInterface::DynamicLocationPreferencesForm, type: :model do
+    include Rails.application.routes.url_helpers
+
+    subject(:form) do
+      described_class.new(preference:, dynamic_location_preferences:)
+    end
+
+    let(:preference) do
+      create(
+        :candidate_preference,
+        dynamic_location_preferences: nil,
+      )
+    end
+    let(:dynamic_location_preferences) { true }
+
+    describe 'validations' do
+      it { is_expected.to validate_inclusion_of(:dynamic_location_preferences).in_array([true, false]) }
+    end
+
+    describe '#save' do
+      it 'updates a preference with dynamic_location_preferences' do
+        expect { form.save }.to change(preference, :dynamic_location_preferences).from(nil).to(true)
+      end
+    end
+
+    describe '#next_path' do
+      let(:preference) { create(:candidate_preference) }
+
+      context 'with return_to review' do
+        it 'sets the next path to review path' do
+          expect(form.next_path(return_to: 'review')).to eq(
+            candidate_interface_draft_preference_path(preference),
+          )
+        end
+      end
+
+      context 'when applied only to salaries courses' do
+        let(:preference) { create(:candidate_preference) }
+
+        it 'sets the next path to funding_type' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(true)
+
+          expect(form.next_path).to eq(
+            new_candidate_interface_draft_preference_funding_type_preference_path(preference),
+          )
+        end
+      end
+
+      context 'when applied to fee courses' do
+        let(:preference) { create(:candidate_preference) }
+
+        it 'sets the next path to review path' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(false)
+
+          expect(form.next_path).to eq(
+            candidate_interface_draft_preference_path(preference),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/funding_type_preference_form_spec.rb
+++ b/spec/forms/candidate_interface/funding_type_preference_form_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+module CandidateInterface
+  RSpec.describe CandidateInterface::FundingTypePreferenceForm, type: :model do
+    include Rails.application.routes.url_helpers
+
+    subject(:form) do
+      described_class.new(preference:, funding_type:)
+    end
+
+    let(:preference) do
+      create(
+        :candidate_preference,
+        funding_type: nil,
+        training_locations:,
+      )
+    end
+    let(:funding_type) { 'fee' }
+    let(:training_locations) { 'anywhere' }
+
+    describe 'validations' do
+      it { is_expected.to validate_inclusion_of(:funding_type).in_array(%w[fee salary]) }
+    end
+
+    describe '#save!' do
+      it 'updates a preference with funding_type' do
+        expect { form.save! }.to change(preference, :funding_type).from(nil).to('fee')
+      end
+    end
+
+    describe '#back_path' do
+      context 'with return_to review' do
+        it 'sets the back link to review path' do
+          expect(form.back_path(return_to: 'review')).to eq(
+            candidate_interface_draft_preference_path(preference),
+          )
+        end
+      end
+
+      context 'when training location is anywhere' do
+        it 'sets the back link training_locations' do
+          expect(form.back_path).to eq(
+            new_candidate_interface_draft_preference_training_location_path(preference),
+          )
+        end
+      end
+
+      context 'when training location is specific' do
+        let(:training_locations) { 'specific' }
+
+        it 'sets the back link to dynamic locations' do
+          expect(form.back_path).to eq(
+            new_candidate_interface_draft_preference_dynamic_location_preference_path(preference),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/location_preferences_required_form_spec.rb
+++ b/spec/forms/candidate_interface/location_preferences_required_form_spec.rb
@@ -1,18 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::LocationPreferencesRequiredForm, type: :model do
+  include Rails.application.routes.url_helpers
+
   subject(:form) do
     described_class.new({ preference: })
   end
 
   let(:preference) do
-    create(:candidate_preference)
+    create(:candidate_preference, funding_type:, training_locations:)
   end
+  let(:funding_type) { 'fee' }
+  let(:training_locations) { 'anywhere' }
 
   describe '#valid?' do
     it 'returns error if there are no location preferences' do
       expect(form.valid?).to be false
       expect(form.errors[:base].first).to eq 'Add an area you can train in'
+    end
+  end
+
+  describe '#back_path' do
+    context 'when funding_type is present' do
+      it 'sets the back path to funding type' do
+        expect(form.back_path).to eq(
+          new_candidate_interface_draft_preference_funding_type_preference_path(preference),
+        )
+      end
+    end
+
+    context 'when training_locations is anywhere' do
+      let(:funding_type) { nil }
+
+      it 'sets the back path to training_locations' do
+        expect(form.back_path).to eq(
+          new_candidate_interface_draft_preference_training_location_path(preference),
+        )
+      end
+    end
+
+    context 'when training_locations is specific' do
+      let(:funding_type) { nil }
+      let(:training_locations) { 'specific' }
+
+      it 'sets the back path to dynamic locations' do
+        expect(form.back_path).to eq(
+          new_candidate_interface_draft_preference_dynamic_location_preference_path(preference),
+        )
+      end
     end
   end
 end

--- a/spec/forms/candidate_interface/location_preferences_required_form_spec.rb
+++ b/spec/forms/candidate_interface/location_preferences_required_form_spec.rb
@@ -29,10 +29,22 @@ RSpec.describe CandidateInterface::LocationPreferencesRequiredForm, type: :model
       end
     end
 
+    context 'when candidate applied only to salaried courses' do
+      it 'sets the back path to funding type' do
+        allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(true)
+
+        expect(form.back_path).to eq(
+          new_candidate_interface_draft_preference_funding_type_preference_path(preference),
+        )
+      end
+    end
+
     context 'when training_locations is anywhere' do
       let(:funding_type) { nil }
 
       it 'sets the back path to training_locations' do
+        allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(false)
+
         expect(form.back_path).to eq(
           new_candidate_interface_draft_preference_training_location_path(preference),
         )
@@ -44,6 +56,8 @@ RSpec.describe CandidateInterface::LocationPreferencesRequiredForm, type: :model
       let(:training_locations) { 'specific' }
 
       it 'sets the back path to dynamic locations' do
+        allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(false)
+
         expect(form.back_path).to eq(
           new_candidate_interface_draft_preference_dynamic_location_preference_path(preference),
         )

--- a/spec/forms/candidate_interface/training_locations_form_spec.rb
+++ b/spec/forms/candidate_interface/training_locations_form_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+module CandidateInterface
+  RSpec.describe TrainingLocationsForm, type: :model do
+    include Rails.application.routes.url_helpers
+
+    subject(:form) do
+      described_class.new(preference:, training_locations:)
+    end
+
+    let(:preference) do
+      create(
+        :candidate_preference,
+        training_locations: existing_training_locations,
+      )
+    end
+    let(:existing_training_locations) { nil }
+    let(:training_locations) { 'anywhere' }
+
+    describe 'validations' do
+      it { is_expected.to validate_inclusion_of(:training_locations).in_array(%w[anywhere specific]) }
+    end
+
+    describe '#save!' do
+      context 'when training_locations is anywhere' do
+        it 'updates a preference with training_locations' do
+          expect { form.save! }.to change(preference, :training_locations).from(nil).to('anywhere')
+        end
+      end
+
+      context 'when training_locations is specific' do
+        let(:training_locations) { 'specific' }
+
+        it 'updates a preference with training_locations' do
+          create(
+            :application_form,
+            :completed,
+            candidate: preference.candidate,
+            submitted_application_choices_count: 1,
+          )
+
+          expect { form.save! }.to change(preference, :training_locations).from(nil).to('specific')
+            .and change(preference.location_preferences, :count).from(0).to(1)
+        end
+      end
+    end
+
+    describe '#next_step_path' do
+      context 'with return_to review and training_locations anywhere' do
+        let(:existing_training_locations) { 'anywhere' }
+
+        it 'sets the next path to funding_type' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(true)
+
+          expect(form.next_step_path(return_to: 'review')).to eq(
+            candidate_interface_draft_preference_path(preference),
+          )
+        end
+      end
+
+      context 'with applied_only to salaried and training_locations anywhere' do
+        let(:existing_training_locations) { 'anywhere' }
+
+        it 'sets the next path to funding_type' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(true)
+
+          expect(form.next_step_path).to eq(
+            new_candidate_interface_draft_preference_funding_type_preference_path(preference),
+          )
+        end
+      end
+
+      context 'when training_locations anywhere' do
+        let(:existing_training_locations) { 'anywhere' }
+
+        it 'sets the next path to review' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(false)
+
+          expect(form.next_step_path).to eq(
+            candidate_interface_draft_preference_path(preference),
+          )
+        end
+      end
+
+      context 'when training_locations is specific' do
+        let(:existing_training_locations) { 'specific' }
+
+        it 'sets the next path to location_preferences' do
+          allow(preference).to receive(:applied_only_to_salaried_courses?).and_return(false)
+
+          expect(form.next_step_path).to eq(
+            candidate_interface_draft_preference_location_preferences_path(preference),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -533,4 +533,63 @@ RSpec.describe Candidate do
       expect(candidate.redacted_full_name_current_cycle).to eq('t***** t*****')
     end
   end
+
+  describe '#applied_only_to_salaried_courses?' do
+    it 'returns true if applied only to salary or apprenticeship course' do
+      application_form = create(
+        :application_form,
+        :completed,
+      )
+      salary_course = create(:course, funding_type: 'salary')
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option: create(:course_option, course: salary_course),
+      )
+      apprenticeship_course = create(:course, funding_type: 'apprenticeship')
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option: create(:course_option, course: apprenticeship_course),
+      )
+
+      candidate = application_form.candidate
+
+      expect(candidate.applied_only_to_salaried_courses?).to be(true)
+    end
+
+    it 'returns false if appliedto salary, apprenticeship and fee course' do
+      application_form = create(
+        :application_form,
+        :completed,
+      )
+      salary_course = create(:course, funding_type: 'salary')
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option: create(:course_option, course: salary_course),
+      )
+      apprenticeship_course = create(:course, funding_type: 'apprenticeship')
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option: create(:course_option, course: apprenticeship_course),
+      )
+      fee_course = create(:course, funding_type: 'fee')
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option: create(:course_option, course: fee_course),
+      )
+
+      candidate = application_form.candidate
+
+      expect(candidate.applied_only_to_salaried_courses?).to be(false)
+    end
+  end
 end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -79,12 +79,58 @@ RSpec.describe 'Candidate adds preferences' do
 
     when_i_check_dynamic_locations
     when_i_click('Continue')
-    then_i_am_redirected_to_review_page
+    then_i_am_redirected_funding_type_page
 
     when_i_click('Back')
     then_i_am_redirected_to_the_dynamic_locations_page
     and_the_dynamic_locations_is_checked
+    when_i_click('Continue')
 
+    then_i_am_redirected_funding_type_page
+    when_i_click('Continue')
+    then_i_get_an_error('Select if you would consider a fee-funded course')
+
+    when_i_check_yes_fee_funding_courses
+    when_i_click('Continue')
+    then_i_am_redirected_to_review_page
+
+    when_i_click('Back')
+    then_i_am_redirected_funding_type_page
+    and_the_funding_type_is_checked
+    when_i_click('Continue')
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_to_application_choices_with_success_message
+  end
+
+  scenario 'Candidate opts in to find a candidate with specific locations and applied to fee funded courses' do
+    given_i_am_signed_in(funding_type: 'fee')
+    and_feature_flag_is_enabled
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_opt_in_page
+    and_i_opt_in_to_find_a_candidate
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_training_locations
+    and_i_select_specific_locations
+    when_i_click('Continue')
+    then_i_am_redirected_to_location_preferences(location_preferences)
+
+    when_i_click('Add another area')
+    and_i_input_a_location
+    when_i_click('Add area')
+    then_i_am_redirected_to_location_preferences(new_locations)
+
+    when_i_click_change_on_the_last_location
+    and_i_edit_a_location
+    when_i_click('Update training area')
+    then_i_am_redirected_to_location_preferences(updated_locations)
+    when_i_click('Continue')
+    then_i_am_redirected_to_the_dynamic_locations_page
+
+    when_i_check_dynamic_locations
     when_i_click('Continue')
     then_i_am_redirected_to_review_page
 
@@ -108,7 +154,32 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_training_locations
     when_i_select_anywhere
     and_i_click('Continue')
+    then_i_am_redirected_funding_type_page
 
+    when_i_check_yes_fee_funding_courses
+    when_i_click('Continue')
+    then_i_am_redirected_to_review_page_without_locations
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_to_application_choices_with_success_message
+  end
+
+  scenario 'Candidate opts in to find a candidate for anywhere in England and applied to fee funded courses' do
+    given_i_am_signed_in(funding_type: 'fee')
+    and_feature_flag_is_enabled
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_opt_in_page
+    when_i_click('Continue')
+    then_i_get_an_error('Select whether to make your application details visible to other training providers')
+
+    and_i_opt_in_to_find_a_candidate
+    when_i_click('Continue')
+
+    then_i_am_redirected_to_training_locations
+    when_i_select_anywhere
+    and_i_click('Continue')
     then_i_am_redirected_to_review_page_without_locations
 
     when_i_click('Submit preferences')
@@ -151,7 +222,7 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_application_choices
   end
 
-  def given_i_am_signed_in
+  def given_i_am_signed_in(funding_type: 'salary')
     given_i_am_signed_in_with_one_login
     @application = create(
       :application_form,
@@ -166,7 +237,7 @@ RSpec.describe 'Candidate adds preferences' do
       longitude: -2.2426305,
       provider:,
     )
-    course = create(:course, provider:)
+    course = create(:course, provider:, funding_type:)
     course_option = create(
       :course_option,
       site:,
@@ -198,6 +269,8 @@ RSpec.describe 'Candidate adds preferences' do
     and_i_click('Continue')
     when_i_check_dynamic_locations
     and_i_click('Continue')
+    when_i_check_yes_fee_funding_courses
+    when_i_click('Continue')
     and_i_click('Submit preferences')
     then_i_am_redirected_to_application_choices_with_success_message
   end
@@ -455,5 +528,18 @@ RSpec.describe 'Candidate adds preferences' do
 
   def then_it_saves_successfully
     and_the_distance_is_updated
+  end
+
+  def then_i_am_redirected_funding_type_page
+    expect(page).to have_content('Would you consider fee-funded courses?')
+  end
+
+  def when_i_check_yes_fee_funding_courses
+    choose 'Yes, I would apply to a fee-funded course'
+  end
+
+  def and_the_funding_type_is_checked
+    funding_type = find_by_id('candidate-interface-funding-type-preference-form-funding-type-fee-field')
+    expect(funding_type).to be_checked
   end
 end

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Candidate edits published preference' do
   after { FeatureFlag.deactivate(:candidate_preferences) }
 
+  let(:provider) { create(:provider) }
+
   scenario 'Candidate edits share preferences' do
     given_i_am_signed_in
     and_feature_flag_is_enabled
@@ -73,17 +75,59 @@ RSpec.describe 'Candidate edits published preference' do
     and_there_are_no_location_preferences
   end
 
-  def given_i_am_signed_in
+  scenario 'Candidate edits funding_type' do
+    given_i_am_signed_in(funding_type: 'salary')
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    and_i_click('Change whether you would consider fee-funded courses')
+    then_i_am_redirected_to_fee_funding_page
+    and_the_funding_type_is_checked
+
+    when_i_check_no_only_salary_courses
+    and_i_click('Continue')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+    and_only_interested_in_salary_courses
+  end
+
+  scenario 'Candidate edits funding_type without setting it in the first place' do
+    given_i_am_signed_in(funding_type: 'salary')
+    and_candidate_preference_funding_type_is_nil
+    and_feature_flag_is_enabled
+
+    given_i_am_on_the_application_choices_page
+    when_i_click('Change your sharing and location settings')
+    and_i_click('Select whether you would consider fee-funded courses')
+    then_i_am_redirected_to_fee_funding_page
+
+    when_i_check_no_only_salary_courses
+    and_i_click('Continue')
+    then_i_am_redirected_to_preference_review_page
+
+    when_i_click('Submit preferences')
+    then_i_am_redirected_on_the_application_choices_page
+    and_the_candidate_preference_id_is_changed
+    and_only_interested_in_salary_courses
+  end
+
+  def given_i_am_signed_in(funding_type: 'fee')
     given_i_am_signed_in_with_one_login
     @application = create(
       :application_form,
       :completed,
       candidate: @current_candidate,
     )
+    course = create(:course, provider:, funding_type:)
     @choice = create(
       :application_choice,
       :awaiting_provider_decision,
       application_form: @application,
+      course_option: create(:course_option, course:),
     )
     @existing_candidate_preference = create(
       :candidate_preference,
@@ -147,7 +191,7 @@ RSpec.describe 'Candidate edits published preference' do
   end
 
   def when_i_navigate_to_dynamic_locations
-    click_on 'Change updating your locations when you apply to a new course'
+    click_on 'Change your locations when you apply to a new course'
   end
 
   def when_i_select_anywhere_in_england
@@ -156,5 +200,26 @@ RSpec.describe 'Candidate edits published preference' do
 
   def and_i_select_no_dynamic_locations
     choose 'No'
+  end
+
+  def then_i_am_redirected_to_fee_funding_page
+    expect(page).to have_content('Would you consider fee-funded courses?')
+  end
+
+  def and_the_funding_type_is_checked
+    funding_type = find_by_id('candidate-interface-funding-type-preference-form-funding-type-fee-field')
+    expect(funding_type).to be_checked
+  end
+
+  def when_i_check_no_only_salary_courses
+    choose 'No, I am only interested in salaried or apprenticeship routes into teaching'
+  end
+
+  def and_only_interested_in_salary_courses
+    @current_candidate.published_preferences.last.funding_type == 'salary'
+  end
+
+  def and_candidate_preference_funding_type_is_nil
+    @existing_candidate_preference.update(funding_type: nil)
   end
 end


### PR DESCRIPTION
## Context

We want to allow the candidate to express their preference to what
course funding type they want to be invited to.

We want to add another step in the candidate preferences that asks the
candidate to express this preference.

This new step is going to be shown conditionally. If the candidate has
applied to any fee course we will not show this new step and assume they
are interested in fee courses.

We only show this new step if the candidate only applied to salary
courses.

Because we are introducing this step now, when candidates have
set their preferences already. We will give the candidates that applied
only to salary courses to specific this preference when they go back and
edit their preferences.

Work on the provider side to use this funding type preference will
follow.

Also moved some methods that set the back/next path into form objects to test them properly.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review



https://github.com/user-attachments/assets/11d59ac3-1f87-4371-ade7-23765c73d5a9




Go on to the review app or locally.
Login as a candidate that only applied to salary courses.
Set/Update candidate preferences
Click back links

Login as a canddiate that applied to fee courses or a combination of fee/salary ones.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
