### PR TITLE
[1050] Block provider from inviting candidate to courses they have applied to

### DIFF
--- a/app/forms/provider_interface/pool_invite_form.rb
+++ b/app/forms/provider_interface/pool_invite_form.rb
@@ -8,6 +8,7 @@ module ProviderInterface
     validates :course_id, presence: true
     validate :course_is_open if -> { course.present? }
     validate :already_invited_to_course if -> { course.present? }
+    validate :already_applied_to_course if -> { course.present? }
 
     def initialize(current_provider_user:, candidate: nil, pool_invite_form_params: {})
       @current_provider_user = current_provider_user
@@ -75,6 +76,10 @@ module ProviderInterface
     def already_invited_to_course
       existing_invite = Pool::Invite.published.find_by(course_id:, candidate_id: candidate.id).present?
       errors.add(:course_id, :already_invited) if existing_invite
+    end
+
+    def already_applied_to_course
+      errors.add(:course_id, :already_applied) if course_id.to_i.in? candidate.current_application.already_applied_course_ids
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -724,6 +724,20 @@ class ApplicationForm < ApplicationRecord
       (right_to_work_or_study_yes? && immigration_status.in?(VISAS_REQUIRING_SPONSORSHIP))
   end
 
+  def already_applied_course_ids
+    return [] if application_choices.blank?
+
+    application_choices.visible_to_provider
+                       .joins(:course_option, :current_course_option)
+                       .left_joins(:original_course_option)
+                       .select(
+                         'application_choices.id',
+                         'course_options.course_id AS course_id',
+                         'current_course_options_application_choices.course_id AS current_course_id',
+                         'original_course_options_application_choices.course_id AS original_course_id',
+                       ).flat_map { |ac| [ac.course_id, ac.current_course_id, ac.original_course_id] }.compact.uniq
+  end
+
 private
 
   def geocode_address_and_update_region_if_required

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -157,6 +157,7 @@ en:
               blank: Select a course
               invalid: Course is not available
               already_invited: Select a different course. You have invited this person to the selected course already
+              already_applied: Select a different course. The candidate has already applied to the selected course
         provider_interface/pool_invite_message_form:
           attributes:
             provider_message:

--- a/spec/forms/provider_interface/pool_invite_form_spec.rb
+++ b/spec/forms/provider_interface/pool_invite_form_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe ProviderInterface::PoolInviteForm, type: :model do
         expect(form.errors[:course_id]).to eq(['Select a different course. You have invited this person to the selected course already'])
       end
     end
+
+    context 'when the candidate has applied to the course already' do
+      it 'raises an error' do
+        _application_choice = create(:application_choice, :awaiting_provider_decision, course_option: build(:course_option, course:), application_form: candidate.current_application)
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:course_id]).to eq(['Select a different course. The candidate has already applied to the selected course'])
+      end
+    end
+
+    context 'when the course has changed on an application form to match the selected course' do
+      it 'raises an error' do
+        application_choice = create(:application_choice, :awaiting_provider_decision, application_form: candidate.current_application)
+        application_choice.update_course_option_and_associated_fields!(create(:course_option, course:))
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:course_id]).to eq(['Select a different course. The candidate has already applied to the selected course'])
+      end
+    end
   end
 
   describe '.build_from_invite' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1624,4 +1624,25 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#already_applied_course_ids' do
+    it 'returns course ids for submitted applications' do
+      original_course_option = create(:course_option)
+      changed_to_course_option = create(:course_option, course: build(:course, provider: original_course_option.provider))
+      some_other_course_option = create(:course_option)
+      course_option_for_draft = create(:course_option)
+
+      application_form = create(:application_form)
+      create(:application_choice, :unsubmitted, course_option: course_option_for_draft, application_form:)
+      create(:application_choice, :interviewing, course_option: some_other_course_option, application_form:)
+      changed_application_choice = create(:application_choice, :awaiting_provider_decision, course_option: original_course_option, application_form:)
+      changed_application_choice.update_course_option_and_associated_fields!(changed_to_course_option)
+
+      expect(application_form.already_applied_course_ids).to contain_exactly(
+        original_course_option.course.id,
+        changed_to_course_option.course.id,
+        some_other_course_option.course.id,
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to keep providers from inviting candidates to courses for which they have already applied -- in some cases, candidates have been invited to apply to courses they have already been rejected from. 

## Changes proposed in this pull request

When a provider tries to invite a candidate to a course for which they already have an application, they will see an error message. 
The ticket says to remove the courses from the list, but I have assumed we want to handle it in the [same way we handle people being invited to a course they have already been invited to](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10471) -- show it on the list and then an error if it's selected. 

https://github.com/user-attachments/assets/14527ca6-59f1-4b13-ab7e-c9b9ac15b9bd

## Guidance to review
In the review app or locally, try inviting a candidate to a course for which they have applied. The application has to be visible to provider, so if it's draft, it won't be blocked.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
