### PR TITLE
Create invites show page

### DIFF
--- a/app/components/candidate_interface/invites_component.html.erb
+++ b/app/components/candidate_interface/invites_component.html.erb
@@ -15,7 +15,7 @@
             <%= govuk_link_to t('.view_application'), application_choice_link(invite) %>
           </div>
         <% else %>
-          <%= govuk_link_to t('.view_course'), invite.course.find_url %>
+          <%= govuk_link_to t('.view_invite'), candidate_interface_invite_path(invite) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/controllers/candidate_interface/invites_controller.rb
+++ b/app/controllers/candidate_interface/invites_controller.rb
@@ -7,6 +7,10 @@ module CandidateInterface
       @invites = current_application.published_invites.includes(:application_choice)
     end
 
+    def show
+      @invite = Pool::Invite.find(params[:id])
+    end
+
     def redirect_if_feature_off_and_no_submitted_application
       unless FeatureFlag.active?(:candidate_preferences) && current_application.submitted_applications?
         redirect_to root_path

--- a/app/views/candidate_interface/invites/show.html.erb
+++ b/app/views/candidate_interface/invites/show.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title, t('.title', provider: @invite.provider_name) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_invites_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-8"><%= t('.heading', provider: @invite.provider_name) %></h1>
+
+    <% if @invite.provider_message? %>
+      <h2 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2"><%= t('.provider_message', provider: @invite.provider_name) %></h2>
+      <div class="govuk-inset-text govuk-!-margin-top-0">
+        <p class="govuk-body"><%= markdown_to_html(@invite.message_content) %></p>
+      </div>
+    <% end %>
+
+      <%= govuk_summary_list(actions: false) do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.course')) %>
+          <% row.with_value(text: @invite.course.name_and_code) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.fee')) %>
+          <% if @invite.course.fee_international.nil? %>
+            <% row.with_value(text: t('.uk_fee_details', uk_fee: number_to_currency(@invite.course.fee_domestic))) %>
+          <% else %>
+            <% row.with_value(text: t('.both_fee_details_html', uk_fee: number_to_currency(@invite.course.fee_domestic), non_uk_fee: number_to_currency(@invite.course.fee_international))) %>
+          <% end %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.length')) %>
+          <% row.with_value(text: t('.length_details', length: DisplayCourseLength.call(course_length: @invite.course.course_length), mode: @invite.course.study_mode.humanize.downcase)) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.age')) %>
+          <% row.with_value(text: t('.age_details', range: @invite.course.age_range, level: @invite.course.level)) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.qualification')) %>
+          <% row.with_value(text: @invite.course.qualifications_to_s) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t('.start_date')) %>
+          <% row.with_value(text: @invite.course.start_date.to_fs(:month_and_year)) %>
+        <% end %>
+      <% end %>
+
+    <p class="govuk-body"><%= govuk_link_to(t('.view_course'), @invite.course.find_url, new_tab: true) %></p>
+  </div>
+</div>

--- a/config/locales/candidate_interface/invites.yml
+++ b/config/locales/candidate_interface/invites.yml
@@ -4,3 +4,23 @@ en:
       index:
         your_invitations: Your invitations
         no_invitations: You have no invitations
+      show:
+        title: Invite from %{provider} - Application sharing
+        heading: Your invitation from %{provider}
+        provider_message: "%{provider} included this message:"
+        course: Course
+        fee: Course fee
+        uk_fee_details: "%{uk_fee} for UK citizens"
+        both_fee_details_html: "%{uk_fee} for UK citizens <br> %{non_uk_fee} for non-UK citizens"
+        length: Course length
+        length_details: "%{length} - %{mode}"
+        age: Age range
+        age_details: "%{range} %{level}"
+        qualification: Qualification
+        start_date: Start date
+        view_course: View full course details
+        apply_legend: Do you want to apply for this course?
+        submit_text: Continue
+        accept: Yes I want to submit an application to this course
+        decline: No I am not interested in this course
+        decline_caption: You can still apply for this course later if you change your mind

--- a/config/locales/candidate_interface/invites_component.yml
+++ b/config/locales/candidate_interface/invites_component.yml
@@ -3,4 +3,4 @@ en:
     invites_component:
       title_html: "<p class='govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold'>%{provider_name}</p>"
       view_application: View application
-      view_course: View course
+      view_invite: View invite

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -15,7 +15,7 @@ namespace :candidate_interface, path: '/candidate' do
   end
 
   resources :account_recovery_requests, only: %i[new create], path: 'account-recovery-requests'
-  resources :invites, only: %i[index], path: 'application-sharing'
+  resources :invites, only: %i[index show], path: 'application-sharing'
 
   resources :share_details, only: :index, path: 'share-details'
 

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Canddiate views their invites' do
+RSpec.describe 'Candidate views their invites' do
   include CandidateHelper
 
   before { FeatureFlag.activate(:candidate_preferences) }
@@ -10,6 +10,18 @@ RSpec.describe 'Canddiate views their invites' do
     given_i_am_signed_in
     and_i_am_on_the_application_choices_page
     when_i_click('Application sharing')
+    then_i_can_see_my_invites
+
+    when_i_click('View application')
+    then_i_see_my_application
+
+    when_i_click('Back')
+    then_i_can_see_my_invites
+
+    when_i_click('View invite')
+    then_i_see_the_invite
+
+    when_i_click('Back')
     then_i_can_see_my_invites
   end
 
@@ -47,8 +59,8 @@ RSpec.describe 'Canddiate views their invites' do
         "#{@invite.provider_name} #{@invite.course_name_code_and_study_mode}",
       )
       expect(page).to have_link(
-        'View course',
-        href: @invite.course.find_url,
+        'View invite',
+        href: candidate_interface_invite_path(@invite),
       )
     end
 
@@ -65,6 +77,14 @@ RSpec.describe 'Canddiate views their invites' do
       )
       expect(page).to have_content('Applied')
     end
+  end
+
+  def then_i_see_the_invite
+    expect(page).to have_content "Your invitation from #{@invite.course.provider.name}"
+  end
+
+  def then_i_see_my_application
+    expect(page).to have_content "Your application to #{@applied_invite.application_choice.provider.name}"
   end
 
   def and_i_am_on_the_application_choices_page

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -499,6 +499,10 @@ RSpec.describe 'Candidate adds preferences' do
     expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
+  def then_i_am_redirected_to_application_choices
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+  end
+
   def and_i_complete_the_flow_for_adding_a_choice_with_invalid_coordinates
     choose 'Yes, I know where I want to apply'
     click_link_or_button('Continue')


### PR DESCRIPTION
## Context

This is the second PR for allowing candidates to respond to FAC invites. This is the invite show page without the form functionality and builds on the migration PR ([#10988](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10988)).

## Changes proposed in this pull request

- New show page
- link to show page form invite list
- Update route

## Guidance to review

- Create invites with various messages (as a provider)
- As a candidate, apply to one of the courses you've been invited to
- Then go to the Application sharing tab
- The link on the list should go to the invitation if there is no application
- Check navigation (back links)

<img width="801" height="817" alt="Screenshot 2025-07-22 at 10 41 01" src="https://github.com/user-attachments/assets/92620f3c-8251-4c59-8c27-3aa94e93c379" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
