### PR TITLE
Confirm Deferrals flow

### DIFF
--- a/app/controllers/provider_interface/deferred_offer/checks_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/checks_controller.rb
@@ -1,27 +1,13 @@
 module ProviderInterface
   module DeferredOffer
     class ChecksController < ProviderInterface::ProviderInterfaceController
+      include ProviderInterface::DeferredOffer::Navigation
+
       def show
         @deferred_offer = DeferredOfferConfirmation.find_or_initialize_by(
           provider_user: current_provider_user,
           offer: offer,
-        ) do |deferred_offer|
-          deferred_offer.course = offer.course
-          deferred_offer.location = offer.site
-          deferred_offer.study_mode = offer.study_mode
-        end
-      end
-
-    private
-
-      def offer
-        application_choice.offer
-      end
-
-      def application_choice
-        @application_choice ||= GetApplicationChoicesForProviders.call(
-          providers: current_provider_user.providers,
-        ).find(params.require(:application_choice_id))
+        )
       end
     end
   end

--- a/app/controllers/provider_interface/deferred_offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/conditions_controller.rb
@@ -1,4 +1,6 @@
 class ProviderInterface::DeferredOffer::ConditionsController < ProviderInterface::ProviderInterfaceController
+  include ProviderInterface::DeferredOffer::Navigation
+
   def edit
     @conditions_form = DeferredOfferConfirmation::ConditionsForm.find_or_initialize_by(
       provider_user: current_provider_user,
@@ -13,7 +15,7 @@ class ProviderInterface::DeferredOffer::ConditionsController < ProviderInterface
     )
 
     if @conditions_form.update(conditions_form_params)
-      redirect_to provider_interface_deferred_offer_check_path(application_choice)
+      redirect_to provider_interface_application_choice_path(application_choice)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -23,15 +25,5 @@ private
 
   def conditions_form_params
     params.expect(deferred_offer_confirmation_conditions_form: [:conditions_status])
-  end
-
-  def offer
-    application_choice.offer
-  end
-
-  def application_choice
-    @application_choice ||= GetApplicationChoicesForProviders.call(
-      providers: current_provider_user.providers,
-    ).find(params.require(:application_choice_id))
   end
 end

--- a/app/controllers/provider_interface/deferred_offer/courses_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/courses_controller.rb
@@ -1,4 +1,6 @@
 class ProviderInterface::DeferredOffer::CoursesController < ProviderInterface::ProviderInterfaceController
+  include ProviderInterface::DeferredOffer::Navigation
+
   def edit
     @course_form = DeferredOfferConfirmation::CourseForm.find_or_initialize_by(
       provider_user: current_provider_user,
@@ -13,7 +15,7 @@ class ProviderInterface::DeferredOffer::CoursesController < ProviderInterface::P
     )
 
     if @course_form.update(course_form_params)
-      redirect_to provider_interface_deferred_offer_check_path(application_choice)
+      redirect_to next_step_path(@course_form)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -23,15 +25,5 @@ private
 
   def course_form_params
     params.expect(deferred_offer_confirmation_course_form: %i[course_id course_id_raw])
-  end
-
-  def offer
-    application_choice.offer
-  end
-
-  def application_choice
-    @application_choice ||= GetApplicationChoicesForProviders.call(
-      providers: current_provider_user.providers,
-    ).find(params.require(:application_choice_id))
   end
 end

--- a/app/controllers/provider_interface/deferred_offer/location_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/location_controller.rb
@@ -1,4 +1,6 @@
 class ProviderInterface::DeferredOffer::LocationController < ProviderInterface::ProviderInterfaceController
+  include ProviderInterface::DeferredOffer::Navigation
+
   def edit
     @location_form = DeferredOfferConfirmation::LocationForm.find_or_initialize_by(
       provider_user: current_provider_user,
@@ -13,7 +15,7 @@ class ProviderInterface::DeferredOffer::LocationController < ProviderInterface::
     )
 
     if @location_form.update(location_form_params)
-      redirect_to provider_interface_deferred_offer_check_path(application_choice)
+      redirect_to next_step_path(@location_form)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -23,15 +25,5 @@ private
 
   def location_form_params
     params.expect(deferred_offer_confirmation_location_form: %i[site_id site_id_raw])
-  end
-
-  def offer
-    application_choice.offer
-  end
-
-  def application_choice
-    @application_choice ||= GetApplicationChoicesForProviders.call(
-      providers: current_provider_user.providers,
-    ).find(params.require(:application_choice_id))
   end
 end

