### PR TITLE
Lb/1083 carry over candidate preferences into a duplicate state

### DIFF
--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -8,8 +8,11 @@ module CandidateInterface
         LocationPreferenceDecorator.new(location)
       end
 
-      @back_path = LocationPreferencesRequiredForm.new(preference: @preference)
-        .back_path
+      @back_path = if params[:return_to] == 'application-sharing'
+                     candidate_interface_invites_path
+                   else
+                     LocationPreferencesRequiredForm.new(preference: @preference).back_path
+                   end
     end
 
     def update

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -78,9 +78,9 @@ module CandidateInterface
     end
 
     def redirect_to_review_for_duplicate_preferences
-      preference = current_application.duplicated_preferences.first
+      preference = current_application.duplicated_preferences.last
       if preference.present?
-        redirect_to candidate_interface_draft_preference_path(preference)
+        redirect_to candidate_interface_draft_preference_path(preference, return_to: 'application-sharing')
       end
     end
 

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class PoolOptInsController < CandidateInterfaceController
+    before_action :redirect_to_review_for_duplicate_preferences, only: :new
     before_action :set_preference, only: %i[edit update]
     before_action :set_back_path, only: %i[edit update]
     before_action :redirect_to_root_path_if_flag_is_inactive
@@ -73,6 +74,13 @@ module CandidateInterface
 
       if @preference.blank?
         redirect_to candidate_interface_invites_path
+      end
+    end
+
+    def redirect_to_review_for_duplicate_preferences
+      preference = current_application.duplicated_preferences.first
+      if preference.present?
+        redirect_to candidate_interface_draft_preference_path(preference)
       end
     end
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -17,6 +17,7 @@ module CandidateInterface
           @preference.location_preferences.destroy_all
         end
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
+        current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
       end
 
       flash[:success] = if @preference.opt_in?

--- a/app/forms/candidate_interface/pool_opt_ins_form.rb
+++ b/app/forms/candidate_interface/pool_opt_ins_form.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class PoolOptInsForm
     include ActiveModel::Model
-    DEFAULT_RADIUS = 10
 
     attr_accessor :pool_status, :opt_out_reason
     attr_reader :current_candidate, :preference

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -39,6 +39,10 @@ class ApplicationForm < ApplicationRecord
     class_name: 'ApplicationQualification',
   )
 
+  has_many :preferences, dependent: :destroy, class_name: 'CandidatePreference'
+  has_many :published_preferences, -> { where(status: 'published') }, dependent: :destroy, class_name: 'CandidatePreference'
+  has_many :duplicated_preferences, -> { where(status: 'duplicated') }, dependent: :destroy, class_name: 'CandidatePreference'
+
   has_many :application_references
   has_many :application_work_history_breaks, as: :breakable
   has_many :emails

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -37,6 +37,7 @@ class Candidate < ApplicationRecord
   )
   has_many :preferences, dependent: :destroy, class_name: 'CandidatePreference'
   has_many :published_preferences, -> { where(status: 'published') }, dependent: :destroy, class_name: 'CandidatePreference'
