### PR TITLE
Increase prod postgres stg from 128G to 256G

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -23,7 +23,7 @@
   "redis_queue_sku_name": "Premium",
   "redis_cache_capacity": 2,
   "postgres_enable_high_availability": true,
-  "postgres_flexible_server_storage_mb": 131072,
+  "postgres_flexible_server_storage_mb": 262144,
   "enable_alerting": true,
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189p01attpdexp",


### PR DESCRIPTION
## Context

The prod postgres database server is using 80% of 128G allocated.
As MS recommend 10-15% free space for db upgrades, we will update to 256G.
This will cause a cost increase of £21.76 p/m to the apply product code.

Storage for premium ssd can be increased online without impact, as per [here](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-scale-storage-size?tabs=portal-scale-storage-size-ssd%2Cportal-scale-storage-size-ssd-v2#steps-to-scale-storage-size-premium-ssd) however there is a note in a linked doc that if you use terraform it can cause a vm restart if changing storage_tier. And this change will move the tier from P10 to P15.
So we should
1. change the storage size via the portal
2. merge the PR once storage has increased (before merging any other PR)

## Changes proposed in this pull request

Increase postgres_flexible_server_storage_mb to 262144

## Guidance to review

make production deploy-plan

# module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place
        name                          = "s189p01-att-production-psql"
      ~ storage_mb                    = 131072 -> 262144
      ~ storage_tier                  = "P10" -> "P15"

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
