### PR TITLE
Take candidates out of pool based on invites

### DIFF
--- a/app/components/candidate_interface/applications_invite_reminder_banner_component.html.erb
+++ b/app/components/candidate_interface/applications_invite_reminder_banner_component.html.erb
@@ -1,0 +1,11 @@
+<%= govuk_notification_banner(title_text: 'Important') do %>
+  <p class='govuk-body'><%= banner_text %></p>
+
+  <%= govuk_list type: list_type do %>
+    <% invites.each do |invite| %>
+      <%= tag.li do %>
+        <%= govuk_link_to("#{invite.course.name_and_code} at #{invite.provider_name}", edit_candidate_interface_invite_path(invite)) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/applications_invite_reminder_banner_component.rb
+++ b/app/components/candidate_interface/applications_invite_reminder_banner_component.rb
@@ -1,0 +1,23 @@
+class CandidateInterface::ApplicationsInviteReminderBannerComponent < ViewComponent::Base
+  attr_reader :invites
+
+  def initialize(invites:)
+    @invites = invites
+  end
+
+  def render?
+    invites.not_responded.any?
+  end
+
+  def banner_text
+    if invites.not_responded.many?
+      'Respond to these invitations. You will not receive new invitations until you respond.'
+    else
+      'Respond to this invitation to continue receiving invitations to apply to courses.'
+    end
+  end
+
+  def list_type
+    invites.many? ? :bullet : nil
+  end
+end

--- a/app/components/candidate_interface/applications_invite_reminder_banner_component.rb
+++ b/app/components/candidate_interface/applications_invite_reminder_banner_component.rb
@@ -11,9 +11,9 @@ class CandidateInterface::ApplicationsInviteReminderBannerComponent < ViewCompon
 
   def banner_text
     if invites.not_responded.many?
-      'Respond to these invitations. You will not receive new invitations until you respond.'
+      t('.many_invites_content')
     else
-      'Respond to this invitation to continue receiving invitations to apply to courses.'
+      t('.one_invite_content')
     end
   end
 

--- a/app/components/candidate_interface/invite_reminder_banner_component.html.erb
+++ b/app/components/candidate_interface/invite_reminder_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(
-  title_text: 'Important',
-  text: 'You have invitations that are awaiting a response. You cannot receive further invitations to courses until you respond to them.',
+  title_text: t('.important'),
+  text: t('.content'),
 ) %>

--- a/app/components/candidate_interface/invite_reminder_banner_component.html.erb
+++ b/app/components/candidate_interface/invite_reminder_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(
+  title_text: 'Important',
+  text: 'You have invitations that are awaiting a response. You cannot receive further invitations to courses until you respond to them.',
+) %>

--- a/app/components/candidate_interface/invite_reminder_banner_component.rb
+++ b/app/components/candidate_interface/invite_reminder_banner_component.rb
@@ -1,0 +1,11 @@
+class CandidateInterface::InviteReminderBannerComponent < ViewComponent::Base
+  attr_reader :invites
+
+  def initialize(invites:)
+    @invites = invites
+  end
+
+  def render?
+    invites.not_responded.count >= 2
+  end
+end

--- a/app/components/candidate_interface/invite_reminder_banner_component.rb
+++ b/app/components/candidate_interface/invite_reminder_banner_component.rb
@@ -6,6 +6,6 @@ class CandidateInterface::InviteReminderBannerComponent < ViewComponent::Base
   end
 
   def render?
-    invites.not_responded.count >= 2
+    invites.not_responded.count >= Pool::Invite::NUMBER_OF_INVITES_TO_REMOVE_FROM_POOL
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -510,7 +510,7 @@ class CandidateMailer < ApplicationMailer
     @preferences_url = candidate_preferences_link(pool_invite.candidate)
     @invite_url = edit_candidate_interface_invite_url(pool_invite)
     @application_form = pool_invite.application_form
