### PR TITLE
Add application process guidance back to start page

### DIFF
--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -22,6 +22,10 @@
         t('continue'),
         OneLogin.bypass? ? '/auth/one-login-developer' : "/auth/one-login?path=#{@referer_path}",
       ) %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('govuk.read_application_process_guidance'), candidate_interface_guidance_path %>.
+      </p>
     <% else %>
      <%= form_with(
         model: @create_account_or_sign_in_form,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
     find_a_course_url: https://nationalcareers.service.gov.uk/find-a-course/search
   govuk:
     one_login_account_guidance: You need a GOV.UK One Login to sign in to this service. You can create one if you do not already have one.
+    read_application_process_guidance: Read about application timings and deadlines
     url: https://www.gov.uk
     terms_conditions_url: https://www.gov.uk/help/terms-conditions
     safeguarding: https://www.gov.uk/tell-employer-or-college-about-criminal-record


### PR DESCRIPTION
## Context

This link to /candidate/about-the-teacher-training-application-process was removed when we added one login. Probably by mistake.

This commit adds it back.

## Changes proposed in this pull request

## Guidance to review


<img width="955" height="557" alt="image" src="https://github.com/user-attachments/assets/db854792-b7e4-46b2-adf0-5892feb87922" />

The link goes here https://www.apply-for-teacher-training.service.gov.uk/candidate/about-the-teacher-training-application-process


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
