### PR TITLE
Backfill course_open on pool_invites

### DIFF
--- a/app/services/data_migrations/backfill_course_open_on_pool_invite.rb
+++ b/app/services/data_migrations/backfill_course_open_on_pool_invite.rb
@@ -1,0 +1,16 @@
+module DataMigrations
+  class BackfillCourseOpenOnPoolInvite
+    TIMESTAMP = 20250724092408
+    MANUAL_RUN = false
+
+    def change
+      courses = Course.current_cycle.joins(:published_invites).distinct
+
+      ActiveRecord::Base.transaction do
+        courses.find_each do |course|
+          course.published_invites.update_all(course_open: course.open?)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCourseOpenOnPoolInvite',
   'DataMigrations::BackfillApplicationFormOnCandidatePreferences',
   'DataMigrations::DropGroupedInviteEmailFeatureFlag',
   'DataMigrations::BackfillApplicationFormOnPoolInvites',

--- a/spec/services/data_migrations/backfill_course_open_on_pool_invite_spec.rb
+++ b/spec/services/data_migrations/backfill_course_open_on_pool_invite_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCourseOpenOnPoolInvite do
+  describe '#change' do
+    it 'sets the course_open field based on the course.open?' do
+      invite_1 = create(
+        :pool_invite,
+        :sent_to_candidate,
+        course: create(:course, :unavailable),
+        course_open: true,
+      )
+      invite_2 = create(
+        :pool_invite,
+        :sent_to_candidate,
+        course: create(:course, :open),
+        course_open: false,
+      )
+
+      described_class.new.change
+
+      expect(invite_1.reload.course_open).to be(false)
+      expect(invite_2.reload.course_open).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Now that we added the course_open boolean field on the pool_invites we need to backfill this field.

This should get all courses in current cycle with published invites and update the invites based on the course open value.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