-    @not_responded_invites = @application_form.not_responded_published_invites.count
+    @not_responded_invites_count = @application_form.not_responded_published_invites.count
 
     email_for_candidate(
       @application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -509,10 +509,15 @@ class CandidateMailer < ApplicationMailer
     @pool_invite = pool_invite
     @preferences_url = candidate_preferences_link(pool_invite.candidate)
     @invite_url = edit_candidate_interface_invite_url(pool_invite)
-    application_form = pool_invite.application_form
+    @application_form = pool_invite.application_form
+    @not_responded_invites = @application_form.not_responded_published_invites.count
 
     email_for_candidate(
-      application_form,
+      @application_form,
+      subject: I18n.t!('candidate_mailer.candidate_invite.subject'),
+      layout: false,
+    )
+  end
 
   def invites_chaser(invites)
     @invites = invites.map do |invite|

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -513,6 +513,21 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       application_form,
+
+  def invites_chaser(invites)
+    @invites = invites.map do |invite|
+      Struct.new(:course_name, :url, :sent_time, :sent_date).new(
+        course_name: invite.course_name_and_code,
+        url: edit_candidate_interface_invite_url(id: invite.id),
+        sent_time: invite.sent_to_candidate_at.to_fs(:govuk_time),
+        sent_date: invite.sent_to_candidate_at.to_fs(:govuk_date),
+      )
+    end
+    @invites_url = candidate_interface_invites_url
+    @application_form = invites.first.application_form
+
+    email_for_candidate(
+      @application_form,
       subject: I18n.t!('candidate_mailer.candidate_invite.subject'),
       layout: false,
     )

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -533,7 +533,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       @application_form,
-      subject: I18n.t!('candidate_mailer.candidate_invite.subject'),
+      subject: I18n.t!('candidate_mailer.invites_chaser.subject'),
       layout: false,
     )
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -56,6 +56,7 @@ class ApplicationForm < ApplicationRecord
   has_many :application_feedback
 
   has_many :published_invites, -> { published }, class_name: 'Pool::Invite'
+  has_many :not_responded_published_invites, -> { published.not_responded.where(course_open: true) }, class_name: 'Pool::Invite'
 
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :unsubmitted, -> { where(submitted_at: nil) }

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -33,6 +33,11 @@ class ChaserSent < ApplicationRecord
     find_a_candidate_feature_launch: 'find_a_candidate_feature_launch',
 
     ######################################
+    ####  Pool Invite   ####
+    ######################################
+    pool_invite: 'pool_invite',
+
+    ######################################
     ####          References          ####
     ######################################
 

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -1,6 +1,8 @@
 class Pool::Invite < ApplicationRecord
   NUMBER_OF_INVITES_TO_REMOVE_FROM_POOL = 2
 
+  include Chased
+
   belongs_to :candidate
   belongs_to :application_form
   belongs_to :application_choice, optional: true
@@ -17,6 +19,7 @@ class Pool::Invite < ApplicationRecord
 
   delegate :name, to: :provider, prefix: true
   delegate :name_code_and_study_mode, to: :course, prefix: true
