### PR TITLE
Change FAC worker to add candidate funding type preference

### DIFF
--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       course { association :course, :open, recruitment_cycle_year: }
     end
 
+    trait :fee do
+      course { association :course, :open, funding_type: 'fee', recruitment_cycle_year: }
+    end
+
     trait :tda do
       course { association :course, :open, :teacher_degree_apprenticeship, recruitment_cycle_year: }
     end

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
   describe '#perform' do
     it 'creates CandidatePoolApplication records' do
       application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: application_form.candidate,
+      )
       stub_application_forms_in_the_pool(application_form.id)
 
       expect {
@@ -15,6 +19,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
     it 'does not create duplicate CandidatePoolApplication records' do
       application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: application_form.candidate,
+      )
       create(:candidate_pool_application, application_form: application_form)
       stub_application_forms_in_the_pool(application_form.id)
 
@@ -25,6 +33,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
     it 'removes existing CandidatePoolApplication records before inserting new ones' do
       application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: application_form.candidate,
+      )
       create(:candidate_pool_application, application_form: application_form)
       stub_application_forms_in_the_pool(ApplicationForm.none)
 
@@ -36,6 +48,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     it 'removes existing and adds new CandidatePoolApplication records' do
       existing_application_in_pool = create(:application_form, :completed, submitted_application_choices_count: 1)
       new_application_for_pool = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: new_application_for_pool.candidate,
+      )
       create(:candidate_pool_application, application_form: existing_application_in_pool)
       stub_application_forms_in_the_pool(new_application_for_pool.id)
 
@@ -49,6 +65,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to a full-time course' do
       it 'sets study_mode_full_time to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         course_option = create(:course_option, study_mode: 'full_time')
         _application_choice = create(:application_choice,
                                      status: :awaiting_provider_decision,
@@ -66,6 +86,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to a part-time course' do
       it 'sets study_mode_part_time to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         course_option = create(:course_option, study_mode: 'part_time')
         _application_choice = create(:application_choice,
                                      status: :awaiting_provider_decision,
@@ -83,6 +107,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to both full-time and part-time courses' do
       it 'sets both study_mode_full_time and study_mode_part_time to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         full_time_course_option = create(:course_option, study_mode: 'full_time')
         part_time_course_option = create(:course_option, study_mode: 'part_time')
         _application_choice1 = create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: full_time_course_option)
@@ -99,6 +127,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       context 'when one of the application choices is unsubmitted' do
         it 'does not set the study mode based on the unsubmitted choice' do
           application_form = create(:application_form)
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           full_time_course_option = create(:course_option, study_mode: 'full_time')
           part_time_course_option = create(:course_option, study_mode: 'part_time')
           _submitted_full_time_application = create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: full_time_course_option)
@@ -117,6 +149,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to a postgraduate course' do
       it 'sets course_type_postgraduate to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         course_option = create(:course_option, course: create(:course, program_type: 'higher_education_programme'))
         create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: course_option)
 
@@ -132,6 +168,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to an undergraduate course' do
       it 'sets course_type_undergraduate to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         course_option = create(:course_option, course: create(:course, program_type: 'teacher_degree_apprenticeship'))
         create(:application_choice,
                status: :awaiting_provider_decision,
@@ -149,6 +189,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'when the candidate has applied to both postgraduate and undergraduate courses' do
       it 'sets both course_type_postgraduate and course_type_undergraduate to true' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         postgraduate_course_option = create(:course_option, course: create(:course, program_type: 'higher_education_programme'))
         undergraduate_course_option = create(:course_option, course: create(:course, program_type: 'teacher_degree_apprenticeship'))
         create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: postgraduate_course_option)
@@ -165,6 +209,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       context 'when one of the application choices is unsubmitted' do
         it 'does not set the course type based on the unsubmitted choice' do
           application_form = create(:application_form)
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           postgraduate_course_option = create(:course_option, course: create(:course, program_type: 'higher_education_programme'))
           undergraduate_course_option = create(:course_option, course: create(:course, program_type: 'teacher_degree_apprenticeship'))
           _submitted_postgraduate_application = create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: postgraduate_course_option)
