### PR TITLE
lb/1180 redirecting bug

### DIFF
--- a/app/models/provider_interface/candidate_pool_filter.rb
+++ b/app/models/provider_interface/candidate_pool_filter.rb
@@ -62,7 +62,10 @@ module ProviderInterface
           sister_filter.update(filters:, updated_at: 2.seconds.ago)
         end
       else
-        provider_user_filter.save(updated_at: Time.zone.now)
+        ActiveRecord::Base.transaction do
+          provider_user_filter.update(updated_at: Time.zone.now)
+          sister_filter.update(updated_at: 2.seconds.ago)
+        end
       end
     end
 

--- a/spec/models/provider_interface/candidate_pool_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_pool_filter_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe ProviderInterface::CandidatePoolFilter do
 
         expect { filter.save }.not_to change {
           current_provider_user.find_a_candidate_not_seen_filter&.filters
-        }.from(nil)
+        }.from({})
       end
     end
 


### PR DESCRIPTION
## Context

[This PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/11048) didn't completely fix the problem. Thanks @CatalinVoineag for noting it. 

## Changes proposed in this pull request

We should update the `updated_at` field on the sister filter when viewing the index filter, even without filters applied.

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
