### PR TITLE
Confirm Deferred Offer bugs

### DIFF
--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -1,17 +1,28 @@
 class DeferredOfferConfirmation < ApplicationRecord
   class CourseForm < DeferredOfferConfirmation
     validates :course_id, presence: true
-    validate :no_raw_input
 
-    attr_accessor :course_id_raw
+    attr_reader :course_id_raw
+    validate :no_raw_input
 
     def courses_for_select
       @courses_for_select ||= offer.provider.courses
            .where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
            .includes(:provider, :accredited_provider)
-           .distinct
            .order(:name)
     end
+
+    def default_value_for_select
+      return course_id_raw if course_id_raw.present?
+
+      course_available_for_select? ? course_id : nil
+    end
+
+    def course_available_for_select?
+      courses_for_select.pluck(:id).include?(course_id)
+    end
+
+    def course_not_available_for_select? = !course_available_for_select?
 
   private
 

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -120,9 +120,9 @@ class DeferredOfferConfirmation < ApplicationRecord
 
   after_initialize do
     if course_id.nil? && site_id.nil? && study_mode.nil?
-      self.course_id ||= offer.course.id
-      self.site_id ||= offer.site.id
-      self.study_mode ||= offer.study_mode
+      self.course_id = provider.courses.current_cycle.find_by(code: offer_course.code)&.id || offer_course.id
+      self.site_id = course.sites.find_by(code: offer_site.code)&.id || offer_site.id
+      self.study_mode = offer.study_mode
     end
   end
 

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -127,7 +127,7 @@ class DeferredOfferConfirmation < ApplicationRecord
   end
 
   before_save do
-    return if course.blank?
+    next if course.blank?
 
     self.location = nil unless location_in_cycle?
     self.study_mode = nil unless study_mode_in_cycle?

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -19,7 +19,7 @@ class DeferredOfferConfirmation < ApplicationRecord
     end
 
     def course_available_for_select?
-      courses_for_select.pluck(:id).include?(course_id)
+      courses_for_select.exists?(course_id)
     end
 
   private
@@ -75,7 +75,7 @@ class DeferredOfferConfirmation < ApplicationRecord
     end
 
     def location_available_for_select?
-      locations_for_select.pluck(:id).include?(site_id)
+      locations_for_select.exists?(id: site_id)
     end
 
   private

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -19,7 +19,7 @@ class DeferredOfferConfirmation < ApplicationRecord
     end
 
     def course_available_for_select?
-      courses_for_select.exists?(course_id)
+      courses_for_select.exists?(id: course_id)
     end
 
   private

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -54,7 +54,7 @@ class DeferredOfferConfirmation < ApplicationRecord
          scopes: false
 
     def study_modes_for_select
-      validating_course_study_modes.map { |course_study_mode| SelectOption.new(id: course_study_mode, name: course_study_mode.humanize) }
+      course_study_modes.map { |course_study_mode| SelectOption.new(id: course_study_mode, name: course_study_mode.humanize) }
     end
   end
 
@@ -65,7 +65,7 @@ class DeferredOfferConfirmation < ApplicationRecord
     validates :site_id, presence: true
 
     def locations_for_select
-      course_sites.order(:name)
+      course_sites.distinct.order(:name)
     end
 
     def default_value_for_select

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -90,7 +90,7 @@ class DeferredOfferConfirmation < ApplicationRecord
 
   delegate :application_choice, :conditions, :provider, to: :offer
   delegate :name_and_code, to: :provider, prefix: true, allow_nil: true
-  delegate :name_and_code, to: :validating_course, prefix: :course, allow_nil: true
+  delegate :name_and_code, to: :course, prefix: true, allow_nil: true
   delegate :name_and_address, to: :location, prefix: true, allow_nil: true
   delegate :site, :study_mode, :course, to: :offer, prefix: true
   delegate :study_modes, :sites, to: :validating_course, prefix: true

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -2,7 +2,7 @@ class DeferredOfferConfirmation < ApplicationRecord
   class CourseForm < DeferredOfferConfirmation
     validates :course_id, presence: true
 
-    attr_reader :course_id_raw
+    attr_accessor :course_id_raw
     validate :no_raw_input
 
     def courses_for_select
@@ -15,14 +15,12 @@ class DeferredOfferConfirmation < ApplicationRecord
     def default_value_for_select
       return course_id_raw if course_id_raw.present?
 
