### PR TITLE
Capture exception when trying to save site

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -33,7 +33,7 @@ module TeacherTrainingPublicAPI
 
       api_sites_and_study_modes.each do |api_site, study_mode|
         site = create_or_update_site(api_site)
-        create_or_update_course_option(site, study_mode)
+        create_or_update_course_option(site, study_mode) if site.present?
       end
 
       # 2. Disable or delete CourseOptions that exist in Apply but are not
@@ -50,6 +50,10 @@ module TeacherTrainingPublicAPI
 
       site&.save!
       site
+    rescue StandardError => e
+      message = "SyncSites error, provider_id =  #{provider.id}, api_site_uuid = #{api_site.uuid} api_site_name = #{api_site.name}"
+      Sentry.capture_exception(e, message:)
+      nil
     end
 
     def create_or_update_course_option(site, study_mode)


### PR DESCRIPTION
## Context

We have been receiving Sentry errors when syncing 2026 courses. The actual error is obscured by a DFE Analytics errors. 

In production there are 37 sites for provider 1176, but there are 579 that come back from the API. So early on the site sync, something is going wrong and no further sites are synced. See dead jobs in the the production sidekiq queue.

## Changes proposed in this pull request

This will help surface the error and also allow the job to continue running and successfully sync (any subsequent sites)

## Guidance to review

Happy to take suggestions.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