+  delegate :name_and_code, to: :course, prefix: true
 
   enum :status, {
     draft: 'draft',

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -1,4 +1,6 @@
 class Pool::Invite < ApplicationRecord
+  NUMBER_OF_INVITES_TO_REMOVE_FROM_POOL = 2
+
   belongs_to :candidate
   belongs_to :application_form
   belongs_to :application_choice, optional: true

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -24,6 +24,8 @@
   <% end %>
 <% end %>
 
+<%= render CandidateInterface::ApplicationsInviteReminderBannerComponent.new(invites: current_application.not_responded_published_invites) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
   <% if current_application.after_apply_deadline? %>

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -4,6 +4,7 @@
 <%= render CandidateInterface::ReopenBannerComponent.new(flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
+<%= render CandidateInterface::InviteReminderBannerComponent.new(invites: @not_responded_invites) %>
 
 <% if current_candidate.recoverable? %>
   <%= govuk_notification_banner(title_text: t('account_recovery_banner.title'), success: false) do |nb| %>

--- a/app/views/candidate_mailer/candidate_invite.text.erb
+++ b/app/views/candidate_mailer/candidate_invite.text.erb
@@ -17,8 +17,8 @@ Age range: <%= @pool_invite.course.age_range %>
 Qualification: <%= @pool_invite.course.qualifications_to_s %>
 Start date: <%= @pool_invite.course.start_date.to_fs(:short_month_and_year) %>
 
-<% if @not_responded_invites >= 2 %>
-This is the <%= TextOrdinalizer.call(@not_responded_invites) %> invitation to apply you have received. If you do not respond you will not receive any more invitations in future.
+<% if @not_responded_invites_count >= Pool::Invite::NUMBER_OF_INVITES_TO_REMOVE_FROM_POOL %>
+This is the <%= TextOrdinalizer.call(@not_responded_invites_count) %> invitation to apply you have received. If you do not respond you will not receive any more invitations in future.
 <% end %>
 
 [Review and respond to this invitation](<%= @invite_url %>)

--- a/app/views/candidate_mailer/candidate_invite.text.erb
+++ b/app/views/candidate_mailer/candidate_invite.text.erb
@@ -17,6 +17,10 @@ Age range: <%= @pool_invite.course.age_range %>
 Qualification: <%= @pool_invite.course.qualifications_to_s %>
 Start date: <%= @pool_invite.course.start_date.to_fs(:short_month_and_year) %>
 
+<% if @not_responded_invites >= 2 %>
+This is the <%= TextOrdinalizer.call(@not_responded_invites) %> invitation to apply you have received. If you do not respond you will not receive any more invitations in future.
+<% end %>
+
 [Review and respond to this invitation](<%= @invite_url %>)
 
 <% if @pool_invite.message_content.present? %>

--- a/app/views/candidate_mailer/invites_chaser.text.erb
+++ b/app/views/candidate_mailer/invites_chaser.text.erb
@@ -1,0 +1,16 @@
+<%# If you update this, please update the preview template for provider invite message as well %>
+Dear <%= @application_form.first_name %>,
+
+You have received invitations from training providers to apply to courses:
+
+<% @invites.each do |invite| %>
+  [<%= invite.course_name %>](<%= invite.url %>) received at <%= invite.sent_time %> on date <%= invite.sent_date %>
+<% end %>
+
+Because you have not responded to these invitations, we have hidden you from search results.
+
+## Any applications you have already submitted or that you go on to submit yourself are not affected.
+
+[Sign in to Apply for teacher training to review and respond to your invites](<%= @invites_url %>)
+
+You can either decline an invitation to a course or submit an application.  

--- a/app/views/candidate_mailer/invites_chaser.text.erb
+++ b/app/views/candidate_mailer/invites_chaser.text.erb
@@ -11,6 +11,6 @@ Because you have not responded to these invitations, we have hidden you from sea
 
 ## Any applications you have already submitted or that you go on to submit yourself are not affected.
 
-[Sign in to Apply for teacher training to review and respond to your invites](<%= @invites_url %>)
+[Sign in to review and respond to your invites](<%= @invites_url %>)
 
 You can either decline an invitation to a course or submit an application.  

--- a/app/views/candidate_mailer/invites_chaser.text.erb
+++ b/app/views/candidate_mailer/invites_chaser.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>,
 You have received invitations from training providers to apply to courses:
 
 <% @invites.each do |invite| %>
-  [<%= invite.course_name %>](<%= invite.url %>) received at <%= invite.sent_time %> on date <%= invite.sent_date %>
+  [<%= invite.course_name %>](<%= invite.url %>) received at <%= invite.sent_time %> on <%= invite.sent_date %>
 <% end %>
 
 Because you have not responded to these invitations, we have hidden you from search results.

--- a/app/views/provider_interface/candidate_pool/invites/show.html.erb
+++ b/app/views/provider_interface/candidate_pool/invites/show.html.erb
@@ -19,6 +19,7 @@
     </p>
     <%= govuk_list(
           [
+            t('.hidden_criteria'),
             t('.they_have_submitted_an_application'),
             t('.they_have_chosen_not_to_continue'),
           ],

--- a/app/workers/find_a_candidate/pool_invite_chaser_worker.rb
+++ b/app/workers/find_a_candidate/pool_invite_chaser_worker.rb
@@ -1,0 +1,25 @@
+module FindACandidate
+  class PoolInviteChaserWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :default
+
+    def perform
+      invites = Pool::Invite.current_cycle.published.not_responded
+        .where.missing(:chasers_sent)
+        .where(
+          application_form_id: Pool::Invite.current_cycle.published.not_responded
+            .where.missing(:chasers_sent)
+            .where('sent_to_candidate_at <= ? ', 1.day.ago)
+            .group(:application_form_id)
+            .having('COUNT(*) >= ?', Pool::Invite::NUMBER_OF_INVITES_TO_REMOVE_FROM_POOL)
+            .select(:application_form_id),
+        )
+      .select(:id, :application_form_id)
+
+      invites.group_by(&:application_form_id).each_value do |grouped_invites|
+        SendChaserWorker.perform_async(grouped_invites.map(&:id))
+      end
+    end
+  end
+end

--- a/app/workers/find_a_candidate/send_chaser_worker.rb
+++ b/app/workers/find_a_candidate/send_chaser_worker.rb
@@ -1,0 +1,23 @@
+module FindACandidate
+  class SendChaserWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :default
+
+    def perform(invite_ids)
+      ActiveRecord::Base.transaction do
+        invites = Pool::Invite.current_cycle.published.not_responded
+          .where.missing(:chasers_sent)
+          .where(id: invite_ids)
+
+        if invites.present?
+          CandidateMailer.invites_chaser(invites).deliver_now
+
+          invites.each do |invite|
+            ChaserSent.create!(chased: invite, chaser_type: 'pool_invite')
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -20,6 +20,7 @@ class Clock
 
   # Hourly jobs
 
+  every(1.hour, 'FindACandidate::PoolInviteChaserWorker', at: '**:35', skip_first_run: true) { FindACandidate::PoolInviteChaserWorker.perform_async }
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async }
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
     ProcessStaleApplicationsWorker.perform_async

--- a/config/locales/candidate_interface/applications_invite_reminder_banner_component.yml
+++ b/config/locales/candidate_interface/applications_invite_reminder_banner_component.yml
@@ -1,0 +1,5 @@
+en:
+  candidate_interface:
+    applications_invite_reminder_banner_component:
+      many_invites_content: Respond to these invitations. You will not receive new invitations until you respond.
+      one_invite_content: Respond to this invitation to continue receiving invitations to apply to courses.

--- a/config/locales/candidate_interface/invite_reminder_banner_component.yml
+++ b/config/locales/candidate_interface/invite_reminder_banner_component.yml
@@ -1,0 +1,5 @@
+en:
+  candidate_interface:
+    invite_reminder_banner_component:
+      important: Important
+      content: You have invitations that are awaiting a response. You cannot receive further invitations to courses until you respond to them.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -103,3 +103,5 @@ en:
         body:
           invite_to_submit: "%{provider_name} has reviewed your application details and would like you to submit an application to"
           you_are_receiving: "You are receiving this email because you chose to share your application details with training providers."
+    invites_chaser:
+      subject: 'Reminder: respond to your course invitations'

--- a/config/locales/provider_interface/candidate_pool_invites.yml
+++ b/config/locales/provider_interface/candidate_pool_invites.yml
@@ -27,6 +27,7 @@ en:
           caption: "Candidate number: %{candidate_id}"
           you_cannot_see: You cannot see this candidate’s profile information.
           this_could_be_because: "This could be because:"
+          hidden_criteria: we have hidden them from search results because they have not responded to invitation emails
           they_have_submitted_an_application: they have submitted an application to another training provider
           they_have_chosen_not_to_continue: they have chosen not to continue appearing in Find candidates searches
           because_you_have_invited_them: Because you have invited them, they could still submit an application to your course.

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -113,6 +113,7 @@ en:
             new_interview: A training provider has scheduled an interview with a candidate.
           candidate_find_a_candidate:
             candidate_invite: Find a candidate invitation email.
+            invites_chaser: Chaser email for candidates to respond to their invites if they are out of the pool because they didn't respond
           provider_mailer:
             application_submitted: Missing description
             application_submitted_with_safeguarding_issues: Missing description

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -113,6 +113,7 @@ en:
             new_interview: A training provider has scheduled an interview with a candidate.
           candidate_find_a_candidate:
             candidate_invite: Find a candidate invitation email.
+            candidate_invite_limit_reached: Find a candidate invitation email when candidate reaches the maximum invites allowed.
             invites_chaser: Chaser email for candidates to respond to their invites if they are out of the pool because they didn't respond
           provider_mailer:
             application_submitted: Missing description

--- a/spec/mailers/previews/candidate/find_a_candidate_preview.rb
+++ b/spec/mailers/previews/candidate/find_a_candidate_preview.rb
@@ -26,4 +26,25 @@ class Candidate::FindACandidatePreview < ActionMailer::Preview
 
     CandidateMailer.candidate_invite(invite)
   end
+
+  def invites_chaser
+    application_form = FactoryBot.create(
+      :application_form,
+      :minimum_info,
+      first_name: 'Fred',
+    )
+
+    invite = FactoryBot.create(
+      :pool_invite,
+      :sent_to_candidate,
+      application_form:,
+    )
+    second_invite = FactoryBot.create(
+      :pool_invite,
+      :sent_to_candidate,
+      application_form:,
+    )
+
+    CandidateMailer.invites_chaser([invite, second_invite])
+  end
 end

--- a/spec/mailers/previews/candidate/find_a_candidate_preview.rb
+++ b/spec/mailers/previews/candidate/find_a_candidate_preview.rb
@@ -16,12 +16,50 @@ class Candidate::FindACandidatePreview < ActionMailer::Preview
 
     invite = FactoryBot.create(
       :pool_invite,
+      :sent_to_candidate,
       candidate:,
       application_form:,
       provider:,
       course:,
       provider_message: true,
       message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
+    )
+
+    CandidateMailer.candidate_invite(invite)
+  end
+
+  def candidate_invite_limit_reached
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(
+      :application_form,
+      :minimum_info,
+      candidate: candidate,
+      first_name: 'Fred',
+    )
+
+    provider = FactoryBot.create(:provider)
+    course = FactoryBot.create(:course,
+                               provider: provider,
+                               fee_domestic: 9535,
+                               fee_international: 15430)
+
+    invite = FactoryBot.create(
+      :pool_invite,
+      :sent_to_candidate,
+      candidate:,
+      application_form:,
+      provider:,
+      course:,
+      provider_message: true,
+      message_content: "# Hello\r\n## Please apply to my course\r\n\r\n^ Some content\r\n\r\nByee",
+    )
+    _second_invite = FactoryBot.create(
+      :pool_invite,
+      :sent_to_candidate,
+      candidate:,
+      application_form:,
+      provider:,
+      course:,
     )
 
     CandidateMailer.candidate_invite(invite)

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe 'Docs' do
       candidate_mailer-offer_40_day
       candidate_mailer-offer_50_day
       candidate_mailer-candidate_invite
+      candidate_mailer-invites_chaser
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/find_a_candidate/pool_invite_chaser_worker_spec.rb
+++ b/spec/workers/find_a_candidate/pool_invite_chaser_worker_spec.rb
@@ -1,0 +1,180 @@
+require 'rails_helper'
+
+module FindACandidate
+  RSpec.describe PoolInviteChaserWorker do
+    describe '#perform' do
+      context 'without chasers and invites over limit' do
+        it 'enqueues chaser worker' do
+          application_form = create(:application_form, :completed)
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.days.ago,
+            application_form:,
+          )
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.days.ago,
+            application_form:,
+          )
+          second_application_form = create(:application_form, :completed)
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form: second_application_form,
+          )
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form: second_application_form,
+          )
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).to have_received(:perform_async).twice
+        end
+      end
+
+      context 'with chasers and new invites over limit' do
+        it 'enqueues chaser worker' do
+          application_form = create(:application_form, :completed)
+          invite_1 = create(:pool_invite, :sent_to_candidate, application_form:)
+          invite_2 = create(:pool_invite, :sent_to_candidate, application_form:)
+          _invite_3 = create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+          )
+          _invite_4 = create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+          )
+          create(:chaser_sent, chased: invite_1, chaser_type: 'pool_invite')
+          create(:chaser_sent, chased: invite_2, chaser_type: 'pool_invite')
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).to have_received(:perform_async).once
+        end
+      end
+
+      context 'with chasers and no new invites' do
+        it 'does not enqueue chaser worker' do
+          application_form = create(:application_form, :completed)
+          invite_1 = create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+          )
+          invite_2 = create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+          )
+
+          create(:chaser_sent, chased: invite_1, chaser_type: 'pool_invite')
+          create(:chaser_sent, chased: invite_2, chaser_type: 'pool_invite')
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).not_to have_received(:perform_async)
+        end
+      end
+
+      context 'without chasers but invites in previous cycle' do
+        it 'does not enqueue chaser worker' do
+          application_form = create(:application_form, :completed)
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+            recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          )
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+            recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+          )
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).not_to have_received(:perform_async)
+        end
+      end
+
+      context 'without chasers but invites not published' do
+        it 'does not enqueue chaser worker' do
+          application_form = create(:application_form, :completed)
+          create(:pool_invite, application_form:)
+          create(:pool_invite, application_form:)
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).not_to have_received(:perform_async)
+        end
+      end
+
+      context 'without chasers but invites already responded' do
+        it 'does not enqueue chaser worker' do
+          application_form = create(:application_form, :completed)
+          create(
+            :pool_invite,
+            application_form:,
+            candidate_decision: 'applied',
+            sent_to_candidate_at: 25.hours.ago,
+          )
+          create(
+            :pool_invite,
+            application_form:,
+            candidate_decision: 'applied',
+            sent_to_candidate_at: 25.hours.ago,
+          )
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).not_to have_received(:perform_async)
+        end
+      end
+
+      context 'without chasers but invites are not old enough' do
+        it 'does not enqueue chaser worker' do
+          application_form = create(:application_form, :completed)
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 2.hours.ago,
+            application_form:,
+          )
+          create(
+            :pool_invite,
+            status: 'published',
+            sent_to_candidate_at: 25.hours.ago,
+            application_form:,
+          )
+          allow(SendChaserWorker).to receive(:perform_async)
+
+          described_class.new.perform
+
+          expect(SendChaserWorker).not_to have_received(:perform_async)
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/find_a_candidate/send_chaser_worker_spec.rb
+++ b/spec/workers/find_a_candidate/send_chaser_worker_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe FindACandidate::SendChaserWorker do
+  describe '#perform' do
+    context 'without chasers' do
+      it 'creates chasers' do
+        invite_1 = create(:pool_invite, :sent_to_candidate)
+        invite_2 = create(:pool_invite, :sent_to_candidate)
+
+        expect {
+          described_class.new.perform([invite_1.id, invite_2.id])
+        }.to(change { ChaserSent.count }.from(0).to(2))
+      end
+    end
+
+    context 'with_chasers' do
+      it 'does not creates chasers' do
+        invite_1 = create(:pool_invite, :sent_to_candidate)
+        invite_2 = create(:pool_invite, :sent_to_candidate)
+        create(:chaser_sent, chased: invite_1, chaser_type: 'pool_invite')
+        create(:chaser_sent, chased: invite_2, chaser_type: 'pool_invite')
+
+        expect {
+          described_class.new.perform([invite_1.id, invite_2.id])
+        }.not_to(change { ChaserSent.count })
+      end
+    end
+
+    context 'without chasers but not current_cycle' do
+      it 'does not creates chasers' do
+        invite_1 = create(
+          :pool_invite,
+          :sent_to_candidate,
+          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        )
+        invite_2 = create(
+          :pool_invite,
+          :sent_to_candidate,
+          recruitment_cycle_year: RecruitmentCycleTimetable.previous_year,
+        )
+
+        expect {
+          described_class.new.perform([invite_1.id, invite_2.id])
+        }.not_to(change { ChaserSent.count })
+      end
+    end
+
+    context 'without chasers but invites not published' do
+      it 'does not creates chasers' do
+        invite_1 = create(:pool_invite)
+        invite_2 = create(:pool_invite)
+
+        expect {
+          described_class.new.perform([invite_1.id, invite_2.id])
+        }.not_to(change { ChaserSent.count })
+      end
+    end
+
+    context 'without chasers but invites responded' do
+      it 'does not creates chasers' do
+        invite_1 = create(:pool_invite, candidate_decision: 'applied')
+        invite_2 = create(:pool_invite, candidate_decision: 'applied')
+
+        expect {
+          described_class.new.perform([invite_1.id, invite_2.id])
+        }.not_to(change { ChaserSent.count })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Please review by commit.

