### PR TITLE
Allow providers to filter by fee based courses in FAC

### DIFF
--- a/app/components/provider_interface/find_candidates/filters_component.html.erb
+++ b/app/components/provider_interface/find_candidates/filters_component.html.erb
@@ -135,6 +135,18 @@
             </div>
 
             <div class="govuk-form-group filter-group">
+              <%= f.govuk_collection_check_boxes(
+                :funding_type,
+                funding_type_options,
+                :value,
+                :name,
+                legend: { text: t('.funding_type'), size: 's' },
+                small: true,
+                include_hidden: false,
+              ) %>
+            </div>
+
+            <div class="govuk-form-group filter-group">
               <h3 class="govuk-heading-m">
                 <%= t('.visa_sponsorship') %>
               </h3>

--- a/app/components/provider_interface/find_candidates/filters_component.rb
+++ b/app/components/provider_interface/find_candidates/filters_component.rb
@@ -22,6 +22,9 @@ module ProviderInterface
           course_type: {
             options: course_type_options,
           },
+          funding_type: {
+            options: funding_type_options,
+          },
           visa_sponsorship: {
             options: visa_sponsorship_options,
           },
@@ -64,6 +67,17 @@ module ProviderInterface
             name: value.split('_').join(' ').capitalize,
           )
         end
+      end
+
+      def funding_type_options
+        funding_type = Struct.new(:value, :name)
+
+        [
+          funding_type.new(
+            value: 'fee',
+            name: 'fee-funded only'.capitalize,
+          ),
+        ]
       end
 
       def course_type_options

--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -70,6 +70,7 @@ module ProviderInterface
           study_mode: [],
           course_type: [],
           visa_sponsorship: [],
+          funding_type: [],
         )
       end
 

--- a/app/controllers/provider_interface/candidate_pool/not_seen_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/not_seen_controller.rb
@@ -40,6 +40,7 @@ module ProviderInterface
           study_mode: [],
           course_type: [],
           visa_sponsorship: [],
+          funding_type: [],
         )
       end
     end

--- a/app/models/candidate_pool_application.rb
+++ b/app/models/candidate_pool_application.rb
@@ -10,6 +10,7 @@ class CandidatePoolApplication < ApplicationRecord
     scope = filter_by_study_mode(scope, filters)
     scope = filter_by_course_type(scope, filters)
     scope = filter_by_needs_visa(scope, filters)
+    scope = filter_by_funding_type(scope, filters)
 
     ApplicationForm.where(id: scope.select(:application_form_id))
   end
@@ -81,5 +82,13 @@ class CandidatePoolApplication < ApplicationRecord
     end
 
     scope.where(attributes)
+  end
+
+  def self.filter_by_funding_type(scope, filters)
+    return scope if filters[:funding_type].blank?
+
+    if filters[:funding_type].include?('fee')
+      scope.where(course_funding_type_fee: true)
+    end
   end
 end

--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -14,6 +14,7 @@ module ProviderInterface
       study_mode
       course_type
       visa_sponsorship
+      funding_type
     ].freeze
     ATTRIBUTES.each do |attribute|
       attribute attribute.to_sym

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -97,10 +97,12 @@ en:
         remove_hint_study_mode: Remove study type filter
         remove_hint_course_type: Remove course type filter
         remove_hint_visa_sponsorship: Remove visa sponsorship filter
+        remove_hint_funding_type: Remove funding type filter
         location: 'Town, city or postcode:'
         remove_location_hint: Remove candidate location preference filter
         study_mode: Study type
         course_type: Course type
+        funding_type: Funding type
         visa_sponsorship: Candidate visa requirements
         subjects_applied_to: Subjects previously applied to
         candidate_location_preference: Candidate location preferences

--- a/spec/models/candidate_pool_application_spec.rb
+++ b/spec/models/candidate_pool_application_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe CandidatePoolApplication do
         application_form: subject_candidate_form,
         candidate: subject_candidate_form.candidate,
         subject_ids: [1],
