### PR TITLE
Link a application choice to an invite on submission of choice

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -51,6 +51,8 @@ class ApplicationForm < ApplicationRecord
 
   has_many :application_feedback
 
+  has_many :invites, -> { published }, class_name: 'Pool::Invite'
+
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :unsubmitted, -> { where(submitted_at: nil) }
   scope :inactive_since, ->(time) { where('application_forms.updated_at < ?', time) }

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -14,6 +14,11 @@ class Pool::Invite < ApplicationRecord
     published: 'published',
   }, default: :draft
 
+  enum :candidate_decision, {
+    not_responded: 'not_responded',
+    applied: 'applied',
+  }, default: :not_responded
+
   scope :not_sent_to_candidate, -> { where(sent_to_candidate_at: nil) }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :with_matching_application_choices, -> { where(matching_application_choices_exists_sql) }

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -29,6 +29,14 @@ module CandidateInterface
           preference: application_form.candidate.published_preferences.last,
           application_choice:,
         )
+
+        invite = application_form.invites.find_by(course_id: application_choice.course.id)
+        if invite.present?
+          invite.update(
+            application_choice_id: application_choice.id,
+            candidate_decision: 'applied',
+          )
+        end
       end
     end
 

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -142,6 +142,38 @@ module CandidateInterface
             application_choice:,
           )
         end
+
+        context 'when invite exists' do
+          it 'saves the application_choice on the invite' do
+            invite = create(
+              :pool_invite,
+              course: application_choice.course,
+              status: 'published',
+              application_form: application_choice.application_form,
+              candidate: application_choice.application_form.candidate,
+            )
+
+            submit_application
+
+            expect(invite.reload.application_choice_id).to eq(application_choice.id)
+            expect(invite.reload.candidate_decision).to eq('applied')
+          end
+        end
+
+        context 'when invite does not exists' do
+          it 'does not saves the application_choice on the invite' do
+            invite = create(
+              :pool_invite,
+              course: application_choice.course,
+              status: 'published',
+            )
+
+            submit_application
+
+            expect(invite.reload.application_choice_id).to be_nil
+            expect(invite.reload.candidate_decision).to eq('not_responded')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

This will save an application_choice_id on the invite if the course applied is the same as the invite course. Don't think we need to check original course here.

It also sets the invite#candidate_decision to applied.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Can pull this locally and apply to an invited course, the invite should have an application_choice id after that.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
