### PR TITLE
Change wording around QTS

### DIFF
--- a/config/vendor_api/experimental-v1.0.yml
+++ b/config/vendor_api/experimental-v1.0.yml
@@ -32,7 +32,7 @@ paths:
           schema:
             type: string
         - name: for_ratified_courses
-          description: Generate applications for courses your organisation awards Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
+          description: Generate applications for courses your organisation gives Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
           in: query
           schema:
             type: string


### PR DESCRIPTION
## Context

The market regulation team have communicated that all reference to Qualified Teacher Status (QTS) should not include the terminology:

recommend/recommended
award/awarded
standards

Instead of referring to the ‘award’ of QTS and ‘recommending’ trainees for QTS, guidance should now refer to trainees holding, achieving or gaining QTS. This is to clarify the DfE’s legal position in the process and the fact that DfE does not award QTS – if a trainee meets the requirements for QTS then they automatically hold it.

This is the only spot I found where we refer to QTS this way

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Are there any other places? I've done a grep search of the project for QTS, full and acronym

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
