### PR TITLE
Redirect to application choices when carry over

### DIFF
--- a/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
+++ b/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
@@ -24,4 +24,3 @@
       ) %>
 </p>
 <%= govuk_button_to t('.button_update_your_details'), candidate_interface_carry_over_path %>
-

--- a/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
+++ b/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
@@ -1,40 +1,27 @@
 <% content_for :title, t('page_titles.start_carry_over_between_cycles') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('page_titles.start_carry_over_between_cycles') %></h1>
-    <p class="govuk-body">
-      <%= t(
-            '.application_deadline_has_passed_for_academic_year',
-            academic_year: application_form_academic_cycle,
-            start_month_year: application_form_start_month_year,
-          ) %>
-    </p>
-    <% if application_choices.present? %>
-      <p class="govuk-body">
-        <%= t('.application_status_change_explanation') %>
-      </p>
-    <% end %>
+<h1 class="govuk-heading-l"><%= t('page_titles.start_carry_over_between_cycles') %></h1>
+<p class="govuk-body">
+  <%= t(
+        '.application_deadline_has_passed_for_academic_year',
+        academic_year: application_form_academic_cycle,
+        start_month_year: application_form_start_month_year,
+      ) %>
+</p>
+<% if application_choices.present? %>
+  <p class="govuk-body">
+    <%= t('.application_status_change_explanation') %>
+  </p>
+<% end %>
 
-    <h2 class="govuk-heading-m"><%= t('.what_happens_next') %></h2>
+<h2 class="govuk-heading-m"><%= t('.what_happens_next') %></h2>
 
-    <p class="govuk-body">
-      <%= t(
-            '.application_process_description',
-            next_academic_year: next_academic_cycle,
-            apply_reopens_date: apply_reopens_date.to_fs(:govuk_date),
-          ) %>
-    </p>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <%= govuk_button_to t('.button_update_your_details'), candidate_interface_carry_over_path %>
-  </div>
+<p class="govuk-body">
+  <%= t(
+        '.application_process_description',
+        next_academic_year: next_academic_cycle,
+        apply_reopens_date: apply_reopens_date.to_fs(:govuk_date),
+      ) %>
+</p>
+<%= govuk_button_to t('.button_update_your_details'), candidate_interface_carry_over_path %>
 
-  <div class="govuk-grid-column-full">
-    <%= render CandidateInterface::ApplicationChoiceListComponent.new(
-      application_form: @application_form,
-      application_choices:,
-      current_tab_name: params[:current_tab_name],
-    ) %>
-  </div>
-</div>

--- a/app/components/candidate_interface/carry_over_mid_cycle_component.html.erb
+++ b/app/components/candidate_interface/carry_over_mid_cycle_component.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, t('page_titles.start_carry_over') %>
 
-
 <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
 
 <p class="govuk-body">

--- a/app/components/candidate_interface/carry_over_mid_cycle_component.html.erb
+++ b/app/components/candidate_interface/carry_over_mid_cycle_component.html.erb
@@ -1,27 +1,14 @@
 <% content_for :title, t('page_titles.start_carry_over') %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
+<h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
 
-    <p class="govuk-body">
-      You started an application for courses starting in the <%= application_form_academic_cycle %> academic year, which have now closed.
-    </p>
+<p class="govuk-body">
+  You started an application for courses starting in the <%= application_form_academic_cycle %> academic year, which have now closed.
+</p>
 
-    <p class="govuk-body">
-      Continue your application to apply for courses starting in the <%= next_academic_cycle %> academic year instead.
-    </p>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <%= govuk_button_to t('continue'), candidate_interface_carry_over_path %>
-  </div>
+<p class="govuk-body">
+  Continue your application to apply for courses starting in the <%= next_academic_cycle %> academic year instead.
+</p>
 
-  <div class="govuk-grid-column-full">
-    <%= render CandidateInterface::ApplicationChoiceListComponent.new(
-      application_form: @application_form,
-      application_choices:,
-      current_tab_name: params[:current_tab_name],
-    ) %>
-  </div>
-</div>
+<%= govuk_button_to t('continue'), candidate_interface_carry_over_path %>

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -9,9 +9,7 @@ module CandidateInterface
     def interstitial
       current_candidate.update!(course_from_find_id: nil)
 
-      if current_application.submitted? && current_application.v23?
-        redirect_to candidate_interface_start_carry_over_path
-      elsif current_application.contains_course?(course_from_find)
+      if current_application.contains_course?(course_from_find)
         flash[:warning] = "You have already added an application for #{course_from_find.name}. #{view_context.link_to('Find a different course to apply to', find_url, class: 'govuk-link')}."
         redirect_to course_choices_page
       elsif current_application.cannot_add_more_choices?

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ApplicationChoicesController < CandidateInterfaceController
     before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
-    before_action CarryOverFilter
+    before_action CarryOverFilter, except: :index
 
     before_action SubmissionPermissionFilter, only: %i[submit confirm_destroy destroy]
     before_action :redirect_to_your_applications_if_submitted, only: %i[submit confirm_destroy destroy]

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -2,10 +2,6 @@ module CandidateInterface
   class CarryOverController < CandidateInterfaceController
     before_action AlreadyCarriedOverFilter
 