- This will remove candidates with 2 or more not_responded invites from the pool
- Will send chasers after 24 hours
- And display banners to encourage the candidate to respond to invites

The first time the chaser worker runs, it will send a chaser to over 400 candidates.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

[Candidate invite email with 1 invite](https://apply-review-11036.test.teacherservices.cloud/rails/mailers/candidate/find_a_candidate/candidate_invite)
[Candidate invite email with more than 1 invite ](https://apply-review-11036.test.teacherservices.cloud/rails/mailers/candidate/find_a_candidate/candidate_invite_limit_reached)
[Chaser email](https://apply-review-11036.test.teacherservices.cloud/rails/mailers/candidate/find_a_candidate/invites_chaser)
[Mailers index](https://apply-review-11036.test.teacherservices.cloud/support/docs/mailers)

If you want to test it on review and want to be sent emails use your candidate:
Candidate 33 has Pete's email
Candidate 35 has Rebecca's email
Candidate 41 has Lori's email
Candidate 50 has my email
Candidate 51 has Dan's email
Candidate 52 has David's email

To receive chasers you need to update the invites to be 'older than 24 hours' and call the chaser worker

```
Pool::Invite.update_all(sent_to_candidate_at: 2.days.ago)
FindACandidate::PoolInviteChaserWorker.perform_sync
```

In the console. Review or local


https://github.com/user-attachments/assets/c3ef7b28-ef7e-4447-8562-2a75dc6e48a9



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