@@ -183,6 +231,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'populating subject_ids' do
       it 'sets subject_ids to the subjects of the courses' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         subject = create(:subject)
         course_option = create(:course_option, course: create(:course, subjects: [subject]))
         create(:application_choice, status: :awaiting_provider_decision, application_form: application_form, course_option: course_option)
@@ -196,6 +248,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
       it 'sets subject_ids to unique subjects of all courses' do
         application_form = create(:application_form)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         subject1 = create(:subject, id: 999991) # id set to ensure we're not picking up some other id
         subject2 = create(:subject, id: 999992) # id set to ensure we're not picking up some other id
         course_option1 = create(:course_option, course: create(:course, subjects: [subject1]))
@@ -215,6 +271,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
       context 'when one of the application choices is unsubmitted' do
         it 'does not set the subject ids based on the unsubmitted choice' do
           application_form = create(:application_form)
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           subject1 = create(:subject, id: 999991) # id set to ensure we're not picking up some other id
           subject2 = create(:subject, id: 999992) # id set to ensure we're not picking up some other id
           course_option1 = create(:course_option, course: create(:course, subjects: [subject1]))
@@ -236,6 +296,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
         application_form = create(:application_form, :completed,
                                   submitted_application_choices_count: 1,
                                   right_to_work_or_study: nil)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         stub_application_forms_in_the_pool(application_form.id)
 
         described_class.new.perform
@@ -250,6 +314,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
         application_form = create(:application_form, :completed,
                                   submitted_application_choices_count: 1,
                                   right_to_work_or_study: :decide_later)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         stub_application_forms_in_the_pool(application_form.id)
 
         described_class.new.perform
@@ -264,6 +332,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
         application_form = create(:application_form, :completed,
                                   submitted_application_choices_count: 1,
                                   right_to_work_or_study: :no)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         stub_application_forms_in_the_pool(application_form.id)
 
         described_class.new.perform
@@ -280,6 +352,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
                                     submitted_application_choices_count: 1,
                                     right_to_work_or_study: :yes,
                                     immigration_status: 'student_visa')
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           stub_application_forms_in_the_pool(application_form.id)
 
           described_class.new.perform
@@ -295,6 +371,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
                                     submitted_application_choices_count: 1,
                                     right_to_work_or_study: :yes,
                                     immigration_status: 'skilled_worker_visa')
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           stub_application_forms_in_the_pool(application_form.id)
 
           described_class.new.perform
@@ -310,6 +390,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
                                     submitted_application_choices_count: 1,
                                     right_to_work_or_study: :yes,
                                     immigration_status: 'eu_settled')
+          create(
+            :candidate_preference,
+            candidate: application_form.candidate,
+          )
           stub_application_forms_in_the_pool(application_form.id)
 
           described_class.new.perform
@@ -323,6 +407,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
     context 'rejected_provider_ids' do
       it 'sets to [] when there are no rejections' do
         application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         stub_application_forms_in_the_pool(application_form.id)
 
         expect(application_form.application_choices.rejected).to eq []
@@ -335,6 +423,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
       it 'does not include provider ids from choices with other statuses' do
         application_form = create(:application_form, :completed)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         rejected_choice = create(:application_choice, :rejected, application_form:)
         another_reject_choice = create(:application_choice, :rejected, application_form:)
         create(:application_choice, :withdrawn, application_form:)
@@ -354,6 +446,10 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
         second_rejected_course = create(:course, provider:)
 
         application_form = create(:application_form, :completed)
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+        )
         create(:application_choice, :rejected, application_form:, course_option: build(:course_option, course: first_rejected_course))
         create(:application_choice, :rejected, application_form:, course_option: build(:course_option, course: second_rejected_course))
 
@@ -363,6 +459,170 @@ RSpec.describe FindACandidate::PopulatePoolWorker do
 
         candidate_pool_application = CandidatePoolApplication.last
         expect(candidate_pool_application.rejected_provider_ids).to eq([provider.id])
