### PR TITLE
Making Application States easier to understand

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -50,6 +50,8 @@ class ApplicationStateChange
     alias_method :reapply?, :reapply
     alias_method :terminal?, :terminal
     alias_method :in_progress?, :in_progress
+
+    delegate :to_s, to: :id
   end
 
   def self.all

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -25,6 +25,123 @@ class ApplicationStateChange
     @application_choice = application_choice
   end
 
+  ApplicationState = Data.define(:id,
+                                 :visible_to_provider,
+                                 :interviewable,
+                                 :offered,
+                                 :post_offered,
+                                 :offer_accepted,
+                                 :unsuccessful,
+                                 :carry_over,
+                                 :successful,
+                                 :pending_provider_decision,
+                                 :reapply,
+                                 :terminal,
+                                 :in_progress) do
+    alias_method :visible_to_provider?, :visible_to_provider
+    alias_method :interviewable?, :interviewable
+    alias_method :offered?, :offered
+    alias_method :post_offered?, :post_offered
+    alias_method :offer_accepted?, :offer_accepted
+    alias_method :unsuccessful?, :unsuccessful
+    alias_method :carry_over?, :carry_over
+    alias_method :successful?, :successful
+    alias_method :pending_provider_decision?, :pending_provider_decision
+    alias_method :reapply?, :reapply
+    alias_method :terminal?, :terminal
+    alias_method :in_progress?, :in_progress
+  end
+
+  def self.all
+    [
+      ApplicationState.new(id: :withdrawn, visible_to_provider: true, interviewable: false, offered: false, post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: true, terminal: true, in_progress: false),
+      ApplicationState.new(id: :unsubmitted, visible_to_provider: false, interviewable: false, offered: false, post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false, successful: false, pending_provider_decision: false, reapply: false, terminal: false, in_progress: false),
+      ApplicationState.new(id: :awaiting_provider_decision, visible_to_provider: true, interviewable: true, offered: false, post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false, successful: false, pending_provider_decision: true, reapply: false, terminal: false, in_progress: true),
+      ApplicationState.new(id: :inactive, visible_to_provider: true, interviewable: true, offered: false, post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: false, successful: false, pending_provider_decision: false, reapply: false, terminal: true, in_progress: false),
+      ApplicationState.new(id: :interviewing, visible_to_provider: true, interviewable: true, offered: false, post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false, successful: false, pending_provider_decision: true, reapply: false, terminal: false, in_progress: true),
+      ApplicationState.new(id: :rejected, visible_to_provider: true, interviewable: false, offered: false, post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: true, terminal: true, in_progress: false),
+      ApplicationState.new(id: :application_not_sent, visible_to_provider: false, interviewable: false, offered: false, post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: false, terminal: true, in_progress: false),
+      ApplicationState.new(id: :offer, visible_to_provider: true, interviewable: false, offered: true, post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false, successful: true, pending_provider_decision: false, reapply: false, terminal: false, in_progress: true),
+      ApplicationState.new(id: :offer_withdrawn, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: true, terminal: true, in_progress: false),
+      ApplicationState.new(id: :declined, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: true, terminal: true, in_progress: false),
+      ApplicationState.new(id: :pending_conditions, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false, successful: true, pending_provider_decision: false, reapply: false, terminal: false, in_progress: true),
+      ApplicationState.new(id: :conditions_not_met, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: true, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: false, terminal: true, in_progress: false),
+      ApplicationState.new(id: :recruited, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false, successful: true, pending_provider_decision: false, reapply: false, terminal: true, in_progress: true),
+      ApplicationState.new(id: :cancelled, visible_to_provider: false, interviewable: false, offered: false, post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true, successful: false, pending_provider_decision: false, reapply: true, terminal: true, in_progress: false),
+      ApplicationState.new(id: :offer_deferred, visible_to_provider: true, interviewable: false, offered: true, post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false, successful: true, pending_provider_decision: false, reapply: false, terminal: false, in_progress: true),
+    ]
+  end
+
+  def self.where(**args)
+    all.select do |state|
+      args.all? do |attr, values|
+        Array.wrap(values).any? do |value|
+          state.public_send(attr) == value
+        end
+      end
+    end
+  end
+
+  def self.find(state_id)
+    all.find { |state| state.id == state_id }
+  end
+
+  def self.not_visible_to_provider
+    where(visible_to_provider: false)
+  end
+
+  def self.visible_to_provider
+    where(visible_to_provider: true)
+  end
+
+  def self.interviewable
+    where(interviewable: true)
+  end
+
+  def self.offered
+    where(offered: true)
+  end
+
+  def self.post_offered
+    where(post_offered: true)
+  end
+
+  def self.offer_accepted
+    where(offer_accepted: true)
+  end
+
+  def self.unsuccessful
+    where(unsuccessful: true)
+  end
+
+  def self.carry_over
+    where(carry_over: true)
+  end
+
+  def self.successful
+    where(successful: true)
+  end
+
+  def self.pending_provider_decision
+    where(pending_provider_decision: true)
+  end
+
+  def self.pending_provider_decision_or_inactive
+    pending_provider_decision | where(id: :inactive)
+  end
+
+  def self.reapply
+    where(reapply: true)
+  end
+
+  def self.terminal
+    where(terminal: true)
+  end
+
+  def self.in_progress
+    where(in_progress: true)
+  end
+
   # When updating states, do not forget to run:
   #
   #   bundle exec rake generate_state_diagram

