### PR TITLE
Change precision on preferences longitude and latitude fields

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -148,7 +148,7 @@ jobs:
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
-        offset-date: [real_world, after_apply_deadline, before_apply_reopens, after_apply_reopens]
+        offset-date: [real_world, before_apply_reopens, after_apply_reopens]
         # Use these offsets through mid-cycle
         # offset-date: [real_world]
 

--- a/db/migrate/20250918120635_change_precision_on_latitude_and_longitude_floats.rb
+++ b/db/migrate/20250918120635_change_precision_on_latitude_and_longitude_floats.rb
@@ -1,0 +1,15 @@
+class ChangePrecisionOnLatitudeAndLongitudeFloats < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      change_column :candidate_location_preferences, :latitude, :decimal, precision: 12, scale: 8
+      change_column :candidate_location_preferences, :longitude, :decimal, precision: 12, scale: 8
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :candidate_location_preferences, :latitude, :float
+      change_column :candidate_location_preferences, :longitude, :float
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_125509) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_18_120635) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -412,8 +412,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_125509) do
   create_table "candidate_location_preferences", force: :cascade do |t|
     t.string "name", null: false
     t.float "within", null: false
-    t.float "latitude"
-    t.float "longitude"
+    t.decimal "latitude", precision: 12, scale: 8
+    t.decimal "longitude", precision: 12, scale: 8
     t.bigint "candidate_preference_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Context

We are having problems syncing longitude and latitude fields to big query. There is a check in Sidekiq that verifies that `JSON.parse(JSON.dump(item)) == item`

For some floats, this fails (TLDR, JSON.dump uses C to do its magic, but C uses a different protocol for floats, so this fails. For instance `JSON.parse(JSON.dump(51.518959368993855)) => 51.51895936899385` and the check fails.

Fortunately, a decimal point to 6 places is accurate to a meter, so we really don't need this level of precision. 

## Changes proposed in this pull request
Also, the `after_apply_deadline` specs were failing because it was time travelling to the same day twice, but we are now after the apply deadline in real life, so this extra set of tests isn't necessary. 

A migration to change the precision to something that won't fail in the strict_arguments! check in Sidekiq.

## Guidance to review

Note, I've run this against our sanitized production dump and it took `0.4382s` so I'm not concerned about running it in here. 

There are two other tables that use longitude and latitude. 
1. `sites` We ran into this problem when syncing over the 2026 sites, so we just stopped sending the data to big query 
2. `provider` we haven't run into this problem yet, but will put a ticket in the back log to do the same as we've done in this PR.  

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