+      end
+    end
+
+    context 'with course_funding_type_fee' do
+      it 'sets course_funding_type_fee true when open to fee funding courses' do
+        # this is here to make sure the query is scoped to the correct candidate
+        unrelated_form = create(:application_form, :completed)
+        create(
+          :application_choice,
+          application_form: unrelated_form,
+          course: create(:course_option, :tda).course,
+        )
+        application_form = create(
+          :application_form,
+          :completed,
+          submitted_application_choices_count: 1,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: 'fee',
+        )
+
+        stub_application_forms_in_the_pool(application_form.id)
+
+        described_class.new.perform
+
+        candidate_pool_application = CandidatePoolApplication.last
+        expect(candidate_pool_application.course_funding_type_fee).to be true
+      end
+
+      it 'sets course_funding_type_fee true when open to fee funding courses but applied to salary' do
+        unrelated_form = create(:application_form, :completed)
+        create(
+          :application_choice,
+          application_form: unrelated_form,
+          course: create(:course_option, :tda).course,
+        )
+        application_form = create(
+          :application_form,
+          :completed,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :tda).course,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: nil,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: 'fee',
+        )
+
+        stub_application_forms_in_the_pool(application_form.id)
+
+        described_class.new.perform
+
+        candidate_pool_application = CandidatePoolApplication.last
+        expect(candidate_pool_application.course_funding_type_fee).to be true
+      end
+
+      it 'sets course_funding_type_fee true when applied to fee funded courses but no preference' do
+        unrelated_form = create(:application_form, :completed)
+        create(
+          :application_choice,
+          application_form: unrelated_form,
+          course: create(:course_option, :tda).course,
+        )
+        application_form = create(
+          :application_form,
+          :completed,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :fee).course,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :tda).course,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: nil,
+        )
+
+        stub_application_forms_in_the_pool(application_form.id)
+
+        described_class.new.perform
+
+        candidate_pool_application = CandidatePoolApplication.last
+        expect(candidate_pool_application.course_funding_type_fee).to be true
+      end
+
+      it 'sets course_funding_type_fee false when preference is only salary' do
+        unrelated_form = create(:application_form, :completed)
+        create(
+          :application_choice,
+          application_form: unrelated_form,
+          course: create(:course_option, :fee).course,
+        )
+        application_form = create(
+          :application_form,
+          :completed,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :fee).course,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :tda).course,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: 'salary',
+        )
+
+        stub_application_forms_in_the_pool(application_form.id)
+
+        described_class.new.perform
+
+        candidate_pool_application = CandidatePoolApplication.last
+        expect(candidate_pool_application.course_funding_type_fee).to be false
+      end
+
+      it 'sets course_funding_type_fee false when no preference but only applied to salary courses' do
+        unrelated_form = create(:application_form, :completed)
+        create(
+          :application_choice,
+          application_form: unrelated_form,
+          course: create(:course_option, :fee).course,
+        )
+        application_form = create(
+          :application_form,
+          :completed,
+        )
+        create(
+          :application_choice,
+          application_form:,
+          course: create(:course_option, :tda).course,
+        )
+        create(
+          :candidate_preference,
+          candidate: application_form.candidate,
+          funding_type: nil,
+        )
+
+        stub_application_forms_in_the_pool(application_form.id)
+
+        described_class.new.perform
+
+        candidate_pool_application = CandidatePoolApplication.last
+        expect(candidate_pool_application.course_funding_type_fee).to be false
       end
     end
   end


### PR DESCRIPTION
## Context

Now that candidates can add their funding type preference, we need to allow providers to filter by this preference.

Before that, we need to update the FAC worker to populate the course_funding_type_fee column on CandidatePoolApplication

This will be true or false.
- True if the candidate expressed a preference to be invited to fee courses
- True if they didn't express this preference but they already applied to fee courses
- False if they expressed no preference in fee courses
- False if they didn't express any preference but only applied to salary courses this includes apprenticeships

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Bit harder to test this one. Maybe pull locally and run the worker and check CandidatePoolApplications?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
