### PR TITLE
Change invitation to invite on application sharing pages

### DIFF
--- a/config/locales/candidate_interface/invites.yml
+++ b/config/locales/candidate_interface/invites.yml
@@ -2,11 +2,11 @@ en:
   candidate_interface:
     invites:
       index:
-        your_invitations: Your invitations
-        no_invitations: You have no invitations
+        your_invitations: Your invites
+        no_invitations: You have no invites
       show:
         title: Invite from %{provider} - Application sharing
-        heading: Your invitation from %{provider}
+        heading: Your invite from %{provider}
         provider_message: "%{provider} included this message:"
         course: Course
         fee: Course fee

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Candidate views their invites' do
   end
 
   def then_i_see_the_invite
-    expect(page).to have_content "Your invitation from #{@invite.course.provider.name}"
+    expect(page).to have_content "Your invite from #{@invite.course.provider.name}"
   end
 
   def then_i_see_my_application


### PR DESCRIPTION
## Context

We have decided to use invites rather than invitation on these pages, but I forgot to make the change before merging (doh!)

## Changes proposed in this pull request

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
