### PR TITLE
Change cycle dates generator

### DIFF
--- a/app/services/support_interface/recruitment_cycle_timetable_generator.rb
+++ b/app/services/support_interface/recruitment_cycle_timetable_generator.rb
@@ -87,14 +87,16 @@ module SupportInterface
     end
 
     def generate_find_closes_at(recruitment_cycle_year)
+      # Find should always open on the closest Tues to 1st Oct
+      # And because find opens depends on find closes, find_closes_at should be closest Monday to 1st Oct
       oct_first = Time.zone.local(recruitment_cycle_year, 10, 1, 23, 59, 59)
 
       if oct_first.monday?
         oct_first
-      elsif oct_first.tuesday? || oct_first.wednesday? || oct_first.thursday?
-        oct_first - 1.day
-      else
+      elsif oct_first.friday? || oct_first.on_weekend?
         oct_first.next_occurring(:monday)
+      else
+        oct_first.prev_occurring(:monday)
       end
     end
 

--- a/spec/services/support_interface/recruitment_cycle_timetable_generator_spec.rb
+++ b/spec/services/support_interface/recruitment_cycle_timetable_generator_spec.rb
@@ -44,20 +44,20 @@ RSpec.describe SupportInterface::RecruitmentCycleTimetableGenerator do
       expect { generate_timetables }.to change { RecruitmentCycleTimetable.count }.by(10)
     end
 
-    it 'all timetables have find_closes_at dates between 30 Sep and 5 Oct' do
+    it 'all timetables have find_closes_at dates between 28 Sep and 5 Oct' do
       generate_timetables
       timetables.pluck(:recruitment_cycle_year, :find_closes_at).each do |recruitment_cycle_year, find_closes_at|
-        earliest_date = Time.zone.local(recruitment_cycle_year, 9, 30)
+        earliest_date = Time.zone.local(recruitment_cycle_year, 9, 28)
         latest_date = Time.zone.local(recruitment_cycle_year, 10, 5).end_of_day
         expect(find_closes_at.between?(earliest_date, latest_date)).to be true
       end
     end
 
-    it 'all timetables have find_opens_at dates that are between 1 Oct and 6 Oct' do
+    it 'all timetables have find_opens_at dates that are between 29 Sept and 5 Oct' do
       generate_timetables
       timetables.pluck(:recruitment_cycle_year, :find_opens_at).each do |recruitment_cycle_year, find_opens_at|
-        earliest_date = Time.zone.local(recruitment_cycle_year - 1, 10, 1)
-        latest_date = Time.zone.local(recruitment_cycle_year - 1, 10, 6)
+        earliest_date = Time.zone.local(recruitment_cycle_year - 1, 9, 29)
+        latest_date = Time.zone.local(recruitment_cycle_year - 1, 10, 12)
         expect(find_opens_at.between?(earliest_date, latest_date)).to be true
       end
     end


### PR DESCRIPTION
## Context

Apply and find along with policy have agreed to change the cycle dates.

The main change concerns find opening. Find will open on the closest
Tuesday in working days to the 1st of October. And based on that other
dates changed, like when apply opens.


This commit changes the generator to apply this rule.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

To test, locally run

```
RecruitmentCycleTimetable.where('recruitment_cycle_year >= 2025').delete_all

SupportInterface::RecruitmentCycleTimetableGenerator.call(2025)
SupportInterface::RecruitmentCycleTimetableGenerator.call(2026)
SupportInterface::RecruitmentCycleTimetableGenerator.call(2027)
```

Then compare the dates of the generated cycles to this https://dfedigital.atlassian.net/wiki/spaces/AAMIAT/pages/5400297521/2027+and+future+recruitment+cycle+dates#Option-2

They should match



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
