### PR TITLE
Add confirmation page for pool_opt in

### DIFF
--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -5,6 +5,8 @@ module CandidateInterface
     before_action :set_back_path, only: %i[edit update]
     before_action :redirect_to_root_path_if_flag_is_inactive
 
+    def show; end
+
     def new
       @back_path = if just_submitted?
                      candidate_interface_application_choices_path

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -21,11 +21,7 @@ module CandidateInterface
         PreferencesEmail.call(preference: @preference)
       end
 
-      flash[:success] = if @preference.opt_in?
-                          t('.success_opt_in')
-                        else
-                          t('.success_opt_out')
-                        end
+      flash[:success] = t('.success_opt_out') if @preference.opt_out?
 
       # This will have no effect if the candidate has not been sent the email
       exp = FieldTest::Experiment.find('find_a_candidate/candidate_feature_launch_email')
@@ -35,7 +31,7 @@ module CandidateInterface
         exp.convert(current_candidate, goal: :opt_out)
       end
 
-      redirect_to candidate_interface_invites_path
+      redirect_to show_candidate_interface_pool_opt_ins_path
     end
 
   private

--- a/app/views/candidate_interface/pool_opt_ins/show.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for :browser_title, t('.title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text: t('.title'), text: t('.panel_body')) %>
+
+    <p class="govuk-body">
+      <%= t('.email_html', email_address: govuk_mail_to(current_candidate.email_address)) %>
+    </p>
+
+    <p class="govuk-body">
+      <%= t('.guidance') %>
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        t('.change_preferences'),
+        candidate_interface_draft_preference_publish_preferences_path(
+          current_application.published_preference,
+        ),
+      ) %>
+    </p>
+
+    <h2 class='govuk-heading-m'><%= t('.what_happens_next') %></h2>
+
+    <%= govuk_list(
+      [
+        t('.pool_visibility_criteria_1'),
+        t('.pool_visibility_criteria_2'),
+        t('.pool_visibility_criteria_3'),
+        t('.pool_visibility_criteria_4'),
+      ],
+      type: :bullet,
+    ) %>
+
+    <%= govuk_inset_text(text: t('.application_guidance')) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        t('.sharing_application_guidance'),
+        candidate_interface_share_details_path,
+      ) %>
+    </p>
+  </div>
+</div>

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -2,7 +2,6 @@ en:
   candidate_interface:
     publish_preferences:
       create:
-        success_opt_in: You are sharing your application details with providers you have not applied to
         success_opt_out: You are not sharing your application details with providers you have not applied to
       show:
         title: Check your application sharing preferences
@@ -56,16 +55,23 @@ en:
         fee_funding_type: Courses with fees to pay and salaried courses
         salary_funding_type: Salaried courses only
     pool_opt_ins:
+      show:
+        title: You have chosen to share your application details
+        panel_body: You have also set your preferences
+        email_html: We have sent a confirmation email to %{email_address}
+        guidance: So that the course you have just applied to has time to review your application properly, we will not share your details until they have made a decision.  
+        change_preferences: Change your application sharing preferences
+        what_happens_next: What happens next? 
+        pool_visibility_criteria_1: If all of the applications that you have submitted yourself are unsuccessful, your details will be visible to other training providers.
+        pool_visibility_criteria_2: If a training provider sees your information and thinks you could be a good fit for a course that they have spaces on, they can send you an invitation to apply.
+        pool_visibility_criteria_3: If you want to apply to the course, you can draft and submit an application.
+        pool_visibility_criteria_4: The provider will review your application and decide whether to invite you to interview.
+        application_guidance: Do not wait to be invited to apply to courses. You should continue to search for and apply to courses yourself.
+        sharing_application_guidance: Find out more about how application sharing works  
       new:
         title: Do you want to make your application details visible to other training providers?
       edit:
         title: Do you want to make your application details visible to other training providers?
-      show:
-        title: Check your application sharing preferences
-        share_information: Do you want to be invited to apply to similar courses?
-        preferred_locations: Areas you can train in
-        change: Change
-        submit: Submit preferences
       create:
         opt_out_message: You are not sharing your application details with providers you have not applied to
       update:

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -36,7 +36,11 @@ namespace :candidate_interface, path: '/candidate' do
 
   resources :share_details, only: :index, path: 'share-details'
 
-  resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in'
+  resources :pool_opt_ins, only: %i[new create edit update], path: 'preferences-opt-in' do
+    collection do
+      get 'show', as: :show
+    end
+  end
   resources :draft_preferences, only: %i[show update], path: 'preferences' do
     resources :training_locations, only: %i[new create], path: 'training-locations'
     resources :location_preferences, path: 'location-preferences'

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Candidate adds preferences' do
     when_i_click('Update your preferences')
     then_i_am_redirected_to_review_page
     when_i_click('Submit preferences')
-    then_i_am_redirected_to_application_choices_with_success_message
+    then_i_am_redirected_to_confirmation_page
     and_my_duplicate_preference_is_published
   end
 
@@ -89,9 +89,9 @@ RSpec.describe 'Candidate adds preferences' do
     end
   end
 