-    def start
-      redirect_to candidate_interface_application_choices_path
-    end
-
     def create
       CarryOverApplication.new(current_application).call
       redirect_to candidate_interface_details_path

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action AlreadyCarriedOverFilter
 
     def start
-      @application_form = current_application
+      redirect_to candidate_interface_application_choices_path
     end
 
     def create

--- a/app/filters/already_carried_over_filter.rb
+++ b/app/filters/already_carried_over_filter.rb
@@ -1,11 +1,10 @@
 class AlreadyCarriedOverFilter < ApplicationFilter
-  delegate :candidate_interface_details_path,
-           :candidate_interface_start_carry_over_path,
+  delegate :candidate_interface_application_choices_path,
            to: :controller
 
   def call
     return if current_application.carry_over?
 
-    redirect_to candidate_interface_details_path
+    redirect_to candidate_interface_application_choices_path
   end
 end

--- a/app/filters/carry_over_filter.rb
+++ b/app/filters/carry_over_filter.rb
@@ -1,9 +1,9 @@
 class CarryOverFilter < ApplicationFilter
-  delegate :candidate_interface_start_carry_over_path, :params, to: :controller
+  delegate :candidate_interface_application_choices_path, :params, to: :controller
 
   def call
     return unless current_application.carry_over?
 
-    redirect_to candidate_interface_start_carry_over_path(current_tab_name: params[:current_tab_name])
+    redirect_to candidate_interface_application_choices_path(current_tab_name: params[:current_tab_name])
   end
 end

--- a/app/filters/unsuccessful_carry_over_filter.rb
+++ b/app/filters/unsuccessful_carry_over_filter.rb
@@ -1,9 +1,9 @@
 class UnsuccessfulCarryOverFilter < ApplicationFilter
-  delegate :candidate_interface_start_carry_over_path, to: :controller
+  delegate :candidate_interface_application_choices_path, to: :controller
 
   def call
     return if current_application.can_add_course_choice? || current_application.carry_over?
 
-    redirect_to candidate_interface_start_carry_over_path if current_application.v23?
+    redirect_to candidate_interface_application_choices_path if current_application.v23?
   end
 end

--- a/app/views/candidate_interface/carry_over/start.html.erb
+++ b/app/views/candidate_interface/carry_over/start.html.erb
@@ -1,5 +1,0 @@
-<% if RecruitmentCycleTimetable.currently_between_cycles? %>
-  <%= render(CandidateInterface::CarryOverBetweenCyclesComponent.new(application_form: @application_form)) %>
-<% else %>
-  <%= render(CandidateInterface::CarryOverMidCycleComponent.new(application_form: @application_form)) %>
-<% end %>

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -97,7 +97,6 @@ namespace :candidate_interface, path: '/candidate' do
 
     get '/review/submitted/:id' => 'application_form#review_previous_application', as: :review_previous_application
 
-    get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
     post '/carry-over' => 'carry_over#create', as: :carry_over
 
     resource :adviser_sign_ups, path: 'adviser-sign-ups', only: %i[new create show]

--- a/spec/components/candidate_interface/carry_over_between_cycles_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_between_cycles_component_spec.rb
@@ -20,24 +20,4 @@ RSpec.describe CandidateInterface::CarryOverBetweenCyclesComponent do
       expect(result).to have_no_content('The status of some of your applications might have changed automatically. Contact the provider if you have questions about your application.')
     end
   end
-
-  context 'application choices are present', time: after_apply_deadline do
-    it 'renders the component without information about status changes' do
-      application_form = create(:application_form, application_choices: [build(:application_choice, :rejected)])
-      timetable = application_form.recruitment_cycle_timetable
-      result = render_inline(described_class.new(application_form:))
-
-      expect(result).to have_content('The application deadline has passed')
-      expect(result).to have_content('What happens next')
-
-      next_academic_year = timetable.relative_next_timetable.academic_year_range_name
-      expect(result).to have_content("You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.")
-
-      apply_reopens_date = timetable.relative_next_timetable.apply_opens_at.to_fs(:govuk_date)
-      expect(result).to have_content("You will be able to apply for these courses from #{apply_reopens_date}.")
-      expect(result).to have_button('Update your details')
-
-      expect(result).to have_content('The status of some of your applications might have changed automatically. Contact the provider if you have questions about your application.')
-    end
-  end
 end

--- a/spec/components/candidate_interface/carry_over_mid_cycle_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_mid_cycle_component_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe CandidateInterface::CarryOverMidCycleComponent do
     expect(result.text).to include('Continue your application')
   end
 
-  context 'after the new recruitment cycle begins year' do
-    before do
-      TestSuiteTimeMachine.travel_permanently_to(current_timetable.apply_opens_at)
-    end
-
+  context 'after the new recruitment cycle begins year', time: mid_cycle do
     it 'renders the correct academic years' do
       application_year = current_year - 1
       application_form = build(:completed_application_form, recruitment_cycle_year: application_year)

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -385,6 +385,10 @@ FactoryBot.define do
       recruitment_cycle_year { 2023 }
     end
 