--- a/app/controllers/provider_interface/deferred_offer/navigation.rb
+++ b/app/controllers/provider_interface/deferred_offer/navigation.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ProviderInterface::DeferredOffer::Navigation
+  extend ActiveSupport::Concern
+
+  included do
+  private
+
+    def next_step_path(deferred_offer_confirmation)
+      deferred_offer_confirmation.valid?(:submit)
+
+      if deferred_offer_confirmation.errors.include?(:course)
+        return provider_interface_deferred_offer_course_path(application_choice)
+      end
+
+      if deferred_offer_confirmation.errors.include?(:location)
+        return provider_interface_deferred_offer_location_path(application_choice)
+      end
+
+      if deferred_offer_confirmation.errors.include?(:study_mode)
+        return provider_interface_deferred_offer_study_mode_path(application_choice)
+      end
+
+      provider_interface_deferred_offer_check_path(application_choice)
+    end
+
+    def offer
+      application_choice.offer
+    end
+
+    def application_choice
+      @application_choice ||= GetApplicationChoicesForProviders.call(
+        providers: current_provider_user.providers,
+      ).find(params.require(:application_choice_id))
+    end
+  end
+end

--- a/app/controllers/provider_interface/deferred_offer/root_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/root_controller.rb
@@ -1,0 +1,12 @@
+class ProviderInterface::DeferredOffer::RootController < ProviderInterface::ProviderInterfaceController
+  include ProviderInterface::DeferredOffer::Navigation
+
+  def show
+    deferred_offer_confirmation = DeferredOfferConfirmation.find_or_initialize_by(
+      provider_user: current_provider_user,
+      offer: offer,
+    )
+
+    redirect_to next_step_path(deferred_offer_confirmation)
+  end
+end

--- a/app/controllers/provider_interface/deferred_offer/study_mode_controller.rb
+++ b/app/controllers/provider_interface/deferred_offer/study_mode_controller.rb
@@ -1,4 +1,6 @@
 class ProviderInterface::DeferredOffer::StudyModeController < ProviderInterface::ProviderInterfaceController
+  include ProviderInterface::DeferredOffer::Navigation
+
   def edit
     @study_mode_form = DeferredOfferConfirmation::StudyModeForm.find_or_initialize_by(
       provider_user: current_provider_user,
@@ -13,7 +15,7 @@ class ProviderInterface::DeferredOffer::StudyModeController < ProviderInterface:
     )
 
     if @study_mode_form.update(study_mode_form_params)
-      redirect_to provider_interface_deferred_offer_check_path(application_choice)
+      redirect_to next_step_path(@study_mode_form)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -23,15 +25,5 @@ private
 
   def study_mode_form_params
     params.expect(deferred_offer_confirmation_study_mode_form: [:study_mode])
-  end
-
-  def offer
-    application_choice.offer
-  end
-
-  def application_choice
-    @application_choice ||= GetApplicationChoicesForProviders.call(
-      providers: current_provider_user.providers,
-    ).find(params.require(:application_choice_id))
   end
 end

--- a/app/views/provider_interface/deferred_offer/checks/show.html.erb
+++ b/app/views/provider_interface/deferred_offer/checks/show.html.erb
@@ -71,9 +71,11 @@
       <%= render ProviderInterface::ConditionsListComponent.new(@deferred_offer.conditions) %>
     </div>
 
-    <%= govuk_button_link_to(
-          'Continue',
-          provider_interface_deferred_offer_conditions_path(@deferred_offer.application_choice),
-        ) %>
+    <%= if @deferred_offer.valid?(:submit)
+          govuk_button_link_to(
+            'Continue',
+            provider_interface_deferred_offer_conditions_path(@deferred_offer.application_choice),
+          )
+        end %>
   </div>
 </div>

--- a/app/views/provider_interface/deferred_offer/courses/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/courses/edit.html.erb
@@ -10,11 +10,15 @@
         <%= render DfE::Autocomplete::View.new(
           form,
           attribute_name: :course_id,
-          form_field: form.govuk_select(
+          form_field: form.govuk_collection_select(
             :course_id,
-            options_for_select(@course_form.course_options, @course_form.course_id),
-            label: { text: t('.page_title'), size: 'xl' },
+            @course_form.courses_for_select,
+            :id,
+            :name_and_code,
+            options: { prompt: '' },
             caption: { text: @course_form.application_choice.application_form.full_name, size: 'xl' },
+            label: { text: t('.page_title'), size: 'xl' },
+            hint: { text: t('.course_id.fieldset_hint') },
             data: { controller: 'autocomplete' },
           ),
         ) %>
@@ -23,11 +27,12 @@
               :course_id,
               @course_form.courses_for_select,
               :id,
-              collection_course_options_with_provider_name,
+              :name_and_code,
               :description,
               bold_labels: false,
-              legend: { text: t('.page_title'), size: 'xl' },
               caption: { text: @course_form.application_choice.application_form.full_name, size: 'xl' },
+              legend: { text: t('.page_title'), size: 'xl' },
+              hint: { text: t('.course_id.fieldset_hint') },
             ) %>
       <% end %>
 

