### PR TITLE
[lb/1302] Show previous teacher training to provider and support

### DIFF
--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -2,8 +2,10 @@
 
 <% unless hiding_safeguarding_issues? %>
   <section class="app-section govuk-!-width-two-thirds">
-    <h3 class="govuk-heading-m" id="criminal-convictions-and-professional-misconduct">Criminal record and professional misconduct</h3>
+    <h3 class="govuk-heading-m" id="criminal-convictions-and-professional-misconduct">
+      <%= t('provider_interface.safeguarding_declaration_component.safeguarding_heading_title') %>
+    </h3>
 
-    <%= render SummaryListComponent.new(rows: rows) %>
+    <%= render SummaryListComponent.new(rows:) %>
   </section>
 <% end %>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,11 +1,9 @@
 <%= render ProviderInterface::PermissionsDebugCommentComponent.new(auth_analysis: @analysis) %>
 
-<% unless hiding_safeguarding_issues? %>
-  <section class="app-section govuk-!-width-two-thirds">
-    <h3 class="govuk-heading-m" id="criminal-convictions-and-professional-misconduct">
-      <%= t('provider_interface.safeguarding_declaration_component.safeguarding_heading_title') %>
-    </h3>
+<section class="app-section govuk-!-width-two-thirds">
+  <h3 class="govuk-heading-m" id="criminal-convictions-and-professional-misconduct">
+    <%= t('provider_interface.safeguarding_declaration_component.safeguarding_heading_title') %>
+  </h3>
 
-    <%= render SummaryListComponent.new(rows:) %>
-  </section>
-<% end %>
+  <%= render SummaryListComponent.new(rows:) %>
+</section>

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -37,10 +37,6 @@ module ProviderInterface
       end
     end
 
-    def hiding_safeguarding_issues?
-      application_choice.application_form.never_asked?
-    end
-
     def safeguarding_information
       if current_user_has_permission_to_view_safeguarding_information?
         application_choice.application_form.safeguarding_issues

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -24,7 +24,7 @@ module ProviderInterface
         rows << { key: I18n.t('provider_interface.safeguarding_declaration_component.safeguarding_information'), value: safeguarding_information }
       end
 
-      rows
+      previous_training_rows(rows)
     end
 
   private
@@ -45,8 +45,24 @@ module ProviderInterface
       if current_user_has_permission_to_view_safeguarding_information?
         application_choice.application_form.safeguarding_issues
       else
-        I18n.t('provider_interface.safeguarding_declaration_component.cannot_see_safeguarding_information')
+        t('provider_interface.safeguarding_declaration_component.cannot_see_safeguarding_information')
       end
+    end
+
+    def previous_training_rows(rows)
+      return rows if previous_training_record.blank?
+
+      rows << { key: t('provider_interface.safeguarding_declaration_component.have_you_started'), value: previous_training_record.started.capitalize }
+
+      if previous_training_record.started_yes?
+        rows.tap do |collection|
+          collection << { key: t('provider_interface.safeguarding_declaration_component.name_of_training_provider'), value: previous_training_record.provider_name }
+          collection << { key: t('provider_interface.safeguarding_declaration_component.training_dates'), value: previous_training_record.formatted_dates }
+          collection << { key: t('provider_interface.safeguarding_declaration_component.details'), value: previous_training_record.details }
+        end
+      end
+
+      rows
     end
 
     def current_user_has_permission_to_view_safeguarding_information?
@@ -54,7 +70,15 @@ module ProviderInterface
     end
 
     def safeguarding_issues_declared?
-      application_choice.application_form.has_safeguarding_issues_to_declare?
+      application_form.has_safeguarding_issues_to_declare?
+    end
+
+    def application_form
+      @application_form ||= application_choice.application_form
+    end
+
+    def previous_training_record
+      @previous_training_record ||= @application_form.published_previous_teacher_training
     end
   end
 end

--- a/app/components/support_interface/safeguarding_issues_component.html.erb
+++ b/app/components/support_interface/safeguarding_issues_component.html.erb
@@ -1,2 +1,23 @@
-<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
-<p class="govuk-body"><%= message %></p>
+<section id="safeguarding-section" class="app-section govuk-!-width-two-thirds">
+  <% if previous_training_record.present? %>
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">
+      <%= t('support_interface.safeguarding_issues_component.previous_training_heading') %>
+    </h2>
+
+    <%= govuk_summary_list(actions: false) do |summary_list| %>
+      <% training_rows.each do |training_row| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: training_row[:key]) %>
+          <% row.with_value(text: training_row[:value]) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">
+    <%= t('support_interface.safeguarding_issues_component.criminal_convictions_heading') %>
+  </h2>
+  <p class="govuk-body">
+    <%= message %>
+  </p>
+</section>