+    trait :previous_cycle do
+      recruitment_cycle_year { CycleTimetableHelper.previous_year }
+    end
+
     trait :carry_over do
       completed
       recruitment_cycle_year { CycleTimetableHelper.current_year }

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'After sign in redirects' do
   context 'when course from find is not present', time: mid_cycle do
     let(:candidate) { create(:candidate, course_from_find: nil) }
 
-    context 'when application is pre continuous applications' do
-      let!(:application_form) { create(:application_form, :completed, :pre_continuous_applications, candidate: candidate) }
+    context 'when application is in the previous cycle' do
+      let!(:application_form) { create(:application_form, :completed, :previous_cycle, candidate: candidate) }
 
       it 'redirects to start carry over' do
         get candidate_interface_interstitial_path
@@ -23,7 +23,7 @@ RSpec.describe 'After sign in redirects' do
       end
     end
 
-    context 'when application is continuous applications' do
+    context 'when application is in the current cycle' do
       let!(:application_form) { create(:application_form, :minimum_info, submitted_at: nil, candidate: candidate) }
 
       it 'redirects to application details path' do

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'After sign in redirects' do
 
       it 'redirects to start carry over' do
         get candidate_interface_interstitial_path
-        expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
     end
 
@@ -55,15 +55,6 @@ RSpec.describe 'After sign in redirects' do
         follow_redirect!
         expect(response).to redirect_to(candidate_interface_application_offer_dashboard_path)
       end
-    end
-  end
-
-  context 'when application submitted and non continuous applications' do
-    let!(:application_form) { create(:application_form, :completed, :pre_continuous_applications, candidate: candidate) }
-
-    it 'redirects to application complete path' do
-      get candidate_interface_interstitial_path
-      expect(response).to redirect_to(candidate_interface_start_carry_over_path)
     end
   end
 

--- a/spec/requests/candidate_interface/cycle_redirects_spec.rb
+++ b/spec/requests/candidate_interface/cycle_redirects_spec.rb
@@ -3,12 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Cycle redirects' do
   include Devise::Test::IntegrationHelpers
 
-  top_level_application_routes = %w[
-    candidate_interface_details_path
-    candidate_interface_application_choices_path
-  ]
-
-  section_routes = [
+  all_routes = [
+    'candidate_interface_details_path',
     'candidate_interface_contact_information_review_path',
     ['candidate_interface_gcse_review_path', { subject: 'english' }],
     ['candidate_interface_gcse_review_path', { subject: 'maths' }],
@@ -21,9 +17,7 @@ RSpec.describe 'Cycle redirects' do
     'candidate_interface_review_safeguarding_path',
     'candidate_interface_becoming_a_teacher_show_path',
     'candidate_interface_interview_preferences_show_path',
-  ]
-
-  all_routes = top_level_application_routes.concat(section_routes).map { |path| Array.wrap(path) }
+  ].map { |path| Array.wrap(path) }
 
   let(:candidate) { create(:candidate) }
   let(:carry_over) { false }
@@ -43,13 +37,13 @@ RSpec.describe 'Cycle redirects' do
     all_routes.each do |path|
       it "does not redirect #{path.join(' - ')} to the start-carry-over path" do
         get public_send(*path)
-        expect(response).not_to redirect_to(candidate_interface_start_carry_over_path)
+        expect(response).not_to redirect_to(candidate_interface_application_choices_path)
       end
     end
 
-    it 'redirects start-carry-over path to the application details path' do
+    it 'redirects start-carry-over path to the application choices path' do
       get candidate_interface_start_carry_over_path
