### PR TITLE
Only update a published preference once the submit button is clicked

### DIFF
--- a/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
@@ -5,6 +5,10 @@ module CandidateInterface
     before_action :redirect_to_root_path_if_flag_is_inactive
 
     def new
+      if @preference.published?
+        @preference = @preference.create_draft_dup
+      end
+
       @dynamic_location_preferences_form = DynamicLocationPreferencesForm.new(
         {
           dynamic_location_preferences: @preference.dynamic_location_preferences,

--- a/app/controllers/candidate_interface/funding_type_preferences_controller.rb
+++ b/app/controllers/candidate_interface/funding_type_preferences_controller.rb
@@ -5,6 +5,10 @@ module CandidateInterface
     before_action :set_back_path
 
     def new
+      if @preference.published?
+        @preference = @preference.create_draft_dup
+      end
+
       @funding_type_preference_form = FundingTypePreferenceForm.new(
         {
           funding_type: @preference.funding_type,

--- a/app/controllers/candidate_interface/training_locations_controller.rb
+++ b/app/controllers/candidate_interface/training_locations_controller.rb
@@ -5,6 +5,10 @@ module CandidateInterface
     before_action :set_submit_path, only: :new
 
     def new
+      if @preference.published?
+        @preference = @preference.create_draft_dup
+      end
+
       @training_locations_form = TrainingLocationsForm.build_from_preference(@preference)
     end
 

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'Candidate edits published preference' do
   end
 
   def and_the_candidate_preference_id_is_changed
-    @current_candidate.published_preferences.last != @existing_candidate_preference
+    expect(@current_candidate.published_preferences.last).not_to eq(@existing_candidate_preference)
   end
 
   def and_there_are_no_location_preferences


### PR DESCRIPTION
## Context

When we expanded the candidate_preferences form we forgot to add the functionality to not edit the published preference in place, from the review page of the published preferences.

This commit fixes this, by dupping the published preference into a draft preference which will take it's place only once the candidate submits the form.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


Before 

https://github.com/user-attachments/assets/a104aaf2-55c5-4b8a-82ba-571289efe4fe

After


https://github.com/user-attachments/assets/d78c1097-c1d2-4a0a-9125-e1a4b7212c41




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
