### PR TITLE
Render correct titles on application choices index page

### DIFF
--- a/app/components/candidate_interface/after_deadline_content_component.html.erb
+++ b/app/components/candidate_interface/after_deadline_content_component.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, t('page_titles.your_applications') %>
+
 <h1 class="govuk-heading-l">
   <%= t('after_deadline_content_component.title') %>
 </h1>

--- a/app/components/candidate_interface/carried_over_content_component.html.erb
+++ b/app/components/candidate_interface/carried_over_content_component.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, t('page_titles.your_applications') %>
+
 <h1 class="govuk-heading-l">
   <%= t('carried_over_content_component.title') %>
 </h1>

--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, t('page_titles.your_applications') %>
+
 <h1 class="govuk-heading-xl">
   <%= t('mid_cycle_content_component.title') %>
 </h1>

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -1,4 +1,3 @@
-<%= content_for :title, t('page_titles.your_applications') %>
 <%= render 'banners' %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Context
The index page was rendering a title, but then some of the components it was rendering also rendered titles, so the titles were a bit messy, things like:

 `<title>Your applicationsThe application deadline has passed - Apply for teacher training - [GOV.UK](http://gov.uk/)</title>`

## Changes proposed in this pull request

Remove the title from the index page and add titles into the content components where they were missing.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
