### PR TITLE
Reject by default banner

### DIFF
--- a/app/components/provider_interface/reject_by_default_banner_component.html.erb
+++ b/app/components/provider_interface/reject_by_default_banner_component.html.erb
@@ -1,4 +1,5 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
-  <% notification_banner.with_heading(text: t('.heading', deadline_date: reject_by_default_deadline[:day_and_month])) %>
-  <p class="govuk-body"><%= t('.text', deadline_time: reject_by_default_deadline[:time], deadline_date: reject_by_default_deadline[:full_date]) %></p>
+  <% notification_banner.with_heading(text: t('.heading', deadline: timetable.reject_by_default_at.to_fs(:day_and_month))) %>
+  <p class="govuk-body"><%= t('.text', deadline: timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)) %></p>
 <% end %>
+x

--- a/app/components/provider_interface/reject_by_default_banner_component.html.erb
+++ b/app/components/provider_interface/reject_by_default_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
+  <% notification_banner.with_heading(text: t('.heading', deadline_date: reject_by_default_deadline[:day_and_month])) %>
+  <p class="govuk-body"><%= t('.text', deadline_time: reject_by_default_deadline[:time], deadline_date: reject_by_default_deadline[:full_date]) %></p>
+<% end %>

--- a/app/components/provider_interface/reject_by_default_banner_component.rb
+++ b/app/components/provider_interface/reject_by_default_banner_component.rb
@@ -1,0 +1,21 @@
+class ProviderInterface::RejectByDefaultBannerComponent < ViewComponent::Base
+  def render?
+    show_reject_by_default_banner?
+  end
+
+  def reject_by_default_deadline
+    {
+      full_date: timetable.reject_by_default_at.to_fs(:govuk_date),
+      day_and_month: timetable.reject_by_default_at.to_fs(:day_and_month),
+      time: timetable.reject_by_default_at.to_fs(:govuk_time),
+    }
+  end
+
+  def show_reject_by_default_banner?
+    Time.zone.now.between?(timetable.apply_deadline_at, timetable.reject_by_default_at)
+  end
+
+  def timetable
+    RecruitmentCycleTimetable.current_timetable
+  end
+end

--- a/app/components/provider_interface/reject_by_default_banner_component.rb
+++ b/app/components/provider_interface/reject_by_default_banner_component.rb
@@ -3,19 +3,11 @@ class ProviderInterface::RejectByDefaultBannerComponent < ViewComponent::Base
     show_reject_by_default_banner?
   end
 
-  def reject_by_default_deadline
-    {
-      full_date: timetable.reject_by_default_at.to_fs(:govuk_date),
-      day_and_month: timetable.reject_by_default_at.to_fs(:day_and_month),
-      time: timetable.reject_by_default_at.to_fs(:govuk_time),
-    }
-  end
-
   def show_reject_by_default_banner?
     Time.zone.now.between?(timetable.apply_deadline_at, timetable.reject_by_default_at)
   end
 
   def timetable
-    RecruitmentCycleTimetable.current_timetable
+    @timetable ||= RecruitmentCycleTimetable.current_timetable
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -2,6 +2,8 @@
 
 <%= render ServiceInformationBanner.new(namespace: :provider) %>
 
+<%= render ProviderInterface::RejectByDefaultBannerComponent.new %>
+
 <h1 class="govuk-heading-l">Applications (<%= @pagy.count %>)</h1>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_choices) do %>

--- a/config/locales/components/provider_interface/reject_by_default_banner_component.yml
+++ b/config/locales/components/provider_interface/reject_by_default_banner_component.yml
@@ -1,5 +1,5 @@
 en:
   provider_interface:
     reject_by_default_banner_component:
-      heading: Make decisions on all received applications before %{deadline_date}
-      text: All applications that you have not made a decision on will be rejected automatically at %{deadline_time} on %{deadline_date}.
+      heading: Make decisions on all received applications before %{deadline}
+      text: All applications that you have not made a decision on will be rejected automatically at %{deadline}.

--- a/config/locales/components/provider_interface/reject_by_default_banner_component.yml
+++ b/config/locales/components/provider_interface/reject_by_default_banner_component.yml
@@ -1,0 +1,5 @@
+en:
+  provider_interface:
+    reject_by_default_banner_component:
+      heading: Make decisions on all received applications before %{deadline_date}
+      text: All applications that you have not made a decision on will be rejected automatically at %{deadline_time} on %{deadline_date}.

--- a/spec/components/provider_interface/reject_by_default_banner_component_spec.rb
+++ b/spec/components/provider_interface/reject_by_default_banner_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::RejectByDefaultBannerComponent, type: :component do
+  describe '#render' do
+    it 'renders between Apply deadline and Reject by default deadline' do
+      travel_temporarily_to(current_timetable.apply_deadline_at + 1.day) do
+        deadline_time = current_timetable.reject_by_default_at.to_fs(:govuk_time)
+        deadline_date = current_timetable.reject_by_default_at.to_fs(:govuk_date)
+        result = render_inline(described_class.new)
+        expect(result.text).to include(
+          "All applications that you have not made a decision on will be rejected automatically at #{deadline_time} on #{deadline_date}.",
+        )
+      end
+    end
+
+    it 'does not render outside of date range' do
+      travel_temporarily_to(current_timetable.apply_deadline_at - 2.weeks) do
+        result = render_inline(described_class.new)
+        expect(result.text).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

While testing EOC journeys in our Bug Party on 2 September 2024, we wondered whether it’s clear to Manage users on-service that the decline reject by default deadline is coming. We have decided to **show this banner between the apply deadline and the reject by default date** (for this year **it will show between the 16 and 24 September 2025)**.

## Changes proposed in this pull request

- Add banner component
- Add render logic **between apply deadline and the reject by default date**

## Guidance to review

Use the date-adjusted review app to:
- Sign in as a provider
- Review the rendered component on the application choices index page
- Review the spec file `spec/components/provider_interface/reject_by_default_banner_component_spec.rb`
- Change the Apply deadline date in support/settings to a future date and make sure the banner is no longer visible

<img width="693" height="675" alt="Screenshot 2025-08-20 at 09 20 26" src="https://github.com/user-attachments/assets/674f1d5f-f7bd-46d3-b4a3-a2f8e6299dc1" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
