### PR TITLE
Change time taken to run reject by default worker

### DIFF
--- a/app/workers/end_of_cycle/reject_by_default_worker.rb
+++ b/app/workers/end_of_cycle/reject_by_default_worker.rb
@@ -3,11 +3,12 @@ module EndOfCycle
     include Sidekiq::Worker
 
     BATCH_SIZE = 120
+    STAGGER_OVER = 1.hour
 
     def perform(force = false)
       return unless EndOfCycle::JobTimetabler.new.run_reject_by_default? || force
 
-      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, applications|
+      BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
         RejectByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end


### PR DESCRIPTION
## Context

We will reject by default about 10k applications, starting at 11:59 tonight. Currently, we stagger the work over 5 hours. There really is no need for it to take that long. Compare with 30k unsubmitted applications which we stagger over 2 hours. 

## Changes proposed in this pull request

Change the stagger over time to be 1 hour instead of the default of 5. 

## Guidance to review

Any objections? Is this too risky, could do it over 90 minutes maybe if people think this is too big of a change. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
