### PR TITLE
Added Autocomplete to Course select

### DIFF
--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -11,6 +11,7 @@ import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 import { Application } from '@hotwired/stimulus'
 import LocationAutocompleteController from './controllers/location_autocomplete_controller'
 import CopyToClipboardController from './controllers/copy_to_clipboard_controller.js'
+import AutocompleteController from './controllers/autocomplete_controller'
 import showMoreShowLess from './components/show-more-show-less'
 import personalStatementToggle from './components/toggle_personal_statement'
 
@@ -19,6 +20,7 @@ require.context('govuk-frontend/dist/govuk/assets')
 window.Stimulus = Application.start()
 window.Stimulus.register('location-autocomplete', LocationAutocompleteController)
 window.Stimulus.register('copy-to-clipboard', CopyToClipboardController)
+window.Stimulus.register('autocomplete', AutocompleteController)
 
 govUKFrontendInitAll()
 initWarnOnUnsavedChanges()

--- a/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
+++ b/app/frontend/packs/autocompletes/candidate/candidate-autocomplete-inputs.js
@@ -1,3 +1,7 @@
+// You can now use the Stimulus controller to add autocompletes to any select field
+// by adding `data-controller="autocomplete"`
+// see `app/frontend/packs/controllers/autocomplete_controller.js`
+
 const countryAutocompleteInputs = {
   inputIds: [
     'candidate-interface-contact-details-form-country-field',

--- a/app/frontend/packs/controllers/autocomplete_controller.js
+++ b/app/frontend/packs/controllers/autocomplete_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from '@hotwired/stimulus'
+import accessibleAutocomplete from 'accessible-autocomplete'
+
+// Connects to data-controller="autocomplete"
+export default class extends Controller {
+  connect () {
+    const selectElement = this.element
+
+    // Replace "Select a ..." with empty string
+    const emptyOption = selectElement.querySelector("[value='']")
+    if (emptyOption) {
+      emptyOption.innerHTML = ''
+    }
+
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement,
+      autoselect: false,
+      confirmOnBlur: false,
+      showAllValues: true
+    })
+  }
+}

--- a/app/views/provider_interface/deferred_offer/courses/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/courses/edit.html.erb
@@ -9,12 +9,13 @@
       <% if @course_form.courses_for_select.count > 20 %>
         <%= form.govuk_collection_select(
               :course_id,
-              @course_form.courses_for_select,
+              select_course_options_with_provider_name(@course_form.courses_for_select),
               :id,
-              collection_course_options_with_provider_name,
+              :name,
               label: { text: t('.page_title'), size: 'xl' },
               caption: { text: @course_form.application_choice.application_form.full_name, size: 'xl' },
               data: { controller: 'autocomplete' },
+              options: { selected: nil },
             ) %>
       <% else %>
         <%= form.govuk_collection_radio_buttons(

--- a/app/views/provider_interface/deferred_offer/courses/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/courses/edit.html.erb
@@ -14,6 +14,7 @@
               collection_course_options_with_provider_name,
               label: { text: t('.page_title'), size: 'xl' },
               caption: { text: @course_form.application_choice.application_form.full_name, size: 'xl' },
+              data: { controller: 'autocomplete' },
             ) %>
       <% else %>
         <%= form.govuk_collection_radio_buttons(


### PR DESCRIPTION
## Context

The Course list may be lengthy, and we want to be able to type the course name to find it. 

## Changes proposed in this pull request

- This is implemented using a Stimulus controller.
- Existing method of adding an identifier to an ever-growing list can be replaced by using the Stimulus controller. Note added to the file where these inputs are listed. 

## Guidance to review

1. Sign in to the Support console
2. then sign in as a Provider User "Susan Upport"
3. then visit https://apply-review-11164.test.teacherservices.cloud/provider/applications/5/deferred-offer/check
4. click "Change" next to the course details
5. Use the autocomplete select

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