-      expect(response).to redirect_to(candidate_interface_details_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 
@@ -59,13 +53,13 @@ RSpec.describe 'Cycle redirects' do
     all_routes.each do |path|
       it "redirects #{path.join(' - ')} to the start-carry-over path" do
         get public_send(*path)
-        expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
     end
 
-    it 'does not redirect the start-carry-over path to the application details path' do
+    it 'redirects start-carry-over path to the application choices path' do
       get candidate_interface_start_carry_over_path
-      expect(response).not_to redirect_to(candidate_interface_details_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 end

--- a/spec/requests/candidate_interface/cycle_redirects_spec.rb
+++ b/spec/requests/candidate_interface/cycle_redirects_spec.rb
@@ -40,11 +40,6 @@ RSpec.describe 'Cycle redirects' do
         expect(response).not_to redirect_to(candidate_interface_application_choices_path)
       end
     end
-
-    it 'redirects start-carry-over path to the application choices path' do
-      get candidate_interface_start_carry_over_path
-      expect(response).to redirect_to(candidate_interface_application_choices_path)
-    end
   end
 
   context 'when application is able to carry over', time: mid_cycle do
@@ -55,11 +50,6 @@ RSpec.describe 'Cycle redirects' do
         get public_send(*path)
         expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
-    end
-
-    it 'redirects start-carry-over path to the application choices path' do
-      get candidate_interface_start_carry_over_path
-      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 end

--- a/spec/requests/candidate_interface/personal_statement_spec.rb
+++ b/spec/requests/candidate_interface/personal_statement_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
     end
 
     context 'when the application form is from an old cycle' do
-      let(:application_form) { create(:application_form, :submitted, :pre_continuous_applications, candidate: candidate) }
+      let(:application_form) { create(:application_form, :submitted, :previous_cycle, candidate: candidate) }
 
-      it 'redirects to the carry over page' do
+      it 'redirects to the application choices page' do
         get candidate_interface_becoming_a_teacher_show_path
 
-        expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
     end
 
@@ -65,16 +65,16 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
       end
 
       context 'when the application form is from an old cycle' do
-        let(:application_form) { create(:application_form, :pre_continuous_applications, :submitted, candidate: candidate) }
+        let(:application_form) { create(:application_form, :previous_cycle, :submitted, candidate: candidate) }
 
         it 'redirects to the complete page' do
           patch candidate_interface_new_becoming_a_teacher_path, params: params
 
-          expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+          expect(response).to redirect_to(candidate_interface_application_choices_path)
         end
       end
 
-      context 'when the application form is submitted in continuous applications' do
+      context 'when the application form is in the current cycle' do
         let(:application_form) { create(:application_form, :submitted, candidate: candidate) }
 
         it 'redirects to the review page' do
@@ -141,16 +141,16 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
       end
 
       context 'when the application form is from old cycles' do
-        let!(:application_form) { create(:application_form, :submitted, :pre_continuous_applications, candidate: candidate) }
+        let!(:application_form) { create(:application_form, :submitted, :previous_cycle, candidate: candidate) }
 
         it 'redirects to the complete page' do
           patch candidate_interface_edit_becoming_a_teacher_path, params: params
 
-          expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+          expect(response).to redirect_to(candidate_interface_application_choices_path)
         end
       end
 
-      context 'when the application form is submitted in continuous applications' do
+      context 'when the application form is in the current cycle' do
         let!(:application_form) { create(:application_form, :submitted, candidate: candidate) }
 
         it 'redirects to the review page' do

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Submit to continuous apps' do
 
   context 'when old cycles trying to cheat and submit into the new cycle' do
     let(:application_form) do
-      create(:application_form, :previous_cycle, :completed, :with_degree, submitted_at: nil)
+      create(:application_form, :completed, :previous_cycle, :with_degree, submitted_at: nil)
     end
 
     it 'redirects to the application choices path' do

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Submit to continuous apps' do
       expect(choice.reload).to be_awaiting_provider_decision
     end
 
-    context 'when canddiate preferences FeatureFlag is off' do
+    context 'when candidate preferences FeatureFlag is off' do
       before do
         FeatureFlag.deactivate(:candidate_preferences)
         post candidate_interface_course_choices_submit_course_choice_path(choice.id)
@@ -42,12 +42,13 @@ RSpec.describe 'Submit to continuous apps' do
 
   context 'when old cycles trying to cheat and submit into the new cycle' do
     let(:application_form) do
-      create(:application_form, :completed, :with_degree, submitted_at: nil, recruitment_cycle_year: previous_year)
+      create(:application_form, :previous_cycle, :completed, :with_degree, submitted_at: nil)
     end
 
-    it 'be successful' do
+    it 'redirects to the application choices path' do
       post candidate_interface_course_choices_submit_course_choice_path(choice.id)
-      expect(response).to redirect_to(candidate_interface_start_carry_over_path)
+
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
 
     it 'does not change choice status' do

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
         )
     end
 
-    context 'when pre continuous applications' do
+    context 'when the application form is from a previous cycle' do
       let(:application_choice) do
         create(:application_choice,
                :rejected,
-               application_form: create(:application_form, :completed, :pre_continuous_applications),
+               application_form: create(:application_form, :completed, :previous_cycle),
                course_option:)
       end
 
@@ -39,7 +39,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
         expect(response).to have_http_status :found
 
         get candidate_interface_application_choices_path
-        expect(response.redirect_url).to eq candidate_interface_start_carry_over_url
+        expect(response).to have_http_status :ok
       end
     end
 

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -109,9 +109,14 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
     expect(page).to have_no_link('Check and submit your application')
   end
 
-  def and_i_can_see_the_carry_over_content
-    expect(page).to have_title 'Continue your application'
+  def then_i_see_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Continue'
+    end
   end
+  alias_method :and_i_can_see_the_carry_over_content, :then_i_see_the_carry_over_content
 
   def when_i_click_on_continue
     click_link_or_button 'Continue'

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
       when_i_sign_in_again
       and_i_visit_the_application_dashboard
       then_i_cannot_submit_my_application
-      and_i_am_redirected_to_the_carry_over_interstitial
+      and_i_can_see_the_carry_over_content
 
       when_i_click_on_continue
       then_i_see_my_details
@@ -47,7 +47,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
       when_i_sign_in_again
       and_i_visit_the_application_dashboard
       then_i_cannot_submit_my_application
-      and_i_am_redirected_to_the_carry_over_interstitial
+      and_i_can_see_the_carry_over_content
 
       when_i_click_on_continue
       then_i_see_my_details
@@ -109,8 +109,8 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
     expect(page).to have_no_link('Check and submit your application')
   end
 
-  def and_i_am_redirected_to_the_carry_over_interstitial
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def and_i_can_see_the_carry_over_content
+    expect(page).to have_title 'Continue your application'
   end
 
   def when_i_click_on_continue

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -95,8 +95,10 @@ private
 
   def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
-    expect(page).to have_content 'The application deadline has passed'
-    expect(page).to have_button 'Update your details'
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def and_i_am_able_to_carry_over_my_application

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Carry over after rejecting offer', time: CycleTimetableHelper.mi
     then_i_see_both_offers
     and_i_am_not_on_the_carry_over_page
 
-    and_i_cannot_navigate_to_the_carry_over_page
     and_i_can_navigate_to_the_application_choices_page
 
     when_i_decline_the_first_offer
@@ -18,12 +17,11 @@ RSpec.describe 'Carry over after rejecting offer', time: CycleTimetableHelper.mi
     and_i_am_not_on_the_carry_over_page
     and_i_see_one_offer_and_one_declined_application
 
-    and_i_cannot_navigate_to_the_carry_over_page
     and_i_can_navigate_to_the_application_choices_page
 
     when_i_decline_the_remaining_offer
     then_the_second_offer_is_declined
-    then_i_am_on_the_carry_over_page
+    then_i_see_the_carry_over_content
     and_i_am_able_to_carry_over_my_application
   end
 
@@ -69,11 +67,6 @@ private
     expect(page).to have_content 'Your applications'
   end
 
-  def and_i_cannot_navigate_to_the_carry_over_page
-    visit candidate_interface_start_carry_over_path
-    expect(page).to have_current_path candidate_interface_details_path
-  end
-
   def and_i_can_navigate_to_the_application_choices_page
     visit candidate_interface_application_choices_path
     expect(page).to have_current_path candidate_interface_application_choices_path
@@ -100,9 +93,10 @@ private
     click_on 'Yes I’m sure – decline this offer'
   end
 
-  def then_i_am_on_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_see_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'The application deadline has passed'
+    expect(page).to have_button 'Update your details'
   end
 
   def and_i_am_able_to_carry_over_my_application

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
     given_i_have_an_empty_submitted_application_from_last_cycle
     and_i_am_signed_in_as_a_candidate
     and_i_visit_the_application_dashboard
-    then_i_have_the_option_to_carry_over_an_application
+    then_i_see_the_carry_over_content
   end
 
   scenario 'Candidate carries over empty application to new cycle through the carry over interstitial' do
@@ -171,10 +171,10 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   def then_i_am_ask_to_apply_for_courses_into_the_new_recruitment_cycle
     expect(page).to have_content("courses starting in the #{@previous_year} to #{@current_year} academic year, which have now closed.")
     expect(page).to have_content("apply for courses starting in the #{@current_year} to #{@next_year} academic year instead.")
-    then_i_have_the_option_to_carry_over_an_application
+    then_i_see_the_carry_over_content
   end
 
-  def then_i_have_the_option_to_carry_over_an_application
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
     given_i_have_an_empty_submitted_application_from_last_cycle
     and_i_am_signed_in_as_a_candidate
     and_i_visit_the_application_dashboard
-    then_i_am_on_the_pages_that_is_possible_to_carry_over_an_application
+    then_i_have_the_option_to_carry_over_an_application
   end
 
   scenario 'Candidate carries over empty application to new cycle through the carry over interstitial' do
@@ -171,13 +171,15 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   def then_i_am_ask_to_apply_for_courses_into_the_new_recruitment_cycle
     expect(page).to have_content("courses starting in the #{@previous_year} to #{@current_year} academic year, which have now closed.")
     expect(page).to have_content("apply for courses starting in the #{@current_year} to #{@next_year} academic year instead.")
-    then_i_am_on_the_pages_that_is_possible_to_carry_over_an_application
+    then_i_have_the_option_to_carry_over_an_application
   end
 
-  def then_i_am_on_the_pages_that_is_possible_to_carry_over_an_application
-    # rubocop:disable Capybara/CurrentPathExpectation
-    expect(page.current_path).to eq(candidate_interface_start_carry_over_path)
-    # rubocop:enable Capybara/CurrentPathExpectation
+  def then_i_have_the_option_to_carry_over_an_application
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Continue'
+    end
   end
 
   def when_i_carry_over

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -118,7 +118,11 @@ private
   alias_method :and_i_sign_in, :when_i_sign_in
 
   def then_i_am_asked_to_carry_over
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def and_i_have_submitted_apply_again_course_choices

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
     and_today_is_after_apply_deadline
 
     when_i_sign_in
-    then_i_am_asked_to_carry_over
+    then_i_see_the_carry_over_content
 
     when_i_carry_over
     then_i_am_redirected_to_continuous_application_details_page
@@ -34,7 +34,7 @@ RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
     and_today_is_after_find_reopens
 
     when_i_sign_in
-    then_i_am_asked_to_carry_over
+    then_i_see_the_carry_over_content
 
     when_i_carry_over
     then_i_am_redirected_to_continuous_application_details_page
@@ -49,7 +49,7 @@ RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
     and_today_is_after_find_reopens
 
     when_i_sign_in
-    then_i_am_asked_to_carry_over
+    then_i_see_the_carry_over_content
 
     when_i_carry_over
     then_i_am_redirected_to_continuous_application_details_page
@@ -117,7 +117,7 @@ private
   end
   alias_method :and_i_sign_in, :when_i_sign_in
 
-  def then_i_am_asked_to_carry_over
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Carry over unsubmitted application' do
 
     when_the_apply_deadline_passes
     and_i_sign_in_again
-    and_i_have_to_carry_my_application_over
+    and_i_carry_over_my_application
     then_i_see_the_references_section
     and_references_is_marked_as_incomplete
 
@@ -39,9 +39,12 @@ RSpec.describe 'Carry over unsubmitted application' do
     given_i_am_signed_in_with_one_login
   end
 
-  def and_i_have_to_carry_my_application_over
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
-    click_link_or_button 'Update your details'
+  def and_i_carry_over_my_application
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      click_link_or_button 'Update your details'
+    end
   end
 
   def then_i_see_the_references_section

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Carry over application and submit new application choices' do
     and_the_cancel_unsubmitted_applications_worker_runs
 
     when_i_sign_in_again
-    then_i_am_redirected_to_the_carry_over_interstitial
+    then_i_can_see_the_carry_over_content
 
     when_i_click_on_continue
     then_i_see_application_details_page
@@ -85,8 +85,12 @@ private
     click_on 'Your applications'
   end
 
-  def then_i_am_redirected_to_the_carry_over_interstitial
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_can_see_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Continue'
+    end
   end
 
   def when_i_click_on_continue

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Carry over application and submit new application choices' do
     and_the_cancel_unsubmitted_applications_worker_runs
 
     when_i_sign_in_again
-    then_i_can_see_the_carry_over_content
+    then_i_see_the_carry_over_content
 
     when_i_click_on_continue
     then_i_see_application_details_page
@@ -85,7 +85,7 @@ private
     click_on 'Your applications'
   end
 
-  def then_i_can_see_the_carry_over_content
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   scenario 'a candidate who was unsuccessful from years ago can carry over mid cycle' do
     given_i_applied_two_years_ago
     when_i_sign_in
-    then_i_am_on_the_carry_over_page_mid_cycle
+    then_i_can_see_the_carry_over_content_for_mid_cycle
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -24,7 +24,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_applied_two_years_ago
     and_the_apply_deadline_passes
     when_i_sign_in
-    then_i_am_on_the_carry_over_page_between_cycles
+    then_i_can_see_the_carry_over_content_for_between_cycles
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -36,7 +36,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_have_an_application_with_a_rejection
     and_the_apply_deadline_passes
     when_i_sign_in
-    then_i_am_on_the_carry_over_page_between_cycles
+    then_i_can_see_the_carry_over_content_for_between_cycles
 
     and_i_carry_over_my_application_between_cycles
     then_i_can_edit_my_details
@@ -46,7 +46,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_have_an_application_with_a_rejection
     and_the_next_cycle_opens
     when_i_sign_in
-    then_i_am_on_the_carry_over_page_mid_cycle
+    then_i_can_see_the_carry_over_content_for_mid_cycle
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -122,14 +122,22 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     expect(page).to have_content "You can apply for courses starting in the #{current_timetable.academic_year_range_name} academic year instead."
   end
 
-  def then_i_am_on_the_carry_over_page_mid_cycle
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_can_see_the_carry_over_content_for_mid_cycle
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Continue your application'
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Continue'
+    end
   end
 
-  def then_i_am_on_the_carry_over_page_between_cycles
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_can_see_the_carry_over_content_for_between_cycles
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'The application deadline has passed'
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def and_i_can_view_my_unsuccessful_application

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   scenario 'a candidate who was unsuccessful from years ago can carry over mid cycle' do
     given_i_applied_two_years_ago
     when_i_sign_in
-    then_i_can_see_the_carry_over_content_for_mid_cycle
+    then_i_see_the_carry_over_content_for_mid_cycle
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -24,7 +24,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_applied_two_years_ago
     and_the_apply_deadline_passes
     when_i_sign_in
-    then_i_can_see_the_carry_over_content_for_between_cycles
+    then_i_see_the_carry_over_content_for_between_cycles
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -36,7 +36,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_have_an_application_with_a_rejection
     and_the_apply_deadline_passes
     when_i_sign_in
-    then_i_can_see_the_carry_over_content_for_between_cycles
+    then_i_see_the_carry_over_content_for_between_cycles
 
     and_i_carry_over_my_application_between_cycles
     then_i_can_edit_my_details
@@ -46,7 +46,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_have_an_application_with_a_rejection
     and_the_next_cycle_opens
     when_i_sign_in
-    then_i_can_see_the_carry_over_content_for_mid_cycle
+    then_i_see_the_carry_over_content_for_mid_cycle
     and_i_can_view_my_unsuccessful_application
 
     when_i_click_back
@@ -122,7 +122,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     expect(page).to have_content "You can apply for courses starting in the #{current_timetable.academic_year_range_name} academic year instead."
   end
 
-  def then_i_can_see_the_carry_over_content_for_mid_cycle
+  def then_i_see_the_carry_over_content_for_mid_cycle
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Continue your application'
 
@@ -131,7 +131,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     end
   end
 
-  def then_i_can_see_the_carry_over_content_for_between_cycles
+  def then_i_see_the_carry_over_content_for_between_cycles
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'The application deadline has passed'
 

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Candidate does not act on offer between cycles' do
     when_the_decline_by_default_date_has_passed
     and_i_sign_in
     and_i_navigate_to_my_applications
-    then_i_am_able_to_start_carry_over
+    then_i_see_the_carry_over_content
     then_i_see_my_declined_application
     and_i_can_carry_over_my_application
   end
@@ -88,7 +88,7 @@ private
     click_on 'Your applications'
   end
 
-  def then_i_am_able_to_start_carry_over
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -16,23 +16,17 @@ RSpec.describe 'Candidate does not act on offer between cycles' do
     then_i_cannot_carry_over_my_application
     and_i_see_offer
 
-    when_i_visit_the_start_carry_over_page_directly
-    then_i_am_redirected_to_details_page
-
     when_the_reject_by_default_deadline_has_passed
     and_i_sign_in
     and_i_navigate_to_my_applications
     then_i_see_the_offer
     and_i_cannot_carry_over_my_application
 
-    when_i_visit_the_start_carry_over_page_directly
-    then_i_am_redirected_to_details_page
-
     when_the_decline_by_default_date_has_passed
     and_i_sign_in
     and_i_navigate_to_my_applications
-    then_i_am_redirected_to_start_carry_over
-    then_i_see_my_declined_application_on_the_carry_over_page
+    then_i_am_able_to_start_carry_over
+    then_i_see_my_declined_application
     and_i_can_carry_over_my_application
   end
 
@@ -44,12 +38,9 @@ RSpec.describe 'Candidate does not act on offer between cycles' do
     then_i_see_the_offer_and_unsuccessful_applications
     and_i_cannot_carry_over_my_application
 
-    when_i_visit_the_start_carry_over_page_directly
-    then_i_am_redirected_to_details_page
-
     when_the_decline_by_default_date_has_passed
     and_i_sign_in
-    then_i_see_my_declined_application_on_the_carry_over_page
+    then_i_see_my_declined_application
     and_i_see_unsuccessful_application_choices
     and_i_can_carry_over_my_application
   end
@@ -62,7 +53,7 @@ RSpec.describe 'Candidate does not act on offer between cycles' do
 
     when_then_new_cycle_start
     and_i_sign_in
-    then_i_see_my_declined_application_on_the_carry_over_page
+    then_i_see_my_declined_application
     and_i_can_carry_over_my_application
   end
 
@@ -97,8 +88,12 @@ private
     click_on 'Your applications'
   end
 
-  def then_i_am_redirected_to_start_carry_over
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_am_able_to_start_carry_over
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def then_i_see_the_offer
@@ -139,8 +134,7 @@ private
     advance_time_to(after_find_opens(next_year))
   end
 
-  def then_i_see_my_declined_application_on_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_see_my_declined_application
     expect(page).to have_content 'The application deadline has passed'
     expect(page).to have_content 'Declined'
   end
@@ -159,12 +153,4 @@ private
     )
   end
   alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application
