### PR TITLE
Allow "Add another" button to span the full width of the table

### DIFF
--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -54,7 +54,7 @@
             <% end %>
 
             <% body.with_row do |row| %>
-              <%= row.with_cell do %>
+              <%= row.with_cell(colspan: 4) do %>
                 <%= govuk_button_link_to(
                   t('.add_another_location'),
                   new_candidate_interface_draft_preference_location_preference_path(@preference),


### PR DESCRIPTION
## Context

On small screen sizes, the button text wraps onto a spearte line. This is caused by the button being enclosed in a cell within the table

## Changes proposed in this pull request

- Change the `rowspan` of the cell to be the full width of the table (4 columns)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

### Screenshots

| size | before | after |
|---|---|---|
| mobile | ![Areas you can train in - Apply for teacher training - GOV_UK · 2 32pm · 08-04 (1)](https://github.com/user-attachments/assets/cc122ea8-9804-4a95-adf7-3bf9b68513b9) | ![Areas you can train in - Apply for teacher training - GOV_UK · 2 32pm · 08-04 (2)](https://github.com/user-attachments/assets/3df111a6-4ea0-47af-aaec-9b8e9b20c3df) |
| above mobile | ![Areas you can train in - Apply for teacher training - GOV_UK](https://github.com/user-attachments/assets/5c8e0f75-f806-4cc7-88cd-89f3e09795c6) | ![Areas you can train in - Apply for teacher training - GOV_UK · 2 32pm · 08-04](https://github.com/user-attachments/assets/6d36673b-288b-4152-a966-91fcbe650f06) |

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