--- a/spec/models/application_state_change/application_state_spec.rb
+++ b/spec/models/application_state_change/application_state_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ApplicationStateChange do
+RSpec.describe ApplicationStateChange::ApplicationState do
   describe '.all' do
     it 'returns all application states with their attributes' do
       states = described_class.all
@@ -14,7 +14,7 @@ RSpec.describe ApplicationStateChange do
         :conditions_not_met, :recruited, :cancelled, :offer_deferred
       )
 
-      expect(states).to all(be_a(ApplicationStateChange::ApplicationState))
+      expect(states).to all(be_a(described_class))
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe ApplicationStateChange do
       state = described_class.find(:withdrawn)
 
       expect(state.id).to eq(:withdrawn)
-      expect(state).to be_a(ApplicationStateChange::ApplicationState)
+      expect(state).to be_a(described_class)
     end
 
     it 'returns nil form unknown ids' do
@@ -39,7 +39,7 @@ RSpec.describe ApplicationStateChange do
 
       expect(states.size).to eq(2)
       expect(states.map(&:id)).to contain_exactly(:withdrawn, :unsubmitted)
-      expect(states).to all(be_a(ApplicationStateChange::ApplicationState))
+      expect(states).to all(be_a(described_class))
     end
 
     it 'returns an empty array for unknown ids' do

