### PR TITLE
Dynamic content for adding application on application details

### DIFF
--- a/app/views/candidate_interface/details/index.html.erb
+++ b/app/views/candidate_interface/details/index.html.erb
@@ -81,7 +81,11 @@
     <% elsif @application_form_presenter.can_submit_more_applications? %>
       <div class="app-grid-column--grey">
         <h2 class="govuk-heading-m">You have completed your details</h2>
-        <p class="govuk-body">You can now start applying to courses.</p>
+        <% if current_application.application_choices.any? %>
+          <p class="govuk-body">You can apply to courses now.</p>
+        <% else %>
+          <p class="govuk-body">You can now start applying to courses.</p>
+        <% end %>
         <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
       </div>
     <% end %>

--- a/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe 'Marking section as complete or incomplete' do
     when_i_visit_the_details_page
     then_i_see_the_complete_details_text
 
+    when_i_dont_have_any_application_choices
+    and_i_visit_the_details_page
+    then_i_see_the_complete_details_text_for_application_without_choices
+
     when_i_mark_a_section_as_incomplete
     then_i_dont_see_the_complete_details_text
 
@@ -157,23 +161,32 @@ RSpec.describe 'Marking section as complete or incomplete' do
   def when_i_visit_the_details_page
     visit candidate_interface_details_path
   end
+  alias_method :and_i_visit_the_details_page, :when_i_visit_the_details_page
 
   def then_i_see_the_complete_details_text
     expect(page).to have_text('You can add your applications.')
     expect(page).to have_text('You have completed your details')
+    expect(page).to have_text('You can apply to courses now.')
+  end
+
+  def then_i_see_the_complete_details_text_for_application_without_choices
     expect(page).to have_text('You can now start applying to courses.')
   end
 
   def then_i_dont_see_the_complete_details_text
     expect(page).to have_no_text('You can add your applications.')
     expect(page).to have_no_text('You have completed your details')
-    expect(page).to have_no_text('You can now start applying to courses.')
+    expect(page).to have_no_text('You can apply to courses now.')
   end
 
   def when_i_add_the_maximum_number_of_choices
     (ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES - 1).times do
       create(:application_choice, :unsubmitted, application_form: @application_form)
     end
+  end
+
+  def when_i_dont_have_any_application_choices
+    @application_form.application_choices.map(&:delete)
   end
 
   def and_i_mark_the_section_as_incomplete(section_name)


### PR DESCRIPTION
## Context

We want to make the Add application content on the 'Your details' page more dynamic.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
| With applications |  Without applications |
| -- | -- |
| <img width="1186" height="322" alt="with applications" src="https://github.com/user-attachments/assets/197bd083-4bdb-408e-8208-9cdde03746b0" /> | <img width="1067" height="326" alt="without applications" src="https://github.com/user-attachments/assets/ab70e76a-3655-434e-8ed4-327e55ca0be7" /> |

On review app you can impersonate a candidate with and without applications.
 




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
