### PR TITLE
Allow provider users to add a description to api tokens

### DIFF
--- a/app/components/provider_interface/api_tokens_table_component.rb
+++ b/app/components/provider_interface/api_tokens_table_component.rb
@@ -14,16 +14,18 @@ module ProviderInterface
         t('.last_used_at'),
         t('.created_at'),
         t('.created_by'),
+        t('.description'),
       ]
     end
 
     def rows
       api_tokens.map do |token|
         [
-          token.id.to_s,
+          "##{token.id}",
           last_used_at_cell(token),
           created_at_cell(token),
           created_by_cell(token),
+          description_cell(token),
         ]
       end
     end
@@ -44,6 +46,10 @@ module ProviderInterface
       else
         t('.default_user')
       end
+    end
+
+    def description_cell(token)
+      token.description.presence || t('.no_description')
     end
 
     def call

--- a/app/controllers/provider_interface/api_tokens_controller.rb
+++ b/app/controllers/provider_interface/api_tokens_controller.rb
@@ -10,15 +10,24 @@ module ProviderInterface
     end
 
     def new
-      @api_token = @provider.vendor_api_tokens.new
+      @api_token = APITokenForm.new(provider: @provider)
     end
 
     def create
-      @unhashed_token = VendorAPIToken.create_with_random_token!(provider: @provider)
-      render :show
+      @api_token = APITokenForm.new(description_param, provider: @provider)
+      if @api_token.valid?
+        @unhashed_token = @api_token.save!
+        render :show
+      else
+        render :new
+      end
     end
 
   private
+
+    def description_param
+      params.expect(provider_interface_api_token_form: :description)
+    end
 
     def redirect_if_feature_flag_inactive
       if FeatureFlag.inactive?(:api_token_management)
@@ -33,7 +42,7 @@ module ProviderInterface
     end
 
     def set_provider
-      @provider = current_provider_user.providers.find(params[:organisation_id])
+      @provider = current_provider_user.providers.find(params.expect(:organisation_id))
     end
   end
 end

--- a/app/forms/provider_interface/api_token_form.rb
+++ b/app/forms/provider_interface/api_token_form.rb
@@ -1,0 +1,21 @@
+module ProviderInterface
+  class APITokenForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :description
+
+    validates :description, presence: true
+
+    def initialize(attributes = {}, provider:)
+      @provider = provider
+      super(attributes)
+    end
+
+    def save!
+      return false unless valid?
+
+      VendorAPIToken.create_with_random_token!({ description: }, provider: @provider)
+    end
+  end
+end

--- a/app/models/vendor_api_token.rb
+++ b/app/models/vendor_api_token.rb
@@ -5,9 +5,9 @@ class VendorAPIToken < ApplicationRecord
 
   scope :used_in_last_3_months, -> { where('last_used_at >= ?', 3.months.ago) }
 
-  def self.create_with_random_token!(provider:)
+  def self.create_with_random_token!(attributes = {}, provider:)
     unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
-    create!(hashed_token:, provider:)
+    create!(attributes.merge({ hashed_token:, provider: }))
     unhashed_token
   end
 

--- a/app/views/provider_interface/api_tokens/index.html.erb
+++ b/app/views/provider_interface/api_tokens/index.html.erb
@@ -23,7 +23,9 @@
     <% if @can_manage_tokens %>
       <%= govuk_button_link_to t('.add_token'), new_provider_interface_organisation_settings_organisation_api_token_path(@provider) %>
     <% end %>
+  </div>
 
+  <div class="govuk-grid-column-full">
     <% if @api_tokens.none? %>
       <p class="govuk-body"><%= t('.no_tokens') %></p>
     <% else %>

