### PR TITLE
Make the banner order consistent in candidate interface

### DIFF
--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -1,4 +1,3 @@
-<%= render(CandidateInterface::DeadlineBannerComponent.new(application_form:, flash_empty: flash.empty?)) %>
 <h1 class="govuk-heading-xl">
   <%= t('mid_cycle_content_component.title') %>
 </h1>

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -1,5 +1,7 @@
 <%= content_for :title, t('page_titles.your_applications') %>
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
+<%= render CandidateInterface::DeadlineBannerComponent.new(application_form: current_application, flash_empty: flash.empty?) %>
+<%= render CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent.new(application_form: current_application) %>
 
 <% if current_candidate.recoverable? %>
   <%= govuk_notification_banner(title_text: t('account_recovery_banner.title'), success: false) do |nb| %>
@@ -24,7 +26,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  <%= render CandidateInterface::SponsorshipApplicationDeadlines::ApplicationsDashboardBannerComponent.new(application_form: current_application) %>
   <% if current_application.after_apply_deadline? %>
 <!--      It is after the deadline, but candidate has inflight applications (eg, awaiting decision) -->
     <%= render CandidateInterface::AfterDeadlineContentComponent.new(application_form: current_application) %>


### PR DESCRIPTION
## Context

Previously the banners in the 'Your applications' page were not in the same order as on 'Your details'. The width of the banners on 'Your applications' was also not the same as on `Your details`.

This commit fixes this

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

# Before
| Your details    | Your applications |
| -------- | ------- |
| <img width="1455" height="1057" alt="image" src="https://github.com/user-attachments/assets/5c787684-28cf-47ce-8c0d-97051579e4db" />  | <img width="1495" height="1120" alt="image" src="https://github.com/user-attachments/assets/bdc5a272-f3d1-4082-a170-ce82233d6bae" />  |

# After
| Your details | Your applications |
| -------- | -------- |
| <img width="1409" height="902" alt="2025-07-11_11-04" src="https://github.com/user-attachments/assets/85a32533-c592-49a8-8f53-a8f446f2fcde" /> | <img width="1322" height="868" alt="2025-07-11_11-04_1" src="https://github.com/user-attachments/assets/a5f556b0-e0bf-41c4-96bd-1f484f1b2f14" /> |


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
