### PR TITLE
Show visa or immigration status where sponsorship not required

### DIFF
--- a/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
@@ -3,4 +3,10 @@
     <% row.with_key { t('.visa_sponsorship') } %>
     <% row.with_value { visa_sponsorship_value } %>
   <% end %>
+  <% unless application_form.requires_visa_sponsorship? %>
+    <% summary_list.with_row do|row| %>
+      <% row.with_key { t('.visa_or_immigration_status') } %>
+      <% row.with_value { visa_status_value } %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/provider_interface/find_candidates/right_to_work_component.rb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.rb
@@ -7,9 +7,17 @@ class ProviderInterface::FindCandidates::RightToWorkComponent < ViewComponent::B
 
   def visa_sponsorship_value
     if application_form.requires_visa_sponsorship?
-      'Required'
+      t('.required')
     else
-      'Not required'
+      t('.not_required')
+    end
+  end
+
+  def visa_status_value
+    if application_form.british_or_irish?
+      t('.british_or_irish')
+    else
+      t(".#{application_form.immigration_status.presence || 'unknown'}")
     end
   end
 end

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -3,6 +3,28 @@ en:
     find_candidates:
       right_to_work_component:
         visa_sponsorship: Visa sponsorship
+        required: Required
+        not_required: Not required
+        unknown: Unknown
+        visa_or_immigration_status: Visa or immigration status
+        eu_settled: EU settled status
+        eu_pre_settled: EU pre-settled status
+        indefinite_leave_to_remain_in_the_uk: Indefinite leave to remain in the UK
+        student_visa: Student visa
+        graduate_visa: Graduate visa
+        skilled_worker_visa: Skilled Worker visa
+        dependent_on_partners_or_parents_visa: Dependent on partner’s or parent’s visa
+        family_visa: Family visa
+        british_national_overseas_visa: British National (Overseas) visa
+        uk_ancestry_visa: UK Ancestry visa
+        high_potential_individual_visa: High Potential Individual visa
+        youth_mobility_scheme: Youth Mobility Scheme
+        india_young_professionals_scheme_visa: India Young Professionals Scheme visa
+        ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa: Ukraine Family Scheme or Ukraine Sponsorship Scheme visa
+        afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)
+        refugee_status: Refugee status
+        other: Other
+        british_or_irish: British or Irish citizen
       application_choices_component:
         subtitle: Application %{counter}
         subject: Subject

--- a/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
@@ -1,0 +1,23 @@
+class ProviderInterface::FindCandidates::RightToWorkComponentPreview < ViewComponent::Preview
+  def candidate_requires_sponsorship
+    application_form = FactoryBot.build(:application_form, right_to_work_or_study: 'no')
+
+    render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
+  end
+
+  def candidate_british_does_not_require_sponsorship
+    application_form = FactoryBot.build(:application_form, right_to_work_or_study: nil, first_nationality: 'British')
+
+    render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
+  end
+
+  def candidate_has_visa_does_not_require_sponsorship
+    application_form = FactoryBot.build(
+      :application_form,
+      right_to_work_or_study: 'yes',
+      immigration_status: 'indefinite_leave_to_remain_in_the_uk',
+    )
+
+    render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
+  end
+end

--- a/spec/components/provider_interface/find_candidates/right_to_work_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/right_to_work_component_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::FindCandidates::RightToWorkComponent, type: :component do
+  context 'candidates is british or irish' do
+    it 'shows the immigration status' do
+      application_form = build(:application_form, right_to_work_or_study: nil, first_nationality: 'British')
+
+      render_inline(described_class.new(application_form:))
+
+      expect(page).to have_content 'Not required'
+      expect(page).to have_content 'Visa or immigration status'
+      expect(page).to have_content 'British or Irish citizen'
+    end
+  end
+
+  context 'candidates has visa and does not need sponsorship' do
+    it 'renders immigration status' do
+      application_form = build(:application_form, right_to_work_or_study: 'yes', immigration_status: 'indefinite_leave_to_remain_in_the_uk')
+
+      render_inline(described_class.new(application_form:))
+
+      expect(page).to have_content 'Not required'
+      expect(page).to have_content 'Visa or immigration status'
+      expect(page).to have_content 'Indefinite leave to remain in the UK'
+    end
+  end
+
+  context 'candidate requires sponsorship' do
+    it 'does not render immigration status' do
+      application_form = build(:application_form, right_to_work_or_study: 'no')
+
+      render_inline(described_class.new(application_form:))
+
+      expect(page).to have_content 'Required'
+      expect(page).to have_no_content 'Visa or immigration status'
+    end
+  end
+end


### PR DESCRIPTION
## Context

On a Find a Candidate profile, we do not show a candidate’s full visa/immigration status, we just state whether they require a visa or not. This was an attempt to reduce bias by not disclosing unnecessary background information.

However, in research we saw providers not trusting what they were shown. Even if we stated a candidate did not require a visa, they would sometimes question whether the candidate had a student or graduate visa which might not be sufficient in order to train with them.

## Changes proposed in this pull request

- Where sponsorship is required, we don't give immigration status
- Where we say it is not required, we show providers the status to reassure them.

## Guidance to review
You can have a look at the previews on the review app. 
[Candidate is British](https://apply-review-10941.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/right_to_work_component/candidate_british_does_not_require_sponsorship)
[Candidate has visa with right to work or study](https://apply-review-10941.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/right_to_work_component/candidate_has_visa_does_not_require_sponsorship)
[Candidate requires sponsorship](https://apply-review-10941.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/right_to_work_component/candidate_requires_sponsorship)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
