### PR TITLE
LB/1180 Redirect to correct tab after sending an invitation

### DIFF
--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -54,11 +54,15 @@ module ProviderInterface
     end
 
     def save
-      if valid? && apply_filters
+      return false unless valid?
+
+      if apply_filters
         ActiveRecord::Base.transaction do
           provider_user_filter.update(filters:, updated_at: Time.zone.now)
           sister_filter.update(filters:, updated_at: 2.seconds.ago)
         end
+      else
+        provider_user_filter.save(updated_at: Time.zone.now)
       end
     end
 


### PR DESCRIPTION
## Context

Bug found where we were redirecting to the invite tab instead of the All or new tab if the invite tab had been clicked

## Changes proposed in this pull request

The bug was caused because we were not saving the filters for all or new on the initial load of the page. 

## Guidance to review

- Login as a proivder
- Go on FAC, on the invites tab
- Switch back to All tab or New tab
- Invite someone
- You should be redirected to the last tab you visited


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
