### PR TITLE
Order candidate invites by sent_to_candidate_at

### DIFF
--- a/app/controllers/candidate_interface/invites_controller.rb
+++ b/app/controllers/candidate_interface/invites_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     before_action :redirect_if_feature_off_and_no_submitted_application
 
     def index
-      @invites = current_application.published_invites.includes(:application_choice)
+      @invites = current_application.published_invites.includes(:application_choice).order(sent_to_candidate_at: :desc)
     end
 
     def show


### PR DESCRIPTION
## Context

We want the newest(by sent_to_candidate_at) invites at the top

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The view invite invites are at the top

| Before | After |
| -- | -- |
| <img width="1166" height="774" alt="image" src="https://github.com/user-attachments/assets/429acd21-74a2-406c-b040-b4d732da087e" /> | <img width="1191" height="811" alt="image" src="https://github.com/user-attachments/assets/e6bce1b3-120b-4140-8de0-0667440ec8c7" /> |


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
