### PR TITLE
Added helper methods to Invite and Invite Decline Reason

### DIFF
--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -89,4 +89,16 @@ class Pool::Invite < ApplicationRecord
       )
     SQL
   end
+
+  def decline_reasons_include_only_salaried?
+    published_invite_decline_reasons.any?(&:reason_only_salaried?)
+  end
+
+  def decline_reasons_include_location_not_convenient?
+    published_invite_decline_reasons.any?(&:reason_location_not_convenient?)
+  end
+
+  def decline_reasons_include_no_longer_interested?
+    published_invite_decline_reasons.any?(&:reason_no_longer_interested?)
+  end
 end

--- a/app/models/pool/invite_decline_reason.rb
+++ b/app/models/pool/invite_decline_reason.rb
@@ -5,4 +5,22 @@ class Pool::InviteDeclineReason < ApplicationRecord
     draft: 'draft',
     published: 'published',
   }, default: :draft
+
+  def reason_only_salaried?
+    reason_inquiry.only_salaried?
+  end
+
+  def reason_location_not_convenient?
+    reason_inquiry.location_not_convenient?
+  end
+
+  def reason_no_longer_interested?
+    reason_inquiry.no_longer_interested?
+  end
+
+private
+
+  def reason_inquiry
+    (reason || '').inquiry
+  end
 end

--- a/spec/models/pool/invite_decline_reason_spec.rb
+++ b/spec/models/pool/invite_decline_reason_spec.rb
@@ -15,4 +15,46 @@ RSpec.describe Pool::InviteDeclineReason do
         .backed_by_column_of_type(:string)
     }
   end
+
+  describe '#reason_only_salaried?' do
+    it 'returns false when reason is not set' do
+      decline_reason = build(:pool_invite_decline_reason, reason: nil)
+
+      expect(decline_reason).not_to be_reason_only_salaried
+    end
+
+    it 'returns true when reason is only_salaried' do
+      decline_reason = build(:pool_invite_decline_reason, reason: 'only_salaried')
+
+      expect(decline_reason).to be_reason_only_salaried
+    end
+  end
+
+  describe '#reason_location_not_convenient?' do
+    it 'returns false when reason is not set' do
+      decline_reason = build(:pool_invite_decline_reason, reason: nil)
+
+      expect(decline_reason).not_to be_reason_location_not_convenient
+    end
+
+    it 'returns true when reason is location_not_convenient' do
+      decline_reason = build(:pool_invite_decline_reason, reason: 'location_not_convenient')
+
+      expect(decline_reason).to be_reason_location_not_convenient
+    end
+  end
+
+  describe '#reason_no_longer_interested?' do
+    it 'returns false when reason is not set' do
+      decline_reason = build(:pool_invite_decline_reason, reason: nil)
+
+      expect(decline_reason).not_to be_reason_no_longer_interested
+    end
+
+    it 'returns true when reason is no_longer_interested' do
+      decline_reason = build(:pool_invite_decline_reason, reason: 'no_longer_interested')
+
+      expect(decline_reason).to be_reason_no_longer_interested
+    end
+  end
 end

--- a/spec/models/pool/invite_spec.rb
+++ b/spec/models/pool/invite_spec.rb
@@ -185,4 +185,67 @@ RSpec.describe Pool::Invite do
       expect(invite.matching_application_choice).to eq application_choice
     end
   end
+
+  describe '#decline_reasons_include_only_salaried?' do
+    it 'returns false when no decline reasons exist' do
+      invite = build(:pool_invite)
+      expect(invite.decline_reasons_include_only_salaried?).to be false
+    end
+
+    it 'returns false when no published decline reasons exist' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :draft, invite: invite)
+
+      expect(invite.decline_reasons_include_only_salaried?).to be false
+    end
+
+    it 'returns true when a published decline reason is only_salaried' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :published, reason: 'only_salaried', invite: invite)
+
+      expect(invite.decline_reasons_include_only_salaried?).to be true
+    end
+  end
+
+  describe '#decline_reasons_include_location_not_convenient?' do
+    it 'returns false when no decline reasons exist' do
+      invite = build(:pool_invite)
+      expect(invite.decline_reasons_include_location_not_convenient?).to be false
+    end
+
+    it 'returns false when no published decline reasons exist' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :draft, invite: invite)
+
+      expect(invite.decline_reasons_include_location_not_convenient?).to be false
+    end
+
+    it 'returns true when a published decline reason is location_not_convenient' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :published, reason: 'location_not_convenient', invite: invite)
+
+      expect(invite.decline_reasons_include_location_not_convenient?).to be true
+    end
+  end
+
+  describe '#decline_reasons_include_no_longer_interested?' do
+    it 'returns false when no decline reasons exist' do
+      invite = build(:pool_invite)
+      expect(invite.decline_reasons_include_no_longer_interested?).to be false
+    end
+
+    it 'returns false when no published decline reasons exist' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :draft, invite: invite)
+
+      expect(invite.decline_reasons_include_no_longer_interested?).to be false
+    end
+
+    it 'returns true when a published decline reason is no_longer_interested' do
+      invite = create(:pool_invite)
+      create(:pool_invite_decline_reason, :published, reason: 'no_longer_interested', invite: invite)
+
+      expect(invite.decline_reasons_include_no_longer_interested?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Context

These helpers make it easy to query whether an Invite has been declined for a given reason

Extracted from https://github.com/DFE-Digital/apply-for-teacher-training/pull/11047

## Changes proposed in this pull request

Added helpers for reasons

## Guidance to review

- n/a


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
