### PR TITLE
[lb/1252] Include time when telling candidate about apply opening date

### DIFF
--- a/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
+++ b/app/components/candidate_interface/carry_over_between_cycles_component.html.erb
@@ -20,7 +20,7 @@
   <%= t(
         '.application_process_description',
         next_academic_year: next_academic_cycle,
-        apply_reopens_date: apply_reopens_date.to_fs(:govuk_date),
+        apply_reopens_date: apply_reopens_date.to_fs(:govuk_date_time_time_first),
       ) %>
 </p>
 <%= govuk_button_to t('.button_update_your_details'), candidate_interface_carry_over_path %>

--- a/spec/components/candidate_interface/carry_over_between_cycles_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_between_cycles_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::CarryOverBetweenCyclesComponent do
       next_academic_year = timetable.next_available_academic_year_range
       expect(result).to have_content("You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.")
 
-      apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date)
+      apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
       expect(result).to have_content("You will be able to apply for these courses from #{apply_reopens_date}.")
       expect(result).to have_button('Update your details')
 


### PR DESCRIPTION
## Context

EoC bug party content related change -- we want to include the time as well as the date when talking about the apply opening date.

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="921" height="218" alt="image" src="https://github.com/user-attachments/assets/8c6a2beb-a819-4a59-a8f1-06c5d8ecbcd4" /> | <img width="923" height="216" alt="image" src="https://github.com/user-attachments/assets/0e8671d7-0810-4917-93eb-940c5c3ebc59" /> |


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
