### PR TITLE
Make each environment's Postgres version configurable

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ../..:/workspaces:cached
     command: sleep infinity
   postgres:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,7 @@ jq 1.6
 make 4.2.1
 terraform 1.7.4
 redis 7.0.12
-postgres 14.7
+postgres 16.10
 kubelogin 0.1.0
 kubectl 1.29.1
 caddy 2.7.6

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ A service for candidates to [apply for teacher training](https://www.apply-for-t
 ### Production dependencies
 
 | Dependency            | Version |
-| ---                   |---------|
+|-----------------------|---------|
 | [Ruby](.ruby-version) | 3.4.4   |
 | Node.js               | 20.11.0 |
 | Yarn                  | 1.22.19 |
-| PostgreSQL            | 14      |
+| PostgreSQL            | 16      |
 | Redis                 | 6.0.x   |
 
 ### Development dependencies

--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -12,7 +12,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_alerting
   azure_enable_backup_storage    = var.deploy_azure_backing_services
-  server_version                 = "14"
+  server_version                 = var.postgres_server_version
   admin_username                 = local.infra_secrets.POSTGRES_ADMIN_USERNAME
   admin_password                 = local.infra_secrets.POSTGRES_ADMIN_PASSWORD
   azure_sku_name                 = var.postgres_flexible_server_sku

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -46,6 +46,7 @@ variable "clock_worker_replicas" { default = 1 }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
 variable "postgres_flexible_server_storage_mb" { default = 32768 }
 variable "postgres_enable_high_availability" { default = false }
+variable "postgres_server_version" { default = "14" }
 variable "redis_cache_capacity" { default = 1 }
 variable "redis_cache_family" { default = "C" }
 variable "redis_cache_sku_name" { default = "Standard" }

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -6,6 +6,7 @@
   "namespace": "development",
   "db_sslmode": "prefer",
   "deploy_azure_backing_services": false,
+  "postgres_server_version": "15",
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189d01attrvexp",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -6,7 +6,7 @@
   "namespace": "development",
   "db_sslmode": "prefer",
   "deploy_azure_backing_services": false,
-  "postgres_server_version": "15",
+  "postgres_server_version": "16",
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189d01attrvexp",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"

--- a/terraform/aks/workspace_variables/pt_review.tfvars.json
+++ b/terraform/aks/workspace_variables/pt_review.tfvars.json
@@ -6,7 +6,7 @@
   "cluster": "platform-test",
   "deploy_azure_backing_services": true,
   "create_storage_account": true,
-  "postgres_server_version": "15",
+  "postgres_server_version": "16",
   "data_exports_storage_account_name": "s189t01attrvexp",
   "db_sslmode": "prefer",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"

--- a/terraform/aks/workspace_variables/pt_review.tfvars.json
+++ b/terraform/aks/workspace_variables/pt_review.tfvars.json
@@ -6,6 +6,7 @@
   "cluster": "platform-test",
   "deploy_azure_backing_services": true,
   "create_storage_account": true,
+  "postgres_server_version": "15",
   "data_exports_storage_account_name": "s189t01attrvexp",
   "db_sslmode": "prefer",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -17,7 +17,7 @@
   "worker_replicas": 1,
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
-  "postgres_server_version": "15",
+  "postgres_server_version": "16",
   "enable_alerting": true,
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189t01attqaexp",

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -17,6 +17,7 @@
   "worker_replicas": 1,
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
+  "postgres_server_version": "15",
   "enable_alerting": true,
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189t01attqaexp",

--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -8,6 +8,7 @@
   "deploy_azure_backing_services": false,
   "db_sslmode": "prefer",
   "create_storage_account": true,
+  "postgres_server_version": "15",
   "data_exports_storage_account_name": "mystorageaccount",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
   "enable_logit": true

--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -8,7 +8,7 @@
   "deploy_azure_backing_services": false,
   "db_sslmode": "prefer",
   "create_storage_account": true,
-  "postgres_server_version": "15",
+  "postgres_server_version": "16",
   "data_exports_storage_account_name": "mystorageaccount",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
   "enable_logit": true


### PR DESCRIPTION
## Context

Introduces a variable  to configure Postgres server versions 

## Changes proposed in this pull request

Includes updating QA to PG ~15~ 16

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
