### PR TITLE
Close courses for invites on application deadline

### DIFF
--- a/app/workers/end_of_cycle/close_courses_on_invites.rb
+++ b/app/workers/end_of_cycle/close_courses_on_invites.rb
@@ -1,0 +1,13 @@
+module EndOfCycle
+  class CloseCoursesOnInvites
+    include Sidekiq::Worker
+
+    def perform(force = false)
+      return unless EndOfCycle::JobTimetabler.new.run_cancel_unsubmitted_applications? || force
+
+      Pool::Invite.current_cycle.published.update_all(
+        course_open: false,
+      )
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -64,6 +64,7 @@ class Clock
   # End of cycle application choice status jobs
   # Changes unsubmitted application choices to 'application_not_sent'
   every(1.day, 'EndOfCycle::CancelUnsubmittedApplicationsWorker', at: '18:01') { EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_async }
+  every(1.day, 'EndOfCycle::CloseCoursesOnInvites', at: '18:01') { EndOfCycle::CloseCoursesOnInvites.perform_async }
   # Reject any application choices that are still awaiting provider decision (interviewing, inactive, and awaiting decision)
   every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision

--- a/spec/workers/end_of_cycle/close_courses_on_invites_spec.rb
+++ b/spec/workers/end_of_cycle/close_courses_on_invites_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::CloseCoursesOnInvites do
+  describe '#perform' do
+    context 'when force is true', time: mid_cycle do
+      it 'closes the courses on published invites' do
+        not_responded = create(:pool_invite, :sent_to_candidate)
+        accepted = create(:pool_invite, :sent_to_candidate, candidate_decision: 'accepted')
+        declined = create(:pool_invite, :sent_to_candidate, candidate_decision: 'declined')
+        draft = create(:pool_invite)
+
+        expect { described_class.new.perform(true) }.to change { not_responded.reload.course_open }
+          .from(true).to(false)
+          .and(change { accepted.reload.course_open }.from(true).to(false))
+          .and(change { declined.reload.course_open }.from(true).to(false))
+          .and(not_change { draft.reload.course_open })
+      end
+    end
+
+    context 'when force is false mid cycle', time: mid_cycle do
+      it 'does not close the courses on published invites' do
+        not_responded = create(:pool_invite, :sent_to_candidate)
+        accepted = create(:pool_invite, :sent_to_candidate, candidate_decision: 'accepted')
+        declined = create(:pool_invite, :sent_to_candidate, candidate_decision: 'declined')
+        draft = create(:pool_invite)
+
+        expect { described_class.new.perform(false) }.to not_change { not_responded.reload.course_open }
+          .and not_change { accepted.reload.course_open }
+          .and not_change { declined.reload.course_open }
+          .and(not_change { draft.reload.course_open })
+      end
+    end
+
+    context 'when force is false on application_deadline', time: cancel_application_deadline do
+      it 'closes the courses on published invites' do
+        not_responded = create(:pool_invite, :sent_to_candidate)
+        accepted = create(:pool_invite, :sent_to_candidate, candidate_decision: 'accepted')
+        declined = create(:pool_invite, :sent_to_candidate, candidate_decision: 'declined')
+        draft = create(:pool_invite)
+
+        expect { described_class.new.perform(false) }.to change { not_responded.reload.course_open }
+          .from(true).to(false)
+          .and(change { accepted.reload.course_open }.from(true).to(false))
+          .and(change { declined.reload.course_open }.from(true).to(false))
+          .and(not_change { draft.reload.status })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This adds a worker that will close all courses for published invites on the day of the application deadline.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
