### PR TITLE
[lb/1218] Review dates and times for end of cycle jobs

### DIFF
--- a/app/lib/end_of_cycle/job_timetabler.rb
+++ b/app/lib/end_of_cycle/job_timetabler.rb
@@ -7,26 +7,22 @@ module EndOfCycle
       @timetable = timetable || RecruitmentCycleTimetable.current_timetable
     end
 
-    def run_reject_by_default?
-      current_time.between?(reject_by_default_at, reject_by_default_at + 1.day)
+    def run_cancel_unsubmitted_applications?
+      current_time.between?(apply_deadline_at, reject_by_default_at)
     end
 
-    def cancel_unsubmitted_applications?
-      current_date == apply_deadline_at.to_date
+    def run_reject_by_default?
+      current_time.between?(reject_by_default_at, decline_by_default_at)
     end
 
     def run_decline_by_default?
-      current_date.between?(decline_by_default_at, find_closes_at)
+      current_time.between?(decline_by_default_at, find_closes_at)
     end
 
   private
 
     def current_time
       Time.zone.now
-    end
-
-    def current_date
-      Time.zone.now.to_date
     end
   end
 end

--- a/app/workers/end_of_cycle/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/end_of_cycle/cancel_unsubmitted_applications_worker.rb
@@ -5,7 +5,7 @@ module EndOfCycle
     BATCH_SIZE = 200
 
     def perform(force = false)
-      return unless EndOfCycle::JobTimetabler.new.cancel_unsubmitted_applications? || force
+      return unless EndOfCycle::JobTimetabler.new.run_cancel_unsubmitted_applications? || force
 
       BatchDelivery.new(relation:, stagger_over: 2.hours, batch_size: BATCH_SIZE).each do |batch_time, applications|
         CancelUnsubmittedApplicationsSecondaryWorker.perform_at(batch_time, applications.pluck(:id))

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -67,7 +67,7 @@ class Clock
   # Reject any application choices that are still awaiting provider decision (interviewing, inactive, and awaiting decision)
   every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision
-  every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '01:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
+  every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
 
   # Daily jobs - mon-thurs only
   every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 4) }) { SendStatsSummaryToSlack.new.perform }

--- a/spec/lib/end_of_cycle/job_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/job_timetabler_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::JobTimetabler do
+  describe 'run_cancel_unsubmitted_applications?' do
+    it 'does not run before apply deadline' do
+      travel_temporarily_to(current_timetable.apply_deadline_at - 1.minute) do
+        expect(described_class.new.run_cancel_unsubmitted_applications?).to be false
+      end
+    end
+
+    it 'does not run after reject by default' do
+      travel_temporarily_to(current_timetable.reject_by_default_at + 1.second) do
+        expect(described_class.new.run_cancel_unsubmitted_applications?).to be false
+      end
+    end
+
+    it 'runs between apply deadline and reject by default' do
+      travel_temporarily_to(current_timetable.reject_by_default_at - 1.minute) do
+        expect(described_class.new.run_cancel_unsubmitted_applications?).to be true
+      end
+    end
+  end
+
+  describe 'run_reject_by_default?' do
+    it 'does not run before reject_by_default_at' do
+      travel_temporarily_to(current_timetable.reject_by_default_at - 1.minute) do
+        expect(described_class.new.run_reject_by_default?).to be false
+      end
+    end
+
+    it 'does not run after decline by default at' do
+      travel_temporarily_to(current_timetable.decline_by_default_at + 1.second) do
+        expect(described_class.new.run_reject_by_default?).to be false
+      end
+    end
+
+    it 'runs between reject by default and decline by default' do
+      travel_temporarily_to(current_timetable.decline_by_default_at - 1.minute) do
+        expect(described_class.new.run_reject_by_default?).to be true
+      end
+    end
+  end
+
+  describe 'run_decline_by_default?' do
+    it 'does not run before decline by default' do
+      travel_temporarily_to(current_timetable.decline_by_default_at - 1.minute) do
+        expect(described_class.new.run_decline_by_default?).to be false
+      end
+    end
+
+    it 'does not run after find closes' do
+      travel_temporarily_to(current_timetable.find_closes_at + 1.second) do
+        expect(described_class.new.run_decline_by_default?).to be false
+      end
+    end
+
+    it 'runs between decline by default and find closes' do
+      travel_temporarily_to(current_timetable.find_closes_at - 1.minute) do
+        expect(described_class.new.run_decline_by_default?).to be true
+      end
+    end
+  end
+end

--- a/spec/support/cycle_timetable_helper.rb
+++ b/spec/support/cycle_timetable_helper.rb
@@ -98,6 +98,11 @@ module_function
     timetable.reject_by_default_at + 1.day
   end
 
+  def after_decline_by_default(year = nil)
+    timetable = get_timetable(year)
+    timetable.decline_by_default_at + 1.day
+  end
+
   def reject_by_default_run_date(year = nil)
     timetable = get_timetable(year)
     timetable.reject_by_default_at + 1.second

--- a/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
           end
         end
 
-        context 'between cycles, but not on cancel date', time: after_apply_deadline(year) do
+        context 'between cycles, after decline by default date', time: after_decline_by_default(year) do
           it 'does not cancel any applications' do
             create_test_applications
 


### PR DESCRIPTION
## Context

We wanted to review the end of cycle jobs to make sure they were run at sensible times and have already merged in one change (cancelling applications on the apply deadline from 19:00 => 18:01 to coincide with the `apply_deadline_at`.

## Changes proposed in this pull request

These small changes are mostly for consistency as we were doing slightly different things for each job. 
In terms of the clock -- it is fine that that reject by default and decline by default job run at the same time as at least one of them will always return without running. 

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
