### PR TITLE
Add accepted candidate-decision on pool_invite

### DIFF
--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -29,6 +29,7 @@ class Pool::Invite < ApplicationRecord
   enum :candidate_decision, {
     not_responded: 'not_responded',
     applied: 'applied',
+    accepted: 'accepted',
     declined: 'declined',
   }, default: :not_responded
 


### PR DESCRIPTION
## Context

We want to migrate all the pool_invites that have candidate-decision 'applied' to 'accepted'.

This just adds the new enum. A data migration will follow

## Changes proposed in this pull request


## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
