### PR TITLE
Update invite email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -508,6 +508,7 @@ class CandidateMailer < ApplicationMailer
   def candidate_invite(pool_invite)
     @pool_invite = pool_invite
     @preferences_url = candidate_preferences_link(pool_invite.candidate)
+    @invite_url = edit_candidate_interface_invite_url(pool_invite)
     application_form = pool_invite.application_form
 
     email_for_candidate(

--- a/app/views/candidate_mailer/candidate_invite.text.erb
+++ b/app/views/candidate_mailer/candidate_invite.text.erb
@@ -17,14 +17,11 @@ Age range: <%= @pool_invite.course.age_range %>
 Qualification: <%= @pool_invite.course.qualifications_to_s %>
 Start date: <%= @pool_invite.course.start_date.to_fs(:short_month_and_year) %>
 
-[Review the full course details](<%= @pool_invite.course.find_url %>)
+[Review and respond to this invitation](<%= @invite_url %>)
 
 <% if @pool_invite.message_content.present? %>
 ## <%= @pool_invite.course.provider.name %> included this message:
 <%= @pool_invite.message_content %>
 <% end %>
 
-
-<%= t('.body.locations_not_suitable') %>, you can [update your preferences](<%= @preferences_url %>) to appear in more relevant searches.
-
-If you do not want to receive invitations like this, you can [stop providers from viewing your application details](<%= @preferences_url %>).
+<%= t('.body.you_are_receiving') %> [You can change your preferences](<%= @preferences_url %>).

--- a/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
+++ b/app/views/provider_interface/candidate_pool/provider_invite_messages/_invitation_email.html.erb
@@ -2,7 +2,7 @@
   <p class="govuk-body">Dear first name,</p>
 
   <p class="govuk-body">
-  <%= @course.provider.name %> have reviewed your application details and are inviting you to submit an application for:
+  <%= @course.provider.name %> has reviewed your application details and would like you to submit an application to:
   </p>
 
   <h3><%= @course.provider.name %> - <%= @course.name_and_code %></h3>
@@ -22,7 +22,7 @@
   <% end %>
 
   <p class="govuk-body">
-  <%= govuk_link_to('Review the full course details', @course.find_url) %>
+  <%= govuk_link_to('Review and respond to this invitation', '#') %>
   </p>
 
   <p class="govuk-body govuk-!-margin-bottom-0"><%= @course.provider.name %> included this message:</p>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -101,5 +101,5 @@ en:
     candidate_invite:
         subject: A provider has invited you to apply for teacher training
         body:
-          locations_not_suitable: If this course is not in suitable location
-          invite_to_submit: "%{provider_name} have reviewed your application details and are inviting you to submit an application for"
+          invite_to_submit: "%{provider_name} has reviewed your application details and would like you to submit an application to"
+          you_are_receiving: "You are receiving this email because you chose to share your application details with training providers."


### PR DESCRIPTION
## Context

We want to allow candidates to dismiss invites and (later) remove those who do not respond from the pool. This is in order to gain more information on why candidates are not responding to invites, and also to remove unresponsive candidates from the pool.

## Changes proposed in this pull request

- Change the link in the email to say ‘Review and respond to this invitation’ and link to the [new Apply response page](https://trello.com/c/kOhfl51n/1127-fac-allow-candidates-to-respond-to-invites) rather than to the course details on Find.

- The section at the bottom has been revised to try to help with the issue of candidates not knowing what they’ve opted into and to reduce the amount of links in the email to focus on the response one:

“You are receiving this email because you chose to share your application details with training providers. You can change your preferences.”

- The link would go to the [‘Check your application sharing preferences’ page](https://qa.apply-for-teacher-training.service.gov.uk/candidate/preferences/1286/publish-preferences).

## Guidance to review

- http://localhost:3000/rails/mailers/candidate/find_a_candidate/candidate_invite
- See also the mailer preview for the provider before sending the invite:
<img width="483" height="413" alt="Screenshot 2025-08-01 at 13 28 44" src="https://github.com/user-attachments/assets/c45b3ccc-eb48-4fba-9133-3e4605ad5841" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