--- a/app/views/provider_interface/api_tokens/new.html.erb
+++ b/app/views/provider_interface/api_tokens/new.html.erb
@@ -1,16 +1,17 @@
-<% content_for :browser_title, t('.title', provider_name: @provider.name) %>
+<% content_for :browser_title, title_with_error_prefix(t('.title', provider_name: @provider.name), @api_token.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_organisation_settings_organisation_api_tokens_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @api_token, url: provider_interface_organisation_settings_organisation_api_tokens_path(@provider), method: :post do |form| %>
+      <%= form.govuk_error_summary %>
       <h1 class="govuk-heading-l"><%= t('.heading', provider_name: @provider.name) %></h1>
+
+      <%= form.govuk_text_field :description, label: { text: t('.token_description'), size: 's' }, hint: { text: t('.description_hint') } %>
+
       <p class="govuk-body">
         <%= govuk_link_to(
-              t(
-                '.apply_api',
-                environment: HostingEnvironment.environment_name,
-              ),
+              t('.apply_api', environment: HostingEnvironment.environment_name),
               api_docs_home_path,
             ) %>
       </p>

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -29,6 +29,9 @@
         <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Vendor</th>
         <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Last used at</th>
         <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Created at</th>
+        <% if FeatureFlag.active?(:api_token_management) %>
+          <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Description</th>
+        <% end %>
         <th scope='col' class='govuk-table__header'>Actions</th>
       </tr>
     </thead>
@@ -41,6 +44,9 @@
         <td class='govuk-table__cell'><%= token.provider.vendor_name %></td>
         <td class='govuk-table__cell'><%= token.last_used_at ? token.last_used_at.to_fs(:govuk_date_and_time) : 'Never' %></td>
         <td class='govuk-table__cell'><%= token.created_at.to_fs(:govuk_date_and_time) %></td>
+        <% if FeatureFlag.active?(:api_token_management) %>
+          <td class='govuk-table__cell'><%= token.description.presence || 'None' %></td>
+        <% end %>
         <td class='govuk-table__cell'>
           <%= govuk_button_link_to 'Revoke', confirm_revocation_support_interface_api_token_path(token), warning: true %>
         </td>

--- a/config/locales/components/provider_interface/api_tokens_table_component.yml
+++ b/config/locales/components/provider_interface/api_tokens_table_component.yml
@@ -4,7 +4,9 @@ en:
       caption: API tokens
       id: ID
       last_used_at: Last used
+      description: Description
       not_used: Never
       created_at: Created at
       created_by: Created by
       default_user: DFE support user
+      no_description: None

--- a/config/locales/provider_interface/api_tokens.yml
+++ b/config/locales/provider_interface/api_tokens.yml
@@ -11,10 +11,12 @@ en:
       new:
         title: Create an API token for %{provider_name}
         heading: Create an API token
-        create_token: Clicking continue will create a token for %{provider_name}. It will be visible until you navigate away from the page.
+        create_token: Clicking generate will create a token for %{provider_name}. It will be visible until you navigate away from the page.
         generate: Generate
         cancel: Cancel
         apply_api: Apply API documentation (%{environment})
+        token_description: Description
+        description_hint: "Example: Integration with 3rd party recruitment software"
       show:
         title: API token for %{provider_name}
         new_api_token_generated: New API token generated

--- a/config/locales/provider_interface/vendor_api_tokens.yml
+++ b/config/locales/provider_interface/vendor_api_tokens.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        provider_interface/api_token_form:
+          attributes:
+            description:
+              blank: Add a brief description for the new token

--- a/spec/system/provider_interface/viewing_api_tokens_spec.rb
+++ b/spec/system/provider_interface/viewing_api_tokens_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'Organisation users', :with_audited do
     when_i_click_on('Add token')
     and_i_click_on('Generate')
 
+    then_i_see_the_error('Add a brief description for the new token')
+    when_i_add_a_description
+    and_i_click_on('Generate')
+
     then_i_see_the_token
     when_i_click_on('Back')
     then_i_see_my_new_token_in_the_list
@@ -92,6 +96,7 @@ private
       expect(page).to have_content 'Never'
       expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
       expect(page).to have_content @provider_user.email_address
+      expect(page).to have_content 'Token for vendor integration test'
     end
   end
 
@@ -101,6 +106,7 @@ private
       expect(page).to have_content token.last_used_at.to_fs(:govuk_date_and_time)
       expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
       expect(page).to have_content @provider_user.email_address
+      expect(page).to have_content 'Token for vendor integration test'
     end
   end
 
@@ -110,15 +116,12 @@ private
       expect(page).to have_content token.last_used_at.to_fs(:govuk_date_and_time)
       expect(page).to have_content token.created_at.to_fs(:govuk_date_and_time)
       expect(page).to have_content 'DFE support user'
+      expect(page).to have_content 'None'
     end
   end
 
   def and_i_do_not_see_the_add_button
     expect(page).to have_no_button 'Add token'
-  end
-
-  def then_i_see_success_message
-    expect(page).to have_content 'API token deleted'
   end
 
   def given_the_token_has_been_used
@@ -131,22 +134,25 @@ private
     visit url
   end
 
-  def then_i_see_the_warning_page
-    token = VendorAPIToken.last
-    expect(page).to have_content 'Are you sure you want to revoke this token?'
-    expect(page).to have_content "The token was last used on #{token.last_used_at.to_fs(:govuk_date_and_time)}"
-    expect(page).to have_content 'If you delete, any integrations that are still using this token will fail. Only delete if you are confident it is no longer in use.'
-  end
-
   def and_link_to_api_docs
     expect(page).to have_link('Apply API (test)', href: api_docs_home_path)
   end
 
   def then_i_see_the_create_token_page
-    expect(page).to have_content "Clicking continue will create a token for #{@provider.name}. It will be visible until you navigate away from the page."
+    expect(page).to have_content "Clicking generate will create a token for #{@provider.name}. It will be visible until you navigate away from the page."
   end
 
   def then_i_see_the_token
     expect(page).to have_text('New API token generated')
+  end
+
+  def then_i_see_the_error(text)
+    expect(page.title).to include 'Error:'
+    expect(page).to have_content 'There is a problem'
+    expect(page).to have_content(text).twice
+  end
+
+  def when_i_add_a_description
+    fill_in 'Description', with: 'Token for vendor integration test'
   end
 end


### PR DESCRIPTION
## Context

This PR builds on the basic functionality of allowing provider users to add a description to the tokens they create -- this will make the more easily identifiable if they wish to revoke them. 

All of this is behind a feature flag. 

The next PR in this series will be to add this `manage_api_tokens`, which only exists as a column in the db that has to be updated on the rails console, to the provider permissions flow.  Then we'll do some more thorough testing and make sure provider users are aware of it. 

## Changes proposed in this pull request

https://github.com/user-attachments/assets/0d8a1367-6c41-40b1-8c49-1080e703ba28

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
