### PR TITLE
Add application_form_id to candidate preferences

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -15,6 +15,7 @@ shared:
     - updated_at
     - training_locations
     - funding_type
+    - application_form_id
   candidate_location_preferences:
     - id
     - name

--- a/db/migrate/20250715085311_add_application_form_id_to_candidate_preferences.rb
+++ b/db/migrate/20250715085311_add_application_form_id_to_candidate_preferences.rb
@@ -1,0 +1,7 @@
+class AddApplicationFormIdToCandidatePreferences < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :candidate_preferences, :application_form, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -456,6 +456,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_15_095513) do
     t.text "opt_out_reason"
     t.string "training_locations"
     t.string "funding_type"
+    t.bigint "application_form_id"
+    t.index ["application_form_id"], name: "index_candidate_preferences_on_application_form_id"
     t.index ["candidate_id"], name: "index_candidate_preferences_on_candidate_id"
   end
 


### PR DESCRIPTION
## Context

We want to tie the candidate preferences to a recruitment cycle, so we need the reference to be to the application form rather than the candidate. This is the first in a series of PRs around this, and just adds the application_form_id to the candidate preference model.

## Changes proposed in this pull request

Migration to add application_form reference to candidate preferences.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [x] This code does not rely on migrations in the same Pull Request
  - [x] decide whether it needs to be in analytics yml file or analytics blocklist
  - [x] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
