### PR TITLE
Send pool opt_in confirmation email 

### DIFF
--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -18,6 +18,7 @@ module CandidateInterface
         end
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
         current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
+        PreferencesEmail.call(preference: @preference)
       end
 
       flash[:success] = if @preference.opt_in?

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -556,8 +556,6 @@ class CandidateMailer < ApplicationMailer
   end
 
   def pool_opt_in(application_form)
-    return if application_form.emails.where(mail_template: 'pool_opt_in').present?
-
     @share_details_url = candidate_interface_share_details_url
     @update_preferences_url = candidate_interface_draft_preference_publish_preferences_url(
       application_form.published_preference,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -555,6 +555,22 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def pool_opt_in(application_form)
+    return if application_form.emails.where(mail_template: 'pool_opt_in').present?
+
+    @share_details_url = candidate_interface_share_details_url
+    @update_preferences_url = candidate_interface_draft_preference_publish_preferences_url(
+      application_form.published_preference,
+    )
+    @application_sharing_url = candidate_interface_invites_url
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.pool_opt_in.subject'),
+      layout: false,
+    )
+  end
+
 private
 
   def email_for_candidate(application_form, args = {})

--- a/app/services/candidate_interface/preferences_email.rb
+++ b/app/services/candidate_interface/preferences_email.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class PreferencesEmail
+    attr_reader :preference, :application_form
+
+    def initialize(preference:)
+      @preference = preference
+      @application_form = preference.application_form
+    end
+
+    def self.call(preference:)
+      new(preference:).call
+    end
+
+    def call
+      if preference.opt_in? && send_first_opt_in_email?
+        CandidateMailer.pool_opt_in(application_form).deliver_later
+      end
+    end
+
+  private
+
+    def send_first_opt_in_email?
+      application_form.emails.where(mail_template: 'pool_opt_in').blank?
+    end
+  end
+end

--- a/app/views/candidate_mailer/pool_opt_in.text.erb
+++ b/app/views/candidate_mailer/pool_opt_in.text.erb
@@ -1,0 +1,41 @@
+Dear <%= @application_form.first_name %>,
+
+You have chosen to share your application details with training providers who have spaces on their courses. [Read more about how application sharing works](<%= @share_details_url %>).
+
+[Change your decision or update your preferences](<%= @update_preferences_url %>)
+
+## What is application sharing?
+When you have no other applications in progress, your details will be visible in a list that training providers can search through.
+
+They can see your:
+* qualifications
+* work history and unpaid experience
+* most recent personal statement
+* basic information about where you have applied to before, including the name of the training provider and the subject you applied for
+
+If you meet the criteria for courses that they have spaces on, they can send you an invitation to submit an application.
+
+You can decide whether you want to submit an application or not. If you do, then the provider will treat it the same as other applications they receive and decide whether to offer you an interview or not.
+
+^ Do not wait to be invited to apply. Providers offer places on their courses throughout the year and there is a risk that you will not receive any offers if you wait to be invited to apply.
+
+## Will courses I’m invited to be relevant?
+Training providers will filter the list of candidates by:
+* the subjects you have applied for in the past
+* whether you are interested in full or part-time courses
+* whether you would apply for fee-paying or salaried courses only
+* the location that you have said you can train in
+
+This means you should only get invitations to courses that meet your needs. You can [update your preferences](<%= @update_preferences_url %>) to receive more relevant invitations.
+
+## When am I visible in the list?
+Training providers cannot invite candidates who have applications in progress with another training provider. This would give some training providers an unfair advantage in recruitment.
+
+So that the courses you have applied to can have time to review your application properly, we will hide you from other training providers until they have made a decision.
+
+This means that you will only be available for other training providers to invite you to apply to their courses when all of your applications are either:
+* withdrawn by either you or the training provider
+* rejected
+* inactive - which means that the training provider has taken more than 30 working days to make a decision.
+
+You can change your mind about sharing your details or update your preferences in the [application sharing tab in Apply for teacher training courses](<%=  @application_sharing_url %>).

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -1,5 +1,7 @@
 en:
   candidate_mailer:
+    pool_opt_in:
+      subject: You have opted-in to application sharing
     reference_received:
       subject: "%{referee_name} has given you a reference"
     application_choice_submitted:

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -124,6 +124,7 @@ en:
             candidate_invite: Find a candidate invitation email.
             candidate_invite_limit_reached: Find a candidate invitation email when candidate reaches the maximum invites allowed.
             invites_chaser: Chaser email for candidates to respond to their invites if they are out of the pool because they didn't respond
+            pool_opt_in: Email sent the first time the candidate opts into the pool
           provider_mailer:
             application_submitted: Missing description
             application_submitted_with_safeguarding_issues: Missing description

--- a/spec/mailers/previews/candidate/find_a_candidate_preview.rb
+++ b/spec/mailers/previews/candidate/find_a_candidate_preview.rb
@@ -85,4 +85,20 @@ class Candidate::FindACandidatePreview < ActionMailer::Preview
 
     CandidateMailer.invites_chaser([invite, second_invite])
   end
+
+  def pool_opt_in
+    candidate = FactoryBot.create(:candidate)
+    application_form = FactoryBot.create(
+      :application_form,
+      :minimum_info,
+      candidate:,
+      first_name: 'Fred',
+    )
+    FactoryBot.create(
+      :candidate_preference,
+      application_form:,
+    )
+
+    CandidateMailer.pool_opt_in(application_form)
+  end
 end

--- a/spec/services/candidate_interface/preferences_email_spec.rb
+++ b/spec/services/candidate_interface/preferences_email_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PreferencesEmail do
+  let(:preference) { create(:candidate_preference) }
+  let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+  describe '.call' do
+    context 'when opt_in and first email has not sent' do
+      before { allow(CandidateMailer).to receive(:pool_opt_in).and_return(mailer) }
+
+      it 'calls CandidateMailer.pool_opt_in' do
+        described_class.call(preference:)
+
+        expect(CandidateMailer).to have_received(:pool_opt_in).with(
+          preference.application_form,
+        )
+        expect(mailer).to have_received(:deliver_later)
+      end
+    end
+
+    context 'when opt_in and first email has been sent' do
+      let(:email) { create(:email, mail_template: 'pool_opt_in') }
+      let(:preference) do
+        create(
+          :candidate_preference,
+          application_form: email.application_form,
+        )
+      end
+
+      before { allow(CandidateMailer).to receive(:pool_opt_in).and_return(mailer) }
+
+      it 'calls CandidateMailer.pool_opt_in' do
+        described_class.call(preference:)
+
+        expect(CandidateMailer).not_to have_received(:pool_opt_in).with(
+          preference.application_form,
+        )
+      end
+    end
+
+    context 'when opt_out' do
+      let(:preference) { create(:candidate_preference, pool_status: 'opt_out') }
+
+      before { allow(CandidateMailer).to receive(:pool_opt_in).and_return(mailer) }
+
+      it 'calls CandidateMailer.pool_opt_in' do
+        described_class.call(preference:)
+
+        expect(CandidateMailer).not_to have_received(:pool_opt_in).with(
+          preference.application_form,
+        )
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Docs' do
       candidate_mailer-offer_50_day
       candidate_mailer-candidate_invite
       candidate_mailer-invites_chaser
+      candidate_mailer-pool_opt_in
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

We want to send a confirmation email to candidates opting in. This email will only be sent once.

The candidate can opt out and opt in again, in this case we won't be sending this email again.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Email preview
https://apply-review-11236.test.teacherservices.cloud/rails/mailers/candidate/find_a_candidate/pool_opt_in

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
