### PR TITLE
Ensure pool is empty at the end of cycle

### DIFF
--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -4,25 +4,28 @@ class FindACandidate::PopulatePoolWorker
   sidekiq_options queue: :default
 
   def perform
-    application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool
+    if RecruitmentCycleTimetable.current_timetable.between_cycles?
+      CandidatePoolApplication.delete_all
+    else
+      application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool
 
-    applications = application_forms_eligible_for_pool
-                     .joins(application_choices: { course_option: { course: :subjects } })
-                     .joins(candidate: :published_opt_in_preferences)
-                     .where.not(application_choices: { status: 'unsubmitted' })
-                     .select(
-                       'application_forms.id AS application_form_id',
-                       'application_forms.candidate_id AS candidate_id',
-                       "BOOL_OR(course_options.study_mode = 'full_time') AS study_mode_full_time",
-                       "BOOL_OR(course_options.study_mode = 'part_time') AS study_mode_part_time",
-                       "BOOL_OR(courses.program_type != 'TDA') AS course_type_postgraduate",
-                       "BOOL_OR(courses.program_type = 'TDA') AS course_type_undergraduate",
-                       'ARRAY_AGG(DISTINCT subjects.id) AS subject_ids',
-                       "COALESCE(ARRAY_AGG(DISTINCT courses.provider_id) FILTER (WHERE application_choices.status = 'rejected'), '{}') AS rejected_provider_ids",
-                       "MAX(CASE WHEN application_forms.right_to_work_or_study = 'no' OR (application_forms.right_to_work_or_study = 'yes' AND application_forms.immigration_status IN ('student_visa', 'skilled_worker_visa')) THEN 1 ELSE 0 END) = 1 AS needs_visa",
-                       'CURRENT_TIMESTAMP as created_at',
-                       'CURRENT_TIMESTAMP as updated_at',
-                       "MAX(CASE WHEN candidate_preferences.funding_type = 'fee'
+      applications = application_forms_eligible_for_pool
+                       .joins(application_choices: { course_option: { course: :subjects } })
+                       .joins(candidate: :published_opt_in_preferences)
+                       .where.not(application_choices: { status: 'unsubmitted' })
+                       .select(
+                         'application_forms.id AS application_form_id',
+                         'application_forms.candidate_id AS candidate_id',
+                         "BOOL_OR(course_options.study_mode = 'full_time') AS study_mode_full_time",
+                         "BOOL_OR(course_options.study_mode = 'part_time') AS study_mode_part_time",
+                         "BOOL_OR(courses.program_type != 'TDA') AS course_type_postgraduate",
+                         "BOOL_OR(courses.program_type = 'TDA') AS course_type_undergraduate",
+                         'ARRAY_AGG(DISTINCT subjects.id) AS subject_ids',
+                         "COALESCE(ARRAY_AGG(DISTINCT courses.provider_id) FILTER (WHERE application_choices.status = 'rejected'), '{}') AS rejected_provider_ids",
+                         "MAX(CASE WHEN application_forms.right_to_work_or_study = 'no' OR (application_forms.right_to_work_or_study = 'yes' AND application_forms.immigration_status IN ('student_visa', 'skilled_worker_visa')) THEN 1 ELSE 0 END) = 1 AS needs_visa",
+                         'CURRENT_TIMESTAMP as created_at',
+                         'CURRENT_TIMESTAMP as updated_at',
+                         "MAX(CASE WHEN candidate_preferences.funding_type = 'fee'
                           OR EXISTS (
                                SELECT 1
                                FROM   application_forms
@@ -33,30 +36,31 @@ class FindACandidate::PopulatePoolWorker
                          THEN 1
                          ELSE 0
                        END) = 1 AS course_funding_type_fee",
-                     )
-                     .group(:id)
+                       )
+                       .group(:id)
 
-    insert_all_from_eligible_sql = <<~SQL
-      INSERT INTO candidate_pool_applications (
-        application_form_id,
-        candidate_id,
-        study_mode_full_time,
-        study_mode_part_time,
-        course_type_postgraduate,
-        course_type_undergraduate,
-        subject_ids,
-        rejected_provider_ids,
-        needs_visa,
-        created_at,
-        updated_at,
-        course_funding_type_fee
-      )
-      #{applications.to_sql}
-    SQL
+      insert_all_from_eligible_sql = <<~SQL
+        INSERT INTO candidate_pool_applications (
+          application_form_id,
+          candidate_id,
+          study_mode_full_time,
+          study_mode_part_time,
+          course_type_postgraduate,
+          course_type_undergraduate,
+          subject_ids,
+          rejected_provider_ids,
+          needs_visa,
+          created_at,
+          updated_at,
+          course_funding_type_fee
+        )
+        #{applications.to_sql}
+      SQL
 
-    CandidatePoolApplication.transaction do
-      CandidatePoolApplication.delete_all
-      ActiveRecord::Base.connection.execute(insert_all_from_eligible_sql)
+      CandidatePoolApplication.transaction do
+        CandidatePoolApplication.delete_all
+        ActiveRecord::Base.connection.execute(insert_all_from_eligible_sql)
+      end
     end
   end
 end

--- a/spec/support/cycle_timetable_helper.rb
+++ b/spec/support/cycle_timetable_helper.rb
@@ -53,6 +53,7 @@ module_function
     timetable = get_timetable(year)
     timetable.find_opens_at + 1.day
   end
+  alias before_apply_opens after_find_opens
 
   def after_find_closes(year = nil)
     timetable = get_timetable(year)

--- a/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
+++ b/spec/workers/find_a_candidate/populate_pool_worker_spec.rb
@@ -1,7 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe FindACandidate::PopulatePoolWorker do
-  describe '#perform' do
+  describe '#peform after the apply deadline,', time: after_apply_deadline do
+    it 'does not create any CandidatePoolApplication records' do
+      application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: application_form.candidate,
+      )
+      stub_application_forms_in_the_pool(application_form.id)
+
+      expect {
+        described_class.new.perform
+      }.not_to(change { CandidatePoolApplication.count })
+
+      expect(CandidatePoolApplication.count).to eq(0)
+    end
+
+    it 'deletes all records if any exists' do
+      create(:candidate_pool_application)
+
+      expect {
+        described_class.new.perform
+      }.to change { CandidatePoolApplication.count }.from(1).to(0)
+    end
+  end
+
+  describe '#peform before apply opens,', time: before_apply_opens do
+    it 'does not create any CandidatePoolApplication records' do
+      application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+      create(
+        :candidate_preference,
+        candidate: application_form.candidate,
+      )
+      stub_application_forms_in_the_pool(application_form.id)
+
+      expect {
+        described_class.new.perform
+      }.not_to(change { CandidatePoolApplication.count })
+
+      expect(CandidatePoolApplication.count).to eq(0)
+    end
+
+    it 'deletes all records if any exists' do
+      create(:candidate_pool_application)
+
+      expect {
+        described_class.new.perform
+      }.to change { CandidatePoolApplication.count }.from(1).to(0)
+    end
+  end
+
+  describe '#perform before the apply deadline', time: mid_cycle do
     it 'creates CandidatePoolApplication records' do
       application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
       create(


### PR DESCRIPTION
## Context

We do not want providers to see candidates or send invites when no one can apply. So the pool should be empty after the apply deadline and before apply opens. 

## Changes proposed in this pull request

A little conditional to make sure the pool is not populated between cycles, and some tests.

## Guidance to review

We might decide that we want to keep the pool empty for longer, but this is the bare minimum so that we don't have to worry about it when the deadline passes at in September.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
