### PR TITLE
Remove previous_teacher_training & pool_application when deleting application

### DIFF
--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -46,6 +46,7 @@ class DeleteApplication
     application_references
     application_work_history_breaks
     application_feedback
+    previous_teacher_trainings
   ].freeze
 
   def initialize(actor:, application_form:, zendesk_url:, force: false)
@@ -71,6 +72,7 @@ class DeleteApplication
         application_form.candidate.update!(email_address: "deleted-application-#{reference}@example.com")
         application_form.candidate.one_login_auth&.delete
         application_form.candidate.sessions&.destroy_all
+        application_form.candidate_pool_application&.delete
 
         application_form.own_and_associated_audits.destroy_all
         add_audit_event_for_deletion!

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe DeleteApplication do
       expect { session.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it 'deletes candidate_pool_application' do
+      candidate_pool_application = create(:candidate_pool_application, application_form:)
+
+      service.call!
+
+      expect { candidate_pool_application.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it 'replaces all audits with a single entry documenting the deletion' do
       service.call!
 


### PR DESCRIPTION


## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
