### PR TITLE
Add accepted_at on the application_choice for Candidate API 1.4

### DIFF
--- a/app/services/candidate_api/serializers/v1_4.rb
+++ b/app/services/candidate_api/serializers/v1_4.rb
@@ -17,6 +17,25 @@ module CandidateAPI
           program_type: course.program_type,
         )
       end
+
+      def serialize_application_choices(application_form)
+        {
+          data:
+          application_form.application_choices.sort_by(&:id).map do |application_choice|
+            {
+              id: application_choice.id,
+              created_at: application_choice.created_at&.iso8601,
+              updated_at: application_choice.updated_at&.iso8601,
+              sent_to_provider_at: application_choice.sent_to_provider_at&.iso8601,
+              accepted_at: application_choice.accepted_at&.iso8601,
+              status: application_choice.status,
+              provider: serialize_provider(application_choice.provider),
+              course: serialize_course(application_choice.course),
+              interviews: serialize_interviews(application_choice),
+            }
+          end,
+        }
+      end
     end
   end
 end

--- a/config/candidate_api/v1.4.yml
+++ b/config/candidate_api/v1.4.yml
@@ -290,6 +290,11 @@ components:
           format: date-time
           description: The date and time the application choice was submitted to the provider
           example: 2021-05-20T12:34:00Z
+        accepted_at:
+          type: string
+          format: date-time
+          description: The date and time the offer on the application choice was accepted
+          example: 2021-05-20T12:34:00Z
         status:
           type: string
           description: The status of the application choice

--- a/spec/requests/candidate_api/get_candidates_v1_4_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_4_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'GET /candidate-api/v1.4/candidates' do
                                                           level: 'secondary',
                                                           funding_type: 'fee',
                                                           program_type: 'higher_education_salaried_programme'))
-    application_choice = create(:application_choice, :awaiting_provider_decision, application_form:, course_option: course_option)
+    application_choice = create(:application_choice, :accepted, application_form:, course_option: course_option)
 
     get_api_request "#{root_path}?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: candidate_api_token
 
@@ -33,6 +33,7 @@ RSpec.describe 'GET /candidate-api/v1.4/candidates' do
     expect(application_forms_from_response_data.dig(0, 'last_name')).to eq('Doe')
 
     expect(application_forms_from_response_data.dig(0, 'application_choices', 'data', 0, 'id')).to eq(application_choice.id)
+    expect(application_forms_from_response_data.dig(0, 'application_choices', 'data', 0, 'accepted_at')).to eq(application_choice.accepted_at.iso8601)
     expect(application_forms_from_response_data.dig(0, 'application_choices', 'data', 0, 'course', 'level')).to eq('secondary')
     expect(application_forms_from_response_data.dig(0, 'application_choices', 'data', 0, 'course', 'funding_type')).to eq('fee')
     expect(application_forms_from_response_data.dig(0, 'application_choices', 'data', 0, 'course', 'program_type')).to eq('higher_education_salaried_programme')


### PR DESCRIPTION
## Context

This will help the The GIT Marketing to sent their emails when the offer has been accepted.

This is not a braking change, so don't think it's necessary to use a new version.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

You can hit the both candidates and candidate/id endpoints in the 1.4 candidates api. The application_choices should return an `accepted_at` field.

To create a token run  `ServiceAPIUser.candidate_user.create_magic_link_token!`

https://apply-review-11068.test.teacherservices.cloud/candidate-api#applicationchoice-object

<img width="541" height="196" alt="image" src="https://github.com/user-attachments/assets/ef10f398-b951-4d54-9f5c-3cfbaf1368e6" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
