### PR TITLE
Allow active navigation links to be declared by partial controller paths

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -131,6 +131,7 @@ class NavigationItems
               references
               courses
               study_modes
+              provider_interface/deferred_offer
             ],
           ),
         }
@@ -225,7 +226,14 @@ class NavigationItems
   private
 
     def active?(current_controller, active_controllers)
-      current_controller.controller_name.in?(Array.wrap(active_controllers))
+      active_controller_names = Array.wrap(active_controllers)
+      current_controller_path = current_controller.controller_path
+      current_controller_name = current_controller.controller_name
+
+      matching_name = current_controller_name.in?(active_controller_names)
+      matching_path = active_controller_names.any? { |controller_name| current_controller_path.include?(controller_name) }
+
+      matching_name || matching_path
     end
 
     def active_action?(current_controller, active_action)


### PR DESCRIPTION
## Context

This is needed as some flows have multiple controllers, eg deferred_offer has `check`, `course`, `study_mode` `site`, `conditions`. The current setup would require each of these controller names to be added to the list. 

## Changes proposed in this pull request

With this change it allows us to declare a partial path to the controller, ie `provider_interface/deferred_offer` which is the start of the controller path for each of the deferred offer controllers.

## Guidance to review

- N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
