### PR TITLE
Update get_into_teaching gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem 'pagy'
 gem 'bcrypt'
 
 # Adviser sign up integration
-gem 'get_into_teaching_api_client_faraday', github: 'DFE-Digital/get-into-teaching-api-ruby-client', require: 'api/client'
+gem 'get_into_teaching_api_client_faraday', '~> 4.0.0', github: 'DFE-Digital/get-into-teaching-api-ruby-client', require: 'api/client', branch: 'v4-update-faraday'
 
 # PDF generation
 gem 'grover'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,16 +41,18 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 8a0dafe9d40c1f17f64c1ebc8846bcd04c8d7f38
+  revision: cffa24931e0b7f371b5146a7cb29cb58d683236b
+  branch: v4-update-faraday
   specs:
-    get_into_teaching_api_client (3.6.0)
-      faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (3.6.0)
+    get_into_teaching_api_client (4.0.0)
+      faraday (>= 1.0.1, < 3.0)
+      faraday-multipart
+    get_into_teaching_api_client_faraday (4.0.0)
       activesupport
       faraday
       faraday-encoding
       faraday-http-cache
-      faraday_middleware
+      faraday-retry
       faraday_middleware-circuit_breaker
       get_into_teaching_api_client
 
@@ -258,38 +260,22 @@ GEM
       railties (>= 5.0.0)
     faker (2.22.0)
       i18n (>= 1.8.11, < 2)
-    faraday (1.10.4)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.1)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-encoding (0.0.6)
       faraday
-    faraday-excon (1.1.0)
     faraday-gzip (2.0.1)
       faraday (>= 1.0)
       zlib (~> 3.0)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday-httpclient (1.0.1)
     faraday-multipart (1.1.1)
       multipart-post (~> 2.0)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
     faraday_middleware-circuit_breaker (0.6.0)
       faraday (>= 0.9, < 3.0)
       stoplight (>= 2.1, < 4.0)
@@ -460,6 +446,8 @@ GEM
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nenv (0.3.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.9)
       date
       net-protocol
@@ -711,7 +699,6 @@ GEM
       rest-client
     ruby-next-core (1.0.3)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubypants (0.7.1)
     rubyzip (3.0.1)
     safely_block (0.4.1)
@@ -905,7 +892,7 @@ DEPENDENCIES
   faker (= 2.22.0)
   field_test (~> 0.8.0)
   geocoder
-  get_into_teaching_api_client_faraday!
+  get_into_teaching_api_client_faraday (~> 4.0.0)!
   google-cloud-bigquery
   govuk-components (~> 5.11)
   govuk_design_system_formbuilder (~> 5.11.0)


### PR DESCRIPTION
## Context

We need to use the one login gem so that we can implement the
backchannel functionality.

The issue with the get_into_teaching gem is that it uses faraday 1.x.
And one_login was using 2.13. This was causing a conflict that was not
easily fixed.

A separate branch from master is open on the get_into_teaching gem that uses
faraday 2.13. This plays nicely with the one_login faraday.

https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/pull/106

This branch will not be merged into master yet. The team that maintains
this gem wants to test it in their own time. So this means we are the
guinea pigs here.

If you go to the gem PR, you'll see a lot of changes. Most of them are auto-generated. They use openapi generator to generate their gem from swagger docs. When you update the get_into_teaching gem version, you need to generate the code again, which results in a PR with a lot of changes.

Don't think this will cause any issues though. Faraday should work as
before.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I've dev tested endpoints and they work. This doesn't change the get into teaching api, just the faraday library used to return results

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
