### PR TITLE
Push previous_teacher_training to vendor api

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -67,8 +67,21 @@ module VendorAPI
           further_information: application_form.further_information,
           safeguarding_issues_status: application_form.safeguarding_issues_status,
           safeguarding_issues_details_url:,
+          previous_teacher_training: [previous_teacher_training],
           anonymised:,
         },
+      }
+    end
+
+    def previous_teacher_training
+      training = application_form.published_previous_teacher_training
+
+      {
+        started: training&.started == 'yes',
+        provider_name: training&.provider_name,
+        started_at: training&.started_at,
+        ended_at: training&.ended_at,
+        details: training&.details,
       }
     end
 

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -547,6 +547,11 @@ components:
           description: URL to Apply system where safeguarding issues disclosed by the candidate can be access by users with permissions to view safeguarding information.
           example: https://apply-for-teacher-training.service.gov.uk/provider/applications/1#criminal-convictions-and-professional-misconduct
           nullable: true
+        previous_teacher_training:
+          type: array
+          items:
+            "$ref": "#/components/schemas/PreviousTeacherTraining"
+          description: The previous teacher training of the candidate, if they have one.
         anonymised:
           type: boolean
           description: Indicates if a candidate has been removed from the Apply service
@@ -936,6 +941,35 @@ components:
           example: 2019-09-18
           maxLength: 10
           nullable: true
+    PreviousTeacherTraining:
+      type: object
+      properties:
+        started:
+          type: boolean
+          description: Indicates if the candidate started a previous teacher training
+          example: true
+        provider_name:
+          type: string
+          nullable: true
+          description: The provider name of the previous teacher training
+          example: 'Provider name'
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: The time the candidate started their previous teacher training
+          example: 2019-09-18T15:33:49.216Z
+        ended_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: The time the candidate left their previous teacher training
+          example: 2019-09-18T15:33:49.216Z
+        details:
+          type: string
+          nullable: true
+          description: Any additional details about the previous teacher training
+          example: 'Additional details'
     Reference:
       type: object
       additionalProperties: false

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -551,7 +551,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/PreviousTeacherTraining"
-          description: The previous teacher training of the candidate, if they have one.
+          description: The previous teacher training declaration of the candidate, including details if the candidate has previous started training.
         anonymised:
           type: boolean
           description: Indicates if a candidate has been removed from the Apply service

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -345,6 +345,8 @@ FactoryBot.define do
 
         references_count { 2 }
         references_state { :feedback_provided }
+
+        previous_teacher_training_started { true }
       end
 
       after(:create) do |application_form, evaluator|
@@ -378,7 +380,20 @@ FactoryBot.define do
         volunteering_experience = build_list(:application_volunteering_experience, evaluator.volunteering_experiences_count)
         application_form.application_volunteering_experiences << volunteering_experience
 
-        create(:previous_teacher_training, status: 'published', application_form:)
+        if evaluator.previous_teacher_training_started
+          create(
+            :previous_teacher_training,
+            status: 'published',
+            application_form:,
+          )
+        else
+          create(
+            :previous_teacher_training,
+            :not_started,
+            status: 'published',
+            application_form:,
+          )
+        end
 
         application_form.update!(updated_at: original_updated_at)
       end
@@ -433,6 +448,11 @@ FactoryBot.define do
           updated_at: CycleTimetableHelper.mid_cycle,
         )
       end
+    end
+
+    trait :not_started_previous_teacher_training do
+      completed
+      previous_teacher_training_started { false }
     end
 
     factory :completed_application_form do

--- a/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
@@ -237,4 +237,42 @@ RSpec.describe 'ApplicationPresenter' do
       end
     end
   end
+
+  describe '#previous_teacher_training' do
+    context 'when previous_teacher_training exists' do
+      let(:application_form) { create(:application_form, :completed) }
+      let(:application_choice) { create(:application_choice, application_form:) }
+
+      it 'returns the previous_teacher_training' do
+        previous_teacher_training = application_form.published_previous_teacher_training
+
+        expect(application_json.dig(:attributes, :previous_teacher_training)).to eq(
+          [{
+            started: true,
+            provider_name: previous_teacher_training.provider_name,
+            started_at: previous_teacher_training.started_at,
+            ended_at: previous_teacher_training.ended_at,
+            details: previous_teacher_training.details,
+          }],
+        )
+      end
+    end
+
+    context 'when previous_teacher_training does not exists' do
+      let(:application_form) { create(:application_form, :not_started_previous_teacher_training) }
+      let(:application_choice) { create(:application_choice, application_form:) }
+
+      it 'returns no previous_teacher_training' do
+        expect(application_json.dig(:attributes, :previous_teacher_training)).to eq(
+          [{
+            started: false,
+            provider_name: nil,
+            started_at: nil,
+            ended_at: nil,
+            details: nil,
+          }],
+        )
+      end
+    end
+  end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -251,6 +251,15 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
         further_information: nil,
         safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
         safeguarding_issues_details_url: Rails.application.routes.url_helpers.provider_interface_application_choice_url(@provider.application_choices.first.id, anchor: 'criminal-convictions-and-professional-misconduct'),
+        previous_teacher_training: [
+          {
+            details: nil,
+            ended_at: nil,
+            provider_name: nil,
+            started: false,
+            started_at: nil,
+          },
+        ],
         anonymised: false,
         work_experience: {
           jobs: [


### PR DESCRIPTION
## Context

This will show the previous_teacher_training on the applications and applications/:id endpoints

If the previous_teacher_training is nil, the started attributes will be false and the rest of the attributes nill.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Hit these to endpoints, can use this token `RtG15kdxW2zisHoHVcWQ`

Also api docs https://apply-review-11217.test.teacherservices.cloud/api-docs/v1.0/reference#previousteachertraining-object

```
# Applications endpoint
curl https://apply-review-11217.test.teacherservices.cloud/api/v1.0/applications?since="2025-09-24" -H "Authorization: Bearer RtG15kdxW2zisHoHVcWQ" | jq

# Specific application endpoint
curl https://apply-review-11217.test.teacherservices.cloud/api/v1.0/applications/159 -H "Authorization: Bearer RtG15kdxW2zisHoHVcWQ" | jq

```


<img width="772" height="264" alt="image" src="https://github.com/user-attachments/assets/b37cfaf3-25e3-418a-ae92-78b75e235ec2" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
