### PR TITLE
Save application form when creating / updating preferences

### DIFF
--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -30,6 +30,7 @@ module CandidateInterface
       return if invalid?
 
       kwargs = {
+        application_form: @current_candidate.current_application,
         pool_status:,
         opt_out_reason: pool_status == 'opt_in' ? nil : opt_out_reason,
         training_locations: pool_status == 'opt_out' ? nil : preference&.training_locations,

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -1,5 +1,6 @@
 class CandidatePreference < ApplicationRecord
   belongs_to :candidate
+  belongs_to :application_form, optional: true
   has_many :location_preferences, dependent: :destroy, class_name: 'CandidateLocationPreference'
 
   enum :pool_status, {

--- a/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
+++ b/spec/forms/candidate_interface/pool_opt_ins_form_spec.rb
@@ -63,6 +63,7 @@ module CandidateInterface
 
           preference_record = CandidatePreference.last
           expect(preference_record.pool_status).to eq('opt_in')
+          expect(preference_record.application_form).to eq(current_candidate.current_application)
           expect(LocationPreferences).to have_received(:add_default_location_preferences)
         end
       end

--- a/spec/models/candidate_preference_spec.rb
+++ b/spec/models/candidate_preference_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidatePreference do
   describe 'associations' do
     it { is_expected.to belong_to(:candidate) }
+    it { is_expected.to belong_to(:application_form).optional }
     it { is_expected.to have_many(:location_preferences).class_name('CandidateLocationPreference') }
   end
 


### PR DESCRIPTION
## Context

This is the second PR for adding the application form to the candidate preference. The first was a migration to add the column to the database. A third one will backfill the data.

## Changes proposed in this pull request

When we save the candidate preference, we now add the application_form. For this pr, it is marked as optional on the model, but that will be removed in the clean up after the backfill happens. 

## Guidance to review

Is there any other place where we save the candidate preference?


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
