### PR TITLE
[lb/1218] Review end of cycle job run times and dates

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -61,7 +61,7 @@ class Clock
 
   # End of cycle application choice status jobs
   # Changes unsubmitted application choices to 'application_not_sent'
-  every(1.day, 'EndOfCycle::CancelUnsubmittedApplicationsWorker', at: '19:00') { EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_async }
+  every(1.day, 'EndOfCycle::CancelUnsubmittedApplicationsWorker', at: '18:01') { EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_async }
   # Reject any application choices that are still awaiting provider decision (interviewing, inactive, and awaiting decision)
   every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision


### PR DESCRIPTION
## Context

When reviewing the new job to cancel invites that haven’t been responded to, we noticed that the job to cancel draft applications after the apply deadline has passed starts at 19:00 – we think it would make more sense for it to start at 18:01, immediately after the apply deadline.

## Changes proposed in this pull request

Change time to cancel draft applications to coincide with apply deadline

## Guidance to review

The card was for reviewing the times for all the jobs, but I want to get this one today before the job runs in qa. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
