### PR TITLE
Update error handling

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -50,10 +50,9 @@ module TeacherTrainingPublicAPI
 
       site&.save!
       site
-    rescue StandardError => e
-      message = "SyncSites error, provider_id =  #{provider.id}, api_site_uuid = #{api_site.uuid} api_site_name = #{api_site.name}"
-      Sentry.capture_exception(e, message:)
-      nil
+    rescue ArgumentError
+      Sentry.capture_message("SyncSites error, provider_id =  #{provider.id}, api_site_uuid = #{api_site.uuid} api_site_name = #{api_site.name}")
+      site
     end
 
     def create_or_update_course_option(site, study_mode)


### PR DESCRIPTION
## Context

The last thing we did worked in the sense that the job didn't stop, so more course options were synced, but because the error returned nil, the course option didn't save. 

So for provider 1176, course 85941
| Expected number of course options | before error handling | after error handling |
| ----- | ----- | ----- |
| 579   | 37     | 419   |

## Changes proposed in this pull request

The error returns the site now. With this change, we should see the correct number of course options. 

## Guidance to review

Still unclear why some sites are throwing the Argument error when they save. There is nothing in common -- not all of them have neg. values for long or lat for example. The sites are being saved, but it's only the callback that fails. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