+        course_funding_type_fee: true,
       )
       part_time_candidate_form = create(:application_form, :completed)
       create(
@@ -22,6 +23,7 @@ RSpec.describe CandidatePoolApplication do
         candidate: part_time_candidate_form.candidate,
         subject_ids: [1],
         study_mode_part_time: true,
+        course_funding_type_fee: false,
       )
       undergraduate_candidate_form = create(:application_form, :completed)
       create(
@@ -31,6 +33,7 @@ RSpec.describe CandidatePoolApplication do
         subject_ids: [1],
         study_mode_part_time: true,
         course_type_undergraduate: true,
+        course_funding_type_fee: false,
       )
       visa_sponsorship_candidate_form = create(:application_form, :completed)
       create(
@@ -38,6 +41,7 @@ RSpec.describe CandidatePoolApplication do
         application_form: visa_sponsorship_candidate_form,
         candidate: visa_sponsorship_candidate_form.candidate,
         needs_visa: true,
+        course_funding_type_fee: false,
       )
 
       filters = {}
@@ -79,6 +83,15 @@ RSpec.describe CandidatePoolApplication do
 
       expect(application_forms.ids).to contain_exactly(
         undergraduate_candidate_form.id,
+      )
+
+      filters = {
+        funding_type: ['fee'],
+      }
+      application_forms = described_class.filtered_application_forms(filters)
+
+      expect(application_forms.ids).to contain_exactly(
+        subject_candidate_form.id,
       )
 
       filters = {

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe 'Providers views candidate pool list' do
 
     when_i_filter_by_location
     then_i_expect_to_see_filtered_candidates([@declined_candidate_form, @rejected_candidate_form, @visa_sponsorship_form])
+
+    when_i_filter_by_fee_funding_type
+    then_i_expect_to_see_filtered_candidates([@declined_candidate_form, @visa_sponsorship_form])
+
     when_i_filter_by_visa_sponsorship
     then_i_expect_to_see_filtered_candidates([@visa_sponsorship_form])
     and_i_expect_to_see_the_updated_results_count
@@ -102,7 +106,11 @@ RSpec.describe 'Providers views candidate pool list' do
       candidate: declined_candidate,
       submitted_at: Time.zone.today,
     )
-    create(:candidate_pool_application, application_form: @declined_candidate_form)
+    create(
+      :candidate_pool_application,
+      application_form: @declined_candidate_form,
+      course_funding_type_fee: true,
+    )
   end
 
   def set_rejected_candidate_form
@@ -133,6 +141,7 @@ RSpec.describe 'Providers views candidate pool list' do
       :candidate_pool_application,
       application_form: @visa_sponsorship_form,
       needs_visa: true,
+      course_funding_type_fee: true,
     )
   end
 
@@ -247,6 +256,7 @@ RSpec.describe 'Providers views candidate pool list' do
       'Remove study type filter Full time',
       'Remove course type filter Postgraduate',
       'Remove visa sponsorship filter Does not need a visa',
+      'Remove funding type filter Fee-funded only',
     ])
   end
 
@@ -279,5 +289,10 @@ RSpec.describe 'Providers views candidate pool list' do
     within('.moj-filter-layout__content') do
       click_on 'Clear search'
     end
+  end
+
+  def when_i_filter_by_fee_funding_type
+    check('Fee-funded only')
+    first('.govuk-button', text: 'Apply filters').click
   end
 end


### PR DESCRIPTION
## Context

We allowed candidates to express their preference to be invited to fee
funded courses or not.

We need to allow providers to filter by this preference.

We will allow providers just to exclude candidates that are not
interested in fee based courses through their preferences or through
their choices.

Candidates that don't have a preference but only applied to salary
courses will be excluded by this filter.

This filter just uses a boolean course_funding_type_fee on the
candidate_pool_applications table. This is set by the FAC worker every
15 minutes

## Changes proposed in this pull request

Go on review and filter by the new filter?


https://github.com/user-attachments/assets/097250f6-75ae-4942-b997-af22ba6ac4f2



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
