### PR TITLE
[lb/1265] Fix any specs that will fail as we pass through cycle deadlines

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -148,9 +148,9 @@ jobs:
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
-        # offset-date: [real_world, after_apply_deadline, before_apply_reopens, after_apply_reopens]
+        offset-date: [real_world, after_apply_deadline, before_apply_reopens, after_apply_reopens]
         # Use these offsets through mid-cycle
-        offset-date: [real_world]
+        # offset-date: [real_world]
 
         include:
           - tests: unit_shared

--- a/app/forms/candidate_interface/degrees/start_year_form.rb
+++ b/app/forms/candidate_interface/degrees/start_year_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     end
 
     def start_year_in_future_when_degree_completed
-      errors.add(:start_year, :in_the_future) if completed? && start_year.present? && start_year.to_i >= RecruitmentCycleTimetable.next_year
+      errors.add(:start_year, :in_the_future) if completed? && start_year.present? && start_year.to_i >= Time.zone.now.year
     end
 
     def next_step

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -879,6 +879,7 @@ Note: Do not do this if the timetables in these apps have been changed for testi
 ### Finally update the seed data for dev, test and review
 Create a branch locally
 Run `ProductionRecruitmentCycleTimetablesAPI::RefreshSeedData.new.call` -- This updates the csv which is used to seed timetables in review apps, tests, and development
+Update the file `spec/examples/production_recruitment_cycle_timetables_api.json` (easiest way to do this is just hit the [production api](https://www.apply-for-teacher-training.service.gov.uk/publications/recruitment-cycle-timetables.json) and copy and paste the results)
 
 ## Generating Vendor API Tokens
 

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -1,24 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ReopenBannerComponent do
-  let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2025) }
-  let(:after_apply_deadline) { true }
-  let(:flash_empty) { true }
-
-  before do
-    allow(application_form).to receive(:after_apply_deadline?).and_return(after_apply_deadline)
-  end
-
   subject(:rendered_component) { render_inline(described_class.new(flash_empty: flash_empty, application_form: application_form)) }
 
-  context 'after the apply deadline and the flash is empty' do
+  let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2025) }
+
+  context 'after the apply deadline and the flash is empty', time: after_apply_deadline(2025) do
+    let(:flash_empty) { true }
+
     it { is_expected.to have_content('The application deadline has passed') }
     it { is_expected.to have_content('The application deadline has passed for courses starting in the 2025 to 2026 academic year.') }
-    it { is_expected.to have_content('From 9am UK time on 7 October 2025 you will be able to apply for courses starting in the 2025 to 2026 academic year.') }
+    it { is_expected.to have_content('From 9am UK time on 7 October 2025 you will be able to apply for courses starting in the 2026 to 2027 academic year.') }
   end
 
-  context 'before the apply deadline and flash is empty' do
-    let(:after_apply_deadline) { false }
+  context 'before the apply deadline and flash is empty', time: mid_cycle(2025) do
     let(:flash_empty) { true }
 
     subject { rendered_component.text }
@@ -26,8 +21,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
     it { is_expected.to be_blank }
   end
 
-  context 'before the apply deadline and flash is not empty' do
-    let(:after_apply_deadline) { false }
+  context 'before the apply deadline and flash is not empty', time: after_apply_deadline(2025) do
     let(:flash_empty) { false }
 
     subject { rendered_component.text }

