### PR TITLE
Fix invite status bug

### DIFF
--- a/app/services/candidate_interface/invite_application.rb
+++ b/app/services/candidate_interface/invite_application.rb
@@ -21,10 +21,9 @@ module CandidateInterface
       )
 
       if invite.present? && application_choice.persisted?
-        invite.update!(
-          application_choice_id: application_choice.id,
-          candidate_decision: 'accepted',
-        )
+        invite.application_choice_id = application_choice.id
+        invite.candidate_decision = calculate_candidate_decision(invite)
+        invite.save!
       end
     end
 
@@ -33,10 +32,9 @@ module CandidateInterface
     end
 
     def accept_and_link_to_choice!
-      @invite.update!(
-        application_choice:,
-        candidate_decision: 'accepted',
-      )
+      @invite.application_choice_id = application_choice.id
+      @invite.candidate_decision = calculate_candidate_decision(@invite)
+      @invite.save!
     end
 
     def self.unlink_invites_from_choice(application_choice:)
@@ -44,10 +42,23 @@ module CandidateInterface
     end
 
     def unlink_invites_from_choice
-      application_choice.published_invites.update_all(
-        application_choice_id: nil,
-        candidate_decision: 'not_responded',
-      )
+      ActiveRecord::Base.transaction do
+        application_choice.published_invites.each do |invite|
+          invite.application_choice_id = nil
+          invite.candidate_decision = calculate_candidate_decision(invite)
+          invite.save!
+        end
+      end
+    end
+
+    def calculate_candidate_decision(invite)
+      if invite.application_choice_id.nil? && invite.invite_decline_reasons.any?
+        'declined'
+      elsif invite.application_choice_id.nil?
+        'not_responded'
+      elsif invite.application_choice.present?
+        'accepted'
+      end
     end
 
   private
@@ -56,12 +67,18 @@ module CandidateInterface
       # When a candidate creates a draft choice for invited course and changes course to a non invited course
       # We then need to remove the link between the choice and the invite
       if application_choice.current_course == application_choice.original_course
-        application_choice.published_invites.where.not(
-          course_id: application_choice.current_course.id,
-        ).update_all(
-          application_choice_id: nil,
-          candidate_decision: 'not_responded',
-        )
+
+        ActiveRecord::Base.transaction do
+          invites = application_choice.published_invites.where.not(
+            course_id: application_choice.current_course.id,
+          )
+
+          invites.each do |invite|
+            invite.application_choice_id = nil
+            invite.candidate_decision = calculate_candidate_decision(invite)
+            invite.save!
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

There is a bug in the way we set the candidate_decision when a candidate
declined an invite and then creates an application choice for the invited course.

This sets the candidate_decision to `accepted`. But when they delete
their that application choice or they change the course. We need to set
the candidate_decision back to `declined` if they declined it in the
first place.

We know they declined it because we still have a declined reason
attached to the invite, even if the candidate decides to create an
application choice for the invited course, triggering a change in
candidate_decision to `accepted`

Previously we would set the candidate_decision back to `not_responded`.

This was a problem as the candidate already responded to the invite, by
declining. So they will not get any chasers or banners prompting them to
respond to the invite.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Before 


https://github.com/user-attachments/assets/1a520941-f92e-4977-bc88-94936941d305



After

https://github.com/user-attachments/assets/031ce233-0602-4505-a74b-8dfd161744df


You can go on review app and impersonate `stanford.o'connell4319@example.com` https://apply-review-11231.test.teacherservices.cloud/support/applications/78. They have a few invites you can play with.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

