### PR TITLE
[1151] Allow provider users to generate their own API tokens

### DIFF
--- a/app/components/provider_interface/api_tokens_table_component.rb
+++ b/app/components/provider_interface/api_tokens_table_component.rb
@@ -1,0 +1,55 @@
+module ProviderInterface
+  class APITokensTableComponent < ViewComponent::Base
+    include Rails.application.routes.url_helpers
+
+    attr_reader :api_tokens, :can_manage_tokens
+
+    def initialize(api_tokens:)
+      @api_tokens = api_tokens
+    end
+
+    def head
+      [
+        t('.id'),
+        t('.last_used_at'),
+        t('.created_at'),
+        t('.created_by'),
+      ]
+    end
+
+    def rows
+      api_tokens.map do |token|
+        [
+          token.id.to_s,
+          last_used_at_cell(token),
+          created_at_cell(token),
+          created_by_cell(token),
+        ]
+      end
+    end
+
+    def last_used_at_cell(token)
+      token.last_used_at&.to_fs(:govuk_date_and_time) || t('.not_used')
+    end
+
+    def created_at_cell(token)
+      token.created_at.to_fs(:govuk_date_and_time)
+    end
+
+    def created_by_cell(token)
+      created_audit = token.audits.find_by(action: 'create')
+
+      if created_audit.user.present? && created_audit.user_type == 'ProviderUser'
+        created_audit.user.email_address
+      else
+        t('.default_user')
+      end
+    end
+
+    def call
+      govuk_table(head:, rows:) do |table|
+        table.with_caption(text: t('.caption'), html_attributes: { class: 'govuk-visually-hidden' })
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/api_tokens_controller.rb
+++ b/app/controllers/provider_interface/api_tokens_controller.rb
@@ -1,0 +1,32 @@
+module ProviderInterface
+  class APITokensController < ProviderInterfaceController
+    before_action :set_provider
+    before_action :redirect_unless_can_manage_api_tokens, only: %i[create new]
+
+    def index
+      @api_tokens = @provider.vendor_api_tokens.order(:last_used_at)
+      @can_manage_tokens = current_provider_user.authorisation.can_manage_api_tokens?(@provider)
+    end
+
+    def new
+      @api_token = @provider.vendor_api_tokens.new
+    end
+
+    def create
+      @unhashed_token = VendorAPIToken.create_with_random_token!(provider: @provider)
+      render :show
+    end
+
+  private
+
+    def redirect_unless_can_manage_api_tokens
+      unless current_provider_user.authorisation.can_manage_api_tokens?(@provider)
+        redirect_to provider_interface_organisation_settings_path
+      end
+    end
+
+    def set_provider
+      @provider = current_provider_user.providers.find(params[:organisation_id])
+    end
+  end
+end

--- a/app/controllers/provider_interface/api_tokens_controller.rb
+++ b/app/controllers/provider_interface/api_tokens_controller.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class APITokensController < ProviderInterfaceController
+    before_action :redirect_if_feature_flag_inactive
     before_action :set_provider
     before_action :redirect_unless_can_manage_api_tokens, only: %i[create new]
 
@@ -18,6 +19,12 @@ module ProviderInterface
     end
 
   private
+
+    def redirect_if_feature_flag_inactive
+      if FeatureFlag.inactive?(:api_token_management)
+        redirect_to provider_interface_organisation_settings_path
+      end
+    end
 
     def redirect_unless_can_manage_api_tokens
       unless current_provider_user.authorisation.can_manage_api_tokens?(@provider)

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -183,7 +183,7 @@ class NavigationItems
       items = []
 
       unless performing_setup
-        items << NavigationItem.new(t('page_titles.provider.organisation_settings'), provider_interface_organisation_settings_path, active?(current_controller, %w[organisation_settings organisations provider_users provider_relationship_permissions]), [])
+        items << NavigationItem.new(t('page_titles.provider.organisation_settings'), provider_interface_organisation_settings_path, active?(current_controller, %w[organisation_settings organisations provider_users provider_relationship_permissions api_tokens]), [])
 
         items << NavigationItem.new(t('page_titles.provider.account'), provider_interface_account_path, active?(current_controller, %w[account profile notifications]), [])
       end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -21,6 +21,7 @@ class ProviderPermissions < ApplicationRecord
   scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
   scope :view_diversity_information, -> { where(view_diversity_information: true) }
   scope :set_up_interviews, -> { where(set_up_interviews: true) }
