### PR TITLE
Add open date for FAC

### DIFF
--- a/app/models/candidate_pool_application.rb
+++ b/app/models/candidate_pool_application.rb
@@ -94,19 +94,14 @@ class CandidatePoolApplication < ApplicationRecord
 
   def self.closed?
     timetable = RecruitmentCycleTimetable.current_timetable
-    return true if timetable.between_cycles?
-
-    now = Time.zone.now
-    cycle_start = DateTime.new(
-      now.year,
-      timetable.apply_opens_at.month,
-      timetable.apply_opens_at.day,
-    )
-
-    now.between?(cycle_start, open_at)
+    timetable.after_apply_deadline? || Time.zone.now.before?(open_at)
   end
 
   def self.open_at
-    DateTime.new(Time.zone.now.year, 11, 20)
+    timetable = RecruitmentCycleTimetable.current_timetable
+
+    CandidateInterface::InactiveDateCalculator.new(
+      effective_date: timetable.apply_opens_at,
+    ).inactive_date
   end
 end

--- a/app/models/candidate_pool_application.rb
+++ b/app/models/candidate_pool_application.rb
@@ -91,4 +91,22 @@ class CandidatePoolApplication < ApplicationRecord
       scope.where(course_funding_type_fee: true)
     end
   end
+
+  def self.closed?
+    timetable = RecruitmentCycleTimetable.current_timetable
+    return true if timetable.between_cycles?
+
+    now = Time.zone.now
+    cycle_start = DateTime.new(
+      now.year,
+      timetable.apply_opens_at.month,
+      timetable.apply_opens_at.day,
+    )
+
+    now.between?(cycle_start, open_at)
+  end
+
+  def self.open_at
+    DateTime.new(Time.zone.now.year, 11, 20)
+  end
 end

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -4,7 +4,7 @@ class FindACandidate::PopulatePoolWorker
   sidekiq_options queue: :default
 
   def perform
-    if RecruitmentCycleTimetable.current_timetable.between_cycles?
+    if CandidatePoolApplication.closed?
       CandidatePoolApplication.delete_all
     else
       application_forms_eligible_for_pool = Pool::Candidates.new.application_forms_in_the_pool

--- a/spec/models/candidate_pool_application_spec.rb
+++ b/spec/models/candidate_pool_application_spec.rb
@@ -119,4 +119,36 @@ RSpec.describe CandidatePoolApplication do
       expect(application_forms.ids).not_to include(form_rejected_by_both_providers.id)
     end
   end
+
+  describe '.closed?' do
+    context 'after apply deadline', time: after_apply_deadline do
+      it 'returns true' do
+        expect(described_class.closed?).to be(true)
+      end
+    end
+
+    context 'before apply opens', time: before_apply_opens do
+      it 'returns true' do
+        expect(described_class.closed?).to be(true)
+      end
+    end
+
+    context 'before candidate_pool opens', time: DateTime.new(Time.zone.now.year, 11, 20) do
+      it 'returns true' do
+        expect(described_class.closed?).to be(true)
+      end
+    end
+
+    context 'after candidate_pool opens', time: DateTime.new(Time.zone.now.year, 11, 21) do
+      it 'returns false' do
+        expect(described_class.closed?).to be(false)
+      end
+    end
+  end
+
+  describe '.open_at' do
+    it 'returns when the candidate pool opens' do
+      expect(described_class.open_at).to eq(DateTime.new(Time.zone.now.year, 11, 20))
+    end
+  end
 end

--- a/spec/models/candidate_pool_application_spec.rb
+++ b/spec/models/candidate_pool_application_spec.rb
@@ -133,13 +133,13 @@ RSpec.describe CandidatePoolApplication do
       end
     end
 
-    context 'before candidate_pool opens', time: DateTime.new(Time.zone.now.year, 11, 20) do
+    context 'before candidate_pool opens', time: described_class.open_at - 1.day do
       it 'returns true' do
         expect(described_class.closed?).to be(true)
       end
     end
 
-    context 'after candidate_pool opens', time: DateTime.new(Time.zone.now.year, 11, 21) do
+    context 'after candidate_pool opens', time: described_class.open_at + 1.day do
       it 'returns false' do
         expect(described_class.closed?).to be(false)
       end
@@ -148,7 +148,9 @@ RSpec.describe CandidatePoolApplication do
 
   describe '.open_at' do
     it 'returns when the candidate pool opens' do
-      expect(described_class.open_at).to eq(DateTime.new(Time.zone.now.year, 11, 20))
+      expect(described_class.open_at).to eq(
+        DateTime.new(RecruitmentCycleTimetable.previous_year, 11, 19).end_of_day,
+      )
     end
   end
 end


### PR DESCRIPTION
## Context

We don't want to open the FAC feature when apply opens. We want to open it on the 20th of November.

This commit adds some logic to always open the FAC on the 20th of November, after apply opens. Regardless of the cycle year. It will always stay close between cycles and between apply opening and the 20th of November.

An alternative would be to add add candidate_pool_open and closed_at to RecruitmentCycleTimetable but that might become complicated?

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Locally or on the review app. Fast forward to the next cycle and run the pool_worker. You should not have any candidates in the pool

https://github.com/user-attachments/assets/3b56d712-b88c-4966-84be-732d22cd21ba



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
