### PR TITLE
Updated the existing flash message using a View Component

### DIFF
--- a/app/components/candidate_interface/invites/decline_reasons_success_flash_component.rb
+++ b/app/components/candidate_interface/invites/decline_reasons_success_flash_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CandidateInterface::Invites::DeclineReasonsSuccessFlashComponent < ViewComponent::Base
+  def initialize(invite:)
+    @invite = invite
+  end
+
+  def call
+    tag.div do
+      tag.p do
+        concat 'If you have changed your mind you can still '
+        concat govuk_link_to('apply to this course', candidate_interface_course_choices_course_confirm_selection_path(course), class: 'govuk-notification-banner__link')
+      end
+    end
+  end
+
+private
+
+  attr_reader :invite
+
+  delegate :course, to: :invite
+end

--- a/app/controllers/candidate_interface/decline_reasons_controller.rb
+++ b/app/controllers/candidate_interface/decline_reasons_controller.rb
@@ -9,13 +9,12 @@ module CandidateInterface
     def create
       @fac_invite_decline_reason_form = CandidateInterface::FacInviteDeclineReasonsForm.new(fac_invite_decline_reason_form_params)
 
-      if @fac_invite_decline_reason_form.valid?
-        @fac_invite_decline_reason_form.save(@invite)
-        flash[:success] = [t('.header', course: @invite.course.name_and_code,
-                                        provider: @invite.provider_name),
-                           t('.body', link: view_context.govuk_link_to('apply to this course',
-                                                                       candidate_interface_course_choices_course_confirm_selection_path(@invite.course),
-                                                                       class: 'govuk-notification-banner__link'))]
+      if @fac_invite_decline_reason_form.save(@invite)
+        flash[:success] = [
+          t('.header', course: @invite.course.name_and_code,
+                       provider: @invite.provider_name),
+          CandidateInterface::Invites::DeclineReasonsSuccessFlashComponent.new(invite: @invite).render_in(view_context),
+        ]
 
         redirect_to candidate_interface_invites_path
       else

--- a/config/locales/candidate_interface/decline_reasons.yml
+++ b/config/locales/candidate_interface/decline_reasons.yml
@@ -16,4 +16,3 @@ en:
         submit: Save
       create:
         header: You have declined %{course} at %{provider}
-        body: If you have changed your mind you can still %{link}

--- a/spec/components/candidate_interface/invites/decline_reasons_success_flash_component_spec.rb
+++ b/spec/components/candidate_interface/invites/decline_reasons_success_flash_component_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::Invites::DeclineReasonsSuccessFlashComponent do
+  include Rails.application.routes.url_helpers
+
+  it 'renders the component with the invite' do
+    course = build_stubbed(:course)
+    invite = build_stubbed(:pool_invite, course:)
+
+    result = render_inline(described_class.new(invite:))
+
+    expect(result).to have_text('If you have changed your mind you can still apply to this course')
+    expect(result).to have_link('apply to this course', href: candidate_interface_course_choices_course_confirm_selection_path(course))
+  end
+end

--- a/spec/components/previews/candidate_interface/invites/decline_reasons_success_flash_component_preview.rb
+++ b/spec/components/previews/candidate_interface/invites/decline_reasons_success_flash_component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CandidateInterface::Invites::DeclineReasonsSuccessFlashComponentPreview < ViewComponent::Preview
+  include ViewComponent::TestHelpers
+
+  def default
+    invite = FactoryBot.build_stubbed(:pool_invite)
+
+    component_html = render_inline(CandidateInterface::Invites::DeclineReasonsSuccessFlashComponent.new(invite:)).to_s
+
+    render(::FlashMessageComponent.new(flash: {
+      success: [
+        I18n.t('candidate_interface.decline_reasons.create.header',
+               course: invite.course.name_and_code,
+               provider: invite.provider_name),
+        component_html,
+      ],
+    }))
+  end
+end


### PR DESCRIPTION
## Context

We want to add login into the flash success messaging after declining an Invite. To do this we will extract the logic into a View Component. This is the basis of this extraction. 
Extracted from #11047 

## Changes proposed in this pull request

- Extracts the current flash messaging into a view component

## Guidance to review

-N/A


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