-
-  def when_i_visit_the_start_carry_over_page_directly
-    visit candidate_interface_start_carry_over_path
-  end
-
-  def then_i_am_redirected_to_details_page
-    expect(page).to have_current_path candidate_interface_details_path
-  end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe 'Candidate has an application where provider does not make a deci
       then_i_see_my_application_is_awaiting_provider_decision
       then_i_cannot_carry_over_my_application
 
-      when_i_visit_the_start_carry_over_page_directly
-      then_i_am_redirected_to_details_page
-
       when_the_reject_by_default_deadline_has_passed
       and_i_sign_in
       then_i_see_my_application_is_now_unsuccessful
@@ -37,9 +34,6 @@ RSpec.describe 'Candidate has an application where provider does not make a deci
       then_i_see_my_application_is_inactive
       then_i_cannot_carry_over_my_application
 
-      when_i_visit_the_start_carry_over_page_directly
-      then_i_am_redirected_to_details_page
-
       when_the_reject_by_default_deadline_has_passed
       and_i_sign_in
       then_i_see_my_application_is_now_unsuccessful
@@ -55,9 +49,6 @@ RSpec.describe 'Candidate has an application where provider does not make a deci
       and_i_navigate_to_my_applications
       then_i_see_my_application_is_interviewing
       then_i_cannot_carry_over_my_application