--- a/app/components/support_interface/safeguarding_issues_component.rb
+++ b/app/components/support_interface/safeguarding_issues_component.rb
@@ -3,10 +3,38 @@ module SupportInterface
     attr_reader :message
 
     def initialize(application_form:)
+      @application_form = application_form
       @message = SafeguardingStatus.new(
         status: application_form.safeguarding_issues_status,
         i18n_key: 'support_interface.safeguarding_issues_component',
       ).message
+    end
+
+    def previous_training_record
+      @previous_training_record ||= @application_form.published_previous_teacher_training
+    end
+
+    def training_rows
+      return [] if previous_training_record.blank?
+
+      [
+        {
+          key: t('support_interface.safeguarding_issues_component.have_you_started'),
+          value: previous_training_record.started.capitalize,
+        },
+        {
+          key: t('support_interface.safeguarding_issues_component.name_of_training_provider'),
+          value: previous_training_record.provider_name,
+        },
+        {
+          key: t('support_interface.safeguarding_issues_component.training_dates'),
+          value: previous_training_record.formatted_dates,
+        },
+        {
+          key: t('support_interface.safeguarding_issues_component.details'),
+          value: previous_training_record.details,
+        },
+      ].filter { |row| row[:value].present? }
     end
   end
 end

--- a/app/models/previous_teacher_training.rb
+++ b/app/models/previous_teacher_training.rb
@@ -26,6 +26,8 @@ class PreviousTeacherTraining < ApplicationRecord
   end
 
   def formatted_dates
+    return '' if started_at.blank? || ended_at.blank?
+
     "From #{started_at.to_fs(:month_and_year)} to #{ended_at.to_fs(:month_and_year)}"
   end
 end

--- a/config/locales/components/provider_interface/safeguarding_declaration_component.yml
+++ b/config/locales/components/provider_interface/safeguarding_declaration_component.yml
@@ -1,0 +1,9 @@
+en:
+  provider_interface:
+    safeguarding_declaration_component:
+      safeguarding_heading_title: Safeguarding
+      have_you_started: Have you started an initial teacher training course (ITT) before?
+      name_of_training_provider: Name of the training provider
+      training_dates: Training dates
+      details: Details
+

--- a/config/locales/provider_interface/safeguarding.yml
+++ b/config/locales/provider_interface/safeguarding.yml
@@ -6,3 +6,8 @@ en:
       cannot_see_safeguarding_information: You cannot view this because you do not have permission to view criminal record and professional misconduct information.
       has_safeguarding_issues_to_declare: Yes, I want to declare something
       no_safeguarding_issues_to_declare: "No"
+      safeguarding_heading_title: Safeguarding
+      have_you_started: Have you started an initial teacher training course (ITT) before?
+      name_of_training_provider: Name of the training provider
+      training_dates: Training dates
+      details: Details

--- a/config/locales/support_interface/safeguarding_issues.yml
+++ b/config/locales/support_interface/safeguarding_issues.yml
@@ -5,3 +5,10 @@ en:
       not_answered_yet: Not answered yet.
       never_asked: Never asked.
       no_safeguarding_issues_to_declare: The candidate has declared no criminal convictions or other safeguarding issues.
+      criminal_convictions_heading: Criminal convictions and professional misconduct
+      previous_training_heading: Previous teacher training
+      have_you_started: Have you started an initial teacher training course (ITT) before?
+      name_of_training_provider: Name of the training provider
+      training_dates: Training dates
+      details: Details
+

--- a/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
+++ b/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
@@ -8,9 +8,26 @@ module ProviderInterface
       render_component
     end
 
+    def can_view__with_previous_training
+      find_user_and_course safeguarding_access: true
+      build_application_choice :minimum_info
+      FactoryBot.create(
+        :previous_teacher_training,
+        :published,
+        application_form: @application_choice.application_form,
+      )
+      render_component
+    end
+
     def can_view__with_no_safeguarding_issues
       find_user_and_course safeguarding_access: true
       build_application_choice :minimum_info
+      FactoryBot.create(
+        :previous_teacher_training,
+        :not_started,
+        :published,
+        application_form: @application_choice.application_form,
+      )
       render_component
     end
 

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
     )
 
     if previous_training_status == 'no'
-      create(:previous_teacher_training, :started_no, application_form:)
+      create(:previous_teacher_training, :not_started, :published, application_form:)
     end
 
     if previous_training_status == 'yes'

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
           safeguarding_issues: nil,
           safeguarding_issues_status: 'never_asked',
         )
