### PR TITLE
Updated the API scopes to view the current and next cycles

### DIFF
--- a/app/services/candidate_api/serializers/v1_1.rb
+++ b/app/services/candidate_api/serializers/v1_1.rb
@@ -4,8 +4,7 @@ module CandidateAPI
       def index_query(updated_since:)
         Candidate
         .left_outer_joins(:application_forms)
-        .where(application_forms: { recruitment_cycle_year: current_timetable.recruitment_cycle_year })
-        .or(Candidate.where('candidates.created_at > ? ', previous_timetable.apply_deadline_at))
+          .where('application_forms.recruitment_cycle_year >= ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
         .distinct
         .includes(application_forms: :application_choices)
         .where('candidate_api_updated_at > ?', updated_since)
@@ -15,8 +14,7 @@ module CandidateAPI
       def find_query(candidate_id:)
         Candidate
           .left_outer_joins(:application_forms)
-          .where(application_forms: { recruitment_cycle_year: current_timetable.recruitment_cycle_year })
-          .or(Candidate.where('candidates.created_at > ? ', previous_timetable.apply_deadline_at))
+          .where('application_forms.recruitment_cycle_year >= ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
           .includes(application_forms: :application_choices)
           .find(candidate_id)
       end

--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -6,7 +6,7 @@ module CandidateAPI
           .left_outer_joins(application_forms: { application_choices: %i[provider course interviews], application_references: [], application_qualifications: [] })
           .includes(application_forms: { application_choices: %i[provider course course_option interviews], application_qualifications: [], application_references: [] })
           .where('candidates.updated_at > :updated_since OR application_forms.updated_at > :updated_since OR application_choices.updated_at > :updated_since OR "references".updated_at > :updated_since OR application_qualifications.updated_at > :updated_since', updated_since:)
-          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
+          .where('application_forms.recruitment_cycle_year >= ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
           .order(id: :asc)
           .distinct
       end
@@ -15,7 +15,7 @@ module CandidateAPI
         Candidate
           .left_outer_joins(application_forms: { application_choices: %i[provider course interviews], application_references: [], application_qualifications: [] })
           .includes(application_forms: { application_choices: %i[provider course course_option interviews], application_qualifications: [], application_references: [] })
-          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
+          .where('application_forms.recruitment_cycle_year >= ? OR candidates.created_at > ?', current_timetable.recruitment_cycle_year, previous_timetable.apply_deadline_at)
           .find(candidate_id)
       end
 


### PR DESCRIPTION
## Context

The GIT CRM integration is failing on some candidates who have skipped a recruitment cycle year - they were last active in 2024 cycle, dormant through 2025, and have now carried over into 2026. The current scopes only looked at the current cycle or the candidate was created in since the end of the last cycle 🙃

## Changes proposed in this pull request

These changes to the scopes are applied to v1.2 as this is the version of the API that GIT CRM team are using. More recent versions, 1.3 and 1.4 have not been used in the past month.

## Guidance to review

- N/A


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
