### PR TITLE
Change candidate content when hitting the 4 and 15 applications limit

### DIFF
--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -2,7 +2,18 @@
   <%= t('mid_cycle_content_component.title') %>
 </h1>
 <% if application_form_presenter.application_limit_reached? %>
-  <p class="govuk-body"><%= t('mid_cycle_content_component.you_cannot_submit_more', max_number_of_applications:) %></p>
+  <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_submit_more')) %>
+  <p class="govuk-body">This is because you have a total of 15 applications that have been either:</p>
+  <%= govuk_list(
+    [
+      t('mid_cycle_content_component.rejected_by_provider'),
+      t('mid_cycle_content_component.withdrawn_by_provider'),
+      t('mid_cycle_content_component.inactive_html'),
+      t('mid_cycle_content_component.declined_offer'),
+      t('mid_cycle_content_component.conditions_not_met'),
+    ],
+    type: :bullet,
+  ) %>
   <p class="govuk-body"><%= t('mid_cycle_content_component.you_will_be_able_to_apply_again', apply_reopens_date:, next_year:) %></p>
   <p class="govuk-body"><%= t('mid_cycle_content_component.email_for_help_html', email_address: govuk_mail_to(t('mid_cycle_content_component.becoming_a_teacher_email'))) %></p>
 <% elsif application_form_presenter.can_add_more_choices? %>
@@ -14,12 +25,20 @@
   </p>
   <%= govuk_button_link_to t('mid_cycle_content_component.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
-  <p class="govuk-body"><%= t('mid_cycle_content_component.you_cannot_add_any_more_applications') %></p>
+  <p class="govuk-body">You have 4 applications in progress.</p>
+  <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_add_any_more_applications')) %>
   <p class="govuk-body"><%= t('mid_cycle_content_component.you_can_add_more_applications_if') %></p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><%= t('mid_cycle_content_component.one_becomes_unsuccessful') %></li>
-    <li><%= t('mid_cycle_content_component.withdraw_or_remove') %></li>
-  </ul>
+
+  <%= govuk_list(
+    [
+      t('mid_cycle_content_component.rejected_by_provider'),
+      t('mid_cycle_content_component.withdrawn_by_provider'),
+      t('mid_cycle_content_component.inactive_html'),
+      t('mid_cycle_content_component.declined_offer'),
+      t('mid_cycle_content_component.conditions_not_met'),
+    ],
+    type: :bullet,
+  ) %>
   <p class="govuk-body"><%= t('mid_cycle_content_component.once_you_have_reached_the_limit', max_number_of_applications:, next_year:) %></p>
   <p class="govuk-body">
     <%= govuk_link_to t('mid_cycle_content_component.read_how_the_application_process_works'), candidate_interface_guidance_path %>.

--- a/config/locales/components/candidate_interface/mid_cycle_content_component.yml
+++ b/config/locales/components/candidate_interface/mid_cycle_content_component.yml
@@ -1,8 +1,7 @@
 en:
   mid_cycle_content_component:
     title: Your applications
-    you_cannot_submit_more: >
-      You cannot submit any more applications because you have %{max_number_of_applications} unsuccessful applications.
+    you_cannot_submit_more: You cannot submit any more applications this year
     you_will_be_able_to_apply_again: >
       You will be able to apply again in %{apply_reopens_date} when applications open for courses starting in September %{next_year}
     email_for_help_html: Email %{email_address} if you need help with your applications.
@@ -12,11 +11,12 @@ en:
     courses_fill_up_quickly: Courses can fill up quickly, so you should apply as soon as you are ready rather than putting it off.
     read_how_the_application_process_works: Read how the application process works
     add_application: Add application
-    you_cannot_add_any_more_applications: You cannot add any more applications.
-    you_can_add_more_applications_if: "You can add more applications if:"
-    one_becomes_unsuccessful: one of your submitted applications becomes unsuccessful
-    withdraw_or_remove: you withdraw or remove an application
+    you_cannot_add_any_more_applications: You cannot submit any more applications at the moment.
+    you_can_add_more_applications_if: "You can submit another application if one of your applications is either:"
     once_you_have_reached_the_limit: >
-      Once you have a total of %{max_number_of_applications} unsuccessful or withdrawn applications, you will not be
-      able to apply for any more courses until %{next_year}.
-
+      Once you have a total of %{max_number_of_applications} applications that are in one of the states described above, you will not be able to submit any more applications until %{next_year}.
+    rejected_by_provider: rejected by the training provider,
+    withdrawn_by_provider: 'withdrawn by you or the provider'
+    inactive_html: 'submitted over 30 working days ago and still waiting for a response <br> or:'
+    declined_offer: 'you declined the offer'
+    conditions_not_met: 'you did not meet the conditions of an offer'

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -194,10 +194,8 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_can_no_longer_add_more_course_choices
     visit current_path
-    expect(page).to have_content 'You cannot add any more applications.'
-    expect(page).to have_content 'You can add more applications if'
-    expect(page).to have_content 'one of your submitted applications becomes unsuccessful'
-    expect(page).to have_content 'you withdraw or remove an application'
+    expect(page).to have_content 'You have 4 applications in progress'
+    expect(page).to have_content 'You cannot submit any more applications at the moment.'
   end
   alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Candidate submits an application up to 4 choices' do
   end
 
   def and_i_am_unable_to_add_any_further_choices
-    expect(page).to have_content 'You cannot add any more applications.'
+    expect(page).to have_content 'You cannot submit any more applications at the moment.'
   end
 
   def when_i_click(button)

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_am_unable_to_add_any_further_choices
     visit current_path
-    expect(page).to have_content "You cannot submit any more applications because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications."
+    expect(page).to have_content 'You cannot submit any more applications this year'
+    expect(page).to have_content 'This is because you have a total of 15 applications that have been either:'
   end
 
   def when_i_click(button)


### PR DESCRIPTION
## Context


This should make it more obvious what 4 live applications mean and 15 'unsuccessful' applications mean to the candidate

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

4 live limit

<img width="1133" height="614" alt="image" src="https://github.com/user-attachments/assets/7e9dddbb-5c04-47cb-8017-dde47cb76ad2" />


15 limit

<img width="1498" height="661" alt="image" src="https://github.com/user-attachments/assets/44788f43-f02d-449a-b92b-2516b11b40e8" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
