### PR TITLE
Lb/982 Default applications open from to when find opens

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -72,7 +72,7 @@ module TeacherTrainingPublicAPI
       course.accept_science_gcse_equivalency = course_from_api.accept_science_gcse_equivalency
       course.additional_gcse_equivalencies = course_from_api.additional_gcse_equivalencies
       course.age_range = age_range_in_years(course_from_api)
-      course.applications_open_from = course_from_api.applications_open_from
+      course.applications_open_from = course_from_api.applications_open_from.presence || timetable.find_opens_at
       course.application_status = course_from_api.application_status
       course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
       course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
@@ -149,6 +149,10 @@ module TeacherTrainingPublicAPI
       accredited_provider.save!
 
       accredited_provider
+    end
+
+    def timetable
+      @timetable ||= RecruitmentCycleTimetable.find_by(recruitment_cycle_year:)
     end
   end
 end


### PR DESCRIPTION
## Context
The Publish / Find team has found that providers do not really use the applications_open_from date. In nearly all cases, it is set to when find_opens_at. For 2026, they are going to stop asking this question of providers. 

We consume this data and use it in our code base. This initial PR just protects against this value being sent to us as nil. A future PR, to be merged in closer to the start of the new cycle, will just do away with using this field altogether. 

## Changes proposed in this pull request

Add a default to the the applications_open_from field when syncing courses from publish. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
