### PR TITLE
lb/1269 Match new course option when changing course

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_site_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_site_controller.rb
@@ -3,6 +3,17 @@ module CandidateInterface
     class CourseSiteController < CandidateInterface::CourseChoices::BaseController
       include CandidateInterface::CourseChoices::Concerns::DuplicateCourseRedirect
 
+      def edit
+        @wizard = CandidateInterface::CourseChoices::CourseSelectionWizard.new(
+          current_step:,
+          step_params: update_params,
+          current_application:,
+          application_choice:,
+          edit: true,
+        )
+        @wizard.current_step.set_course_option_id
+      end
+
     private
 
       def current_step

--- a/app/forms/candidate_interface/course_choices/course_site_step.rb
+++ b/app/forms/candidate_interface/course_choices/course_site_step.rb
@@ -16,6 +16,18 @@ module CandidateInterface
         %i[provider_id course_id study_mode course_option_id course_option_id_raw]
       end
 
+      def set_course_option_id
+        # This handles if the user has changed course,
+        # the previously selected site will still display,
+        # but the course_option_id will be valid for the newly selected course
+        return '' if @course_option_id.blank?
+
+        site = CourseOption.find_by(id: @course_option_id)&.site
+        return '' if site.blank?
+
+        @course_option_id = course_options.find_by(site:)&.id || ''
+      end
+
       def no_free_text_input
         errors.add(:course_option_id, :blank) if invalid_raw_data?
       end
@@ -35,7 +47,7 @@ module CandidateInterface
       def site_options_for_select
         available_sites.map do |course_option|
           [
-            "#{course_option.site.name} - #{course_option.site.full_address}",
+            course_option.site.name_and_address(' - '),
             course_option.id,
           ]
         end.unshift([nil, nil])

--- a/app/forms/candidate_interface/course_choices/provider_selection_step.rb
+++ b/app/forms/candidate_interface/course_choices/provider_selection_step.rb
@@ -17,7 +17,7 @@ module CandidateInterface
 
       def select_provider_options
         @select_provider_options ||= available_providers.map do |provider|
-          ["#{provider.name} (#{provider.code})", provider.id]
+          [provider.name_and_code, provider.id]
         end.unshift([nil, nil])
       end
 

--- a/spec/forms/candidate_interface/course_choices/course_site_step_spec.rb
+++ b/spec/forms/candidate_interface/course_choices/course_site_step_spec.rb
@@ -15,6 +15,63 @@ RSpec.describe CandidateInterface::CourseChoices::CourseSiteStep do
     it { is_expected.to eq('candidate_interface_course_choices_course_site') }
   end
 
+  describe '#set_course_option_id' do
+    context 'existing course option id is valid for selected course' do
+      it 'does not change course_option_id' do
+        original_course_option = create(:course_option)
+        subject = described_class.new(
+          course_option_id: original_course_option.id,
+          provider_id: original_course_option.provider.id,
+          course_id: original_course_option.course_id,
+          study_mode: original_course_option.study_mode,
+        )
+        subject.set_course_option_id
+        expect(subject.course_option_id).to eq original_course_option.id
+      end
+    end
+
+    context 'existing course option id is not valid for selected course, but site is' do
+      it 'updates the course option to one with the same site' do
+        original_course_option = create(:course_option)
+        new_course = create(:course, provider: original_course_option.provider)
+        new_course_option = create(
+          :course_option,
+          course: new_course,
+          site: original_course_option.site,
+          study_mode: original_course_option.study_mode,
+        )
+        subject = described_class.new(
+          course_option_id: original_course_option.id,
+          provider_id: original_course_option.provider.id,
+          course_id: new_course_option.course_id,
+          study_mode: original_course_option.study_mode,
+        )
+        subject.set_course_option_id
+        expect(subject.course_option_id).to eq new_course_option.id
+      end
+    end
+
+    context 'when site is not valid for selected course' do
+      it 'returns an empty string' do
+        original_course_option = create(:course_option)
+        new_course = create(:course, provider: original_course_option.provider)
+        new_course_option = create(
+          :course_option,
+          course: new_course,
+          study_mode: original_course_option.study_mode,
+        )
+        subject = described_class.new(
+          course_option_id: original_course_option.id,
+          provider_id: original_course_option.provider.id,
+          course_id: new_course_option.course_id,
+          study_mode: original_course_option.study_mode,
+        )
+        subject.set_course_option_id
+        expect(subject.course_option_id).to eq ''
+      end
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:course_option_id) }
 
@@ -67,7 +124,7 @@ RSpec.describe CandidateInterface::CourseChoices::CourseSiteStep do
           provider_id: course.provider_id,
           course_id: course.id,
           course_option_id: course_option.id,
-          course_option_id_raw: "#{course_option.site.name} - #{course_option.site.full_address}",
+          course_option_id_raw: course_option.site.name_and_address(' - '),
         )
         expect(course_site_step.valid?).to be true
       end


### PR DESCRIPTION
## Context

When doing some testing locally for the start of cycle, I came across a little bug for the course option.

To recreate, you can go to QA, which is in the new cycle so has more open courses. 
Select a provider with multiple open courses where the school is selectable (in QA, a good one is Essex Schools ITT)
Select a course and then a site (ie, course option)
From the review page, change the course
When you get to the site page, you'll just see the course option id in the field as free text, not a valid selection.. 

This was because when changing courses, the course option id is no longer one of the course option selectable options. 

## Changes proposed in this pull request

We set the course_option after the course has changed. 
- If the course hasn't changed, the course_option stays the same,
- If the course changes, and it also has a course_option with the same site, we preselect that course_option
- If the course changes and the new course has no course option with the originally selected site, we set the option to blank.

## Guidance to review

This is actually easier to do if you fast forward to 2026 as there are more open courses. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
