### PR TITLE
Improve candidate_interface invites index page 

### DIFF
--- a/app/components/candidate_interface/invites_component.rb
+++ b/app/components/candidate_interface/invites_component.rb
@@ -24,13 +24,19 @@ module CandidateInterface
       end
     end
 
+    def hint_text
+      if invites.blank?
+        t('.no_invites')
+      else
+        t('.previous_invitations_hint')
+      end
+    end
+
     def action_link(invite)
       if invite.applied? && invite.application_choice.present?
         govuk_link_to t('.view_application'), application_choice_link(invite)
-      elsif invite.declined? || !invite.course_open?
-        govuk_link_to t('.view_course'), invite.course.find_url
       else
-        govuk_link_to t('.view_invite'), edit_candidate_interface_invite_path(invite)
+        govuk_link_to t('.view_course'), invite.course.find_url
       end
     end
   end

--- a/app/components/candidate_interface/not_responded_invites_component.html.erb
+++ b/app/components/candidate_interface/not_responded_invites_component.html.erb
@@ -1,7 +1,7 @@
-<h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.previous_invitations') %></h2>
+<h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.awaiting_response') %></h2>
 <p class="govuk-hint govuk-!-margin-top-0"><%= hint_text %></p>
 
-<%= govuk_task_list(id_prefix: 'invites', html_attributes: { class: 'govuk-task-list__row--no-bottom-border' }) do |task_list| %>
+<%= govuk_task_list(id_prefix: 'not-responded-invites', html_attributes: { class: 'govuk-task-list__row--no-bottom-border' }) do |task_list| %>
   <% invites.each do |invite| %>
     <%= task_list.with_item(html_attributes: { id: invite.id }) do |item| %>
       <%= item.with_title(
@@ -11,12 +11,7 @@
       ) %>
 
       <%= item.with_status(html_attributes: { class: 'govuk-grid-column-one-third govuk-!-padding-0' }) do %>
-        <div class="govuk-!-margin-bottom-1">
-          <%= status_tag(invite) %>
-        </div>
-        <div>
-          <%= action_link(invite) %>
-        </div>
+        <%= govuk_link_to t('.view_and_respond'), edit_candidate_interface_invite_path(invite) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/candidate_interface/not_responded_invites_component.rb
+++ b/app/components/candidate_interface/not_responded_invites_component.rb
@@ -1,0 +1,17 @@
+module CandidateInterface
+  class NotRespondedInvitesComponent < ViewComponent::Base
+    attr_reader :invites
+
+    def initialize(invites:)
+      @invites = invites
+    end
+
+    def hint_text
+      if invites.blank?
+        t('.no_invites')
+      else
+        t('.awaiting_response_hint')
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/invites_controller.rb
+++ b/app/controllers/candidate_interface/invites_controller.rb
@@ -5,7 +5,11 @@ module CandidateInterface
     before_action :set_invite, only: %i[edit update]
 
     def index
-      @invites = current_application.published_invites.includes(:application_choice).order(sent_to_candidate_at: :desc)
+      @not_responded_invites = current_application.published_invites.not_responded_course_open
+        .order(sent_to_candidate_at: :desc)
+      @invites = current_application.published_invites.actioned_by_candidate_or_course_closed
+        .includes(:provider, :application_choice, course: :provider)
+        .order(sent_to_candidate_at: :desc)
     end
 
     def edit

--- a/app/frontend/styles/_list.scss
+++ b/app/frontend/styles/_list.scss
@@ -19,3 +19,9 @@
 .govuk-list--bullet > li {
   margin-bottom: govuk-spacing(1);
 }
+
+.govuk-task-list__row--no-bottom-border {
+  .govuk-task-list__item:last-of-type {
+    border-bottom: 0;
+  }
+}

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -27,6 +27,12 @@ class Pool::Invite < ApplicationRecord
     declined: 'declined',
   }, default: :not_responded
 
+  scope :not_responded_course_open, -> { not_responded.where(course_open: true) }
+  scope :actioned_by_candidate_or_course_closed, lambda {
+    where(candidate_decision: %w[applied declined])
+    .or(where(course_open: false))
+  }
+
   scope :not_sent_to_candidate, -> { where(sent_to_candidate_at: nil) }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :with_matching_application_choices, -> { where(matching_application_choices_exists_sql) }

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -32,13 +32,13 @@
       <%= t('page_titles.application_sharing') %>
     </h1>
 
-    <h2 class="govuk-heading-m"><%= t('.your_invitations') %></h2>
+    <div class='govuk-!-margin-bottom-9'>
+      <%= render CandidateInterface::NotRespondedInvitesComponent.new(invites: @not_responded_invites) %>
+    </div>
 
-    <% if @invites.present? %>
+    <div>
       <%= render CandidateInterface::InvitesComponent.new(invites: @invites) %>
-    <% else %>
-      <p class='govuk-body'><%= t('.no_invitations') %></p>
-    <% end %>
+    </div>
   </div>
 
   <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>

--- a/config/locales/candidate_interface/invites_component.yml
+++ b/config/locales/candidate_interface/invites_component.yml
@@ -3,6 +3,8 @@ en:
     invites_component:
       title_html: "<p class='govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold'>%{provider_name}</p>"
       view_application: View application
-      view_invite: View invite
       view_course: View course
+      previous_invitations: Previous invitations
+      previous_invitations_hint: You can still submit an application to open courses you have declined.
+      no_invites: You have no previous invitations
       closed: Closed

