### PR TITLE
Add course recommendation links to emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -81,9 +81,10 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def application_rejected(application_choice)
+  def application_rejected(application_choice, course_recommendation_url = nil)
     @course = application_choice.current_course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+    @course_recommendation_url = course_recommendation_url
 
     email_for_candidate(application_choice.application_form)
   end

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -6,6 +6,10 @@ class SendCandidateRejectionEmail
   end
 
   def call
-    CandidateMailer.application_rejected(application_choice).deliver_later
+    recommended_courses_url = CandidateCoursesRecommender.recommended_courses_url(
+      candidate: application_choice.candidate,
+      locatable: application_choice.course.provider,
+    )
+    CandidateMailer.application_rejected(application_choice, recommended_courses_url).deliver_later
   end
 end

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -13,6 +13,14 @@ Lots of people are successful when they apply again.
 # You can apply again
 
 This year, more people than ever are choosing to apply again.
+
+  <% if @course_recommendation_url %>
+Based on the details in your previous application, you could be suitable for other teacher training courses.
+
+[View similar courses and apply](<%= @course_recommendation_url %>)
+
+You should not submit another application to a course you have already unsuccessfully applied to
+  <% end %>
 <% end %>
 
 <% @application_choice.tailored_advice_reasons.keys.each do |advice_reason_id| %>

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -419,4 +419,43 @@ RSpec.describe CandidateMailer do
       expect(email.body).to have_content 'Learn more about teacher training advisers'
     end
   end
+
+  describe 'Course Recommendations URL' do
+    let(:application_choice) { create(:application_choice, :rejected) }
+
+    context 'when a URL is not provided' do
+      subject(:email) { described_class.application_rejected(application_choice) }
+
+      it 'does not include the URL in the email body' do
+        expect(email.body).to have_no_content 'Based on the details in your previous application, you could be suitable for other teacher training courses.'
+        expect(email.body).to have_no_content 'View similar courses and apply'
+        expect(email.body).to have_no_content 'https://find-teacher-training-courses.service.gov.uk/results'
+        expect(email.body).to have_no_content 'You should not submit another application to a course you have already unsuccessfully applied to'
+      end
+    end
+
+    context 'when a URL is provided' do
+      subject(:email) { described_class.application_rejected(application_choice, 'https://find-teacher-training-courses.service.gov.uk/results') }
+
+      it 'includes the provided URL and content in the email body' do
+        expect(email.body).to have_content 'Based on the details in your previous application, you could be suitable for other teacher training courses.'
+        expect(email.body).to have_content 'View similar courses and apply'
+        expect(email.body).to have_content 'https://find-teacher-training-courses.service.gov.uk/results'
+        expect(email.body).to have_content 'You should not submit another application to a course you have already unsuccessfully applied to'
+      end
+
+      context 'between cycles' do
+        before do
+          allow(RecruitmentCycleTimetable).to receive(:currently_between_cycles?).and_return(true)
+        end
+
+        it 'does not include the URL and content in the email body' do
+          expect(email.body).to have_no_content 'Based on the details in your previous application, you could be suitable for other teacher training courses.'
+          expect(email.body).to have_no_content 'View similar courses and apply'
+          expect(email.body).to have_no_content 'https://find-teacher-training-courses.service.gov.uk/results'
+          expect(email.body).to have_no_content 'You should not submit another application to a course you have already unsuccessfully applied to'
+        end
+      end
+    end
+  end
 end

--- a/spec/mailers/previews/candidate/withdrawals_and_rejections_preview.rb
+++ b/spec/mailers/previews/candidate/withdrawals_and_rejections_preview.rb
@@ -11,6 +11,32 @@ class Candidate::WithdrawalsAndRejectionsPreview < ActionMailer::Preview
     CandidateMailer.application_rejected(application_choice)
   end
 
+  def application_rejected_with_course_recommendation
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      status: :rejected,
+      structured_rejection_reasons: {
+        selected_reasons: [
+          { id: 'teaching_knowledge', label: 'Teaching knowledge, ability and interview performance',
+            selected_reasons: [
+              { id: 'subject_knowledge', label: 'Subject knowledge',
+                details: {
+                  id: 'subject_knowledge_details',
+                  text: 'You did need to improve your knowledge of the subject',
+                } },
+              { id: 'teaching_knowledge_other', label: 'Other',
+                details: {
+                  id: 'teaching_knowledge_other_details',
+                  text: 'You did not demonstrate enough knowledge about teaching in the UK.',
+                } },
+            ] },
+        ],
+      },
+      rejection_reasons_type: :rejection_reasons,
+    )
+    CandidateMailer.application_rejected(application_choice, 'https://find-teacher-training-courses.service.gov.uk/results')
+  end
+
   def application_rejected_international_unverified
     application_choice = FactoryBot.create(
       :application_choice,


### PR DESCRIPTION
## Context

We want to update the content of emails to include a link and content about recommended courses that the Candidate could consider. 

## Changes proposed in this pull request

- Updated application rejected emails to conditionally include the content about recommended courses
- Updated the SendCandidateRejectionEmail worker to generate a recommendation link to include in the mailer

## Guidance to review

- 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
