### PR TITLE
Wipe the immigration status when support user changes right to work

### DIFF
--- a/app/controllers/support_interface/application_forms/immigration_right_to_work_controller.rb
+++ b/app/controllers/support_interface/application_forms/immigration_right_to_work_controller.rb
@@ -11,7 +11,11 @@ module SupportInterface
         @right_to_work_or_study_form = ImmigrationRightToWorkForm.new(right_to_work_params)
 
         if @right_to_work_or_study_form.save(@application_form)
-          redirect_to support_interface_application_form_path(@application_form)
+          if @application_form.immigration_status.nil? && @right_to_work_or_study_form.right_to_work_or_study == 'yes'
+            redirect_to support_interface_application_form_edit_immigration_status_path(@application_form)
+          else
+            redirect_to support_interface_application_form_path(@application_form)
+          end
         else
           render :edit
         end

--- a/app/forms/support_interface/application_forms/immigration_right_to_work_form.rb
+++ b/app/forms/support_interface/application_forms/immigration_right_to_work_form.rb
@@ -22,6 +22,7 @@ module SupportInterface
         application_form.update(
           right_to_work_or_study:,
           right_to_work_or_study_details: set_right_to_work_or_study_details,
+          immigration_status: immigration_status_value(application_form),
           audit_comment:,
         )
       end
@@ -34,6 +35,10 @@ module SupportInterface
 
       def set_right_to_work_or_study_details
         right_to_work_or_study? ? right_to_work_or_study_details : nil
+      end
+
+      def immigration_status_value(application_form)
+        right_to_work_or_study? ? application_form.immigration_status : nil
       end
     end
   end

--- a/spec/forms/support_interface/application_forms/immigration_right_to_work_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/immigration_right_to_work_form_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::ImmigrationRightToWorkForm, type: :model do
+  subject(:form) do
+    described_class.new(
+      right_to_work_or_study:,
+      right_to_work_or_study_details:,
+      audit_comment: 'test',
+    )
+  end
+
+  let(:right_to_work_or_study) { 'yes' }
+  let(:right_to_work_or_study_details) { 'details' }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:right_to_work_or_study) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+  end
+
+  describe '.build_from_application' do
+    it 'creates an object based on the provided ApplicationForm' do
+      application_form = ApplicationForm.new(
+        right_to_work_or_study:,
+        right_to_work_or_study_details:,
+      )
+      form = described_class.build_from_application(application_form)
+
+      expect(form).to have_attributes(
+        right_to_work_or_study:,
+        right_to_work_or_study_details:,
+      )
+    end
+  end
+
+  describe '#save' do
+    context 'invalid' do
+      subject(:form) { described_class.new }
+
+      it 'returns false if not valid' do
+        expect(form.save(ApplicationForm.new)).to be(false)
+      end
+    end
+
+    context 'when right_to_work_or_study is yes' do
+      it 'updates the provided ApplicationForm if valid' do
+        application_form = create(:application_form)
+
+        expect(form.save(application_form)).to be(true)
+        expect(application_form.right_to_work_or_study).to eq('yes')
+        expect(application_form.right_to_work_or_study_details).to eq('details')
+      end
+    end
+
+    context 'when right_to_work_or_study is not yes' do
+      let(:right_to_work_or_study) { 'no' }
+
+      it 'updates application form and sets right_to_work_or_study_details and immigration_status to nil' do
+        application_form = create(:application_form, immigration_status: 'eu_settled')
+
+        expect(form.save(application_form)).to be(true)
+        expect(application_form.right_to_work_or_study).to eq('no')
+        expect(application_form.right_to_work_or_study_details).to be_nil
+        expect(application_form.immigration_status).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
+++ b/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe 'Editing visa or immigration status, EU' do
     when_i_click_the_change_link_next_right_to_work
     and_i_choose_yes
     and_i_continue
-    i_see_the_visa_or_immigration_status_column
 
-    when_i_click_change_visa_or_immigration_status
     and_i_choose_other_and_fill_in_the_details
     and_i_continue
+    i_see_the_visa_or_immigration_status_column
     then_i_see_the_text_i_submitted
   end
 


### PR DESCRIPTION
## Context

When a support user changes the right to work of a candidate the immigration status is not changed.

This commit will set the immigration status to nil if the right to work is not true.

There's also an edge case where the support user needs to set the right to work back to true after setting it to false. In this case we redirect the support user to fill in an immigration status otherwise the candidate will not be able to access their own personal details

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