--- a/spec/examples/production_recruitment_cycle_timetables_api/fetch_all_recruitment_cycles.json
+++ b/spec/examples/production_recruitment_cycle_timetables_api/fetch_all_recruitment_cycles.json
@@ -1,34 +1,44 @@
 {
   "data": [
     {
-      "find_opens_at": "2026-10-01T09:00:00+01:00",
-      "apply_opens_at": "2026-10-08T09:00:00+01:00",
-      "apply_deadline_at": "2027-09-16T18:00:00+01:00",
-      "reject_by_default_at": "2027-09-24T23:59:59+01:00",
-      "decline_by_default_at": "2027-09-29T23:59:59+01:00",
-      "find_closes_at": "2027-09-30T23:59:59+01:00",
-      "recruitment_cycle_year": 2027,
-      "updated_at": "2025-01-31T14:52:26+00:00"
+      "find_opens_at": "2027-10-05T09:00:00+01:00",
+      "apply_opens_at": "2027-10-12T09:00:00+01:00",
+      "apply_deadline_at": "2028-09-19T18:00:00+01:00",
+      "reject_by_default_at": "2028-09-27T23:59:59+01:00",
+      "decline_by_default_at": "2028-10-01T23:59:59+01:00",
+      "find_closes_at": "2028-10-02T23:59:59+01:00",
+      "recruitment_cycle_year": 2028,
+      "updated_at": "2025-08-15T09:48:55+01:00"
     },
     {
-      "find_opens_at": "2025-10-01T09:00:00+01:00",
-      "apply_opens_at": "2025-10-08T09:00:00+01:00",
-      "apply_deadline_at": "2026-09-16T18:00:00+01:00",
-      "reject_by_default_at": "2026-09-24T23:59:59+01:00",
-      "decline_by_default_at": "2026-09-29T23:59:59+01:00",
-      "find_closes_at": "2026-09-30T23:59:59+01:00",
+      "find_opens_at": "2026-09-29T09:00:00+01:00",
+      "apply_opens_at": "2026-10-06T09:00:00+01:00",
+      "apply_deadline_at": "2027-09-21T18:00:00+01:00",
+      "reject_by_default_at": "2027-09-29T23:59:59+01:00",
+      "decline_by_default_at": "2027-10-03T23:59:59+01:00",
+      "find_closes_at": "2027-10-04T23:59:59+01:00",
+      "recruitment_cycle_year": 2027,
+      "updated_at": "2025-08-15T09:48:53+01:00"
+    },
+    {
+      "find_opens_at": "2025-09-30T09:00:00+01:00",
+      "apply_opens_at": "2025-10-07T09:00:00+01:00",
+      "apply_deadline_at": "2026-09-15T18:00:00+01:00",
+      "reject_by_default_at": "2026-09-23T23:59:59+01:00",
+      "decline_by_default_at": "2026-09-27T23:59:59+01:00",
+      "find_closes_at": "2026-09-28T23:59:59+01:00",
       "recruitment_cycle_year": 2026,
-      "updated_at": "2025-01-31T14:52:26+00:00"
+      "updated_at": "2025-08-15T09:48:24+01:00"
     },
     {
       "find_opens_at": "2024-10-01T09:00:00+01:00",
       "apply_opens_at": "2024-10-08T09:00:00+01:00",
       "apply_deadline_at": "2025-09-16T18:00:00+01:00",
       "reject_by_default_at": "2025-09-24T23:59:59+01:00",
-      "decline_by_default_at": "2025-09-29T23:59:59+01:00",
-      "find_closes_at": "2025-09-30T23:59:59+01:00",
+      "decline_by_default_at": "2025-09-28T23:59:59+01:00",
+      "find_closes_at": "2025-09-29T23:59:59+01:00",
       "recruitment_cycle_year": 2025,
-      "updated_at": "2025-01-31T14:52:26+00:00"
+      "updated_at": "2025-08-15T09:45:49+01:00"
     },
     {
       "find_opens_at": "2023-10-03T09:00:00+01:00",
@@ -37,7 +47,6 @@
       "reject_by_default_at": "2024-09-25T23:59:59+01:00",
       "decline_by_default_at": "2024-09-29T23:59:59+01:00",
       "find_closes_at": "2024-09-30T23:59:59+01:00",
-
       "recruitment_cycle_year": 2024,
       "updated_at": "2025-01-31T14:52:26+00:00"
     },

--- a/spec/examples/production_recruitment_cycle_timetables_api/fetch_recruitment_cycle_2025.json
+++ b/spec/examples/production_recruitment_cycle_timetables_api/fetch_recruitment_cycle_2025.json
@@ -5,10 +5,10 @@
       "apply_opens_at": "2024-10-08T09:00:00+01:00",
       "apply_deadline_at": "2025-09-16T18:00:00+01:00",
       "reject_by_default_at": "2025-09-24T23:59:59+01:00",
-      "decline_by_default_at": "2025-09-29T23:59:59+01:00",
-      "find_closes_at": "2025-09-30T23:59:59+01:00",
+      "decline_by_default_at": "2025-09-28T23:59:59+01:00",
+      "find_closes_at": "2025-09-29T23:59:59+01:00",
       "recruitment_cycle_year": 2025,
-      "updated_at": "2025-01-31T14:52:26+00:00"
+      "updated_at": "2025-08-15T09:45:49+01:00"
     }
   ]
 }

