### PR TITLE
Remove navigation to API pages that break the internet

### DIFF
--- a/app/views/support_interface/performance/_performance_navigation.html.erb
+++ b/app/views/support_interface/performance/_performance_navigation.html.erb
@@ -7,8 +7,8 @@
   { name: 'Validation errors', url: support_interface_validation_errors_path },
   { name: 'Email log', url: support_interface_email_log_path },
   { name: 'Provider onboarding', url: support_interface_provider_onboarding_path },
-  { name: 'Vendor API requests', url: support_interface_vendor_api_requests_path },
-  { name: 'Vendor API monitoring', url: support_interface_vendor_api_monitoring_path },
+  # { name: 'Vendor API requests', url: support_interface_vendor_api_requests_path },
+  # { name: 'Vendor API monitoring', url: support_interface_vendor_api_monitoring_path },
   { name: 'Monthly Statistics reports', url: support_interface_monthly_statistics_reports_path },
 ]) %>
 


### PR DESCRIPTION
## Context

We know that the vendor api requests tab and the vendor api monitoring tab both send our db cpu usage through the roof. So this PR just removes the temptation. It doesn't remove the controllers or the logic, as there is a ticket in the back log for making these things work better. This just removes the navigation as a safeguard. 

## Changes proposed in this pull request

Removes navigation to Vendor API requests and Vendor API monitoring


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
