### PR TITLE
Fixes bug which makes Application Choices difficult to click

### DIFF
--- a/app/frontend/styles/_application-item.scss
+++ b/app/frontend/styles/_application-item.scss
@@ -1,5 +1,6 @@
 .app-application-item {
   border-bottom: 1px solid $govuk-border-colour;
+  position: relative;
 
   a {
     text-decoration: none;


### PR DESCRIPTION
## Context

Currently when trying to click an Appliction Choice in a list, the link from the last Application Choice has expanded over a large portion of the page. 

## Changes proposed in this pull request

- Set a `position: relative;` on the Application List Item, which will contain the link. The link has an `position: absolute` `::after` pseudo-element which will take the absolute position of its nearest ancestor with relative positioning. 

## Guidance to review

- Check locally
- As a Candidate, look at a list of your application
- Attempt to click on one of the first in the list and you'll see that you end up viewing details of the last one on the list 
- After this change you should be able to click on each individual Application

This is visible too - the hover state is applied to the last item and does not change. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