-  def then_i_am_redirected_to_application_choices_with_success_message
-    expect(page).to have_current_path(candidate_interface_invites_path)
-    expect(page).to have_content('You are sharing your application details with providers you have not applied to')
+  def then_i_am_redirected_to_confirmation_page
+    expect(page).to have_current_path(show_candidate_interface_pool_opt_ins_path)
+    expect(page).to have_content('You have chosen to share your application details')
   end
 
   def and_my_duplicate_preference_is_published

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Candidate adds preferences' do
     when_i_click('Continue')
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_to_invites_path_with_success_message
+    then_i_am_redirected_to_confirmation_page
   end
 
   scenario 'Candidate opts in to find a candidate with specific locations and applied to fee funded courses' do
@@ -137,7 +137,7 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_review_page
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_to_invites_path_with_success_message
+    then_i_am_redirected_to_confirmation_page
   end
 
   scenario 'Candidate opts in to find a candidate for anywhere in England' do
@@ -164,7 +164,7 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_review_page_without_locations
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_to_invites_path_with_success_message
+    then_i_am_redirected_to_confirmation_page
   end
 
   scenario 'Candidate opts in to find a candidate for anywhere in England and applied to fee funded courses' do
@@ -187,7 +187,7 @@ RSpec.describe 'Candidate adds preferences' do
     then_i_am_redirected_to_review_page_without_locations
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_to_invites_path_with_success_message
+    then_i_am_redirected_to_confirmation_page
   end
 
   scenario 'Candidate edits radius on a dynamic location with invalid site data' do
@@ -277,7 +277,7 @@ RSpec.describe 'Candidate adds preferences' do
     when_i_check_yes_fee_funding_courses
     when_i_click('Continue')
     and_i_click('Submit preferences')
-    then_i_am_redirected_to_invites_path_with_success_message
+    then_i_am_redirected_to_confirmation_page
   end
 
   def and_i_opt_in_to_find_a_candidate
@@ -433,9 +433,9 @@ RSpec.describe 'Candidate adds preferences' do
     expect(page).to have_current_path(candidate_interface_invites_path)
   end
 
-  def then_i_am_redirected_to_invites_path_with_success_message
-    expect(page).to have_current_path(candidate_interface_invites_path)
-    expect(page).to have_content('You are sharing your application details with providers you have not applied to')
+  def then_i_am_redirected_to_confirmation_page
+    expect(page).to have_current_path(show_candidate_interface_pool_opt_ins_path)
+    expect(page).to have_content('You have chosen to share your application details')
   end
 
   def then_i_get_an_error(error_message)

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Candidate edits published preference' do
     when_i_click('Continue')
     then_i_am_redirected_to_preference_review_page
     when_i_click('Submit preferences')
-    then_i_am_redirected_on_the_invites_path
+    then_i_am_redirected_to_the_confirmation_page
     and_the_candidate_preference_id_is_changed
   end
 
@@ -70,7 +70,7 @@ RSpec.describe 'Candidate edits published preference' do
     then_i_am_redirected_to_preference_review_page
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_on_the_invites_path
+    then_i_am_redirected_to_the_confirmation_page
     and_the_candidate_preference_id_is_changed
     and_there_are_no_location_preferences
   end
@@ -90,7 +90,7 @@ RSpec.describe 'Candidate edits published preference' do
     then_i_am_redirected_to_preference_review_page
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_on_the_invites_path
+    then_i_am_redirected_to_the_confirmation_page
     and_the_candidate_preference_id_is_changed
     and_only_interested_in_salary_courses
   end
@@ -110,28 +110,25 @@ RSpec.describe 'Candidate edits published preference' do
     then_i_am_redirected_to_preference_review_page
 
     when_i_click('Submit preferences')
-    then_i_am_redirected_on_the_invites_path
+    then_i_am_redirected_to_the_confirmation_page
     and_the_candidate_preference_id_is_changed
     and_only_interested_in_salary_courses
   end
 
   def given_i_am_signed_in(funding_type: 'fee')
     given_i_am_signed_in_with_one_login
-    @application = create(
-      :application_form,
-      :completed,
-      candidate: @current_candidate,
-    )
+
     course = create(:course, provider:, funding_type:)
     @choice = create(
       :application_choice,
       :awaiting_provider_decision,
-      application_form: @application,
+      application_form: @current_candidate.current_application,
       course_option: create(:course_option, course:),
     )
     @existing_candidate_preference = create(
       :candidate_preference,
       candidate: @current_candidate,
+      application_form: @current_candidate.current_application,
       status: 'published',
       training_locations: 'specific',
       dynamic_location_preferences: true,
@@ -180,6 +177,10 @@ RSpec.describe 'Candidate edits published preference' do
 
   def then_i_am_redirected_on_the_invites_path
     expect(page).to have_current_path(candidate_interface_invites_path)
+  end
+
+  def then_i_am_redirected_to_the_confirmation_page
+    expect(page).to have_current_path(show_candidate_interface_pool_opt_ins_path)
   end
 
   def and_the_candidate_preference_id_is_changed


### PR DESCRIPTION
## Context

We want to send the user to a dedicated confirmation page when they opt into the pool where we can explain how the find a candidate works better.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Can go on review app and update someone's preferences.

<img width="1475" height="1271" alt="image" src="https://github.com/user-attachments/assets/864dabb0-2cb1-4f8f-9fa3-6a9d115b4915" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