--- a/spec/models/application_state_change_spec.rb
+++ b/spec/models/application_state_change_spec.rb
@@ -1,0 +1,610 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationStateChange do
+  describe '.all' do
+    it 'returns all application states with their attributes' do
+      states = described_class.all
+
+      expect(states.size).to eq(15)
+
+      expect(states.map(&:id)).to contain_exactly(
+        :withdrawn, :unsubmitted, :awaiting_provider_decision, :inactive,
+        :interviewing, :rejected, :application_not_sent, :offer,
+        :offer_withdrawn, :declined, :pending_conditions,
+        :conditions_not_met, :recruited, :cancelled, :offer_deferred
+      )
+
+      expect(states).to all(be_a(ApplicationStateChange::ApplicationState))
+    end
+  end
+
+  describe '.find' do
+    it 'returns the correct application state by id' do
+      state = described_class.find(:withdrawn)
+
+      expect(state.id).to eq(:withdrawn)
+      expect(state).to be_a(ApplicationStateChange::ApplicationState)
+    end
+
+    it 'returns nil form unknown ids' do
+      state = described_class.find(:unknown)
+
+      expect(state).to be_nil
+    end
+  end
+
+  describe '.where' do
+    it 'returns the correct application states by ids' do
+      states = described_class.where(id: %i[withdrawn unsubmitted])
+
+      expect(states.size).to eq(2)
+      expect(states.map(&:id)).to contain_exactly(:withdrawn, :unsubmitted)
+      expect(states).to all(be_a(ApplicationStateChange::ApplicationState))
+    end
+
+    it 'returns an empty array for unknown ids' do
+      states = described_class.where(id: [:unknown])
+
+      expect(states).to be_empty
+    end
+
+    it 'returns the correct application states using attributes' do
+      states = described_class.where(
+        offered: true,
+        post_offered: true,
+        terminal: true,
+      )
+
+      expect(states.size).to eq(4)
+      expect(states.map(&:id)).to contain_exactly(
+        :offer_withdrawn, :declined, :conditions_not_met, :recruited
+      )
+    end
+  end
+
+  describe 'scopes' do
+    describe '.not_visible_to_provider' do
+      subject(:scope_method) { described_class.not_visible_to_provider }
+
+      it 'returns only states that are not visible to provider' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :unsubmitted,
+          :application_not_sent,
+          :cancelled,
+        )
+      end
+
+      it 'matches STATES_NOT_VISIBLE_TO_PROVIDER' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER,
+        )
+      end
+    end
+
+    describe '.visible_to_provider' do
+      subject(:scope_method) { described_class.visible_to_provider }
+
+      it 'returns only states that are visible to provider' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :awaiting_provider_decision,
+          :withdrawn,
+          :rejected,
+          :inactive,
+          :interviewing,
+          :offer,
+          :offer_withdrawn,
+          :declined,
+          :pending_conditions,
+          :conditions_not_met,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches STATES_VISIBLE_TO_PROVIDER' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER,
+        )
+      end
+    end
+
+    describe '.interviewable' do
+      subject(:scope_method) { described_class.interviewable }
+
+      it 'returns only states that are interviewable' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :awaiting_provider_decision,
+          :inactive,
+          :interviewing,
+        )
+      end
+
+      it 'matches INTERVIEWABLE_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::INTERVIEWABLE_STATES,
+        )
+      end
+    end
+
+    describe '.offer_accepted' do
+      subject(:scope_method) { described_class.offer_accepted }
+
+      it 'returns only states that have accepted offers' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :pending_conditions,
+          :conditions_not_met,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches ACCEPTED_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::ACCEPTED_STATES,
+        )
+      end
+    end
+
+    describe '.offered' do
+      subject(:scope_method) { described_class.offered }
+
+      it 'returns only states that have offers' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :offer,
+          :offer_withdrawn,
+          :declined,
+          :pending_conditions,
+          :conditions_not_met,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches OFFERED_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::OFFERED_STATES,
+        )
+      end
+    end
+
+    describe '.post_offered' do
+      subject(:scope_method) { described_class.post_offered }
+
+      it 'returns only states that are post-offered' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :offer_withdrawn,
+          :declined,
+          :pending_conditions,
+          :conditions_not_met,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches POST_OFFERED_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::POST_OFFERED_STATES,
+        )
+      end
+    end
+
+    describe '.unsuccessful' do
+      subject(:scope_method) { described_class.unsuccessful }
+
+      it 'returns only states that are unsuccessful' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :application_not_sent,
+          :cancelled,
+          :withdrawn,
+          :rejected,
+          :inactive,
+          :offer_withdrawn,
+          :declined,
+          :conditions_not_met,
+        )
+      end
+
+      it 'matches UNSUCCESSFUL_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::UNSUCCESSFUL_STATES,
+        )
+      end
+    end
+
+    describe '.carry_over' do
+      subject(:scope_method) { described_class.carry_over }
+
+      it 'returns only states that are eligible for carry over' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :application_not_sent,
+          :cancelled,
+          :withdrawn,
+          :rejected,
+          :offer_withdrawn,
+          :declined,
+          :conditions_not_met,
+        )
+      end
+
+      it 'matches CARRY_OVER_ELIGIBLE_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES,
+        )
+      end
+    end
+
+    describe '.successful' do
+      subject(:scope_method) { described_class.successful }
+
+      it 'returns only states that are successful' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :offer,
+          :pending_conditions,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches SUCCESSFUL_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::SUCCESSFUL_STATES,
+        )
+      end
+    end
+
+    describe '.pending_provider_decision' do
+      subject(:scope_method) { described_class.pending_provider_decision }
+
+      it 'returns only states that are pending provider decisions' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :awaiting_provider_decision,
+          :interviewing,
+        )
+      end
+
+      it 'matches DECISION_PENDING_STATUSES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::DECISION_PENDING_STATUSES,
+        )
+      end
+    end
+
+    describe '.pending_provider_decision_or_inactive' do
+      subject(:scope_method) { described_class.pending_provider_decision_or_inactive }
+
+      it 'returns only states that are pending provider decisions or are inactive' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :awaiting_provider_decision,
+          :interviewing,
+          :inactive,
+        )
+      end
+
+      it 'matches DECISION_PENDING_AND_INACTIVE_STATUSES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES,
+        )
+      end
+    end
+
+    describe '.reapply' do
+      subject(:scope_method) { described_class.reapply }
+
+      it 'returns only states that allow reapplying' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :cancelled,
+          :withdrawn,
+          :rejected,
+          :offer_withdrawn,
+          :declined,
+        )
+      end
+
+      it 'matches REAPPLY_STATUSES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::REAPPLY_STATUSES,
+        )
+      end
+    end
+
+    describe '.terminal' do
+      subject(:scope_method) { described_class.terminal }
+
+      it 'returns only states that are terminal' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :application_not_sent,
+          :cancelled,
+          :withdrawn,
+          :rejected,
+          :inactive,
+          :offer_withdrawn,
+          :declined,
+          :conditions_not_met,
+          :recruited,
+        )
+      end
+
+      it 'matches TERMINAL_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::TERMINAL_STATES,
+        )
+      end
+    end
+
+    describe '.in_progress' do
+      subject(:scope_method) { described_class.in_progress }
+
+      it 'returns only states that are in progress' do
+        expect(scope_method.map(&:id)).to contain_exactly(
+          :awaiting_provider_decision,
+          :interviewing,
+          :offer,
+          :pending_conditions,
+          :recruited,
+          :offer_deferred,
+        )
+      end
+
+      it 'matches IN_PROGRESS_STATES' do
+        expect(scope_method.map(&:id)).to match_array(
+          ApplicationStateChange::IN_PROGRESS_STATES,
+        )
+      end
+    end
+  end
+
+  describe 'awaiting_provider_decision state' do
+    subject { described_class.find(:awaiting_provider_decision) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.to be_pending_provider_decision }
+    it { is_expected.to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+
+  describe 'unsubmitted state' do
+    subject { described_class.find(:unsubmitted) }
+
+    it { is_expected.not_to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+
+  describe 'application_not_sent state' do
+    subject { described_class.find(:application_not_sent) }
+
+    it { is_expected.not_to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'cancelled state' do
+    subject { described_class.find(:cancelled) }
+
+    it { is_expected.not_to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'withdrawn state' do
+    subject { described_class.find(:withdrawn) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'rejected state' do
+    subject { described_class.find(:rejected) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'inactive state' do
+    subject { described_class.find(:inactive) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'interviewing state' do
+    subject { described_class.find(:interviewing) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.to be_pending_provider_decision }
+    it { is_expected.to be_interviewable }
+    it { is_expected.not_to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+
+  describe 'offer state' do
+    subject { described_class.find(:offer) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.not_to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+
+  describe 'offer_withdrawn state' do
+    subject { described_class.find(:offer_withdrawn) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'declined state' do
+    subject { described_class.find(:declined) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.not_to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'pending_conditions state' do
+    subject { described_class.find(:pending_conditions) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+
+  describe 'conditions_not_met state' do
+    subject { described_class.find(:conditions_not_met) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.to be_offer_accepted }
+    it { is_expected.to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.to be_unsuccessful }
+    it { is_expected.not_to be_successful }
+    it { is_expected.not_to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'recruited state' do
+    subject { described_class.find(:recruited) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.to be_terminal }
+  end
+
+  describe 'offer_deferred state' do
+    subject { described_class.find(:offer_deferred) }
+
+    it { is_expected.to be_visible_to_provider }
+    it { is_expected.not_to be_pending_provider_decision }
+    it { is_expected.not_to be_interviewable }
+    it { is_expected.to be_offered }
+    it { is_expected.to be_post_offered }
+    it { is_expected.to be_offer_accepted }
+    it { is_expected.not_to be_carry_over }
+    it { is_expected.not_to be_reapply }
+    it { is_expected.not_to be_unsuccessful }
+    it { is_expected.to be_successful }
+    it { is_expected.to be_in_progress }
+    it { is_expected.not_to be_terminal }
+  end
+end

--- a/spec/models/application_state_change_spec.rb
+++ b/spec/models/application_state_change_spec.rb
@@ -353,6 +353,30 @@ RSpec.describe ApplicationStateChange do
     end
   end
 
+  describe 'states make sense' do
+    it 'ensures that no state is both terminal and in progress' do
+      skip 'Recruited is both terminal and in progress, so this test is not valid'
+      terminal_states = described_class.terminal.map(&:id)
+      in_progress_states = described_class.in_progress.map(&:id)
+
+      expect(terminal_states & in_progress_states).to be_empty
+    end
+
+    it 'ensures that no state is both successful and unsuccessful' do
+      successful_states = described_class.successful.map(&:id)
+      unsuccessful_states = described_class.unsuccessful.map(&:id)
+
+      expect(successful_states & unsuccessful_states).to be_empty
+    end
+
+    it 'ensures that no state is both pending provider decision and not visible to provider' do
+      pending_provider_decision_states = described_class.pending_provider_decision.map(&:id)
+      not_visible_to_provider_states = described_class.not_visible_to_provider.map(&:id)
+
+      expect(pending_provider_decision_states & not_visible_to_provider_states).to be_empty
+    end
+  end
+
   describe 'awaiting_provider_decision state' do
     subject { described_class.find(:awaiting_provider_decision) }
 


### PR DESCRIPTION
## Context

We are often asked about the state of an Application and whether it's included in some collection e.g visible to provider?, in progress? etc. It is difficult to visualise which collection include the state eg. `IN_PROGRESS_STATES = DECISION_PENDING_STATUSES + ACCEPTED_STATES + %i[offer].freeze - %i[conditions_not_met]`

## Changes proposed in this pull request

- This PR implements scopes and a Data class backed ApplicationState model with the relevant attributes. 
- We also introduce easily testable scopes for the states, ensuring the match the current implementation. 

## Guidance to review

- This PR is best reviewed by the specs that have been introduced. There is a lot of repetition and the shape of methods has been carefully matched

This table helps visualise the attributes of each state

| State                      | visible_to_provider | pending_provider_decision | interviewable | offered | post_offered | offer_accepted | carry_over | reapply | unsuccessful | successful | in_progress | terminal |
|----------------------------|---------------------|---------------------------|---------------|---------|--------------|----------------|------------|---------|--------------|------------|-------------|----------|
| unsubmitted                | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ❌           | ❌        |
| application_not_sent       | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ❌       | ✅            | ❌          | ❌           | ✅        |
| awaiting_provider_decision | ✅                   | ✅                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ✅           | ❌        |
| cancelled                  | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |
| withdrawn                  | ✅                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |
| rejected                   | ✅                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |
| inactive                   | ✅                   | ❌                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ✅            | ❌          | ❌           | ✅        |
| interviewing               | ✅                   | ✅                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ✅           | ❌        |
| offer                      | ✅                   | ❌                         | ❌             | ✅       | ❌            | ❌              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        |
| offer_withdrawn            | ✅                   | ❌                         | ❌             | ✅       | ✅            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |
| declined                   | ✅                   | ❌                         | ❌             | ✅       | ✅            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |
| pending_conditions         | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        |
| conditions_not_met         | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ✅          | ❌       | ✅            | ❌          | ❌           | ✅        |
| recruited                  | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ✅        |
| offer_deferred             | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        |


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
