### PR TITLE
Allow for subjects not on the drop-down list

### DIFF
--- a/app/forms/candidate_interface/degrees/base_form.rb
+++ b/app/forms/candidate_interface/degrees/base_form.rb
@@ -61,7 +61,7 @@ module CandidateInterface
         institution_name: university_raw || university,
         institution_hesa_code: hesa_institution_code,
         degree_institution_uuid:,
-        subject:,
+        subject: subject_raw || subject,
         subject_hesa_code: structured_degree_data? ? hesa_subject_code : nil,
         degree_subject_uuid:,
         grade: structured_degree_data? ? grade_attributes : (other_grade || map_value_for_no_submitted_international_grade(grade)),


### PR DESCRIPTION
## Context

Some candidates are having trouble entering degrees when they have subjects that are not present on the drop down list. 

## Changes proposed in this pull request

This fixes the bug by checking for raw input before input directly from the drop down.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
