### PR TITLE
Link the invite to an application choice from creation of draft

### DIFF
--- a/app/services/candidate_interface/delete_application_choice.rb
+++ b/app/services/candidate_interface/delete_application_choice.rb
@@ -7,7 +7,14 @@ module CandidateInterface
     def call
       application_form = @application_choice.application_form
 
-      @application_choice.destroy!
+      ActiveRecord::Base.transaction do
+        @application_choice.published_invites.update_all(
+          application_choice_id: nil,
+          candidate_decision: 'not_responded',
+        )
+
+        @application_choice.destroy!
+      end
 
       application_form.update!(course_choices_completed: nil) if application_form.application_choices.empty?
     end

--- a/app/services/candidate_interface/invite_application.rb
+++ b/app/services/candidate_interface/invite_application.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     end
 
     def applied!
-      clean_up_orphan_invites
+      clean_up_disconnected_invites
 
       invite = application_form.published_invites.find_by(
         course_id: application_choice.current_course.id,
@@ -29,7 +29,7 @@ module CandidateInterface
 
   private
 
-    def clean_up_orphan_invites
+    def clean_up_disconnected_invites
       # When a candidate creates a draft choice for invited course and changes course to a non invited course
       # We then need to remove the link between the choice and the invite
       if application_choice.current_course == application_choice.original_course

--- a/app/services/candidate_interface/invite_application.rb
+++ b/app/services/candidate_interface/invite_application.rb
@@ -1,0 +1,45 @@
+module CandidateInterface
+  class InviteApplication
+    attr_reader :application_form, :application_choice
+
+    def initialize(application_form:, application_choice:)
+      @application_form = application_form
+      @application_choice = application_choice
+    end
+
+    def self.applied!(application_form:, application_choice:)
+      new(application_form:, application_choice:).applied!
+    end
+
+    def applied!
+      clean_up_orphan_invites
+
+      invite = application_form.published_invites.find_by(
+        course_id: application_choice.current_course.id,
+        application_choice_id: nil,
+      )
+
+      if invite.present? && application_choice.persisted?
+        invite.update!(
+          application_choice_id: application_choice.id,
+          candidate_decision: 'applied',
+        )
+      end
+    end
+
+  private
+
+    def clean_up_orphan_invites
+      # When a candidate creates a draft choice for invited course and changes course to a non invited course
+      # We then need to remove the link between the choice and the invite
+      if application_choice.current_course == application_choice.original_course
+        application_choice.published_invites.where.not(
+          course_id: application_choice.current_course.id,
+        ).update_all(
+          application_choice_id: nil,
+          candidate_decision: 'not_responded',
+        )
+      end
+    end
+  end
+end

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -29,14 +29,6 @@ module CandidateInterface
           preference: application_form.candidate.published_preferences.last,
           application_choice:,
         )
-
-        invite = application_form.published_invites.find_by(course_id: application_choice.course.id)
-        if invite.present?
-          invite.update(
-            application_choice_id: application_choice.id,
-            candidate_decision: 'applied',
-          )
-        end
       end
     end
 

--- a/spec/services/candidate_interface/invite_application_spec.rb
+++ b/spec/services/candidate_interface/invite_application_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::InviteApplication do
+  let(:application_form) { create(:application_form, :completed) }
+  let(:application_choice) do
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form:,
+    )
+  end
+  let!(:invite) {
+    create(
+      :pool_invite,
+      :sent_to_candidate,
+      application_form:,
+      course: application_choice.course,
+    )
+  }
+
+  describe '.applied' do
+    context 'when applied to invited course' do
+      it 'saves applied state on invite' do
+        described_class.applied!(application_form:, application_choice:)
+
+        expect(invite.reload.application_choice_id).to eq(application_choice.id)
+        expect(invite.reload.applied?).to be(true)
+      end
+    end
+
+    context 'when application_choice has changed course to a non invited course including the original one' do
+      let!(:invite) {
+        create(
+          :pool_invite,
+          :sent_to_candidate,
+          application_form:,
+          application_choice:,
+          candidate_decision: 'applied',
+        )
+      }
+
+      it 'removes the link between the choice and the invite' do
+        described_class.applied!(application_form:, application_choice:)
+
+        expect(invite.reload.application_choice_id).to be_nil
+        expect(invite.reload.applied?).to be(false)
+      end
+    end
+
+    context 'when application_choice has changed course to a non invited course but the original one is an invited one' do
+      let(:original_course) { create(:course) }
+      let(:application_choice) do
+        create(
+          :application_choice,
+          :awaiting_provider_decision,
+          application_form:,
+          course: create(:course),
+          original_course: original_course,
+        )
+      end
+
+      let!(:invite) {
+        create(
+          :pool_invite,
+          :sent_to_candidate,
+          application_form:,
+          application_choice:,
+          course: original_course,
+          candidate_decision: 'applied',
+        )
+      }
+
+      it 'removes the link between the choice and the invite' do
+        described_class.applied!(application_form:, application_choice:)
+
+        expect(invite.reload.application_choice_id).to eq(application_choice.id)
+        expect(invite.reload.applied?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -142,38 +142,6 @@ module CandidateInterface
             application_choice:,
           )
         end
-
-        context 'when invite exists' do
-          it 'saves the application_choice on the invite' do
-            invite = create(
-              :pool_invite,
-              course: application_choice.course,
-              status: 'published',
-              application_form: application_choice.application_form,
-              candidate: application_choice.application_form.candidate,
-            )
-
-            submit_application
-
-            expect(invite.reload.application_choice_id).to eq(application_choice.id)
-            expect(invite.reload.candidate_decision).to eq('applied')
-          end
-        end
-
-        context 'when invite does not exists' do
-          it 'does not saves the application_choice on the invite' do
-            invite = create(
-              :pool_invite,
-              course: application_choice.course,
-              status: 'published',
-            )
-
-            submit_application
-
-            expect(invite.reload.application_choice_id).to be_nil
-            expect(invite.reload.candidate_decision).to eq('not_responded')
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
## Context

The way we used to link the application_choice to an invite was flawed.

When a candidate created a draft application choice for a invited course. We would set the `candidate_decision` to `applied` but the application_choice wasn't saved to DB yet, so the choice id was not saved on the invite.

This caused some errors and some data inconstancies where invites had the `candidate_decision` set to `applied` but no choice id.

This commit fixes this by always linking the choice to the invite if the candidate applied to invited course. We link at the time of draft choice creation. Doing this will allow us to not try to link again when candidate submits the choice.

This is OK with product as it's still showing the intent of the candidate to apply to invite.

There's also an edge case when a candidate creates a draft application choice for invited course and changes to another course they have not been invited. In this case we remove the link between the choice and the invite. We know we can do this because the application choice original course and current course are the same. Even if the candidate changes courses of a draft choice.

If the choice has the original course same as an invited course we don't remove the link between invite and application choice.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Can go on review and create draft applications, submit them, change courses, etc.

Create/delete draft. Submit draft application. Change course on submitted application.
https://github.com/user-attachments/assets/c73c9646-2243-4e36-a3fc-9715512f4e42

  
Find to apply into draft application journey
https://github.com/user-attachments/assets/302d360e-1526-4d7f-ad32-a84288e04ce6



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
