### PR TITLE
[1157] Allow the cycle to start on a Thursday

### DIFF
--- a/app/services/support_interface/recruitment_cycle_timetable_generator.rb
+++ b/app/services/support_interface/recruitment_cycle_timetable_generator.rb
@@ -91,7 +91,7 @@ module SupportInterface
 
       if oct_first.monday?
         oct_first
-      elsif oct_first.tuesday? || oct_first.wednesday?
+      elsif oct_first.tuesday? || oct_first.wednesday? || oct_first.thursday?
         oct_first - 1.day
       else
         oct_first.next_occurring(:monday)


### PR DESCRIPTION
A decision has been made that find / apply should open on tuesday, wednesday or thursday, not just tuesday or wednesday. This means just a small change in our generator.

It also means there will be a change in the 2027 timetable, which I'll generate in production, and then update the seeds locally.  We can also add the 2028 data, as we need to have a few years in advance for all the tests to pass when we switch cycles,

## Context

Allow the first day of the cycle to be on a thursday.

## Changes proposed in this pull request

None

## Guidance to review

- Destroy all the timetables with a recruitment cycle year greater than 2025. 
- Run the generator `SupportInterface::RecruitmentCycleTimetableGenerator.call(2029)`
- The find/apply start dates for 2026-2029 should be as follows:
* Weds 1st/8th Oct 2025,
* Thurs 1st/8th Oct 2026,
* Tues 5th/12th Oct 2027,
* Tues 3rd/10th Oct 2028,


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