-
-      when_i_visit_the_start_carry_over_page_directly
-      then_i_am_redirected_to_details_page
 
       when_the_reject_by_default_deadline_has_passed
       and_i_sign_in
@@ -122,14 +113,6 @@ private
     )
   end
   alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application
-
-  def when_i_visit_the_start_carry_over_page_directly
-    visit candidate_interface_start_carry_over_path
-  end
-
-  def then_i_am_redirected_to_details_page
-    expect(page).to have_current_path candidate_interface_details_path
-  end
 
   def and_i_can_carry_over_my_application
     click_on 'Update your details'

--- a/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
@@ -28,9 +28,6 @@ RSpec.describe 'Candidate receives an offer between cycles' do
     and_i_navigate_to_my_application_choices
     then_i_can_navigate_to_the_offer
     and_i_can_accept_the_offer
-
-    when_i_visit_the_start_carry_over_page_directly
-    then_i_am_redirected_to_my_accepted_offer
   end
 
 private
@@ -79,16 +76,12 @@ private
   end
 
   def and_i_can_carry_over_my_application
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
-    click_on 'Update your details'
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      click_on 'Update your details'
+    end
+
     expect(page).to have_current_path candidate_interface_details_path
-  end
-
-  def when_i_visit_the_start_carry_over_page_directly
-    visit candidate_interface_start_carry_over_path
-  end
-
-  def then_i_am_redirected_to_my_accepted_offer
-    expect(page).to have_current_path candidate_interface_application_offer_dashboard_path
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Views offer and withdraws before carrying over', time: CycleTime
     and_i_can_view_the_application
 
     when_i_withdraw_my_application
