### PR TITLE
Reworked banners based on chat

### DIFF
--- a/app/components/candidate_interface/carried_over_content_component.html.erb
+++ b/app/components/candidate_interface/carried_over_content_component.html.erb
@@ -1,23 +1,14 @@
 <h1 class="govuk-heading-l">
-  <%#= t('carried_over_content_component.title') %>
-  You cannot submit applications at the moment
+  <%= t('carried_over_content_component.title') %>
 </h1>
 <p class="govuk-body">
-  <%#= t('carried_over_content_component.deadline_has_passed', academic_year:, course_start_date:) %>
-
-  You can view and choose courses from <%= date_and_time_find_opens %>.
+  <%= t('carried_over_content_component.view_courses', date_and_time_find_opens:) %>
 </p>
+
+<p class="govuk-body">
+  <%= t('carried_over_content_component.apply_opens', application_form_academic_year_range_name:, date_and_time_apply_opens:) %>
+</p>
+
 <% if application_form_after_find_opens? %>
-  <h2 class="govuk-heading-m">
-    <%= t('carried_over_content_component.what_happens_next') %>
-  </h2>
-  <p class="govuk-body">
-    <%= t('carried_over_content_component.you_can_prepare', next_academic_year: application_form_academic_year_range_name, apply_opens_date: date_and_time_apply_opens) %>
-  </p>
   <%= govuk_button_link_to t('carried_over_content_component.add_application_choice'), candidate_interface_course_choices_do_you_know_the_course_path %>
-<% else %>
-  <p class="govuk-body">
-    <%#= t('carried_over_content_component.apply_opens', apply_opens_date:, next_academic_year:) %>
-    You will be able to submit applications for the <%= application_form_academic_year_range_name %> recruitment cycle from <%= date_and_time_apply_opens %>.
-  </p>
 <% end %>

--- a/app/components/candidate_interface/carried_over_content_component.html.erb
+++ b/app/components/candidate_interface/carried_over_content_component.html.erb
@@ -5,21 +5,19 @@
 <p class="govuk-body">
   <%#= t('carried_over_content_component.deadline_has_passed', academic_year:, course_start_date:) %>
 
-  <!--# Realtime dates-->
-  You can view and choose courses from <%= find_opens_date %>.
+  You can view and choose courses from <%= date_and_time_find_opens %>.
 </p>
-<% if after_find_opens? %>
+<% if application_form_after_find_opens? %>
   <h2 class="govuk-heading-m">
     <%= t('carried_over_content_component.what_happens_next') %>
   </h2>
   <p class="govuk-body">