--- a/app/views/provider_interface/deferred_offer/location/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/location/edit.html.erb
@@ -10,13 +10,17 @@
         <%= render DfE::Autocomplete::View.new(
           form,
           attribute_name: :site_id,
-          form_field: form.govuk_select(
-              :site_id,
-              options_for_select(@location_form.locations_for_select, @location_form.site_id),
-              label: { text: t('.page_title'), size: 'xl' },
-              caption: { text: @location_form.application_choice.application_form.full_name, size: 'xl' },
-              data: { controller: 'autocomplete' },
-            ),
+          form_field: form.govuk_collection_select(
+            :site_id,
+            @location_form.locations_for_select,
+            :id,
+            :name_and_address,
+            options: { prompt: '' },
+            caption: { text: @location_form.application_choice.application_form.full_name, size: 'xl' },
+            label: { text: t('.page_title'), size: 'xl' },
+            hint: { text: t('.site_id.fieldset_hint') },
+            data: { controller: 'autocomplete' },
+          ),
         ) %>
       <% else %>
         <%= form.govuk_collection_radio_buttons(
@@ -26,9 +30,9 @@
               :name,
               :description,
               bold_labels: false,
-              legend: { text: t('.page_title'), size: 'xl' },
               caption: { text: @location_form.application_choice.application_form.full_name, size: 'xl' },
-              hint: proc { t('.site_id.fieldset_hint') },
+              legend: { text: t('.page_title'), size: 'xl' },
+              hint: { text: t('.site_id.fieldset_hint') },
             ) %>
       <% end %>
 

--- a/app/views/provider_interface/deferred_offer/study_mode/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/study_mode/edit.html.erb
@@ -12,9 +12,9 @@
             :id,
             :name,
             bold_labels: false,
-            legend: { text: t('.page_title'), size: 'xl' },
             caption: { text: @study_mode_form.application_choice.application_form.full_name, size: 'xl' },
-            hint: proc { t('.study_mode.fieldset_hint') },
+            legend: { text: t('.page_title'), size: 'xl' },
+            hint: { text: t('.study_mode.fieldset_hint') },
           ) %>
 
       <%= form.govuk_submit t('.submit') %>

--- a/config/locales/provider_interface/deferred_offer.yml
+++ b/config/locales/provider_interface/deferred_offer.yml
@@ -14,7 +14,9 @@ en:
       courses:
         edit:
           page_title: Change course
-          submit: Continue
+          course_id:
+            fieldset_hint: You should confirm a place for this candidate on the original course that they accepted an offer for. If you cannot do this you must discuss the change with the candidate before you confirm their deferred offer.
+          submit: Change course
       study_mode:
         edit:
           page_title: Change study type
@@ -64,3 +66,11 @@ en:
           attributes:
             condition_status:
               blank: Select whether the candidate has met all of the conditions
+        deferred_offer_confirmation:
+          attributes:
+            course:
+              not_in_cycle: "is not available in the current cycle"
+            study_mode:
+              not_available_for_course: "is not available for this course"
+            location:
+              not_available_for_course: "is not available for this course"

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -105,6 +105,7 @@ namespace :provider_interface, path: '/provider' do
 
       # Routes for the final submission to confirm the deferral
       # resource :confirm, only: :create, controller: :confirm
+      root 'root#show'
     end
 
     resource :decision, only: %i[new create], as: :application_choice_decision


### PR DESCRIPTION
## Context

We want to guide the User through the process of Confirming a Deferred offer. In the case where the original course is still available in the current cycle, the User is taken directly to the Check page. 

The User can choose to change any part of the deferral. They may only select Study Modes and Locations that are associated to the Course. If they choose to change the Course and either of the previously selected Study Mode or Location is not available, the User will be directed to choose one.

## Changes proposed in this pull request

- Enabled the flow for the confirm deferral process
- Tidied up the UI and select methods
- Refactored controllers to share functionality
- Added a root path for Confirm Deferrals

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


https://github.com/user-attachments/assets/9ebedfc1-a522-42d7-a272-d9a3da28408e



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