-        expect(result.text).not_to include('Criminal record and professional misconduct')
-        expect(result.text).not_to include('Never asked')
+        expect(result.text).to include('Safeguarding')
+        expect(result.text).to include('No')
       end
     end
 

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -48,12 +48,21 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
     provider_user.provider_permissions.update_all(manage_organisations: status)
   end
 
-  def render_component(user:, safeguarding_issues:, safeguarding_issues_status:)
+  def render_component(user:, safeguarding_issues:, safeguarding_issues_status:, previous_training_status: 'no')
     application_form = create(
       :application_form,
       safeguarding_issues:,
       safeguarding_issues_status:,
     )
+
+    if previous_training_status == 'no'
+      create(:previous_teacher_training, :started_no, application_form:)
+    end
+
+    if previous_training_status == 'yes'
+      create(:previous_teacher_training, :published, application_form:)
+    end
+
     application_choice = create(
       :application_choice,
       application_form:,
@@ -240,6 +249,51 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
       )
       expect_user_cannot_see_safeguarding_information(result)
+    end
+  end
+
+  describe 'previous training content' do
+    let(:provider_user) { create(:provider_user, providers: [ratifying_provider]) }
+
+    before do
+      one_sided_permissions(side_with_access: :training_provider, setup_at: nil)
+
+      user_has_view_safeguarding_information(true)
+      user_has_manage_organisations(true)
+    end
+
+    context 'candidate has a previous training record and no previous training' do
+      it 'shows the previous training row only' do
+        result = render_component(
+          user: provider_user,
+          safeguarding_issues: 'I have a criminal conviction.',
+          safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+          previous_training_status: 'no',
+        )
+
+        expect(result).to have_css('.govuk-summary-list__row', text: 'Have you started an initial teacher training course (ITT) before? No')
+        expect(result).to have_no_css 'Name of the training provider'
+        expect(result).to have_no_text 'Training dates'
+      end
+    end
+
+    context 'candidate has previous training record and previous training' do
+      it 'show previous training record details' do
+        result = render_component(
+          user: provider_user,
+          safeguarding_issues: 'I have a criminal conviction.',
+          safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+          previous_training_status: 'yes',
+        )
+
+        expect(result).to have_css(
+          '.govuk-summary-list__row',
+          text: 'Have you started an initial teacher training course (ITT) before? Yes',
+        )
+        expect(result).to have_css('.govuk-summary-list__key', text: 'Name of the training provider')
+        expect(result).to have_css('.govuk-summary-list__key', text: 'Training dates')
+        expect(result).to have_css('.govuk-summary-list__key', text: 'Details')
+      end
     end
   end
 end

--- a/spec/factories/previous_teacher_training.rb
+++ b/spec/factories/previous_teacher_training.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
       ended_at { nil }
       details { nil }
     end
+
+    trait :published do
+      status { 'published' }
+    end
   end
 end

--- a/spec/system/provider_interface/see_individual_application_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_personal_statement_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
   end
 
   def and_i_will_not_see_the_safeguarding_declaration_details
-    expect(page).to have_content('Criminal record and professional misconduct')
+    expect(page).to have_content('Safeguarding')
     expect(page).to have_no_content('View information disclosed by the candidate')
   end
 
   def then_i_will_see_the_safeguarding_declaration_section
-    expect(page).to have_content('Criminal record and professional misconduct')
+    expect(page).to have_content('Safeguarding')
     expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
   end
 


### PR DESCRIPTION
## Context

Candidates can now declare whether or not they have started teacher training in the past. We need to show that information to providers and support. 

We are showing this to anyone with access to the application, not filtering out for people with permission to see safeguarding information in the way we do safeguarding declarations. 

## Changes proposed in this pull request

### Support interface
| Before | After |
| ------ | ------ |
| <img width="680" height="157" alt="image" src="https://github.com/user-attachments/assets/66e67643-0a17-4fbd-ae43-4402fe87da9d" /> | <img width="662" height="447" alt="image" src="https://github.com/user-attachments/assets/7471b372-9814-4229-b519-12701615807b" /> |

### Provider interface
| Before | After |
| ------ | ------ |
| <img width="929" height="246" alt="image" src="https://github.com/user-attachments/assets/df1f0b3a-6aab-45c4-acf0-55085367049a" /> | <img width="911" height="471" alt="image" src="https://github.com/user-attachments/assets/6dce38e1-efca-42f1-9fea-ea8598bf068a" /> |

## Guidance to review

In the review app, you can view changes to the provider `SafeguardingDeclarationComponent` with various scenarios.

View applications with various training states:
- With previous training (started? yes): https://apply-review-11221.test.teacherservices.cloud/support/applications/74
- With previous training (started? no): https://apply-review-11221.test.teacherservices.cloud/support/applications/72
- Without previous training record: https://apply-review-11221.test.teacherservices.cloud/support/applications/76


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