-    then_i_see_the_carry_over_page
+    then_i_see_the_carry_over_content
     and_my_application_is_withdrawn
 
     and_i_can_carry_over_my_application
@@ -67,8 +67,12 @@ private
     click_on 'Yes I’m sure – withdraw this application'
   end
 
-  def then_i_see_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_see_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def and_my_application_is_withdrawn

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate responds to an invite' do
   scenario 'After apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_respond_to_invite
-    then_i_am_shown_the_carry_over_content
+    then_i_see_the_carry_over_content
   end
 
   scenario 'Candidate accepts an invite and begins confirm selection wizard' do
@@ -63,7 +63,7 @@ RSpec.describe 'Candidate responds to an invite' do
   scenario 'Candidate clicks an email invite link for a closed course after apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     and_i_click_an_old_invite_link_for_an_unavailable_course
-    then_i_am_shown_the_carry_over_content
+    then_i_see_the_carry_over_content
   end
 
   scenario 'Candidate clicks an email invite link for a closed course' do
@@ -272,7 +272,7 @@ private
     visit edit_candidate_interface_invite_path(@invite)
   end
 
-  def then_i_am_shown_the_carry_over_content
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate responds to an invite' do
   scenario 'After apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_respond_to_invite
-    then_i_am_redirected_to_the_carry_over_page
+    then_i_am_shown_the_carry_over_content
   end
 
   scenario 'Candidate accepts an invite and begins confirm selection wizard' do
