### PR TITLE
Migration to drop grouped_invite_email feature flag

### DIFF
--- a/app/services/data_migrations/drop_grouped_invite_email_feature_flag.rb
+++ b/app/services/data_migrations/drop_grouped_invite_email_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropGroupedInviteEmailFeatureFlag
+    TIMESTAMP = 20250715162833
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :grouped_invite_email).destroy_all
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,7 +28,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:candidate_preferences, 'Allow candidates to add their preferences for providers to find them', 'Apply team'],
-    [:grouped_invite_email, 'Sends a collated email containing all unsent invites to a Candidate', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DropGroupedInviteEmailFeatureFlag',
   'DataMigrations::BackfillApplicationFormOnPoolInvites',
   'DataMigrations::MigrateFacFiltersToProviderUserFilters',
   'DataMigrations::BackfillTrainingLocationsOnCandidatePreferences',

--- a/spec/services/data_migrations/drop_grouped_invite_email_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_grouped_invite_email_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropGroupedInviteEmailFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'grouped_invite_email')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'grouped_invite_email')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/services/data_migrations/drop_grouped_invite_email_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_grouped_invite_email_feature_flag_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe DataMigrations::DropGroupedInviteEmailFeatureFlag do
   context 'when the feature flag exists' do
     it 'removes the feature flag' do
-      create(:feature, name: 'grouped_invite_email')
+      Feature.find_or_create_by(name: 'grouped_invite_email')
+
       expect { described_class.new.change }.to change { Feature.count }.by(-1)
       expect(Feature.where(name: 'grouped_invite_email')).to be_blank
     end


### PR DESCRIPTION
## Context

We no longer need or use the grouped_invite_email feature flag

## Changes proposed in this pull request

- Migration to drop grouped_invite_email feature flag

## Guidance to review

-N/A

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
