### PR TITLE
Bug: Do not carry over invalid safeguarding status

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -118,6 +118,14 @@ class DuplicateApplication
         )
         new_application_form.update!(previous_teacher_training_completed: true)
       end
+
+      if original_application_form.never_asked?
+        new_application_form.update!(
+          safeguarding_issues_completed: nil,
+          safeguarding_issues_status: 'not_answered_yet',
+          safeguarding_issues_completed_at: nil,
+        )
+      end
     end
   end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -206,4 +206,20 @@ RSpec.describe DuplicateApplication do
       expect(duplicate_application_form.application_references).to all(be_feedback_provided.or(be_not_requested_yet))
     end
   end
+
+  context 'when application form has safeguarding status as never asked' do
+    before do
+      @original_application_form.update!(
+        safeguarding_issues_status: 'never_asked',
+        safeguarding_issues_completed: true,
+        safeguarding_issues_completed_at: 1.second.ago,
+      )
+    end
+
+    it 'reverts safeguarding issues completed status to false and removes the status' do
+      expect(duplicate_application_form.safeguarding_issues_completed).to be_nil
+      expect(duplicate_application_form.safeguarding_issues_completed_at).to be_nil
+      expect(duplicate_application_form.safeguarding_issues_status).to eq 'not_answered_yet'
+    end
+  end
 end


### PR DESCRIPTION
## Context

There are three 2024 applications with a safeguarding status of 'never asked'. One of them carried over to 2025 -- the section was marked as completed and they were able to submit without ever having been asked about safeguarding. (currently awaiting provider decision, will be rejected this evening, reject by default date)

## Changes proposed in this pull request

This PR makes sure that if anyone has a 'never_asked' status for safeguarding, they will need to complete that section again. 

## Guidance to review

Locally, find a 2025 application in 2025 with 'never_asked' as safeguarding_issues_status. Carry over their application to 2026. You should need to complete the safeguarding section again. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