+  scope :manage_api_tokens, -> { where(manage_api_tokens: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
     providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for.order(:name)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,6 +28,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:candidate_preferences, 'Allow candidates to add their preferences for providers to find them', 'Apply team'],
+    [:api_token_management, 'Allow provider users to manage their own api tokens', 'Apply team'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -79,6 +79,11 @@ class ProviderAuthorisation
     errors.blank?
   end
 
+  def can_manage_api_tokens?(provider)
+    user_level_can?(permission: :set_up_interviews, provider:) &&
+      user_level_can?(permission: :make_decisions, provider:)
+  end
+
   def can_manage_organisations_for_at_least_one_provider?
     providers_that_actor_can_manage_organisations_for.any?
   end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -80,8 +80,7 @@ class ProviderAuthorisation
   end
 
   def can_manage_api_tokens?(provider)
-    user_level_can?(permission: :set_up_interviews, provider:) &&
-      user_level_can?(permission: :make_decisions, provider:)
+    user_level_can?(permission: :manage_api_tokens, provider:)
   end
 
   def can_manage_organisations_for_at_least_one_provider?

--- a/app/views/provider_interface/api_tokens/index.html.erb
+++ b/app/views/provider_interface/api_tokens/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :browser_title, t('.title', provider_name: @provider.name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @provider.name %></span>
+      <%= t('.api_tokens') %>
+    </h1>
+    <p class="govuk-body">
+      <%= t(
+            '.what_tokens_are_for_html',
+            link: govuk_link_to(
+              t(
+                '.apply_api',
+                environment: HostingEnvironment.environment_name,
+              ),
+              api_docs_home_path,
+            ),
+          ) %>
+    </p>
+
+    <% if @can_manage_tokens %>
+      <%= govuk_button_link_to t('.add_token'), new_provider_interface_organisation_settings_organisation_api_token_path(@provider) %>
+    <% end %>
+
+    <% if @api_tokens.none? %>
+      <p class="govuk-body"><%= t('.no_tokens') %></p>
+    <% else %>
+      <%= render ProviderInterface::APITokensTableComponent.new(api_tokens: @api_tokens) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/api_tokens/new.html.erb
+++ b/app/views/provider_interface/api_tokens/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :browser_title, t('.title', provider_name: @provider.name) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_api_tokens_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @api_token, url: provider_interface_organisation_settings_organisation_api_tokens_path(@provider), method: :post do |form| %>
+      <h1 class="govuk-heading-l"><%= t('.heading', provider_name: @provider.name) %></h1>
+      <p class="govuk-body">
+        <%= govuk_link_to(
+              t(
+                '.apply_api',
+                environment: HostingEnvironment.environment_name,
+              ),
+              api_docs_home_path,
+            ) %>
+      </p>
+      <p class="govuk-body">
+        <%= t('.create_token', provider_name: @provider.name) %>
+      </p>
+
+      <%= form.govuk_submit t('.continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/api_tokens/new.html.erb
+++ b/app/views/provider_interface/api_tokens/new.html.erb
@@ -18,7 +18,7 @@
         <%= t('.create_token', provider_name: @provider.name) %>
       </p>
 
-      <%= form.govuk_submit t('.continue') %>
+      <%= form.govuk_submit t('.generate') %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/api_tokens/show.html.erb
+++ b/app/views/provider_interface/api_tokens/show.html.erb
@@ -1,0 +1,15 @@
+<% content_for :browser_title, t('.title', provider_name: @provider.name) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_api_tokens_path(@provider)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @unhashed_token.present? %>
+      <%= govuk_panel(title_text: t('.new_api_token_generated')) do %>
+        <%= t('.your_token_is_html', token: @unhashed_token) %>
+      <% end %>
+      <p class="govuk-body">
+        <%= t('.note_this_down_and_keep_safe') %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -20,11 +20,13 @@
             <% end %>
           </li>
         <% end %>
-        <li>
-          <%= govuk_link_to provider_interface_organisation_settings_organisation_api_tokens_path(provider) do %>
-            <%= t('page_titles.provider.api_tokens') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
-          <% end %>
-        </li>
+        <% if FeatureFlag.active?(:api_token_management) %>
+          <li>
+            <%= govuk_link_to provider_interface_organisation_settings_organisation_api_tokens_path(provider) do %>
+              <%= t('page_titles.provider.api_tokens') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
+            <% end %>
+          </li>
+        <% end %>
       </ul>
     <% end %>
   </div>

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -20,6 +20,11 @@
             <% end %>
           </li>
         <% end %>
+        <li>
+          <%= govuk_link_to provider_interface_organisation_settings_organisation_api_tokens_path(provider) do %>
+            <%= t('page_titles.provider.api_tokens') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
+          <% end %>
+        </li>
       </ul>
     <% end %>
   </div>

--- a/config/locales/components/provider_interface/api_tokens_table_component.yml
+++ b/config/locales/components/provider_interface/api_tokens_table_component.yml
@@ -1,0 +1,10 @@
+en:
+  provider_interface:
+    api_tokens_table_component:
+      caption: API tokens
+      id: ID
+      last_used_at: Last used
+      not_used: Never
+      created_at: Created at
+      created_by: Created by
+      default_user: DFE support user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
       organisation_permissions: Organisation permissions
       change_organisation_permissions: Change permissions
       users: Users
+      api_tokens: API tokens
       confirm_delete_user: Confirm that you want to delete this user from %{provider_name}
       export_hesa_data: Export data for Higher Education Statistics Agency (HESA)
       status_of_active_applications: Status of active applications

--- a/config/locales/provider_interface/api_tokens.yml
+++ b/config/locales/provider_interface/api_tokens.yml
@@ -1,0 +1,22 @@
+en:
+  provider_interface:
+    api_tokens:
+      index:
+        title: API tokens for %{provider_name}
+        add_token: Add token
+        no_tokens: There are no API tokens for this organisation
+        api_tokens: API tokens
+        apply_api: Apply API (%{environment})
+        what_tokens_are_for_html: These tokens are for vendor or in-house integrations with the %{link}.
+      new:
+        title: Create an API token for %{provider_name}
+        heading: Create an API token
+        create_token: Clicking continue will create a token for %{provider_name}. It will be visible until you navigate away from the page.
+        continue: Continue
+        cancel: Cancel
+        apply_api: Apply API documentation (%{environment})
+      show:
+        title: API token for %{provider_name}
+        new_api_token_generated: New API token generated
+        your_token_is_html: Your token is <br><code>%{token}</code>
+        note_this_down_and_keep_safe: Note down this code and keep it safe. You will not be able to retreive it once you leave this page.

--- a/config/locales/provider_interface/api_tokens.yml
+++ b/config/locales/provider_interface/api_tokens.yml
@@ -12,7 +12,7 @@ en:
         title: Create an API token for %{provider_name}
         heading: Create an API token
         create_token: Clicking continue will create a token for %{provider_name}. It will be visible until you navigate away from the page.
-        continue: Continue
+        generate: Generate
         cancel: Cancel
         apply_api: Apply API documentation (%{environment})
       show:

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -184,6 +184,8 @@ namespace :provider_interface, path: '/provider' do
         end
       end
 
+      resources :api_tokens, path: 'api-tokens', only: %i[index new create]
+
       namespace :user_invitation, path: 'user' do
         resource :personal_details, path: '', only: %i[new create]
         resource :permissions, only: %i[new create]

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -76,5 +76,11 @@ FactoryBot.define do
         user.notification_preferences.update_all_preferences(true)
       end
     end
+
+    trait :with_manage_api_tokens do
+      after(:create) do |user, _evaluator|
+        user.provider_permissions.update_all(make_decisions: true, set_up_interviews: true)
+      end
+    end
   end
 end

--- a/spec/factories/provider_user.rb
+++ b/spec/factories/provider_user.rb
@@ -79,7 +79,7 @@ FactoryBot.define do
 
     trait :with_manage_api_tokens do
       after(:create) do |user, _evaluator|
-        user.provider_permissions.update_all(make_decisions: true, set_up_interviews: true)
+        user.provider_permissions.update_all(manage_api_tokens: true)
       end
     end
   end

--- a/spec/factories/vendor_api_token.rb
+++ b/spec/factories/vendor_api_token.rb
@@ -10,5 +10,9 @@ FactoryBot.define do
         hashed_token
       end
     end
+
+    trait :with_last_used_at do
+      last_used_at { 2.days.ago }
+    end
   end
 end

--- a/spec/models/provider_permissions_spec.rb
+++ b/spec/models/provider_permissions_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe ProviderPermissions do
         expect(described_class.set_up_interviews).to match_array(interview_permissions)
       end
     end
+
+    describe '#manage_api_tokens' do
+      it 'returns all permissions where "manage_api_tokens" is set to true' do
+        with_permission = create(:provider_permissions, manage_api_tokens: true)
+        create(:provider_permissions, manage_api_tokens: false)
+
+        expect(described_class.manage_api_tokens).to contain_exactly(with_permission)
+      end
+    end
   end
 
   describe '.possible_permissions' do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -46,6 +46,25 @@ RSpec.describe ProviderAuthorisation do
     end
   end
 
+  describe '#can_manage_api_tokens?' do
+    let(:provider_for_no_permission) { create(:provider) }
+    let(:provider_for_with_permission) { create(:provider) }
+    let(:provider_user) { create(:provider_user) }
+
+    before do
+      create(:provider_permissions, manage_api_tokens: true, provider_user:, provider: provider_for_with_permission)
+      create(:provider_permissions, manage_api_tokens: false, provider_user:, provider: provider_for_no_permission)
+    end
+
+    it 'returns false if does not have permission for the provider given' do
+      expect(described_class.new(actor: provider_user).can_manage_api_tokens?(provider_for_no_permission)).to be false
+    end
+
+    it 'returns true if does have permission for the provider given' do
+      expect(described_class.new(actor: provider_user).can_manage_api_tokens?(provider_for_with_permission)).to be true
+    end
+  end
+
   describe '#can_make_decisions?' do
     let(:training_provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
     let(:training_provider) { training_provider_user.providers.first }

--- a/spec/system/provider_interface/viewing_api_tokens_spec.rb
+++ b/spec/system/provider_interface/viewing_api_tokens_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'Organisation users', :with_audited do
   include DfESignInHelpers
   include Rails.application.routes.url_helpers
 
+  before { FeatureFlag.activate(:api_token_management) }
+
   scenario 'viewing and adding api tokens' do
     given_i_am_a_provider_user_signed_in_with_permissions_to_manage_tokens
 

--- a/spec/system/provider_interface/viewing_api_tokens_spec.rb
+++ b/spec/system/provider_interface/viewing_api_tokens_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe 'Organisation users', :with_audited do
+  include DfESignInHelpers
+  include Rails.application.routes.url_helpers
+
+  scenario 'viewing and adding api tokens' do
+    given_i_am_a_provider_user_signed_in_with_permissions_to_manage_tokens
+
+    when_i_navigate_to_the_api_tokens_page
+    then_i_see_the_no_tokens_message
+    and_link_to_api_docs
+
+    when_i_click_on('Add token')
+    then_i_see_the_create_token_page
+
+    when_i_click_on('Back')
+    then_i_see_the_no_tokens_message
+
+    when_i_click_on('Add token')
+    and_i_click_on('Continue')
+
+    then_i_see_the_token
+    when_i_click_on('Back')
+    then_i_see_my_new_token_in_the_list
+
+    given_the_token_has_been_used
+    when_i_refresh_the_page
+    then_i_see_the_token_in_the_list_with_last_used_date
+  end
+
+  scenario 'viewing list only' do
+    given_i_am_a_provider_user_signed_in_without_permissions_to_manage_tokens
+    and_a_token_exists_that_has_been_used
+
+    when_i_navigate_to_the_api_tokens_page
+    then_i_see_the_token_created_by_support_user_in_the_list_with_last_used_date
+    and_i_do_not_see_the_add_button
+  end
+
+private
+
+  def when_i_click_on(text)
+    click_on text
+  end
+  alias_method :and_i_click_on, :when_i_click_on
+
+  def given_i_am_a_provider_user_signed_in_with_permissions_to_manage_tokens
+    @provider = build(:provider)
+    @provider_user = create(
+      :provider_user,
+      :with_manage_api_tokens,
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      email_address: 'email@provider.ac.uk',
+      providers: [@provider],
+    )
+    user_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def given_i_am_a_provider_user_signed_in_without_permissions_to_manage_tokens
+    @provider = build(:provider)
+    @provider_user = create(
+      :provider_user,
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      email_address: 'email@provider.ac.uk',
+      providers: [@provider],
+    )
+    user_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_a_token_exists_that_has_been_used
+    create(:vendor_api_token, :with_last_used_at, provider: @provider)
+  end
+
+  def when_i_navigate_to_the_api_tokens_page
+    visit provider_interface_path
+    click_on 'Organisation settings'
+    click_on 'API tokens'
+  end
+
+  def then_i_see_the_no_tokens_message
+    expect(page).to have_content 'There are no API tokens for this organisation'
+  end
+
+  def then_i_see_my_new_token_in_the_list
+    token = VendorAPIToken.last
+    within('.govuk-table') do
+      expect(page).to have_content 'Never'
+      expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
+      expect(page).to have_content @provider_user.email_address
+    end
+  end
+
+  def then_i_see_the_token_in_the_list_with_last_used_date
+    token = VendorAPIToken.last
+    within('.govuk-table') do
+      expect(page).to have_content token.last_used_at.to_fs(:govuk_date_and_time)
+      expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
+      expect(page).to have_content @provider_user.email_address
+    end
+  end
+
+  def then_i_see_the_token_created_by_support_user_in_the_list_with_last_used_date
+    token = VendorAPIToken.last
+    within('.govuk-table') do
+      expect(page).to have_content token.last_used_at.to_fs(:govuk_date_and_time)
+      expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
+      expect(page).to have_content 'DFE support user'
+    end
+  end
+
+  def and_i_do_not_see_the_add_button
+    expect(page).to have_no_button 'Add token'
+  end
+
+  def then_i_see_success_message
+    expect(page).to have_content 'API token deleted'
+  end
+
+  def given_the_token_has_been_used
+    token = VendorAPIToken.last
+    token.update(last_used_at: 2.days.ago)
+  end
+
+  def when_i_refresh_the_page
+    url = page.current_url
+    visit url
+  end
+
+  def then_i_see_the_warning_page
+    token = VendorAPIToken.last
+    expect(page).to have_content 'Are you sure you want to revoke this token?'
+    expect(page).to have_content "The token was last used on #{token.last_used_at.to_fs(:govuk_date_and_time)}"
+    expect(page).to have_content 'If you delete, any integrations that are still using this token will fail. Only delete if you are confident it is no longer in use.'
+  end
+
+  def and_link_to_api_docs
+    expect(page).to have_link('Apply API (test)', href: api_docs_home_path)
+  end
+
+  def then_i_see_the_create_token_page
+    expect(page).to have_content "Clicking continue will create a token for #{@provider.name}. It will be visible until you navigate away from the page."
+  end
+
+  def then_i_see_the_token
+    expect(page).to have_text('New API token generated')
+  end
+end

--- a/spec/system/provider_interface/viewing_api_tokens_spec.rb
+++ b/spec/system/provider_interface/viewing_api_tokens_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Organisation users', :with_audited do
     then_i_see_the_no_tokens_message
 
     when_i_click_on('Add token')
-    and_i_click_on('Continue')
+    and_i_click_on('Generate')
 
     then_i_see_the_token
     when_i_click_on('Back')


### PR DESCRIPTION
## Context

We receive requests from providers for us to generate API tokens for them. This can be done in support, but then there is no way for the support user to send the token securely to the user.

Generally our process is to confirm that the person requesting it is a registered user. Then we generate a token for them and send it using some other third-party software with a link that will expire in 24 hours. This is labour intensive (checking user credentials) and relies on a dev signing up to an additional service.

## Changes proposed in this pull request
Basic functionality for a support user, when the feature flag is active, 
to add an API token.
There will be further PRs to 
- Add a description of the token (to make it easier to know which ones to delete)
- Ability to manage api token permissions from support and provider 


## Guidance to review

- Add tokens to UCL, University College London (U80) or GORSE SCITT (Leeds, Bradford, Hull and East Yorkshire)s a support user
- Then login directly as a provider user (dev-provider) (you'll be logged in as Peter Rovider)
- click on 'Organisation settings'. You should see the API tokens link for both institutions. 
- P.rovider doesn't have permission to `manage_api_tokens` for GORSE,. so if you click on that one, you'll see the tokens list, but no option to add a new one.
- P.rovider _does_ have permission for UCL, so if you click on that one, you'll be able to add a token. 
- On the rails console, you can add a `last_used_at` to any of the tokens. It will change what you see on the list and what you see on the list

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