-    <%= t('carried_over_content_component.you_can_prepare', next_academic_year:, apply_opens_date:) %>
+    <%= t('carried_over_content_component.you_can_prepare', next_academic_year: application_form_academic_year_range_name, apply_opens_date: date_and_time_apply_opens) %>
   </p>
   <%= govuk_button_link_to t('carried_over_content_component.add_application_choice'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
   <p class="govuk-body">
     <%#= t('carried_over_content_component.apply_opens', apply_opens_date:, next_academic_year:) %>
-    <!--# Realtime dates-->
-    You will be able to submit applications for the <%= next_academic_year %> recruitment cycle from <%= apply_opens_date %>.
+    You will be able to submit applications for the <%= application_form_academic_year_range_name %> recruitment cycle from <%= date_and_time_apply_opens %>.
   </p>
 <% end %>

--- a/app/components/candidate_interface/carried_over_content_component.html.erb
+++ b/app/components/candidate_interface/carried_over_content_component.html.erb
@@ -1,8 +1,12 @@
 <h1 class="govuk-heading-l">
-  <%= t('carried_over_content_component.title') %>
+  <%#= t('carried_over_content_component.title') %>
+  You cannot submit applications at the moment
 </h1>
 <p class="govuk-body">
-  <%= t('carried_over_content_component.deadline_has_passed', academic_year:, course_start_date:) %>
+  <%#= t('carried_over_content_component.deadline_has_passed', academic_year:, course_start_date:) %>
+
+  <!--# Realtime dates-->
+  You can view and choose courses from <%= find_opens_date %>.
 </p>
 <% if after_find_opens? %>
   <h2 class="govuk-heading-m">
@@ -14,6 +18,8 @@
   <%= govuk_button_link_to t('carried_over_content_component.add_application_choice'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
   <p class="govuk-body">
-    <%= t('carried_over_content_component.apply_opens', apply_opens_date:, next_academic_year:) %>
+    <%#= t('carried_over_content_component.apply_opens', apply_opens_date:, next_academic_year:) %>
+    <!--# Realtime dates-->
+    You will be able to submit applications for the <%= next_academic_year %> recruitment cycle from <%= apply_opens_date %>.
   </p>
 <% end %>

--- a/app/components/candidate_interface/carried_over_content_component.rb
+++ b/app/components/candidate_interface/carried_over_content_component.rb
@@ -8,6 +8,14 @@ module CandidateInterface
       timetable.relative_previous_timetable.academic_year_range_name
     end
 
+    def find_opens_date
+      timetable.find_opens_at.to_fs(:govuk_date_time_time_first)
+    end
+
+    def after_find_opens?
+      Time.zone.now.after? timetable.find_opens_at
+    end
+
     def next_academic_year
       timetable.academic_year_range_name
     end
@@ -16,16 +24,8 @@ module CandidateInterface
       timetable.apply_opens_at.to_fs(:govuk_date_time_time_first)
     end
 
-    def course_start_date
-      timetable.course_start_date.to_fs(:month_and_year)
-    end
-
-    def after_find_opens?
-      Time.zone.now.after? timetable.find_opens_at
-    end
-
     def timetable
-      @timetable ||= @application_form.recruitment_cycle_timetable
+      @timetable ||= RecruitmentCycleTimetable.next_timetable
     end
   end
 end

--- a/app/components/candidate_interface/carried_over_content_component.rb
+++ b/app/components/candidate_interface/carried_over_content_component.rb
@@ -1,31 +1,21 @@
 module CandidateInterface
   class CarriedOverContentComponent < ViewComponent::Base
+    delegate :after_find_opens?,
+             :academic_year_range_name,
+             :apply_opens_at,
+             :find_opens_at,
+             to: :@application_form, prefix: :application_form
+
     def initialize(application_form:)
       @application_form = application_form
     end
 
-    def academic_year
-      timetable.relative_previous_timetable.academic_year_range_name
+    def date_and_time_find_opens
+      application_form_find_opens_at.to_fs(:govuk_date_time_time_first)
     end
 
-    def find_opens_date
-      timetable.find_opens_at.to_fs(:govuk_date_time_time_first)
-    end
-
-    def after_find_opens?
-      Time.zone.now.after? timetable.find_opens_at
-    end
-
-    def next_academic_year
-      timetable.academic_year_range_name
-    end
-
-    def apply_opens_date
-      timetable.apply_opens_at.to_fs(:govuk_date_time_time_first)
-    end
-
-    def timetable
-      @timetable ||= RecruitmentCycleTimetable.next_timetable
+    def date_and_time_apply_opens
+      application_form_apply_opens_at.to_fs(:govuk_date_time_time_first)
     end
   end
 end

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -6,4 +6,8 @@
   <p class="govuk-body">
     <%= t('reopen_banner_component.when_apply_opens', apply_opens_date:, next_academic_year:) %>
   </p>
+
+  Application cycle: <%= @timetable.recruitment_cycle_year %>
+
+  Real Time cycle: <%= current_timetable.recruitment_cycle_year %>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,13 +1,9 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
   <% notification_banner.with_heading(text: t('reopen_banner_component.heading')) %>
   <p class="govuk-body">
-    <%= t('reopen_banner_component.deadline_has_passed', academic_year:) %>
+    <%= t('reopen_banner_component.deadline_has_passed', academic_year: academic_year_range_name) %>
   </p>
   <p class="govuk-body">
-    <%= t('reopen_banner_component.when_apply_opens', apply_opens_date:, next_academic_year:) %>
+    <%= t('reopen_banner_component.when_apply_opens', apply_opens_date: date_and_time_next_apply_opens, next_academic_year: next_academic_year_range_name) %>
   </p>
-
-  Application cycle: <%= @timetable.recruitment_cycle_year %>
-
-  Real Time cycle: <%= current_timetable.recruitment_cycle_year %>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -1,8 +1,9 @@
 class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
   attr_accessor :flash_empty
 
-  def initialize(flash_empty:)
+  def initialize(flash_empty:, application_form:)
     @flash_empty = flash_empty
+    @timetable = application_form.recruitment_cycle_timetable
   end
 
   def render?
@@ -12,11 +13,11 @@ class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
 private
 
   def show_apply_reopen_banner?
-    current_timetable.between_cycles?
+    @timetable.after_apply_deadline?
   end
 
   def academic_year
-    current_timetable.previously_closed_academic_year_range
+    @timetable.previously_closed_academic_year_range
   end
 
   def next_academic_year

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -1,9 +1,15 @@
 class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
   attr_accessor :flash_empty
 
+  delegate :after_apply_deadline?,
+           :academic_year_range_name,
+           :apply_reopens_at,
+           :next_available_academic_year_range,
+           to: :@application_form, prefix: :application_form
+
   def initialize(flash_empty:, application_form:)
     @flash_empty = flash_empty
-    @timetable = application_form.recruitment_cycle_timetable
+    @application_form = application_form
   end
 
   def render?
@@ -13,22 +19,18 @@ class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
 private
 
   def show_apply_reopen_banner?
-    @timetable.after_apply_deadline?
+    application_form_after_apply_deadline?
   end
 
-  def academic_year
-    @timetable.previously_closed_academic_year_range
+  def academic_year_range_name
+    application_form_academic_year_range_name
   end
 
-  def next_academic_year
-    current_timetable.next_available_academic_year_range
+  def date_and_time_next_apply_opens
+    application_form_apply_reopens_at.to_fs(:govuk_date_time_time_first)
   end
 
-  def apply_opens_date
-    current_timetable.apply_reopens_at.to_fs(:govuk_date)
-  end
-
-  def current_timetable
-    @current_timetable ||= RecruitmentCycleTimetable.current_timetable
+  def next_academic_year_range_name
+    application_form_next_available_academic_year_range
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,6 +14,7 @@ class ApplicationForm < ApplicationRecord
            :apply_opens_at,
            :find_opens_at,
            :after_apply_deadline?,
+           :after_find_opens?,
            :before_apply_opens?,
            :cycle_range_name_with_current_indicator,
            :decline_by_default_at,

--- a/app/views/candidate_interface/details/index.html.erb
+++ b/app/views/candidate_interface/details/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.your_details') %>
 
 <%= render CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form_presenter.application_form, flash_empty: flash.empty?) %>
-<%= render CandidateInterface::ReopenBannerComponent.new(flash_empty: flash.empty?) %>
+<%= render CandidateInterface::ReopenBannerComponent.new(application_form: @application_form_presenter.application_form, flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.application_sharing') %>
 
 <%= render CandidateInterface::DeadlineBannerComponent.new(application_form: current_application, flash_empty: flash.empty?) %>
-<%= render CandidateInterface::ReopenBannerComponent.new(flash_empty: flash.empty?) %>
+<%= render CandidateInterface::ReopenBannerComponent.new(application_form: current_application, flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 <%= render CandidateInterface::InviteReminderBannerComponent.new(invites: @not_responded_invites) %>

--- a/config/locales/components/candidate_interface/carried_over_content_component.yml
+++ b/config/locales/components/candidate_interface/carried_over_content_component.yml
@@ -1,10 +1,6 @@
 en:
   carried_over_content_component:
-    title: The application deadline has passed
-    deadline_has_passed: The application deadline has passed for courses starting in the %{academic_year} academic year. You can no longer apply to courses starting in %{course_start_date}
-    what_happens_next: What happens next?
-    you_can_prepare: >
-      You can prepare applications for courses starting in the %{next_academic_year} academic year. You will be able to
-      apply for these courses from %{apply_opens_date}.
+    title: You cannot submit applications at the moment
+    view_courses: You can view and choose courses from %{date_and_time_find_opens}
+    apply_opens: You will be able to submit applications for the %{application_form_academic_year_range_name} recruitment cycle from %{date_and_time_apply_opens}.
     add_application_choice: Choose a course
-    apply_opens: From %{apply_opens_date} you will be able to apply for courses starting in the %{next_academic_year} academic year.

--- a/spec/components/previews/candidate_interface/carried_over_content_component_preview.rb
+++ b/spec/components/previews/candidate_interface/carried_over_content_component_preview.rb
@@ -12,13 +12,13 @@ module CandidateInterface
   end
 
   class AfterFindOpensComponent < CandidateInterface::CarriedOverContentComponent
-    def after_find_opens?
+    def application_form_after_find_opens?
       true
     end
   end
 
   class BeforeFindOpensComponent < CandidateInterface::CarriedOverContentComponent
-    def after_find_opens?
+    def application_form_after_find_opens?
       false
     end
   end

--- a/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
+++ b/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
@@ -1,8 +1,10 @@
 module CandidateInterface
   class ReopenBannerAlertPreview < ViewComponent::Preview
     def reopen_banner_component
+      application_form = FactoryBot.build(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year )
       render CandidateInterface::ReopenBannerComponentPreviewComponent.new(
         flash_empty: true,
+        application_form:,
       )
     end
   end

--- a/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
+++ b/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ReopenBannerAlertPreview < ViewComponent::Preview
     def reopen_banner_component
-      application_form = FactoryBot.build(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year )
+      application_form = FactoryBot.build(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year)
       render CandidateInterface::ReopenBannerComponentPreviewComponent.new(
         flash_empty: true,
         application_form:,

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
+RSpec.describe 'Carry over after the Apply Deadline' do
   include CandidateHelper
 
   before do
-    set_time(mid_cycle)
+    set_time(after_apply_deadline)
   end
 
   scenario 'candidate carries over unsubmitted application after apply deadline' do
     given_i_have_unsubmitted_application
-    and_today_is_after_apply_deadline
 
     when_i_sign_in
     then_i_see_the_carry_over_content
 
     when_i_carry_over
-    then_i_am_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_the_your_details_page
 
     when_i_go_to_your_applications_tab
     then_i_do_not_see_the_add_course_button
-    and_i_see_the_banner_content_for_before_find_opens
+    and_i_see_the_carried_over_banner
     and_i_do_not_see_previous_applications_heading
 
     when_i_visit_add_course_url
@@ -27,21 +26,6 @@ RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
 
     when_i_visit_the_old_complete_page
     then_i_see_a_404_page
-  end
-
-  scenario 'candidate carries over unsubmitted application after find opens deadline' do
-    given_i_have_unsubmitted_application
-    and_today_is_after_find_reopens
-
-    when_i_sign_in
-    then_i_see_the_carry_over_content
-
-    when_i_carry_over
-    then_i_am_redirected_to_continuous_application_details_page
-
-    when_i_go_to_your_applications_tab
-    then_i_can_see_the_add_course_button
-    and_i_see_the_banner_content_for_after_find_opens
   end
 
   scenario 'candidate carries over submitted application after find opens deadline' do
@@ -52,37 +36,31 @@ RSpec.describe 'Carry over unsubmitted applications', :sidekiq do
     then_i_see_the_carry_over_content
 
     when_i_carry_over
-    then_i_am_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_the_your_details_page
 
     when_i_go_to_your_applications_tab
     then_i_can_see_the_add_course_button
-    and_i_see_the_banner_content_for_after_find_opens
+    and_i_see_the_carried_over_banner
   end
 
 private
 
   def given_i_have_unsubmitted_application
     @application_form = create(
-      :completed_application_form,
-      date_of_birth:,
-      submitted_at: nil,
+      :application_form,
+      :completed,
+      :unsubmitted,
+      date_of_birth: Date.new(1964, 9, 1),
       candidate: current_candidate,
     )
-
-    %i[not_requested_yet feedback_requested].each do |feedback_status|
-      create(
-        :reference,
-        feedback_status:,
-        application_form: @application_form,
-      )
-    end
   end
 
   def given_i_have_rejected_application
     @application_form = create(
-      :completed_application_form,
-      date_of_birth:,
-      submitted_at: Time.zone.now,
+      :application_form,
+      :completed,
+      :submitted,
+      date_of_birth: Date.new(1964, 9, 1),
       candidate: current_candidate,
     )
 
@@ -91,19 +69,6 @@ private
       :rejected,
       application_form: @application_form,
     )
-  end
-
-  def and_all_pending_applications_in_the_cycle_are_rejected
-    ProcessStaleApplicationsWorker.perform_async
-  end
-
-  def and_today_is_after_apply_deadline
-    TestSuiteTimeMachine.travel_permanently_to(@application_form.apply_deadline_at + 1.second)
-  end
-  alias_method :given_today_is_after_apply_deadline, :and_today_is_after_apply_deadline
-
-  def given_today_is_after_rejected_by_default_date
-    TestSuiteTimeMachine.travel_permanently_to(@application_form.reject_by_default_at + 1.second)
   end
 
   def and_today_is_after_find_reopens
@@ -115,7 +80,6 @@ private
     login_as(current_candidate)
     visit root_path
   end
-  alias_method :and_i_sign_in, :when_i_sign_in
 
   def then_i_see_the_carry_over_content
     expect(page).to have_current_path candidate_interface_application_choices_path
@@ -125,17 +89,11 @@ private
     end
   end
 
-  def and_i_have_submitted_apply_again_course_choices
-    application_form = current_candidate.application_forms.find_by(phase: 'apply_2')
-    create(:application_choice, :awaiting_provider_decision, application_form:)
-    application_form.update!(submitted_at: Time.zone.now, becoming_a_teacher_completed: true)
-  end
-
   def when_i_carry_over
     click_link_or_button 'Update your details'
   end
 
-  def then_i_am_redirected_to_continuous_application_details_page
+  def then_i_am_redirected_to_the_your_details_page
     expect(page).to have_current_path candidate_interface_details_path
     then_i_see_a_copy_of_my_application
   end
@@ -153,22 +111,18 @@ private
   end
 
   def then_i_can_see_the_add_course_button
-    expect(page).to have_content('Choose a course')
+    expect(page).to have_link('Choose a course', href: candidate_interface_course_choices_do_you_know_the_course_path)
   end
 
-  def and_i_see_the_banner_content_for_before_find_opens
-    relative_next_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
-    apply_reopen_date = relative_next_timetable.apply_opens_at.to_fs(:govuk_date_time_time_first)
-    cycle_range = relative_next_timetable.academic_year_range_name
-    expect(page).to have_content("From #{apply_reopen_date} you will be able to apply for courses starting in the #{cycle_range} academic year.")
-  end
+  def and_i_see_the_carried_over_banner
+    application_form = current_candidate.current_application
+    date_and_time_find_opens = application_form.find_opens_at.to_fs(:govuk_date_time_time_first)
+    application_form_academic_year_range_name = application_form.academic_year_range_name
+    date_and_time_apply_opens = application_form.apply_opens_at.to_fs(:govuk_date_time_time_first)
 
-  def and_i_see_the_banner_content_for_after_find_opens
-    relative_next_timetable = @application_form.recruitment_cycle_timetable.relative_next_timetable
-    apply_reopen_date = relative_next_timetable.apply_opens_at.to_fs(:govuk_date_time_time_first)
-    academic_year_range = relative_next_timetable.academic_year_range_name
-    expect(page).to have_content("You can prepare applications for courses starting in the #{academic_year_range} academic year.")
-    expect(page).to have_content("You will be able to apply for these courses from #{apply_reopen_date}.")
+    expect(page).to have_content('You cannot submit applications at the moment')
+    expect(page).to have_content("You can view and choose courses from #{date_and_time_find_opens}")
+    expect(page).to have_content("You will be able to submit applications for the #{application_form_academic_year_range_name} recruitment cycle from #{date_and_time_apply_opens}.")
   end
 
   def and_i_do_not_see_previous_applications_heading
@@ -191,16 +145,12 @@ private
     expect(page).to have_title('Your details')
 
     click_link_or_button 'Personal information'
-    expect(page).to have_content(date_of_birth.to_fs(:govuk_date))
+    expect(page).to have_content(Date.new(1964, 9, 1).to_fs(:govuk_date))
     and_my_application_is_on_the_new_cycle
   end
 
   def and_my_application_is_on_the_new_cycle
     current_year = @application_form.recruitment_cycle_year
     expect(current_candidate.current_application.reload.recruitment_cycle_year).to be(current_year + 1)
-  end
-
-  def date_of_birth
-    Date.new(1964, 9, 1)
   end
 end


### PR DESCRIPTION
## Context

The current content shown to Candidates revolves around the Apply Deadline passing. We want the content to reflect the stage in the cycle.
For Carried Over candidates, they do not need to see that the deadline has passed, as for them the deadline is almost 1 year away and the cycle has not even started yet. 

## Changes proposed in this pull request

Updates to the content in the Reopen banner displayed on the "Your details" page, this is now only shown after the apply deadline for the cycle based on the Application form's cycle. 

Updates to the Carried Over Content, this no longer refers to the Apply Deadline passing, focusing more on when Find and Apply open. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

**Your Applications - Before Deadline**
<img width="163" height="170" alt="image" src="https://github.com/user-attachments/assets/cc45e1d0-d957-4d81-ab69-1b92bc33abad" />

**Your Applications - Deadline has passed (not able to carry over)**
<img width="163" height="170" alt="image" src="https://github.com/user-attachments/assets/40cec167-c560-4e8b-9f60-8d15faf292db" />

**Your Applications - Deadline has passed (carry over available)**

<img width="163" height="170" alt="image" src="https://github.com/user-attachments/assets/a907e7c5-7810-4c2b-80e2-3a07b7d4749a" />

**Your Applications - Carried over (before Find Opens)**
<img width="1305" height="907" alt="image" src="https://github.com/user-attachments/assets/c6b1d055-ffbd-43bc-a08b-a4a4bd0da6c5" />

**Your Applications - Carried over (after Find Opens)**
<img width="1928" height="628" alt="image" src="https://github.com/user-attachments/assets/d40529cc-6b10-40be-9fa1-f0fffdd964c3" />


**Your Details - Deadline has passed** 

If the Candidate can Carry Over, this page is not accessible.
This message is not visible after the Candidate Carry's over.

<img width="965" height="227" alt="image" src="https://github.com/user-attachments/assets/2de36ea4-5855-4d51-992a-63845340e1a3" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