+  has_many :duplicated_preferences, -> { where(status: 'duplicated') }, dependent: :destroy, class_name: 'CandidatePreference'
   has_many :published_opt_in_preferences, -> { where(status: 'published', pool_status: :opt_in) }, dependent: :destroy, class_name: 'CandidatePreference'
   has_many :published_location_preferences, class_name: 'CandidateLocationPreference', through: :published_preferences, source: :location_preferences
   has_many :published_opt_in_location_preferences, class_name: 'CandidateLocationPreference', through: :published_opt_in_preferences, source: :location_preferences

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -11,6 +11,7 @@ class CandidatePreference < ApplicationRecord
   enum :status, {
     draft: 'draft',
     published: 'published',
+    duplicated: 'duplicated',
   }
 
   enum :training_locations, {

--- a/app/models/candidate_preference.rb
+++ b/app/models/candidate_preference.rb
@@ -1,6 +1,6 @@
 class CandidatePreference < ApplicationRecord
   belongs_to :candidate
-  belongs_to :application_form, optional: true
+  belongs_to :application_form
   has_many :location_preferences, dependent: :destroy, class_name: 'CandidateLocationPreference'
 
   enum :pool_status, {

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -92,6 +92,21 @@ class DuplicateApplication
           w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
         )
       end
+
+      original_candidate_preference = original_application_form.published_preferences.last
+      if original_candidate_preference.present? && original_candidate_preference.opt_in?
+        new_candidate_preference = new_application_form.preferences.create!(
+          **original_candidate_preference.attributes.except(*IGNORED_ATTRIBUTES),
+          status: 'duplicated',
+        )
+        if original_candidate_preference.training_locations_specific?
+          original_candidate_preference.location_preferences.each do |location_preference|
+            new_candidate_preference.location_preferences.create!(
+              location_preference.attributes.except(*IGNORED_ATTRIBUTES),
+            )
+          end
+        end
+      end
     end
   end
 

--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -28,6 +28,7 @@ class GenerateCandidatePoolData
         status: 'published',
         dynamic_location_preferences: true,
         candidate_id: form.candidate_id,
+        application_form_id: form.id,
         training_locations: rand(100) < 20 ? 'anywhere' : 'specific', # 20% anywhere
       }
     end

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -3,8 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
+    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+    <% if @preference.duplicated? %>
+      <p class="govuk-body"><%= t('.duplicated_preference_explanation') %></p>
+    <% end %>
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key { t('.share_information') } %>

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_with model: preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' } do %>
+  <%= f.govuk_radio_buttons_fieldset(
+        :pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
       <%= f.govuk_text_area(

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,8 +1,7 @@
 <%= form_with model: preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset(
-        :pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
+  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
       <%= f.govuk_text_area(

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -61,6 +61,8 @@
 
     <%= govuk_pagination(pagy: @pagy) %>
   <% else %>
-    <p class="govuk-body"><%= @filter.no_results_message %></p>
+    <p class="govuk-body">
+      <%= @filter.no_results_message %>
+    </p>
   <% end %>
 <% end %>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -32,6 +32,7 @@ en:
       submit: Submit preferences
     draft_preferences:
       show:
+        duplicated_preference_explanation: These preferences are based on your settings from the last recruitment cycle.
         title: Check your application sharing preferences
         share_information: Do you want to be invited to apply to similar courses?
         where_can_you_train: Where can you train?

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -1,6 +1,7 @@
 en:
   provider_interface:
     candidate_pool:
+      no_candidates_between_cycles:
       no_candidates: No candidates
       no_candidates_with_id_and_other_filters: There are no candidates that match that candidate number with the filters you have chosen. Remove some of your filters and try again.
       no_candidate_with_id: There are no candidates that match that candidate number. Check the candidate number and try again.

--- a/spec/factories/candidate_preference.rb
+++ b/spec/factories/candidate_preference.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
     funding_type { 'fee' }
   end
 
+  trait :duplicated do
+    status { 'duplicated' }
+  end
+
   trait :anywhere_in_england do
     training_locations { 'anywhere' }
     dynamic_location_preferences { nil }
@@ -16,5 +20,13 @@ FactoryBot.define do
 
   trait :specific_locations do
     training_locations { 'specific' }
+  end
+
+  trait :opt_out do
+    pool_status { 'opt_out' }
+    dynamic_location_preferences { nil }
+    training_locations { nil }
+    funding_type { nil }
+    opt_out_reason { 'I do not want to receive invites' }
   end
 end

--- a/spec/models/candidate_preference_spec.rb
+++ b/spec/models/candidate_preference_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidatePreference do
   describe 'associations' do
     it { is_expected.to belong_to(:candidate) }
-    it { is_expected.to belong_to(:application_form).optional }
+    it { is_expected.to belong_to(:application_form) }
     it { is_expected.to have_many(:location_preferences).class_name('CandidateLocationPreference') }
   end
 

--- a/spec/services/data_migrations/backfill_application_form_on_candidate_preferences_spec.rb
+++ b/spec/services/data_migrations/backfill_application_form_on_candidate_preferences_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe DataMigrations::BackfillApplicationFormOnCandidatePreferences do
   it 'adds an application form to the candidate preference where it is missing' do
     application_form = create(:application_form)
-    without_application_form = create(:candidate_preference, application_form: nil, candidate: application_form.candidate)
+    without_application_form = create(:candidate_preference, application_form:)
+    without_application_form.application_form_id = nil
+    without_application_form.save(validate: false)
     described_class.new.change
 
     expect(without_application_form.reload.application_form_id).to eq application_form.id

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_have_a_duplicate_preference_form
     given_i_am_on_the_share_details_page
 
-    when_i_click('Change your sharing and location settings')
+    when_i_click('Update your preferences')
     then_i_am_redirected_to_review_page
     when_i_click('Submit preferences')
     then_i_am_redirected_to_application_choices_with_success_message
@@ -89,7 +89,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def then_i_am_redirected_to_application_choices_with_success_message
-    expect(page).to have_current_path(candidate_interface_application_choices_path)
+    expect(page).to have_current_path(candidate_interface_invites_path)
     expect(page).to have_content('You are sharing your application details with providers you have not applied to')
   end
 

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate adds preferences' do
+  include CandidateHelper
+
+  let(:provider) { create(:provider) }
+
+  before { FeatureFlag.activate(:candidate_preferences) }
+
+  scenario 'Candidate opts in to find a candidate with specific locations' do
+    given_i_am_signed_in
+    given_i_have_a_duplicate_preference_form
+    given_i_am_on_the_share_details_page
+
+    when_i_click('Change your sharing and location settings')
+    then_i_am_redirected_to_review_page
+    when_i_click('Submit preferences')
+    then_i_am_redirected_to_application_choices_with_success_message
+    and_my_duplicate_preference_is_published
+  end
+
+  def given_i_have_a_duplicate_preference_form
+    @duplicate_preference = create(:candidate_preference, :duplicated, :specific_locations, funding_type: 'salary', application_form: @application)
+    create(:candidate_location_preference, :manchester, candidate_preference: @duplicate_preference)
+  end
+
+  def given_i_am_signed_in(funding_type: 'salary')
+    given_i_am_signed_in_with_one_login
+    @application = create(
+      :application_form,
+      :completed,
+      candidate: @current_candidate,
+    )
+    site = create(
+      :site,
+      latitude: 53.4807593,
+      longitude: -2.2426305,
+      provider:,
+    )
+    course = create(:course, provider:, funding_type:)
+    course_option = create(
+      :course_option,
+      site:,
+      course:,
+    )
+    @choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application,
+      course_option:,
+    )
+  end
+
+  def when_i_click(button)
+    click_link_or_button(button)
+  end
+  alias_method :and_i_click, :when_i_click
+
+  def then_i_am_redirected_to_review_page
+    expect(page).to have_content('Check your application sharing preferences')
+
+    summary_list = [
+      {
+        label: 'Do you want to be invited to apply to similar courses?',
+        value: 'Yes',
+      },
+      { label: 'Where can you train?',
+        value: 'In specific locations' },
+      {
+        label: 'Areas you can train in',
+        value: 'Within 10.0 miles of Manchester',
+      },
+      {
+        label: 'Add the locations of courses you apply to',
+        value: 'Yes',
+      },
+      {
+        label: 'Would you consider fee-funded courses?',
+        value: 'No',
+      },
+    ]
+
+    summary_list.each_with_index do |item, index|
+      within ".govuk-summary-list__row:nth-of-type(#{index + 1})" do
+        expect(page).to have_content(item[:label])
+        expect(page).to have_content(item[:value])
+      end
+    end
+  end
+
+  def then_i_am_redirected_to_application_choices_with_success_message
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+    expect(page).to have_content('You are sharing your application details with providers you have not applied to')
+  end
+
+  def and_my_duplicate_preference_is_published
+    expect(@duplicate_preference.reload.status).to eq 'published'
+  end
+
+  def given_i_am_on_the_share_details_page
+    visit candidate_interface_share_details_path
+
+    expect(page).to have_content('Increase your chances of success by sharing your application details')
+  end
+end


### PR DESCRIPTION
## Context

We want to carry over the pool preferences, including location preferences when a candidate carries over an application form.

## Changes proposed in this pull request
- Slightly unrelated -- make the application_form_id required now that the backfill has run on the candidate preferences (also update the seeds to capture this as well)
- Changes to the DuplicateApplication service to duplicate preferences and location preferences if the candidate has opted in (we don't duplicate it if they have opted out)
- A redirect to go directly to the review page if they start the process and have a duplicate preference
- 
https://github.com/user-attachments/assets/07273567-cb88-4b24-a79c-e919703cdcbd

## Guidance to review

Login as Daryl Strosin, Cleotilde Cormier, Alyse Hartmann, Louie Feest, Ronnie Skiles, Mitchell Weissnat, Emily Runte, or Antonia Kohler -- they all have duplicated preferences.
Submit your first application
When you are prompted to add sharing details, click continue
You should be taken straight to the review page with all the answers already completed.
You should be able to edit things, etc, and then publish

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
