### PR TITLE
make matching_application_choice method more robust

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -16,6 +16,7 @@ class ApplicationChoice < ApplicationRecord
   has_one :accredited_provider, through: :course, class_name: 'Provider'
 
   belongs_to :original_course_option, class_name: 'CourseOption', optional: true
+  has_one :original_course, through: :original_course_option, source: :course
 
   belongs_to :current_course_option, class_name: 'CourseOption'
   has_one :current_site, through: :current_course_option, source: :site

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -40,7 +40,7 @@ class Pool::Invite < ApplicationRecord
   def matching_application_choice
     application_form.application_choices
       .visible_to_provider
-      .find { |choice| choice.course == course }
+      .find { |choice| [choice.course, choice.original_course, choice.current_course].any? { |c| c == course } }
   end
 
   def self.matching_application_choices_exists_sql

--- a/spec/components/previews/provider_interface/candidate_invited_banner_component_preview.rb
+++ b/spec/components/previews/provider_interface/candidate_invited_banner_component_preview.rb
@@ -1,13 +1,13 @@
 class ProviderInterface::CandidateInvitedBannerComponentPreview < ViewComponent::Preview
   def candidate_invited
-    candidate = FactoryBot.create(:candidate)
-    application_form = FactoryBot.create(:application_form, :completed, candidate:, submitted_at: 1.day.ago)
-    pool_invite = FactoryBot.create(:pool_invite, :published, candidate:)
+    application_form = FactoryBot.build(:application_form, :completed, submitted_at: 1.day.ago)
+    application_choice = FactoryBot.create(:application_choice, :awaiting_provider_decision, application_form:)
+    pool_invite = FactoryBot.create(:pool_invite, :published, application_form:, course: application_choice.course)
     provider = pool_invite.provider
     current_provider_user = FactoryBot.create(:provider_user, providers: [provider])
 
     render ProviderInterface::CandidateInvitedBannerComponent.new(
-      application_form:,
+      application_choice:,
       current_provider_user:,
     )
   end

--- a/spec/components/provider_interface/candidate_invited_banner_component_spec.rb
+++ b/spec/components/provider_interface/candidate_invited_banner_component_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe ProviderInterface::CandidateInvitedBannerComponent, type: :compon
     let(:application_choice) do
       create(
         :application_choice,
+        :awaiting_provider_decision,
         application_form:,
         course_option:,
-        status: 'awaiting_provider_decision',
       )
     end
     let!(:pool_invite) { create(:pool_invite, :published, candidate:, application_form:, course:) }
@@ -33,7 +33,7 @@ RSpec.describe ProviderInterface::CandidateInvitedBannerComponent, type: :compon
       let(:current_provider_user) { create(:provider_user, providers: [provider]) }
 
       it 'does not render the banner' do
-        application_choice.update(course_option: other_course_option)
+        application_choice = create(:application_choice, course_option: other_course_option)
 
         result = render_inline(described_class.new(application_choice:, current_provider_user:))
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationChoice do
   it { is_expected.to have_many(:withdrawal_reasons).dependent(:destroy) }
   it { is_expected.to have_many(:draft_withdrawal_reasons).dependent(:destroy) }
   it { is_expected.to have_many(:published_withdrawal_reasons).dependent(:destroy) }
+  it { is_expected.to have_one(:original_course).class_name('Course') }
 
   describe 'auditing', :with_audited do
     it 'creates audit entries' do


### PR DESCRIPTION
## Context

This is a preliminary PR to just make this method more robust in advance of blocking providers from inviting candidates to courses they have already applied to. 

## Changes proposed in this pull request

Now the matching_application_choice method checks the current and original courses. So if a user has applied to one course, and then the provider makes an offer to another course, an invite to either course will be matched on that application_choice

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
