### PR TITLE
feat(2414): ATT remove yaml secrets

### DIFF
--- a/.github/actions/deploy_v2/action.yml
+++ b/.github/actions/deploy_v2/action.yml
@@ -60,8 +60,6 @@ runs:
 
         echo "TERRAFORM_VERSION=$terraform_version" >> $GITHUB_ENV
         echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-        echo "KEY_VAULT_APP_SECRET_NAME=$(jq -r '.key_vault_app_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
-        echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
       env:
         DOCKER_IMAGE: ${{ format('ghcr.io/dfe-digital/apply-teacher-training:{0}', inputs.sha) }}
 
@@ -75,14 +73,6 @@ runs:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}
-
-    - name: Validate Azure Key Vault secrets
-      uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
-      with:
-        KEY_VAULT: ${{ env.KEY_VAULT_NAME }}
-        SECRETS: |
-          ${{ env.KEY_VAULT_APP_SECRET_NAME }}
-          ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
 
     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:
@@ -102,12 +92,14 @@ runs:
       with:
         bundler-cache: true
 
-    - uses: DFE-Digital/keyvault-yaml-secret@v1
+    - name: Fetch secrets from key vault
+      uses: azure/CLI@v2
       id: get_smoke_test_secrets
       with:
-        keyvault: ${{ env.KEY_VAULT_NAME }}
-        secret: APPLY-CYPRESS-SECRETS
-        key: CANDIDATE_TEST_EMAIL
+        inlineScript: |
+          CANDIDATE_TEST_EMAIL=$(az keyvault secret show --name "CANDIDATE-TEST-EMAIL" --vault-name "${{ env.KEY_VAULT_NAME }}" --query "value" -o tsv)
+          echo "::add-mask::$CANDIDATE_TEST_EMAIL"
+          echo "CANDIDATE_TEST_EMAIL=$CANDIDATE_TEST_EMAIL" >> $GITHUB_OUTPUT
 
     - name: Run smoke tests
       shell: bash

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -19,7 +19,6 @@ module "application_configuration" {
     AZURE_STORAGE_CONTAINER    = local.azure_storage_container
   }
 
-  secret_yaml_key = var.key_vault_app_secret_name
 }
 
 module "web_application" {

--- a/terraform/aks/data.tf
+++ b/terraform/aks/data.tf
@@ -3,7 +3,17 @@ data "azurerm_key_vault" "key_vault" {
   resource_group_name = local.app_resource_group_name
 }
 
-data "azurerm_key_vault_secret" "infra_secrets" {
+data "azurerm_key_vault_secret" "statuscake_password" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
-  name         = var.key_vault_infra_secret_name
+  name         = "STATUSCAKE-PASSWORD"
+}
+
+data "azurerm_key_vault_secret" "postgres_admin_username" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "POSTGRES-ADMIN-USERNAME"
+}
+
+data "azurerm_key_vault_secret" "postgres_admin_password" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "POSTGRES-ADMIN-PASSWORD"
 }

--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -13,8 +13,8 @@ module "postgres" {
   azure_enable_monitoring        = var.enable_alerting
   azure_enable_backup_storage    = var.deploy_azure_backing_services
   server_version                 = var.postgres_server_version
-  admin_username                 = local.infra_secrets.POSTGRES_ADMIN_USERNAME
-  admin_password                 = local.infra_secrets.POSTGRES_ADMIN_PASSWORD
+  admin_username                 = data.azurerm_key_vault_secret.postgres_admin_username.value
+  admin_password                 = data.azurerm_key_vault_secret.postgres_admin_password.value
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_storage_mb               = var.postgres_flexible_server_storage_mb
   azure_enable_high_availability = var.postgres_enable_high_availability

--- a/terraform/aks/provider.tf
+++ b/terraform/aks/provider.tf
@@ -25,7 +25,7 @@ provider "azurerm" {
 }
 
 provider "statuscake" {
-  api_token = local.infra_secrets.STATUSCAKE_PASSWORD
+  api_token = data.azurerm_key_vault_secret.statuscake_password.value
 }
 
 provider "kubernetes" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -7,8 +7,6 @@ variable "docker_image" {}
 
 # Key Vault variables
 variable "key_vault_name" {}
-variable "key_vault_infra_secret_name" {}
-variable "key_vault_app_secret_name" {}
 
 variable "gov_uk_host_names" {
   default = []
@@ -108,8 +106,6 @@ locals {
   app_name_suffix = var.app_name_suffix != null ? var.app_name_suffix : var.app_environment
 
   exp_storage_account_name = var.exp_storage_account_name != null ? var.exp_storage_account_name : var.data_exports_storage_account_name
-
-  infra_secrets = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
 
   app_env_values_from_yaml = try(yamldecode(file("${path.module}/workspace-variables/${var.app_environment}_app_env.yml")), {})
 

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "review",
   "key_vault_name": "s189d01-att-rv-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-REVIEW",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "namespace": "development",
   "db_sslmode": "prefer",
   "deploy_azure_backing_services": false,

--- a/terraform/aks/workspace_variables/loadtest.tfvars.json
+++ b/terraform/aks/workspace_variables/loadtest.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "loadtest",
   "key_vault_name": "s189t01-att-lt-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-LOADTEST",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "cluster": "test",
   "namespace": "bat-qa",
   "deploy_azure_backing_services": true,

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "production",
   "key_vault_name": "s189p01-att-pd-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-PRODUCTION",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
   "cluster": "production",
   "namespace": "bat-production",
   "gov_uk_host_names": [

--- a/terraform/aks/workspace_variables/pt_review.tfvars.json
+++ b/terraform/aks/workspace_variables/pt_review.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "review",
   "key_vault_name": "s189t01-att-rv-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-REVIEW",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "cluster": "platform-test",
   "deploy_azure_backing_services": true,
   "create_storage_account": true,

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "qa",
   "key_vault_name": "s189t01-att-qa-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-QA",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "cluster": "test",
   "namespace": "bat-qa",
   "gov_uk_host_names": [

--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "review",
   "key_vault_name": "s189t01-att-rv-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-REVIEW",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "cluster": "test",
   "namespace": "bat-qa",
   "deploy_azure_backing_services": false,

--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "sandbox",
   "key_vault_name": "s189p01-att-sbx-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-SANDBOX",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX",
   "cluster": "production",
   "namespace": "bat-production",
   "gov_uk_host_names": [

--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -1,8 +1,6 @@
 {
   "app_environment": "staging",
   "key_vault_name": "s189t01-att-stg-kv",
-  "key_vault_app_secret_name": "APPLY-APP-SECRETS-STAGING",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
   "cluster": "test",
   "namespace": "bat-staging",
   "gov_uk_host_names": ["staging.apply-for-teacher-training.service.gov.uk","staging.apply-for-teacher-training.education.gov.uk"],


### PR DESCRIPTION
## Context
Improve security by moving from multiple k:v pairs in few yaml secrets to individually defined k:v secrets

https://trello.com/c/2l6dckyW/2414-wait-for-rollover-att-remove-yaml-secrets

## Changes proposed in this pull request
- extract all k:v pairs out of application secrets into individual secrets

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