@@ -63,7 +63,7 @@ RSpec.describe 'Candidate responds to an invite' do
   scenario 'Candidate clicks an email invite link for a closed course after apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     and_i_click_an_old_invite_link_for_an_unavailable_course
-    then_i_am_redirected_to_the_carry_over_page
+    then_i_am_shown_the_carry_over_content
   end
 
   scenario 'Candidate clicks an email invite link for a closed course' do
@@ -272,7 +272,11 @@ private
     visit edit_candidate_interface_invite_path(@invite)
   end
 
-  def then_i_am_redirected_to_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_am_shown_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 end

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate views their invites' do
   scenario 'after apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_application_sharing
-    then_i_am_shown_the_carry_over_content
+    then_i_see_the_carry_over_content
   end
 
   scenario 'list invites' do
@@ -145,7 +145,7 @@ RSpec.describe 'Candidate views their invites' do
     visit candidate_interface_invites_path
   end
 
-  def then_i_am_shown_the_carry_over_content
+  def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
 
     within 'form.button_to[action="/candidate/application/carry-over"]' do

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate views their invites' do
   scenario 'after apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_application_sharing
-    then_i_am_redirected_to_the_carry_over_page
+    then_i_am_shown_the_carry_over_content
   end
 
   scenario 'list invites' do
@@ -145,7 +145,12 @@ RSpec.describe 'Candidate views their invites' do
     visit candidate_interface_invites_path
   end
 
-  def then_i_am_redirected_to_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_am_shown_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
+
 end

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -152,5 +152,4 @@ RSpec.describe 'Candidate views their invites' do
       expect(page).to have_button 'Update your details'
     end
   end
-
 end

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     and_i_click_the_withdraw_link_on_my_first_choice
     and_i_select_some_reasons_and_confirm
 
-    then_i_see_the_carry_over_page
+    then_i_see_the_carry_over_content
     and_i_can_carry_over_my_application
   end
 
@@ -107,8 +107,12 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} withdrew their application"
   end
 
-  def then_i_see_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_start_carry_over_path
+  def then_i_see_the_carry_over_content
+    expect(page).to have_current_path candidate_interface_application_choices_path
+
+    within 'form.button_to[action="/candidate/application/carry-over"]' do
+      expect(page).to have_button 'Update your details'
+    end
   end
 
   def and_i_can_carry_over_my_application


### PR DESCRIPTION
## Context

Currently we redirect the Candidate to the `start-carry-over` page which copies the UI from the Application Choices page. This change simplifies the flow, keeping the Candidate on the Application Choices page but showing them the appropriate content and actions. 
Baseline work happened in #11092 

## Changes proposed in this pull request

- Updated redirect logic
- Removed duplicated content from content components

## Guidance to review

### Review App

The deadline date on the review app has been brought forward to allow Carry Over to come into play. 

Using the [Review App](https://apply-review-11104.test.teacherservices.cloud/support/applications) impersonate a Candidate that is eligible to carry over (not submitted or created any choices, or has all unsuccessful choices).
You should see the Application Choices page (tabs should work) and you will see the Carry Over messaging.
Using the Carry Over functionality will take you into the next cycle 👌


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
