### PR TITLE
Link invite to application choice on course change

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -264,7 +264,17 @@ class ApplicationChoice < ApplicationRecord
     assign_attributes(attrs) # provider_ids_for_access needs this to be set beforehand
     self.provider_ids = provider_ids_for_access
 
-    update!(attrs)
+    invite = application_form.published_invites.find_by(course_id: new_course_option.course_id, application_choice_id: nil)
+
+    ActiveRecord::Base.transaction do
+      if invite.present?
+        invite.update(
+          application_choice_id: id,
+          candidate_decision: 'applied',
+        )
+      end
+      update!(attrs)
+    end
   end
 
   def provider_ids_for_access

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -51,7 +51,7 @@ class ApplicationForm < ApplicationRecord
 
   has_many :application_feedback
 
-  has_many :invites, -> { published }, class_name: 'Pool::Invite'
+  has_many :published_invites, -> { published }, class_name: 'Pool::Invite'
 
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :unsubmitted, -> { where(submitted_at: nil) }

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -1,6 +1,7 @@
 class Pool::Invite < ApplicationRecord
   belongs_to :candidate
   belongs_to :application_form
+  belongs_to :application_choice, optional: true
   belongs_to :provider
   belongs_to :invited_by, class_name: 'ProviderUser'
   belongs_to :course

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -30,7 +30,7 @@ module CandidateInterface
           application_choice:,
         )
 
-        invite = application_form.invites.find_by(course_id: application_choice.course.id)
+        invite = application_form.published_invites.find_by(course_id: application_choice.course.id)
         if invite.present?
           invite.update(
             application_choice_id: application_choice.id,

--- a/spec/factories/pool_invite.rb
+++ b/spec/factories/pool_invite.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     trait :not_sent_to_candidate do
       sent_to_candidate_at { nil }
     end
+
+    trait :with_application_choice do
+      application_choice { create(:application_choice, application_form:) }
+    end
   end
 end


### PR DESCRIPTION
## Context


There is an edge case where a course can change on an application choice for an application form that has an invite to the new course on the application_choice.

In this case we want to link this application_choice to the invite if the courses match. The new course with the course on the invite.

Doing it in update_course_option_and_associated_fields method ensures that we do this link every time a course has changed, including the API.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Easiet to test this is to pull locally and check DB after changing course.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
