### PR TITLE
Rubocop config - stop using frozen string literal magic comment at the top of files

### DIFF
--- a/app/components/candidate_interface/interview_bookings_component.rb
+++ b/app/components/candidate_interface/interview_bookings_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::InterviewBookingsComponent < ViewComponent::Base
   attr_accessor :interview
 

--- a/app/components/candidate_interface/interview_bookings_item_component.rb
+++ b/app/components/candidate_interface/interview_bookings_item_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::InterviewBookingsItemComponent < ViewComponent::Base
   attr_accessor :interview
 

--- a/app/components/candidate_interface/provider_contact_information_component.rb
+++ b/app/components/candidate_interface/provider_contact_information_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::ProviderContactInformationComponent < ViewComponent::Base
   def initialize(provider:)
     @provider = provider

--- a/app/components/publications/data_table_component.rb
+++ b/app/components/publications/data_table_component.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Publications
   class DataTableComponent < ViewComponent::Base
     attr_reader :caption, :title, :data

--- a/app/lib/filtered_mail_payload.rb
+++ b/app/lib/filtered_mail_payload.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class FilteredMailPayload
   attr_reader :formatter
 

--- a/app/models/concerns/adviser_eligibility.rb
+++ b/app/models/concerns/adviser_eligibility.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module AdviserEligibility
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/has_applicable_degree_for_adviser.rb
+++ b/app/models/concerns/has_applicable_degree_for_adviser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module HasApplicableDegreeForAdviser
   extend ActiveSupport::Concern
 

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::ChoicesControllerMatcher
   APPLICATION_CHOICE_CONTROLLER_PATHS = [
     'candidate_interface/course_choices', # the course choice wizard

--- a/app/workers/support/candidates/bulk_unsubscribe_worker.rb
+++ b/app/workers/support/candidates/bulk_unsubscribe_worker.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Support::Candidates::BulkUnsubscribeWorker
   include Sidekiq::Worker
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Devise.setup do |config|
   require 'devise/orm/active_record'
 

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if HostingEnvironment.test_environment? && HostingEnvironment.environment_name != 'test' && ENV.fetch('RACK_MINI_PROFILER', nil) == 'true'
   require 'rack-mini-profiler'
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 return unless defined? SemanticLogger
 
 unless Rails.env.local?

--- a/config/initializers/timeliness.rb
+++ b/config/initializers/timeliness.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Time formats for timeliness are defined here: https://github.com/adzap/timeliness/blob/master/lib/timeliness/definitions.rb
 
 Timeliness.add_formats('time', 'h[.]?')             # Allow 12/24 hour time with no minutes e.g. 14 = 2:00pm, 5 = 5am

--- a/config/rubocop/config/style.yml
+++ b/config/rubocop/config/style.yml
@@ -58,7 +58,7 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  EnforcedStyle: never
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma

--- a/spec/components/previews/candidate_interface/application_choice_item_component_preview.rb
+++ b/spec/components/previews/candidate_interface/application_choice_item_component_preview.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::ApplicationChoiceItemComponentPreview < ViewComponent::Preview
   def unsubmitted
     render_component(:unsubmitted)

--- a/spec/components/previews/candidate_interface/invites/decline_reasons_success_flash_component_preview.rb
+++ b/spec/components/previews/candidate_interface/invites/decline_reasons_success_flash_component_preview.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::Invites::DeclineReasonsSuccessFlashComponentPreview < ViewComponent::Preview
   include ViewComponent::TestHelpers
 

--- a/spec/components/previews/candidate_interface/other_qualifications_review_component_preview.rb
+++ b/spec/components/previews/candidate_interface/other_qualifications_review_component_preview.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::OtherQualificationsReviewComponentPreview < ViewComponent::Preview
   def no_a_levels
     render(

--- a/spec/components/previews/candidate_interface/provider_contact_information_component_preview.rb
+++ b/spec/components/previews/candidate_interface/provider_contact_information_component_preview.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CandidateInterface::ProviderContactInformationComponentPreview < ViewComponent::Preview
   def default
     provider = Provider.new(email_address: 'email@gmail.com', phone_number: '0800 123 4567')


### PR DESCRIPTION
## Context

We no longer need the `frozen_string_literal: true` magic comment at the top of each file. The need for it went away with ruby 3.4, and we are on ruby 3.4.4.

## Changes proposed in this pull request

Rubocop configuration, and then run with the rule set to never require the magic comment. 

## Guidance to review

Any concerns? Objections?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
