### PR TITLE
Keep course_open on invites in sync with publish

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@ class Course < ApplicationRecord
   belongs_to :provider
   has_many :course_options
   has_many :application_choices, through: :course_options
+  has_many :published_invites, -> { published }, class_name: 'Pool::Invite'
   has_many :sites, through: :course_options
   has_many :course_subjects
   has_many :subjects, through: :course_subjects

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -22,6 +22,7 @@ module TeacherTrainingPublicAPI
         course = create_or_update_course(course_from_api)
         if course.present?
           update_sites(course.id, course_from_api.application_status)
+          course.published_invites.update_all(course_open: course.open?)
         end
       end
     rescue JsonApiClient::Errors::ApiError

--- a/spec/factories/pool_invite.rb
+++ b/spec/factories/pool_invite.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     invited_by factory: %i[provider_user]
     recruitment_cycle_year { application_form.recruitment_cycle_year }
     candidate_decision { 'not_responded' }
+    course_open { true }
 
     trait :sent_to_candidate do
       sent_to_candidate_at { Time.current }


### PR DESCRIPTION
## Context

This way we can keep the course_open column in sync with courses from publish.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