--- a/config/locales/candidate_interface/not_responded_invites_component.yml
+++ b/config/locales/candidate_interface/not_responded_invites_component.yml
@@ -1,0 +1,8 @@
+en:
+  candidate_interface:
+    not_responded_invites_component:
+      title_html: "<p class='govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold'>%{provider_name}</p>"
+      view_and_respond: View and respond
+      awaiting_response: Invitations awaiting your response
+      awaiting_response_hint: You should respond to each invitation to apply that you receive.
+      no_invites: You have no invitations that you need to respond to at the moment.

--- a/spec/components/candidate_interface/invites_component_spec.rb
+++ b/spec/components/candidate_interface/invites_component_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe CandidateInterface::InvitesComponent do
     end
   end
 
+  describe '#hint_text' do
+    it 'returns no invites message when no invites' do
+      component = described_class.new(invites: [])
+      render_inline(component)
+
+      expect(component.hint_text).to eq('You have no previous invitations')
+    end
+
+    it 'returns invites message when there are invites' do
+      component = described_class.new(invites: [create(:pool_invite)])
+      render_inline(component)
+
+      expect(component.hint_text).to eq('You can still submit an application to open courses you have declined.')
+    end
+  end
+
   describe '#status_tag' do
     context 'with applied invite' do
       it 'returns the green status tag' do
@@ -131,19 +147,6 @@ RSpec.describe CandidateInterface::InvitesComponent do
         expect(rendered_content).to have_link(
           'View course',
           href: invite.course.find_url,
-        )
-      end
-    end
-
-    context 'anything else' do
-      it 'returns the invite show page action_link' do
-        invite = create(:pool_invite)
-        component = described_class.new(invites: [invite])
-        render_inline(component)
-
-        expect(rendered_content).to have_link(
-          'View invite',
-          href: edit_candidate_interface_invite_path(invite),
         )
       end
     end

--- a/spec/components/candidate_interface/not_responded_invites_component_spec.rb
+++ b/spec/components/candidate_interface/not_responded_invites_component_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NotRespondedInvitesComponent do
+  describe '#hint_text' do
+    it 'returns no invites message when no invites' do
+      component = described_class.new(invites: [])
+      render_inline(component)
+
+      expect(component.hint_text).to eq('You have no invitations that you need to respond to at the moment.')
+    end
+
+    it 'returns invites message when there are invites' do
+      component = described_class.new(invites: [create(:pool_invite)])
+      render_inline(component)
+
+      expect(component.hint_text).to eq('You should respond to each invitation to apply that you receive.')
+    end
+  end
+end

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -112,7 +112,7 @@ private
         "#{@invite.provider_name} #{@invite.course_name_code_and_study_mode}",
       )
       expect(page).to have_link(
-        'View invite',
+        'View and respond',
         href: edit_candidate_interface_invite_path(@invite),
       )
     end
@@ -146,7 +146,7 @@ private
 
   def when_i_click_view_invite_for(invite)
     within ".govuk-task-list__item##{invite.id}" do
-      click_link 'View invite'
+      click_link 'View and respond'
     end
   end
 

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Candidate views their invites' do
     when_i_click('Back')
     then_i_can_see_my_invites
 
-    when_i_click('View invite')
+    when_i_click('View and respond')
     then_i_see_the_invite
 
     when_i_click('Back')
@@ -47,6 +47,20 @@ RSpec.describe 'Candidate views their invites' do
       application_form:,
       status: 'published',
     )
+
+    @declined_invite = create(
+      :pool_invite,
+      candidate_decision: 'declined',
+      application_form:,
+      status: 'published',
+    )
+
+    @course_closed_invite = create(
+      :pool_invite,
+      course_open: false,
+      application_form:,
+      status: 'published',
+    )
   end
 
   def when_i_click(button)
@@ -61,7 +75,7 @@ RSpec.describe 'Candidate views their invites' do
         "#{@invite.provider_name} #{@invite.course_name_code_and_study_mode}",
       )
       expect(page).to have_link(
-        'View invite',
+        'View and respond',
         href: edit_candidate_interface_invite_path(@invite),
       )
     end
@@ -78,6 +92,28 @@ RSpec.describe 'Candidate views their invites' do
         ),
       )
       expect(page).to have_content('Applied')
+    end
+
+    within ".govuk-task-list__item##{@declined_invite.id}" do
+      expect(page).to have_content(
+        "#{@declined_invite.provider_name} #{@declined_invite.course_name_code_and_study_mode}",
+      )
+      expect(page).to have_link(
+        'View course',
+        href: @declined_invite.course.find_url,
+      )
+      expect(page).to have_content('Declined')
+    end
+
+    within ".govuk-task-list__item##{@course_closed_invite.id}" do
+      expect(page).to have_content(
+        "#{@course_closed_invite.provider_name} #{@course_closed_invite.course_name_code_and_study_mode}",
+      )
+      expect(page).to have_link(
+        'View course',
+        href: @course_closed_invite.course.find_url,
+      )
+      expect(page).to have_content('Closed')
     end
   end
 


### PR DESCRIPTION
## Context

This splits the page in two sections. One with invites that need to be
actioned and the other one with actioned invites.

It also implements new statuses.
Closed - invited course is closed
Declined - Candidate declined invite

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Locally or on review app. Login as a candidate with some invites and act on the invites.

https://github.com/user-attachments/assets/2a3845f0-3ddd-438a-8417-24affb5b8cbe



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
