### PR TITLE
Backfill applied application_choice on invites

### DIFF
--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -1,6 +1,7 @@
 class Pool::Invite < ApplicationRecord
   belongs_to :candidate
   belongs_to :application_form
+  belongs_to :application_choice, optional: true
   belongs_to :provider
   belongs_to :invited_by, class_name: 'ProviderUser'
   belongs_to :course

--- a/app/services/data_migrations/backfill_invite_application_choices.rb
+++ b/app/services/data_migrations/backfill_invite_application_choices.rb
@@ -1,0 +1,28 @@
+module DataMigrations
+  class BackfillInviteApplicationChoices
+    TIMESTAMP = 20250717152335
+    MANUAL_RUN = false
+
+    def change
+      invites = Pool::Invite.published
+      .joins(application_form: :application_choices)
+      .where(application_choice_id: nil)
+      .where(application_choices: { status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER })
+      .where(
+        '(SELECT course_id FROM course_options WHERE id = application_choices.original_course_option_id) = pool_invites.course_id OR
+        (SELECT course_id FROM course_options WHERE id = application_choices.current_course_option_id) = pool_invites.course_id OR
+        (SELECT course_id FROM course_options WHERE id = application_choices.course_option_id) = pool_invites.course_id',
+      )
+      .select('DISTINCT ON (pool_invites.id) pool_invites.*, application_choices.id as choice_id')
+
+      ActiveRecord::Base.transaction do
+        invites.find_each do |invite|
+          invite.update(
+            application_choice_id: invite.choice_id,
+            candidate_decision: 'applied',
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillInviteApplicationChoices',
   'DataMigrations::BackfillApplicationFormOnCandidatePreferences',
   'DataMigrations::DropGroupedInviteEmailFeatureFlag',
   'DataMigrations::BackfillApplicationFormOnPoolInvites',

--- a/spec/factories/pool_invite.rb
+++ b/spec/factories/pool_invite.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     trait :not_sent_to_candidate do
       sent_to_candidate_at { nil }
     end
+
+    trait :with_application_choice do
+      application_choice { create(:application_choice, application_form:) }
+    end
   end
 end

--- a/spec/services/data_migrations/backfill_invite_application_choices_spec.rb
+++ b/spec/services/data_migrations/backfill_invite_application_choices_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillInviteApplicationChoices do
+  describe '#change' do
+    let(:migration) { described_class.new.change }
+
+    it 'links invites with application_choices' do
+      provider = create(:provider)
+
+      course = create(:course, :with_a_course_option, provider:)
+      applied_invite = create(:pool_invite, course:, status: 'published')
+      applied_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form: applied_invite.application_form,
+        course_option: course.course_options.first,
+        provider_ids: [provider.id],
+      )
+
+      original_course = create(:course, :with_a_course_option, provider:)
+      changed_course_invite = create(:pool_invite, course: original_course, status: 'published')
+      changed_course_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form: changed_course_invite.application_form,
+        original_course_option: original_course.course_options.first,
+        provider_ids: [provider.id],
+      )
+
+      current_course = create(:course, :with_a_course_option, provider:)
+      current_course_invite = create(:pool_invite, course: current_course, status: 'published')
+      current_course_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form: current_course_invite.application_form,
+        current_course_option: current_course.course_options.first,
+        provider_ids: [provider.id],
+      )
+
+      multiple_choices_course = create(:course, :with_a_course_option, provider:)
+      multiple_choices_invite = create(:pool_invite, course: multiple_choices_course, status: 'published')
+      first_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form: multiple_choices_invite.application_form,
+        current_course_option: multiple_choices_course.course_options.first,
+        provider_ids: [provider.id],
+      )
+      _second_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form: multiple_choices_invite.application_form,
+        current_course_option: multiple_choices_course.course_options.first,
+        provider_ids: [provider.id],
+        created_at: 1.day.ago,
+        updated_at: 1.day.ago,
+      )
+
+      linked_invite = create(:pool_invite, :with_application_choice, status: 'published')
+      normal_invite = create(:pool_invite, status: 'published')
+
+      expect { migration }.to change { applied_invite.reload.application_choice_id }.from(nil).to(applied_choice.id)
+        .and(change { applied_invite.candidate_decision }.from('not_responded').to('applied'))
+        .and(change { changed_course_invite.reload.application_choice_id }.from(nil).to(changed_course_choice.id))
+        .and(change { changed_course_invite.candidate_decision }.from('not_responded').to('applied'))
+        .and(change { current_course_invite.reload.application_choice_id }.from(nil).to(current_course_choice.id))
+        .and(change { current_course_invite.candidate_decision }.from('not_responded').to('applied'))
+        .and(change { multiple_choices_invite.reload.application_choice_id }.from(nil).to(first_choice.id))
+        .and(change { multiple_choices_invite.candidate_decision }.from('not_responded').to('applied'))
+        .and(not_change { normal_invite.reload.application_choice_id })
+        .and(not_change { linked_invite.reload.application_choice_id })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are linking application choices to invites when candidates submit their applications.

We now need to backfill this. To link the application choices to the invites if the courses match.

The query in the data migration is based on scopes we already have but we need to join on application choices.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Run the migration locally

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
