### PR TITLE
Add declined candidate decision to pool invites

### DIFF
--- a/app/components/candidate_interface/invites_component.html.erb
+++ b/app/components/candidate_interface/invites_component.html.erb
@@ -7,16 +7,12 @@
       ) %>
 
       <%= item.with_status do %>
-        <% if invite.applied? && invite.application_choice.present? %>
-          <div class="govuk-!-margin-bottom-1">
-            <%= govuk_tag text: invite.candidate_decision.capitalize, colour: 'green' %>
-          </div>
-          <div>
-            <%= govuk_link_to t('.view_application'), application_choice_link(invite) %>
-          </div>
-        <% else %>
-          <%= govuk_link_to t('.view_invite'), candidate_interface_invite_path(invite) %>
-        <% end %>
+        <div class="govuk-!-margin-bottom-1">
+          <%= status_tag(invite) %>
+        </div>
+        <div>
+          <%= action_link(invite) %>
+        </div>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/candidate_interface/invites_component.rb
+++ b/app/components/candidate_interface/invites_component.rb
@@ -1,9 +1,8 @@
 module CandidateInterface
   class InvitesComponent < ViewComponent::Base
-    attr_reader :application_form, :invites
+    attr_reader :invites
 
-    def initialize(application_form:, invites:)
-      @application_form = application_form
+    def initialize(invites:)
       @invites = invites
     end
 
@@ -12,6 +11,26 @@ module CandidateInterface
         candidate_interface_offer_path(invite.application_choice, return_to: 'invites')
       else
         candidate_interface_course_choices_course_review_path(invite.application_choice, return_to: 'invites')
+      end
+    end
+
+    def status_tag(invite)
+      if invite.applied? && invite.application_choice.present?
+        govuk_tag text: invite.candidate_decision.capitalize, colour: 'green'
+      elsif invite.declined?
+        govuk_tag text: invite.candidate_decision.capitalize, colour: 'red'
+      elsif invite.course_closed?
+        govuk_tag text: t('.closed'), colour: 'grey'
+      end
+    end
+
+    def action_link(invite)
+      if invite.applied? && invite.application_choice.present?
+        govuk_link_to t('.view_application'), application_choice_link(invite)
+      elsif invite.declined? || !invite.course_open?
+        govuk_link_to t('.view_course'), invite.course.find_url
+      else
+        govuk_link_to t('.view_invite'), candidate_interface_invite_path(invite)
       end
     end
   end

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -23,6 +23,7 @@ class Pool::Invite < ApplicationRecord
   enum :candidate_decision, {
     not_responded: 'not_responded',
     applied: 'applied',
+    declined: 'declined',
   }, default: :not_responded
 
   scope :not_sent_to_candidate, -> { where(sent_to_candidate_at: nil) }
@@ -46,6 +47,10 @@ class Pool::Invite < ApplicationRecord
 
   def sent_to_candidate?
     sent_to_candidate_at.present?
+  end
+
+  def course_closed?
+    !course_open?
   end
 
   def matching_application_choice

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -35,7 +35,7 @@
     <h2 class="govuk-heading-m"><%= t('.your_invitations') %></h2>
 
     <% if @invites.present? %>
-      <%= render CandidateInterface::InvitesComponent.new(application_form: current_application, invites: @invites) %>
+      <%= render CandidateInterface::InvitesComponent.new(invites: @invites) %>
     <% else %>
       <p class='govuk-body'><%= t('.no_invitations') %></p>
     <% end %>

--- a/config/locales/candidate_interface/invites_component.yml
+++ b/config/locales/candidate_interface/invites_component.yml
@@ -4,3 +4,5 @@ en:
       title_html: "<p class='govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold'>%{provider_name}</p>"
       view_application: View application
       view_invite: View invite
+      view_course: View course
+      closed: Closed

--- a/spec/components/candidate_interface/invites_component_spec.rb
+++ b/spec/components/candidate_interface/invites_component_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe CandidateInterface::InvitesComponent do
           application_choice: create(:application_choice, :offered),
         )
 
-        component = described_class.new(
-          application_form: invite.application_form,
-          invites: [invite],
-        )
+        component = described_class.new(invites: [invite])
         render_inline(component)
 
         expect(component.application_choice_link(invite)).to eq(
@@ -29,10 +26,7 @@ RSpec.describe CandidateInterface::InvitesComponent do
     context 'when choice does not have offer' do
       it 'returns the review path' do
         invite = create(:pool_invite, :with_application_choice)
-        component = described_class.new(
-          application_form: invite.application_form,
-          invites: [invite],
-        )
+        component = described_class.new(invites: [invite])
         render_inline(component)
 
         expect(component.application_choice_link(invite)).to eq(
@@ -40,6 +34,116 @@ RSpec.describe CandidateInterface::InvitesComponent do
             invite.application_choice,
             return_to: 'invites',
           ),
+        )
+      end
+    end
+  end
+
+  describe '#status_tag' do
+    context 'with applied invite' do
+      it 'returns the green status tag' do
+        invite = create(
+          :pool_invite,
+          application_choice: create(:application_choice, :offered),
+          candidate_decision: 'applied',
+        )
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(component.status_tag(invite)).to eq(
+          '<strong class="govuk-tag govuk-tag--green">Applied</strong>',
+        )
+      end
+    end
+
+    context 'when invite declined' do
+      it 'returns no invites message when no invites' do
+        invite = create(
+          :pool_invite,
+          candidate_decision: 'declined',
+        )
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(component.status_tag(invite)).to eq(
+          '<strong class="govuk-tag govuk-tag--red">Declined</strong>',
+        )
+      end
+    end
+
+    context 'when course invite is closed' do
+      it 'returns no invites message when no invites' do
+        invite = create(
+          :pool_invite,
+          course_open: false,
+        )
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(component.status_tag(invite)).to eq(
+          '<strong class="govuk-tag govuk-tag--grey">Closed</strong>',
+        )
+      end
+    end
+  end
+
+  describe '#action-link' do
+    context 'with applied invite' do
+      it 'returns the applied action_link' do
+        choice = create(:application_choice, :offered)
+        invite = create(
+          :pool_invite,
+          application_choice: choice,
+          candidate_decision: 'applied',
+        )
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(rendered_content).to have_link(
+          'View application',
+          href: candidate_interface_offer_path(
+            invite.application_choice,
+            return_to: 'invites',
+          ),
+        )
+      end
+    end
+
+    context 'with declined invite' do
+      it 'returns the find url action_link' do
+        invite = create(:pool_invite, candidate_decision: 'declined')
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(rendered_content).to have_link(
+          'View course',
+          href: invite.course.find_url,
+        )
+      end
+    end
+
+    context 'with course closed invite' do
+      it 'returns the find url action_link' do
+        invite = create(:pool_invite, course_open: false)
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(rendered_content).to have_link(
+          'View course',
+          href: invite.course.find_url,
+        )
+      end
+    end
+
+    context 'anything else' do
+      it 'returns the invite show page action_link' do
+        invite = create(:pool_invite)
+        component = described_class.new(invites: [invite])
+        render_inline(component)
+
+        expect(rendered_content).to have_link(
+          'View invite',
+          href: candidate_interface_invite_path(invite),
         )
       end
     end


### PR DESCRIPTION
## Context

This adds the declined status to the pool invite and changes the invite component to display the correct status and link on the invite.

This is not the last version of the candidate invites index.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


These links and statuses are specified in the ticket


https://github.com/user-attachments/assets/3523a1b6-1cd1-4e5d-afbd-06e92cdbedaa



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