--- a/spec/lib/production_recruitment_cycle_timetables_api/sync_timetables_with_production_spec.rb
+++ b/spec/lib/production_recruitment_cycle_timetables_api/sync_timetables_with_production_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ProductionRecruitmentCycleTimetablesAPI::SyncTimetablesWithProduc
 
     sync_timetables
 
-    expect(RecruitmentCycleTimetable.count).to eq 9
+    expect(RecruitmentCycleTimetable.count).to eq 10
   end
 
   it 'updates altered timetables to match production' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe CandidateMailer do
     end
   end
 
-  describe 'Course Recommendations URL' do
+  describe 'Course Recommendations URL', time: mid_cycle do
     let(:application_choice) { create(:application_choice, :rejected) }
 
     context 'when a URL is not provided' do

--- a/spec/models/candidate_pool_application_spec.rb
+++ b/spec/models/candidate_pool_application_spec.rb
@@ -148,9 +148,7 @@ RSpec.describe CandidatePoolApplication do
 
   describe '.open_at' do
     it 'returns when the candidate pool opens' do
-      expect(described_class.open_at).to eq(
-        DateTime.new(RecruitmentCycleTimetable.previous_year, 11, 19).end_of_day,
-      )
+      expect(described_class.open_at).to eq(30.business_days.after(current_timetable.apply_opens_at).end_of_day)
     end
   end
 end

--- a/spec/models/chaser_sent_spec.rb
+++ b/spec/models/chaser_sent_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ChaserSent do
     end
 
     context 'apply' do
-      it 'returns records created this cycle' do
+      it 'returns records created this cycle', time: mid_cycle do
         this_year = create(:chaser_sent)
 
         travel_temporarily_to(previous_timetable.find_opens_at) do

--- a/spec/services/generate_candidate_pool_data_spec.rb
+++ b/spec/services/generate_candidate_pool_data_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe GenerateCandidatePoolData do
+  before do
+    TestSuiteTimeMachine.travel_permanently_to(
+      31.business_days.after(current_timetable.apply_opens_at),
+    )
+  end
+
   describe '.call' do
     it 'populated the candidate pool with dummy data' do
       rejected_application_form = create(:application_form, :completed)

--- a/spec/services/seed_timetables_service_spec.rb
+++ b/spec/services/seed_timetables_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SeedTimetablesService do
       json_input = JSON.parse(file)['data']
       described_class.new(json_input).call
 
-      expect(RecruitmentCycleTimetable.count).to eq 9
+      expect(RecruitmentCycleTimetable.count).to eq 10
     end
   end
 end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
       end
     end
 
-    context 'when the closed course exists and has been open' do
+    context 'when the closed course exists and has been open', time: mid_cycle do
       let(:uuid) { SecureRandom.uuid }
       let!(:course) { create(:course, :closed, provider: provider, uuid: uuid) }
       let!(:invite) { create(:pool_invite, :sent_to_candidate, course:, provider:, course_open: false) }

--- a/spec/system/support_interface/change_course_to_different_year_spec.rb
+++ b/spec/system/support_interface/change_course_to_different_year_spec.rb
@@ -80,6 +80,6 @@ RSpec.describe 'Change course choice to a different year' do
 
   def and_i_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
-    expect(page).to have_content("2024: #{@course_option.course.name} (#{@course_option.course.code})")
+    expect(page).to have_content("#{previous_year}: #{@course_option.course.name} (#{@course_option.course.code})")
   end
 end


### PR DESCRIPTION
## Context

We need to ensure that the test suite will continue to pass as we move out of the normal 'mid-cycle' period. This PR runs the tests 
- after the apply deadline
- in the next cycle, before apply opens
- after apply reopens (mid cycle the next year)

## Changes proposed in this pull request

- Changes to individual tests that are dependent on being in a particular time in the cycle.
- Updated the mocked json response for the timetables (and added this as a step for updating timetable in the support playbook)

## Guidance to review

We can either:

1. Switch this back now (once all the tests pass), but put it in our diaries to run the suite like this once a week between now and the apply opening to catch anything that we put in in the mean time that would fail.
2. Keep it in until the new cycle has started. Test suite will take longer to run, but we won't put anything in that needs to be fixed or forget to run it between now and then.

What do you think?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