-      course_available_for_select? ? course_id : nil
+      course_available_for_select? ? (course_id_raw || course_id) : nil
     end
 
     def course_available_for_select?
       courses_for_select.pluck(:id).include?(course_id)
     end
-
-    def course_not_available_for_select? = !course_available_for_select?
 
   private
 

--- a/app/models/deferred_offer_confirmation.rb
+++ b/app/models/deferred_offer_confirmation.rb
@@ -18,10 +18,6 @@ class DeferredOfferConfirmation < ApplicationRecord
       course_available_for_select? ? (course_id_raw || course_id) : nil
     end
 
-    def course_available_for_select?
-      courses_for_select.exists?(id: course_id)
-    end
-
   private
 
     def no_raw_input
@@ -32,6 +28,10 @@ class DeferredOfferConfirmation < ApplicationRecord
       return if selected_course && selected_course.name_and_code == course_id_raw
 
       errors.add(:course_id, :blank)
+    end
+
+    def course_available_for_select?
+      courses_for_select.exists?(id: course_id)
     end
   end
 
@@ -74,11 +74,11 @@ class DeferredOfferConfirmation < ApplicationRecord
       location_available_for_select? ? (site_id_raw || site_id) : nil
     end
 
+  private
+
     def location_available_for_select?
       locations_for_select.exists?(id: site_id)
     end
-
-  private
 
     def no_raw_input
       return if locations_for_select.size < 20

--- a/app/views/provider_interface/deferred_offer/courses/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/courses/edit.html.erb
@@ -15,12 +15,13 @@
             @course_form.courses_for_select,
             :id,
             :name_and_code,
-            options: { prompt: '' },
+            options: { include_blank: '' },
             caption: { text: @course_form.application_choice.application_form.full_name, size: 'xl' },
             label: { text: t('.page_title'), size: 'xl' },
             hint: { text: t('.course_id.fieldset_hint') },
             data: { controller: 'autocomplete' },
           ),
+          html_attributes: { 'data-default-value': @course_form.default_value_for_select },
         ) %>
       <% else %>
         <%= form.govuk_collection_radio_buttons(

--- a/app/views/provider_interface/deferred_offer/location/edit.html.erb
+++ b/app/views/provider_interface/deferred_offer/location/edit.html.erb
@@ -15,12 +15,13 @@
             @location_form.locations_for_select,
             :id,
             :name_and_address,
-            options: { prompt: '' },
+            options: { include_blank: '' },
             caption: { text: @location_form.application_choice.application_form.full_name, size: 'xl' },
             label: { text: t('.page_title'), size: 'xl' },
             hint: { text: t('.site_id.fieldset_hint') },
             data: { controller: 'autocomplete' },
           ),
+          html_attributes: { 'data-default-value': @location_form.default_value_for_select },
         ) %>
       <% else %>
         <%= form.govuk_collection_radio_buttons(

--- a/spec/models/deferred_offer_confirmation_spec.rb
+++ b/spec/models/deferred_offer_confirmation_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DeferredOfferConfirmation do
     it { is_expected.to delegate_method(:conditions).to(:offer) }
     it { is_expected.to delegate_method(:provider).to(:offer) }
     it { is_expected.to delegate_method(:name_and_code).to(:provider).with_prefix.allow_nil }
-    it { is_expected.to delegate_method(:name_and_code).to(:validating_course).with_prefix(:course).allow_nil }
+    it { is_expected.to delegate_method(:name_and_code).to(:course).with_prefix.allow_nil }
     it { is_expected.to delegate_method(:name_and_address).to(:location).with_prefix.allow_nil }
   end
 


### PR DESCRIPTION
## Context

During the last PR #11197 a few bugs were spotted.


## Changes proposed in this pull request

- Ensure that when a course is not available in the current cycle, it does not appear in the course select text input.
- On the check your answers page, the Course name should be present when the course is not available in the current cycle. 
- Made changes to the Locations select to match the behaviour of the Course select

## Guidance to review

**Review app**

Deferred Application without available course - https://apply-review-11248.test.teacherservices.cloud/provider/applications/4/deferred-offer

Deferred Application with available course - https://apply-review-11248.test.teacherservices.cloud/provider/applications/5/deferred-offer


https://github.com/user-attachments/assets/e789c870-2640-482d-a4e5-5fadafa58d4d



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
