### PR TITLE
FAC content updates 

### DIFF
--- a/app/components/candidate_interface/application_visibility_component.html.erb
+++ b/app/components/candidate_interface/application_visibility_component.html.erb
@@ -1,11 +1,13 @@
 <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
   <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
-  <% if pool_opt_in? && invisible? %>
-    <%= t('.body_opt_in_and_not_visible_html') %>
-  <% elsif pool_opt_in? && !invisible? %>
-    <%= t('.body_opt_in_and_visible_html') %>
-  <% else %>
-    <%= t('.body_opt_out_html') %>
+  <% if visible_to_providers? %>
+    <%= t('.opt_in_and_visible_html') %>
+  <% elsif pool_opt_in? && waiting_for_provider_decision? %>
+    <%= t('.opt_in_and_waiting_for_decision_html') %>
+  <% elsif pool_opt_in? && offer? %>
+    <%= t('.opt_in_and_has_offer_html') %>
+  <% elsif pool_opt_out_or_no_preference? %>
+    <%= t('.opt_out_html') %>
   <% end %>
 
   <p class="govuk-body"><%= govuk_link_to(t('.how_sharing_works'), candidate_interface_share_details_path) %></p>

--- a/app/components/candidate_interface/application_visibility_component.html.erb
+++ b/app/components/candidate_interface/application_visibility_component.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
+  <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
+  <% if pool_opt_in? && invisible? %>
+    <%= t('.body_opt_in_and_not_visible_html') %>
+  <% elsif pool_opt_in? && !invisible? %>
+    <%= t('.body_opt_in_and_visible_html') %>
+  <% else %>
+    <%= t('.body_opt_out_html') %>
+  <% end %>
+</div>

--- a/app/components/candidate_interface/application_visibility_component.html.erb
+++ b/app/components/candidate_interface/application_visibility_component.html.erb
@@ -7,4 +7,6 @@
   <% else %>
     <%= t('.body_opt_out_html') %>
   <% end %>
+
+  <p class="govuk-body"><%= govuk_link_to(t('.how_sharing_works'), candidate_interface_share_details_path) %></p>
 </div>

--- a/app/components/candidate_interface/application_visibility_component.html.erb
+++ b/app/components/candidate_interface/application_visibility_component.html.erb
@@ -1,13 +1,16 @@
 <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
   <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
-  <% if visible_to_providers? %>
-    <%= t('.opt_in_and_visible_html') %>
-  <% elsif pool_opt_in? && waiting_for_provider_decision? %>
-    <%= t('.opt_in_and_waiting_for_decision_html') %>
-  <% elsif pool_opt_in? && offer? %>
-    <%= t('.opt_in_and_has_offer_html') %>
-  <% elsif pool_opt_out_or_no_preference? %>
+
+  <% if pool_opt_out_or_no_preference? %>
     <%= t('.opt_out_html') %>
+  <% elsif visible_to_providers? %>
+    <%= t('.opt_in_and_visible_html') %>
+  <% elsif waiting_for_provider_decision? %>
+    <%= t('.opt_in_and_waiting_for_decision_html') %>
+  <% elsif application_form.withdrawn_no_longer_training? %>
+    <%= t('.opt_in_and_withdrawn_no_longer_training_html', link: govuk_link_to('contact support', 'mailto:becomingateacher@digital.education.gov.uk')) %>
+  <% elsif offer? %>
+    <%= t('.opt_in_and_has_offer_html') %>
   <% end %>
 
   <p class="govuk-body"><%= govuk_link_to(t('.how_sharing_works'), candidate_interface_share_details_path) %></p>

--- a/app/components/candidate_interface/application_visibility_component.html.erb
+++ b/app/components/candidate_interface/application_visibility_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
+<div class="govuk-!-margin-top-4">
   <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
 
   <% if pool_opt_out_or_no_preference? %>
@@ -12,6 +12,4 @@
   <% elsif offer? %>
     <%= t('.opt_in_and_has_offer_html') %>
   <% end %>
-
-  <p class="govuk-body"><%= govuk_link_to(t('.how_sharing_works'), candidate_interface_share_details_path) %></p>
 </div>

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -13,7 +13,19 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
     application_form.published_preference&.opt_in?
   end
 
-  def invisible?
-    application_form&.awaiting_provider_decisions?
+  def pool_opt_out_or_no_preference?
+    application_form.published_preference&.opt_out? || application_form.published_preference.nil?
+  end
+
+  def waiting_for_provider_decision?
+    application_form&.awaiting_provider_decisions? # this includes 'interviewing' status
+  end
+
+  def offer?
+    application_form&.offered?
+  end
+
+  def visible_to_providers?
+    application_form.candidate_pool_application.present?
   end
 end

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -1,8 +1,7 @@
 class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
-  attr_reader :current_candidate, :application_form
+  attr_reader :application_form
 
-  def initialize(current_candidate:, application_form:)
-    @current_candidate = current_candidate
+  def initialize(application_form:)
     @application_form = application_form
   end
 
@@ -11,10 +10,10 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
   end
 
   def pool_opt_in?
-    current_candidate.published_preferences&.last&.opt_in?
+    application_form.published_preference&.opt_in?
   end
 
   def invisible?
-    current_candidate.application_forms.last&.awaiting_provider_decisions?
+    application_form&.awaiting_provider_decisions?
   end
 end

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -1,0 +1,20 @@
+class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
+  attr_reader :current_candidate, :application_form
+
+  def initialize(current_candidate:, application_form:)
+    @current_candidate = current_candidate
+    @application_form = application_form
+  end
+
+  def render?
+    FeatureFlag.active?(:candidate_preferences) && application_form.submitted_applications?
+  end
+
+  def pool_opt_in?
+    current_candidate.published_preferences&.last&.opt_in?
+  end
+
+  def invisible?
+    current_candidate.application_forms&.last&.awaiting_provider_decisions? || current_candidate.application_forms&.last&.offered?
+  end
+end

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -18,11 +18,11 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
   end
 
   def waiting_for_provider_decision?
-    application_form&.awaiting_provider_decisions? # this includes 'interviewing' status
+    application_form.awaiting_provider_decisions? # this includes 'interviewing' status
   end
 
   def offer?
-    application_form&.offered?
+    application_form.offered?
   end
 
   def visible_to_providers?

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -6,7 +6,15 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
   end
 
   def render?
-    FeatureFlag.active?(:candidate_preferences) && application_form.submitted_applications?
+    FeatureFlag.active?(:candidate_preferences) &&
+      application_form.submitted_applications? &&
+      (
+        pool_opt_out_or_no_preference? ||
+        visible_to_providers? ||
+        waiting_for_provider_decision? ||
+        application_form.withdrawn_no_longer_training? ||
+        offer?
+      )
   end
 
   def pool_opt_in?

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -6,8 +6,7 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
   end
 
   def render?
-    FeatureFlag.active?(:candidate_preferences) &&
-      application_form.submitted_applications? &&
+    application_form.submitted_applications? &&
       (
         pool_opt_out_or_no_preference? ||
         visible_to_providers? ||

--- a/app/components/candidate_interface/application_visibility_component.rb
+++ b/app/components/candidate_interface/application_visibility_component.rb
@@ -15,6 +15,6 @@ class CandidateInterface::ApplicationVisibilityComponent < ViewComponent::Base
   end
 
   def invisible?
-    current_candidate.application_forms&.last&.awaiting_provider_decisions? || current_candidate.application_forms&.last&.offered?
+    current_candidate.application_forms.last&.awaiting_provider_decisions?
   end
 end

--- a/app/components/candidate_interface/manage_preferences_component.html.erb
+++ b/app/components/candidate_interface/manage_preferences_component.html.erb
@@ -1,8 +1,18 @@
 <div class="govuk-grid-column-three-quarters govuk-!-margin-top-4">
-  <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
+  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
   <% if pool_opt_in? %>
-    <p class="govuk-body"><%= t('.body_opt_in_html', link: govuk_link_to('Change', path_to_change_preferences)) %></p>
+    <p class="govuk-body">
+      <%= t('.body_opt_in_html') %>
+      <% unless application_form.withdrawn_no_longer_training? %>
+        - <%= govuk_link_to('Change', path_to_change_preferences) %>
+      <% end %>
+    </p>
   <% else %>
-    <p class="govuk-body"><%= t('.body_opt_out_html', link: govuk_link_to('Change', path_to_change_preferences)) %></p>
+    <p class="govuk-body">
+      <%= t('.body_opt_out_html') %>
+      <% unless application_form.withdrawn_no_longer_training? %>
+        - <%= govuk_link_to('Change', path_to_change_preferences) %>
+      <% end %>
+    </p>
   <% end %>
 </div>

--- a/app/components/candidate_interface/manage_preferences_component.html.erb
+++ b/app/components/candidate_interface/manage_preferences_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-three-quarters govuk-!-margin-top-4">
+<div class="govuk-!-margin-top-4">
   <h2 class="govuk-heading-m"><%= t('.title') %></h2>
   <% if pool_opt_in? %>
     <p class="govuk-body">

--- a/app/components/candidate_interface/manage_preferences_component.html.erb
+++ b/app/components/candidate_interface/manage_preferences_component.html.erb
@@ -1,22 +1,8 @@
-<div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
+<div class="govuk-grid-column-three-quarters govuk-!-margin-top-4">
   <h2 class="govuk-heading-m"><%= t('.title') %> </h2>
   <% if pool_opt_in? %>
-    <p class="govuk-body"><%= t('.body_opt_in') %></p>
+    <p class="govuk-body"><%= t('.body_opt_in_html', link: govuk_link_to('Change', path_to_change_preferences)) %></p>
   <% else %>
-    <p class="govuk-body"><%= t('.body_opt_out') %></p>
+    <p class="govuk-body"><%= t('.body_opt_out_html', link: govuk_link_to('Change', path_to_change_preferences)) %></p>
   <% end %>
-
-  <%= govuk_list(
-    [
-      govuk_link_to(
-        t('.change_sharing_details'),
-        path_to_change_preferences,
-      ),
-      govuk_link_to(
-        t('.read_about_sharing_details'),
-        candidate_interface_share_details_path,
-      ),
-    ],
-    type: :bullet,
-  ) %>
 </div>

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -445,6 +445,12 @@ class ApplicationForm < ApplicationRecord
       application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
   end
 
+  def withdrawn_no_longer_training?
+    application_choices
+      .where(status: 'withdrawn')
+      .any? { |choice| choice.withdrawal_reasons.any? { |r| r.reason.include?('do-not-want-to-train-anymore') } }
+  end
+
   def provider_decision_made?
     application_choices.present? &&
       application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }

--- a/app/views/candidate_interface/decline_reasons/new.html.erb
+++ b/app/views/candidate_interface/decline_reasons/new.html.erb
@@ -6,11 +6,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
-        <%= t('.heading', provider: @invite.provider_name) %>
-      </h1>
 
-      <%= f.govuk_check_boxes_fieldset(:reasons, legend: nil) do %>
+      <% content_for(:fieldset_legend) do %>
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">
+            <%= t('.caption') %>
+          </span>
+          <%= t('.heading', provider: @invite.provider_name) %>
+        </h1>
+      <% end %>
+
+      <%= f.govuk_check_boxes_fieldset(:reasons, legend: -> { content_for(:fieldset_legend) }) do %>
         <%= f.govuk_check_box(:reasons, 'location_not_convenient', label: { text: t('.reasons.location_not_convenient') }, link_errors: true) %>
         <%= f.govuk_check_box(:reasons, 'wrong_subject', label: { text: t('.reasons.wrong_subject') }) %>
         <%= f.govuk_check_box(:reasons, 'only_salaried', label: { text: t('.reasons.only_salaried') }) %>

--- a/app/views/candidate_interface/draft_preferences/show.html.erb
+++ b/app/views/candidate_interface/draft_preferences/show.html.erb
@@ -4,6 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
     <% if @preference.duplicated? %>
       <p class="govuk-body"><%= t('.duplicated_preference_explanation') %></p>

--- a/app/views/candidate_interface/dynamic_location_preferences/new.html.erb
+++ b/app/views/candidate_interface/dynamic_location_preferences/new.html.erb
@@ -3,6 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <%= form_with(
           model: @dynamic_location_preferences_form,
           url: candidate_interface_draft_preference_dynamic_location_preferences_path(
@@ -13,9 +14,18 @@
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <% content_for(:fieldset_legend) do %>
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">
+            <%= t('.caption') %>
+          </span>
+          <%= t('.title') %>
+        </h1>
+      <% end %>
+
       <%= f.govuk_radio_buttons_fieldset(
           :dynamic_location_preferences,
-          legend: { text: t('.title'), size: 'l' },
+          legend: -> { content_for(:fieldset_legend) },
           hint: { text: t('.hint') },
         ) do %>
         <%= f.govuk_radio_button :dynamic_location_preferences, true, label: { text: 'Yes' }, link_errors: true %>

--- a/app/views/candidate_interface/funding_type_preferences/new.html.erb
+++ b/app/views/candidate_interface/funding_type_preferences/new.html.erb
@@ -23,6 +23,24 @@
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: -> { content_for(:fieldset_legend) }) do %>
+        <%= govuk_warning_text(text: t('.warning')) %>
+
+        <p class='govuk-body'>
+          <%= t(
+            '.funding_information_html',
+            link: govuk_link_to(
+              t('.funding_information'),
+              t('get_into_teaching.url_funding_and_support'),
+              new_tab: true,
+            ),
+          ) %>
+        </p>
+
+        <%= f.govuk_radio_button :funding_type, :fee, label: { text: t('.fee') }, link_errors: true %>
+        <%= f.govuk_radio_button :funding_type, :salary, label: { text: t('.salary') } %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: -> { content_for(:fieldset_legend) }) do %>
         <%= f.govuk_radio_button :funding_type, :fee, label: { text: t('.fee') }, link_errors: true %>
         <%= f.govuk_radio_button :funding_type, :salary, label: { text: t('.salary') }, hint: { text: t('.warning') } %>
       <% end %>

--- a/app/views/candidate_interface/funding_type_preferences/new.html.erb
+++ b/app/views/candidate_interface/funding_type_preferences/new.html.erb
@@ -23,24 +23,6 @@
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: -> { content_for(:fieldset_legend) }) do %>
-        <%= govuk_warning_text(text: t('.warning')) %>
-
-        <p class='govuk-body'>
-          <%= t(
-            '.funding_information_html',
-            link: govuk_link_to(
-              t('.funding_information'),
-              t('get_into_teaching.url_funding_and_support'),
-              new_tab: true,
-            ),
-          ) %>
-        </p>
-
-        <%= f.govuk_radio_button :funding_type, :fee, label: { text: t('.fee') }, link_errors: true %>
-        <%= f.govuk_radio_button :funding_type, :salary, label: { text: t('.salary') } %>
-      <% end %>
-
-      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: -> { content_for(:fieldset_legend) }) do %>
         <%= f.govuk_radio_button :funding_type, :fee, label: { text: t('.fee') }, link_errors: true %>
         <%= f.govuk_radio_button :funding_type, :salary, label: { text: t('.salary') }, hint: { text: t('.warning') } %>
       <% end %>

--- a/app/views/candidate_interface/invites/edit.html.erb
+++ b/app/views/candidate_interface/invites/edit.html.erb
@@ -6,6 +6,7 @@
 
   <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-8"><%= t('.heading', provider: @invite.provider_name) %></h1>
 
   <% if @invite.provider_message? %>

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -44,5 +44,5 @@
 
   <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>
 
-  <%= render CandidateInterface::ApplicationVisibilityComponent.new(current_candidate:, application_form: current_application) %>
+  <%= render CandidateInterface::ApplicationVisibilityComponent.new(application_form: current_application) %>
 </div>

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -43,4 +43,6 @@
   </div>
 
   <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>
+
+  <%= render CandidateInterface::ApplicationVisibilityComponent.new(current_candidate:, application_form: current_application) %>
 </div>

--- a/app/views/candidate_interface/invites/index.html.erb
+++ b/app/views/candidate_interface/invites/index.html.erb
@@ -37,12 +37,18 @@
       <%= render CandidateInterface::NotRespondedInvitesComponent.new(invites: @not_responded_invites) %>
     </div>
 
-    <div>
+    <div class='govuk-!-margin-bottom-9'>
       <%= render CandidateInterface::InvitesComponent.new(invites: @invites) %>
     </div>
+
+    <div class='govuk-!-margin-bottom-9'>
+      <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>
+    </div>
+
+    <div class='govuk-!-margin-bottom-4'>
+      <%= render CandidateInterface::ApplicationVisibilityComponent.new(application_form: current_application) %>
+    </div>
+
+    <p class="govuk-body"><%= govuk_link_to('How application sharing works', candidate_interface_share_details_path) %></p>
   </div>
-
-  <%= render CandidateInterface::ManagePreferencesComponent.new(current_candidate:, application_form: current_application) %>
-
-  <%= render CandidateInterface::ApplicationVisibilityComponent.new(application_form: current_application) %>
 </div>

--- a/app/views/candidate_interface/location_preferences/_form.html.erb
+++ b/app/views/candidate_interface/location_preferences/_form.html.erb
@@ -1,6 +1,7 @@
 <%= form_with model: location_preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= t('.caption') %></span>
   <h1 class="govuk-heading-l"><%= title %></h1>
 
   <%= f.govuk_text_field(

--- a/app/views/candidate_interface/location_preferences/index.html.erb
+++ b/app/views/candidate_interface/location_preferences/index.html.erb
@@ -9,6 +9,7 @@
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>
+      <span class="govuk-caption-l"><%= t('.caption') %></span>
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= t('.title') %></h1>
       <p class="govuk-body"><%= t('.body') %></p>
 

--- a/app/views/candidate_interface/location_preferences/show.html.erb
+++ b/app/views/candidate_interface/location_preferences/show.html.erb
@@ -3,6 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
     <%= govuk_summary_list(actions: false) do |summary_list| %>

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,16 +1,14 @@
 <%= form_with model: preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% content_for(:fieldset_legend) do %>
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">
-        <%= t('.caption') %>
-      </span>
-      <%= t('.title') %>
-    </h1>
+  <% content_for(:fieldset_hint) do %>
+    <span class="radio-buttons-fieldset-hint">
+      <%= t('.hint_html', link: govuk_link_to(t('.link_text'), candidate_interface_share_details_path)) %>
+    </span>
   <% end %>
 
-  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: -> { content_for(:fieldset_legend) }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
+
+  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title') }, hint: -> { content_for(:fieldset_hint) }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
       <%= f.govuk_text_area(

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,7 +1,16 @@
 <%= form_with model: preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title'), size: 'l', class: 'govuk-!-margin-bottom-6' }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
+  <% content_for(:fieldset_legend) do %>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">
+        <%= t('.caption') %>
+      </span>
+      <%= t('.title') %>
+    </h1>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: -> { content_for(:fieldset_legend) }, hint: { text: t('.body'), class: 'radio-buttons-fieldset-hint' }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
       <%= f.govuk_text_area(

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -1,13 +1,7 @@
 <%= form_with model: preference_form, url:, method: do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% content_for(:fieldset_hint) do %>
-    <span class="radio-buttons-fieldset-hint">
-      <%= t('.hint_html', link: govuk_link_to(t('.link_text'), candidate_interface_share_details_path)) %>
-    </span>
-  <% end %>
-
-  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title') }, hint: -> { content_for(:fieldset_hint) }) do %>
+  <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title') }, hint: { text: t('.hint_html', link: govuk_link_to(t('.link_text'), candidate_interface_share_details_path)) }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>
       <%= f.govuk_text_area(

--- a/app/views/candidate_interface/pool_opt_ins/_form.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/_form.html.erb
@@ -7,7 +7,6 @@
     </span>
   <% end %>
 
-
   <%= f.govuk_radio_buttons_fieldset(:pool_status, legend: { text: t('.title') }, hint: -> { content_for(:fieldset_hint) }) do %>
     <%= f.govuk_radio_button :pool_status, :opt_in, label: { text: 'Yes' }, link_errors: true %>
     <%= f.govuk_radio_button :pool_status, :opt_out, label: { text: 'No' } do %>

--- a/app/views/candidate_interface/pool_opt_ins/edit.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/edit.html.erb
@@ -3,6 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
     <%= render(
       'form',
       preference_form: @preference_form,

--- a/app/views/candidate_interface/pool_opt_ins/new.html.erb
+++ b/app/views/candidate_interface/pool_opt_ins/new.html.erb
@@ -3,6 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
+    <h1 class="govuk-heading-l"><%= t('.header') %></h1>
+
+    <span class="govuk-body"><%= t('.body_html') %></span>
+
     <%= render 'form', preference_form: @preference_form, url: candidate_interface_pool_opt_ins_path(**@submit_params), method: :post %>
   </div>
 </div>

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -55,7 +55,7 @@
         <% end %>
       <% end %>
 
-      <% if @preference.funding_type.present? %>
+        <% if @preference.funding_type.present? %>
         <% summary_list.with_row do |row| %>
           <% row.with_key { t('.funding_type') } %>
           <% row.with_value { t(".#{@preference.funding_type}_funding_type") } %>

--- a/app/views/candidate_interface/publish_preferences/show.html.erb
+++ b/app/views/candidate_interface/publish_preferences/show.html.erb
@@ -3,6 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= t('.caption') %></span>
     <h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
     <%= govuk_summary_list do |summary_list| %>

--- a/app/views/candidate_interface/training_locations/new.html.erb
+++ b/app/views/candidate_interface/training_locations/new.html.erb
@@ -13,7 +13,16 @@
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: { text: t('.title'), size: 'l' }) do %>
+      <% content_for(:fieldset_legend) do %>
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">
+            <%= t('.caption') %>
+          </span>
+          <%= t('.title') %>
+        </h1>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset(:training_locations, legend: -> { content_for(:fieldset_legend) }) do %>
         <%= f.govuk_radio_button :training_locations, :anywhere, label: { text: t('.anywhere') }, link_errors: true %>
         <%= f.govuk_radio_button :training_locations, :specific, label: { text: t('.specific') }, hint: { text: t('.specific_locations_hint') } %>
       <% end %>

--- a/config/locales/candidate_interface/application_visibility_component.yml
+++ b/config/locales/candidate_interface/application_visibility_component.yml
@@ -17,6 +17,11 @@ en:
         <br>You have no submitted applications that are waiting for a decision.</p>
 
         <p class="govuk-body">Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
+      opt_in_and_withdrawn_no_longer_training_html: |
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
+        <br>You have withdrawn an application with the reason 'I do not want to train to teach anymore'.</p>
+
+        <p class="govuk-body">We have stopped sharing your application details with other providers. If you want to change this you can %{link}.</p>
       opt_out_html: |
         <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
         <br>You are not sharing your application details with other providers.</p>

--- a/config/locales/candidate_interface/application_visibility_component.yml
+++ b/config/locales/candidate_interface/application_visibility_component.yml
@@ -3,15 +3,16 @@ en:
     application_visibility_component:
       title: Application detail visibility
       body_opt_in_and_not_visible_html: |
-        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.</p>
-        <p class="govuk-body">You have submitted applications that are waiting for a decision.</p>
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
+        <br>You have submitted applications that are waiting for a decision.</p>
 
         <p class="govuk-body">When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
       body_opt_in_and_visible_html: |
-        <p class="govuk-body">Your application details <b>are</b> currently visible to providers.</p>
-        <p class="govuk-body">You have no submitted application that are waiting for a decision.</p>
+        <p class="govuk-body">Your application details <b>are</b> currently visible to other providers.
+        <br>You have no submitted applications that are waiting for a decision.</p>
 
         <p class="govuk-body">Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
       body_opt_out_html: |
-        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.</p>
-        <p class="govuk-body">You are not sharing your application details with other providers</p>
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
+        <br>You are not sharing your application details with other providers.</p>
+      how_sharing_works: How application sharing works

--- a/config/locales/candidate_interface/application_visibility_component.yml
+++ b/config/locales/candidate_interface/application_visibility_component.yml
@@ -2,17 +2,22 @@ en:
   candidate_interface:
     application_visibility_component:
       title: Application detail visibility
-      body_opt_in_and_not_visible_html: |
+      opt_in_and_waiting_for_decision_html: |
         <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
         <br>You have submitted applications that are waiting for a decision.</p>
 
         <p class="govuk-body">When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
-      body_opt_in_and_visible_html: |
+      opt_in_and_has_offer_html:
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
+        <br>You have offers that you need to respond to.</p>
+
+        <p class="govuk-body">When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
+      opt_in_and_visible_html: |
         <p class="govuk-body">Your application details <b>are</b> currently visible to other providers.
         <br>You have no submitted applications that are waiting for a decision.</p>
 
         <p class="govuk-body">Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
-      body_opt_out_html: |
+      opt_out_html: |
         <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.
         <br>You are not sharing your application details with other providers.</p>
       how_sharing_works: How application sharing works

--- a/config/locales/candidate_interface/application_visibility_component.yml
+++ b/config/locales/candidate_interface/application_visibility_component.yml
@@ -1,0 +1,17 @@
+en:
+  candidate_interface:
+    application_visibility_component:
+      title: Application detail visibility
+      body_opt_in_and_not_visible_html: |
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.</p>
+        <p class="govuk-body">You have submitted applications that are waiting for a decision.</p>
+
+        <p class="govuk-body">When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
+      body_opt_in_and_visible_html: |
+        <p class="govuk-body">Your application details <b>are</b> currently visible to providers.</p>
+        <p class="govuk-body">You have no submitted application that are waiting for a decision.</p>
+
+        <p class="govuk-body">Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.</p>
+      body_opt_out_html: |
+        <p class="govuk-body">Your application details are <b>not</b> currently visible to other providers.</p>
+        <p class="govuk-body">You are not sharing your application details with other providers</p>

--- a/config/locales/candidate_interface/decline_reasons.yml
+++ b/config/locales/candidate_interface/decline_reasons.yml
@@ -4,6 +4,7 @@ en:
       new:
         title: Invite from %{provider} - Decline invite - Application sharing
         heading: Why are you not interested in this course invitation?
+        caption: Application sharing
         reasons:
           location_not_convenient: The course location is not convenient for me
           wrong_subject: I do not want to train to teach this subject

--- a/config/locales/candidate_interface/dynamic_location_preferences.yml
+++ b/config/locales/candidate_interface/dynamic_location_preferences.yml
@@ -2,6 +2,7 @@ en:
   candidate_interface:
     dynamic_location_preferences:
       new:
+        caption: Application sharing
         title: Add the locations of courses you apply to
         hint: >
           Each time you apply to a new course, we can add the course location to the places you can train. You will

--- a/config/locales/candidate_interface/invites.yml
+++ b/config/locales/candidate_interface/invites.yml
@@ -7,6 +7,7 @@ en:
       edit:
         title: Invite from %{provider} - Application sharing
         heading: Your invite from %{provider}
+        caption: Application sharing
         provider_message: "%{provider} included this message:"
         course: Course
         fee: Course fee

--- a/config/locales/candidate_interface/manage_preferences_component.yml
+++ b/config/locales/candidate_interface/manage_preferences_component.yml
@@ -2,7 +2,5 @@ en:
   candidate_interface:
     manage_preferences_component:
       title: Sharing your application details
-      body_opt_in: You are sharing your application details with training providers that you have not submitted an application to.
-      body_opt_out: You are not sharing your application details with training providers that you have not submitted an application to.
-      read_about_sharing_details: Read about how sharing your application details works
-      change_sharing_details: Update your preferences
+      body_opt_in_html: You have chosen to share your application details with other providers - %{link}
+      body_opt_out_html: You have chosen not to share your application details with other providers - %{link}

--- a/config/locales/candidate_interface/manage_preferences_component.yml
+++ b/config/locales/candidate_interface/manage_preferences_component.yml
@@ -2,5 +2,5 @@ en:
   candidate_interface:
     manage_preferences_component:
       title: Sharing your application details
-      body_opt_in_html: You have chosen to share your application details with other providers - %{link}
-      body_opt_out_html: You have chosen not to share your application details with other providers - %{link}
+      body_opt_in_html: You have chosen to share your application details with other providers
+      body_opt_out_html: You have chosen not to share your application details with other providers

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -72,6 +72,15 @@ en:
         sharing_application_guidance: Find out more about how application sharing works  
       new:
         title: Do you want to make your application details visible to other training providers?
+        header: Do you want to be invited to similar courses?
+        caption: Application sharing
+        body_html: |
+          <p>You can choose to make your application details visible to other training providers who have spaces on their courses.</p>
+          <p>If a training provider sees your details and thinks you are suitable for their course, they can send you an email inviting you to submit an application - you can choose if you want to apply or not.</p>
+          <p>You can set location preferences for courses that you want to be invited to.</p>
+          <p>You will appear in search results for courses that are similar to ones you have applied to in the past.</p>
+          <p>So that the course you have just applied to has time to review your application properly, we will hide you from the list until they have made a decision.</p>
+          <p>You can change your mind at any time.</p>
       edit:
         title: Do you want to make your application details visible to other training providers?
       create:
@@ -79,8 +88,10 @@ en:
       update:
         opt_out_message: You are not sharing your application details with providers you have not applied to
       form:
-        title: Do you want to make your application details visible to other training providers?
-        body: When you have no applications that are waiting for a decision from a provider, other providers will be able to see your application details and invite you to apply to their courses.
+        title: Would you like to share your application details with other training providers?
+        hint_html: |
+         %{link}
+        link_text: Read more about how application sharing works
         reason_for_opting_out: Why do you not want to share your application details with other providers? (Optional)
         caption: Application sharing
     location_preferences:

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -5,6 +5,7 @@ en:
         success_opt_out: You are not sharing your application details with providers you have not applied to
       show:
         title: Check your application sharing preferences
+        caption: Application sharing
         share_information: Do you want to be invited to apply to similar courses?
         where_can_you_train: Where can you train?
         specific: In specific locations
@@ -35,6 +36,7 @@ en:
       show:
         duplicated_preference_explanation: These preferences are based on your settings from the last recruitment cycle.
         title: Check your application sharing preferences
+        caption: Application sharing
         share_information: Do you want to be invited to apply to similar courses?
         where_can_you_train: Where can you train?
         specific: In specific locations
@@ -80,9 +82,11 @@ en:
         title: Do you want to make your application details visible to other training providers?
         body: When you have no applications that are waiting for a decision from a provider, other providers will be able to see your application details and invite you to apply to their courses.
         reason_for_opting_out: Why do you not want to share your application details with other providers? (Optional)
+        caption: Application sharing
     location_preferences:
       index:
         title: Areas you can train in
+        caption: Application sharing
         body: Training providers will use the locations you enter here to search for candidates near their courses. You should add all locations that you can train in.
         select_locations: Add, change or remove areas
         location: from city, town, or postcode
@@ -101,12 +105,14 @@ en:
         title: Update the area where you can train
         submit_text: Update training area
       form:
+        caption: Application sharing
         within: I can travel up to
         name: from city, town or postcode
         miles: miles
         enter_distance_in_miles: Enter distance in miles
       show:
         title: Do you want to remove this training area?
+        caption: Application sharing
         location: Area
         remove: Yes, remove training area
     funding_type_preferences:

--- a/config/locales/candidate_interface/preferences.yml
+++ b/config/locales/candidate_interface/preferences.yml
@@ -82,6 +82,7 @@ en:
           <p>So that the course you have just applied to has time to review your application properly, we will hide you from the list until they have made a decision.</p>
           <p>You can change your mind at any time.</p>
       edit:
+        caption: Application sharing
         title: Do you want to make your application details visible to other training providers?
       create:
         opt_out_message: You are not sharing your application details with providers you have not applied to

--- a/config/locales/candidate_interface/training_locations.yml
+++ b/config/locales/candidate_interface/training_locations.yml
@@ -3,6 +3,7 @@ en:
     training_locations:
       new:
         title: Where can you train?
+        caption: Application sharing
         anywhere: Anywhere in England
         specific: In specific locations
         specific_locations_hint: Only receive invitations to apply to courses near your chosen locations

--- a/spec/components/candidate_interface/application_visibility_component_spec.rb
+++ b/spec/components/candidate_interface/application_visibility_component_spec.rb
@@ -1,40 +1,96 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :component do
-  describe '#render' do
-    context 'when candidate preference feature flag is enabled' do
-      it 'renders the component' do
-        FeatureFlag.activate(:candidate_preferences)
-        application_form = create(:application_form, :with_accepted_offer)
+  describe '#render?' do
+    before { FeatureFlag.activate(:candidate_preferences) }
 
-        component = described_class.new(application_form:)
-        result = render_inline(component)
+    let(:application_form) { create(:application_form) }
 
-        expect(result.to_html).not_to be_blank
+    subject(:component) { described_class.new(application_form:) }
+
+    context 'when feature flag is off' do
+      before { FeatureFlag.deactivate(:candidate_preferences) }
+
+      it 'returns false' do
+        expect(component.render?).to be false
       end
     end
 
-    context 'when candidate preference feature flag is not enabled' do
-      it 'renders the component' do
-        FeatureFlag.deactivate(:candidate_preferences)
-        application_form = create(:application_form, :with_accepted_offer)
+    context 'when application has not been submitted' do
+      before { allow(application_form).to receive(:submitted_applications?).and_return(false) }
 
-        component = described_class.new(application_form:)
-        result = render_inline(component)
-
-        expect(result.to_html).to be_blank
+      it 'returns false' do
+        expect(component.render?).to be false
       end
     end
 
-    context 'when candidate preference feature flag is enabled but no sent applications' do
-      it 'renders the component' do
-        FeatureFlag.activate(:candidate_preferences)
-        application_form = create(:application_form)
+    context 'when pool_opt_out_or_no_preference is true' do
+      before do
+        create(:candidate_preference, pool_status: 'opt_out', status: 'published', application_form:)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
 
-        component = described_class.new(application_form:)
-        result = render_inline(component)
+      it 'returns true' do
+        expect(component.render?).to be true
+      end
+    end
 
-        expect(result.to_html).to be_blank
+    context 'when visible_to_providers is true' do
+      before do
+        create(:candidate_pool_application, application_form:, candidate: application_form.candidate)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(component.render?).to be true
+      end
+    end
+
+    context 'when waiting_for_provider_decision is true' do
+      before do
+        create(:application_choice, :awaiting_provider_decision, application_form:)
+        create(:candidate_preference, pool_status: 'opt_in', status: 'published', application_form:)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(component.render?).to be true
+      end
+    end
+
+    context 'when withdrawn_no_longer_training is true' do
+      before do
+        withdrawn_choice = create(:application_choice, :withdrawn, application_form:)
+        create(:withdrawal_reason, application_choice: withdrawn_choice, reason: 'do-not-want-to-train-anymore.another_career_path_or_accepted_a_job_offer')
+        create(:candidate_preference, pool_status: 'opt_in', status: 'published', application_form:)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(component.render?).to be true
+      end
+    end
+
+    context 'when offer is true' do
+      before do
+        create(:application_choice, :offered, application_form:)
+        create(:candidate_preference, pool_status: 'opt_in', status: 'published', application_form:)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(component.render?).to be true
+      end
+    end
+
+    context 'when none of the visibility conditions are met' do
+      before do
+        create(:candidate_preference, pool_status: 'opt_in', status: 'published', application_form:)
+        allow(application_form).to receive(:submitted_applications?).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(component.render?).to be false
       end
     end
   end
@@ -108,7 +164,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
     end
   end
 
-  describe 'waiting_for_provider_decision?' do
+  describe '#waiting_for_provider_decision?' do
     it 'displays opted in but not visible to providers if the application form is opted in and has choices awaiting decision' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
@@ -144,7 +200,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
     end
   end
 
-  describe 'offer?' do
+  describe '#offer?' do
     it 'displays opted in but not visible to providers if the application form is opted in and has an offer' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
@@ -163,7 +219,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
     end
   end
 
-  describe 'visible_to_providers?' do
+  describe '#visible_to_providers?' do
     it 'displays opted in and visible if the candidate is in the pool' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
@@ -180,6 +236,29 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
       expect(page).to have_content('Your application details are currently visible to other providers. You have no submitted applications that are waiting for a decision.')
       expect(page).to have_content('Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
+    end
+  end
+
+  describe '#application_form.withdrawn_no_longer_training?' do
+    context 'when application has a withdrawn choice with reason of not training to teach anymore' do
+      it 'renders the withdrawn_no_longer_training content' do
+        FeatureFlag.activate(:candidate_preferences)
+        application_form = create(:application_form)
+        _preference = create(
+          :candidate_preference,
+          pool_status: 'opt_in',
+          status: 'published',
+          application_form:,
+        )
+        withdrawn_offer = create(:application_choice, :withdrawn, application_form:)
+        create(:withdrawal_reason, application_choice: withdrawn_offer, reason: 'do-not-want-to-train-anymore.another_career_path_or_accepted_a_job_offer')
+
+        render_inline(described_class.new(application_form:))
+
+        expect(page).to have_content('Your application details are not currently visible to other providers.')
+        expect(page).to have_content("You have withdrawn an application with the reason 'I do not want to train to teach anymore'.")
+        expect(page).to have_link('contact support', href: 'mailto:becomingateacher@digital.education.gov.uk')
+      end
     end
   end
 end

--- a/spec/components/candidate_interface/application_visibility_component_spec.rb
+++ b/spec/components/candidate_interface/application_visibility_component_spec.rb
@@ -2,19 +2,9 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :component do
   describe '#render?' do
-    before { FeatureFlag.activate(:candidate_preferences) }
-
     let(:application_form) { create(:application_form) }
 
     subject(:component) { described_class.new(application_form:) }
-
-    context 'when feature flag is off' do
-      before { FeatureFlag.deactivate(:candidate_preferences) }
-
-      it 'returns false' do
-        expect(component.render?).to be false
-      end
-    end
 
     context 'when application has not been submitted' do
       before { allow(application_form).to receive(:submitted_applications?).and_return(false) }
@@ -166,7 +156,6 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
   describe '#waiting_for_provider_decision?' do
     it 'displays opted in but not visible to providers if the application form is opted in and has choices awaiting decision' do
-      FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
@@ -183,7 +172,6 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
     end
 
     it 'displays opted in but not visible to providers if the application form is opted in and has choices with a status of interviewing' do
-      FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
@@ -202,7 +190,6 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
   describe '#offer?' do
     it 'displays opted in but not visible to providers if the application form is opted in and has an offer' do
-      FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
@@ -221,7 +208,6 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
   describe '#visible_to_providers?' do
     it 'displays opted in and visible if the candidate is in the pool' do
-      FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
@@ -242,7 +228,6 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
   describe '#application_form.withdrawn_no_longer_training?' do
     context 'when application has a withdrawn choice with reason of not training to teach anymore' do
       it 'renders the withdrawn_no_longer_training content' do
-        FeatureFlag.activate(:candidate_preferences)
         application_form = create(:application_form)
         _preference = create(
           :candidate_preference,

--- a/spec/components/candidate_interface/application_visibility_component_spec.rb
+++ b/spec/components/candidate_interface/application_visibility_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
         FeatureFlag.activate(:candidate_preferences)
         application_form = create(:application_form, :with_accepted_offer)
 
-        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        component = described_class.new(application_form:)
         result = render_inline(component)
 
         expect(result.to_html).not_to be_blank
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
         FeatureFlag.deactivate(:candidate_preferences)
         application_form = create(:application_form, :with_accepted_offer)
 
-        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        component = described_class.new(application_form:)
         result = render_inline(component)
 
         expect(result.to_html).to be_blank
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
         FeatureFlag.activate(:candidate_preferences)
         application_form = create(:application_form)
 
-        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        component = described_class.new(application_form:)
         result = render_inline(component)
 
         expect(result.to_html).to be_blank
@@ -41,30 +41,28 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
   describe '#pool_opt_in?' do
     it 'returns true when candidate has opted in' do
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_in',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = build(:application_form)
 
-      component = described_class.new(current_candidate: candidate, application_form:)
+      component = described_class.new(application_form:)
       expect(component.pool_opt_in?).to be true
     end
 
     it 'returns false when candidate has opted out' do
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_out',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = build(:application_form)
 
-      component = described_class.new(current_candidate: candidate, application_form:)
+      component = described_class.new(application_form:)
       expect(component.pool_opt_in?).to be false
     end
   end
@@ -72,17 +70,16 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
   describe 'invisible?' do
     it 'displays opted in but not visible if the application form is opted in and has choices awaiting decision' do
       FeatureFlag.activate(:candidate_preferences)
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_in',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = create(:application_form, candidate:)
       _application_choice_awaiting_provider_decision = create(:application_choice, :awaiting_provider_decision, application_form:)
 
-      render_inline(described_class.new(current_candidate: candidate, application_form:))
+      render_inline(described_class.new(application_form:))
 
       expect(page).to have_content('Your application details are not currently visible to other providers. You have submitted applications that are waiting for a decision.')
       expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
@@ -90,17 +87,16 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
     it 'displays opted in but not visible if the application form is opted in and has choices with a status of interviewing' do
       FeatureFlag.activate(:candidate_preferences)
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_in',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = create(:application_form, candidate:)
       _application_choice_awaiting_provider_decision = create(:application_choice, :interviewing, application_form:)
 
-      render_inline(described_class.new(current_candidate: candidate, application_form:))
+      render_inline(described_class.new(application_form:))
 
       expect(page).to have_content('Your application details are not currently visible to other providers. You have submitted applications that are waiting for a decision.')
       expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
@@ -108,17 +104,16 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
     it 'displays opted in and visible if the application form is opted in and has no applications awaiting decisions' do
       FeatureFlag.activate(:candidate_preferences)
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_in',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = create(:application_form, candidate:)
       _withdrawn_application_choice = create(:application_choice, :withdrawn, application_form:)
 
-      render_inline(described_class.new(current_candidate: candidate, application_form:))
+      render_inline(described_class.new(application_form:))
 
       expect(page).to have_content('Your application details are currently visible to other providers. You have no submitted applications that are waiting for a decision.')
       expect(page).to have_content('Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
@@ -126,17 +121,16 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
 
     it 'displays opted out if the application form is opted out' do
       FeatureFlag.activate(:candidate_preferences)
-      candidate = create(:candidate)
+      application_form = create(:application_form)
       _preference = create(
         :candidate_preference,
         pool_status: 'opt_out',
         status: 'published',
-        candidate:,
+        application_form:,
       )
-      application_form = create(:application_form, candidate:)
       _any_application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
 
-      render_inline(described_class.new(current_candidate: candidate, application_form:))
+      render_inline(described_class.new(application_form:))
 
       expect(page).to have_content('Your application details are not currently visible to other providers. You are not sharing your application details with other providers.')
     end

--- a/spec/components/candidate_interface/application_visibility_component_spec.rb
+++ b/spec/components/candidate_interface/application_visibility_component_spec.rb
@@ -67,8 +67,49 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
     end
   end
 
-  describe 'invisible?' do
-    it 'displays opted in but not visible if the application form is opted in and has choices awaiting decision' do
+  describe '#pool_opt_out_or_no_preference?' do
+    it 'returns true when candidate has opted out' do
+      application_form = create(:application_form)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_out',
+        status: 'published',
+        application_form:,
+      )
+
+      component = described_class.new(application_form:)
+      expect(component.pool_opt_out_or_no_preference?).to be true
+    end
+
+    it 'returns true when candidate has no published preference' do
+      application_form = create(:application_form)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'draft',
+        application_form:,
+      )
+
+      component = described_class.new(application_form:)
+      expect(component.pool_opt_out_or_no_preference?).to be true
+    end
+
+    it 'returns false when candidate has opted in' do
+      application_form = create(:application_form)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        application_form:,
+      )
+
+      component = described_class.new(application_form:)
+      expect(component.pool_opt_out_or_no_preference?).to be false
+    end
+  end
+
+  describe 'waiting_for_provider_decision?' do
+    it 'displays opted in but not visible to providers if the application form is opted in and has choices awaiting decision' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
@@ -85,7 +126,7 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
       expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
     end
 
-    it 'displays opted in but not visible if the application form is opted in and has choices with a status of interviewing' do
+    it 'displays opted in but not visible to providers if the application form is opted in and has choices with a status of interviewing' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
@@ -101,8 +142,10 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
       expect(page).to have_content('Your application details are not currently visible to other providers. You have submitted applications that are waiting for a decision.')
       expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
     end
+  end
 
-    it 'displays opted in and visible if the application form is opted in and has no applications awaiting decisions' do
+  describe 'offer?' do
+    it 'displays opted in but not visible to providers if the application form is opted in and has an offer' do
       FeatureFlag.activate(:candidate_preferences)
       application_form = create(:application_form)
       _preference = create(
@@ -111,28 +154,32 @@ RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :compon
         status: 'published',
         application_form:,
       )
-      _withdrawn_application_choice = create(:application_choice, :withdrawn, application_form:)
+      _application_choice_awaiting_provider_decision = create(:application_choice, :offered, application_form:)
+
+      render_inline(described_class.new(application_form:))
+
+      expect(page).to have_content('Your application details are not currently visible to other providers. You have offers that you need to respond to.')
+      expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
+    end
+  end
+
+  describe 'visible_to_providers?' do
+    it 'displays opted in and visible if the candidate is in the pool' do
+      FeatureFlag.activate(:candidate_preferences)
+      application_form = create(:application_form)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        application_form:,
+      )
+      _application_choice = create(:application_choice, :withdrawn, application_form:)
+      create(:candidate_pool_application, application_form:, candidate: application_form.candidate)
 
       render_inline(described_class.new(application_form:))
 
       expect(page).to have_content('Your application details are currently visible to other providers. You have no submitted applications that are waiting for a decision.')
       expect(page).to have_content('Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
-    end
-
-    it 'displays opted out if the application form is opted out' do
-      FeatureFlag.activate(:candidate_preferences)
-      application_form = create(:application_form)
-      _preference = create(
-        :candidate_preference,
-        pool_status: 'opt_out',
-        status: 'published',
-        application_form:,
-      )
-      _any_application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
-
-      render_inline(described_class.new(application_form:))
-
-      expect(page).to have_content('Your application details are not currently visible to other providers. You are not sharing your application details with other providers.')
     end
   end
 end

--- a/spec/components/candidate_interface/application_visibility_component_spec.rb
+++ b/spec/components/candidate_interface/application_visibility_component_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationVisibilityComponent, type: :component do
+  describe '#render' do
+    context 'when candidate preference feature flag is enabled' do
+      it 'renders the component' do
+        FeatureFlag.activate(:candidate_preferences)
+        application_form = create(:application_form, :with_accepted_offer)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).not_to be_blank
+      end
+    end
+
+    context 'when candidate preference feature flag is not enabled' do
+      it 'renders the component' do
+        FeatureFlag.deactivate(:candidate_preferences)
+        application_form = create(:application_form, :with_accepted_offer)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).to be_blank
+      end
+    end
+
+    context 'when candidate preference feature flag is enabled but no sent applications' do
+      it 'renders the component' do
+        FeatureFlag.activate(:candidate_preferences)
+        application_form = create(:application_form)
+
+        component = described_class.new(current_candidate: application_form.candidate, application_form:)
+        result = render_inline(component)
+
+        expect(result.to_html).to be_blank
+      end
+    end
+  end
+
+  describe '#pool_opt_in?' do
+    it 'returns true when candidate has opted in' do
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        candidate:,
+      )
+      application_form = build(:application_form)
+
+      component = described_class.new(current_candidate: candidate, application_form:)
+      expect(component.pool_opt_in?).to be true
+    end
+
+    it 'returns false when candidate has opted out' do
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_out',
+        status: 'published',
+        candidate:,
+      )
+      application_form = build(:application_form)
+
+      component = described_class.new(current_candidate: candidate, application_form:)
+      expect(component.pool_opt_in?).to be false
+    end
+  end
+
+  describe 'invisible?' do
+    it 'displays opted in but not visible if the application form is opted in and has choices awaiting decision' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        candidate:,
+      )
+      application_form = create(:application_form, candidate:)
+      _application_choice_awaiting_provider_decision = create(:application_choice, :awaiting_provider_decision, application_form:)
+
+      render_inline(described_class.new(current_candidate: candidate, application_form:))
+
+      expect(page).to have_content('Your application details are not currently visible to other providers. You have submitted applications that are waiting for a decision.')
+      expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
+    end
+
+    it 'displays opted in but not visible if the application form is opted in and has choices with a status of interviewing' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        candidate:,
+      )
+      application_form = create(:application_form, candidate:)
+      _application_choice_awaiting_provider_decision = create(:application_choice, :interviewing, application_form:)
+
+      render_inline(described_class.new(current_candidate: candidate, application_form:))
+
+      expect(page).to have_content('Your application details are not currently visible to other providers. You have submitted applications that are waiting for a decision.')
+      expect(page).to have_content('When all your applications are rejected, withdrawn or inactive, providers will be able to view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
+    end
+
+    it 'displays opted in and visible if the application form is opted in and has no applications awaiting decisions' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_in',
+        status: 'published',
+        candidate:,
+      )
+      application_form = create(:application_form, candidate:)
+      _withdrawn_application_choice = create(:application_choice, :withdrawn, application_form:)
+
+      render_inline(described_class.new(current_candidate: candidate, application_form:))
+
+      expect(page).to have_content('Your application details are currently visible to other providers. You have no submitted applications that are waiting for a decision.')
+      expect(page).to have_content('Because all your applications are rejected, withdrawn or inactive, providers can view your application details and invite you to apply. However, you should continue to apply to courses yourself. Do not wait to be invited.')
+    end
+
+    it 'displays opted out if the application form is opted out' do
+      FeatureFlag.activate(:candidate_preferences)
+      candidate = create(:candidate)
+      _preference = create(
+        :candidate_preference,
+        pool_status: 'opt_out',
+        status: 'published',
+        candidate:,
+      )
+      application_form = create(:application_form, candidate:)
+      _any_application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
+
+      render_inline(described_class.new(current_candidate: candidate, application_form:))
+
+      expect(page).to have_content('Your application details are not currently visible to other providers. You are not sharing your application details with other providers.')
+    end
+  end
+end

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
     context 'when application is withdrawn and no longer training to teach' do
       it 'does not render the Change link' do
-        FeatureFlag.activate(:candidate_preferences)
         candidate = create(:candidate)
         _preference = create(
           :candidate_preference,
@@ -49,7 +48,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
     context 'when application is withdrawn but still training to teach' do
       it 'renders the Change link' do
-        FeatureFlag.activate(:candidate_preferences)
         candidate = create(:candidate)
         _preference = create(
           :candidate_preference,

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
       )
 
       expect(page).to have_link(
-        'Update your preferences',
+        'Change',
         href: candidate_interface_draft_preference_publish_preferences_path(preference),
       )
     end
@@ -91,7 +91,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
       )
 
       expect(page).to have_link(
-        'Update your preferences',
+        'Change',
         href: new_candidate_interface_pool_opt_in_path,
       )
     end
@@ -111,7 +111,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
       )
 
       expect(page).to have_link(
-        'Update your preferences',
+        'Change',
         href: edit_candidate_interface_pool_opt_in_path(
           preference,
         ),

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -557,6 +557,42 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#withdrawn_no_longer_training?' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when a withdrawn application choice has a matching withdrawal reason' do
+      before do
+        withdrawn_choice = create(:application_choice, status: 'withdrawn', application_form:)
+        create(:withdrawal_reason, application_choice: withdrawn_choice, reason: 'do-not-want-to-train-anymore.another_career_path_or_accepted_a_job_offer')
+      end
+
+      it 'returns true' do
+        expect(application_form.withdrawn_no_longer_training?).to be(true)
+      end
+    end
+
+    context 'when no withdrawn application choices have a matching withdrawal reason' do
+      before do
+        withdrawn_choice = create(:application_choice, status: 'withdrawn', application_form:)
+        create(:withdrawal_reason, application_choice: withdrawn_choice, reason: 'applying_to_another_provider.accepted_another_offer')
+      end
+
+      it 'returns false' do
+        expect(application_form.withdrawn_no_longer_training?).to be(false)
+      end
+    end
+
+    context 'when there are no withdrawn application choices' do
+      before do
+        create(:application_choice, status: 'rejected', application_form:)
+      end
+
+      it 'returns false' do
+        expect(application_form.withdrawn_no_longer_training?).to be(false)
+      end
+    end
+  end
+
   describe '#selected_incorrect_number_of_references?' do
     it 'is true when < 2 selections' do
       application_form = create(:application_form)

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
     click_on 'Confirm and submit application'
 
     expect(page).to have_content(
-      'Do you want to make your application details visible to other training providers?',
+      'Do you want to be invited to similar courses?',
     )
     choose 'No'
     click_on 'Continue'

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_review_page
     when_i_click('Submit preferences')
     then_i_am_redirected_to_confirmation_page

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
     then_i_get_an_error('Select whether to make your application details visible to other training providers')
@@ -106,7 +106,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_opt_in_page
     and_i_opt_in_to_find_a_candidate
     when_i_click('Continue')
@@ -141,7 +141,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
     then_i_get_an_error('Select whether to make your application details visible to other training providers')
@@ -167,7 +167,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_opt_in_page
     when_i_click('Continue')
     then_i_get_an_error('Select whether to make your application details visible to other training providers')
@@ -253,7 +253,7 @@ RSpec.describe 'Candidate adds preferences' do
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_opt_in_page
 
     when_i_opt_in_to_find_a_candidate
@@ -315,7 +315,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   def and_i_navigate_to_update_my_preferences
     visit candidate_interface_invites_path
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     and_i_click_the_relevant_change_link
     then_i_see_my_location_preferences_page_including_the_dynamic_location
   end

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe 'Candidate adds preferences' do
   end
 
   def then_i_am_redirected_to_opt_in_page
-    expect(page).to have_content('Do you want to make your application details visible to other training providers?')
+    expect(page).to have_content('Would you like to share your application details with other training providers?')
   end
 
   def then_i_am_redirected_to_training_locations

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Candidate edits published preference' do
     given_i_am_signed_in
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_preference_review_page
 
     when_i_click_change_share_preference
@@ -22,7 +22,7 @@ RSpec.describe 'Candidate edits published preference' do
     given_i_am_signed_in
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_preference_review_page
 
     when_i_click_change_share_preference
@@ -38,7 +38,7 @@ RSpec.describe 'Candidate edits published preference' do
     given_i_am_signed_in
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     then_i_am_redirected_to_preference_review_page
 
     when_i_navigate_to_dynamic_locations
@@ -55,7 +55,7 @@ RSpec.describe 'Candidate edits published preference' do
     given_i_am_signed_in
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     and_i_click('Change where you would like to train')
     then_i_am_redirected_to_the_training_locations_page
 
@@ -73,7 +73,7 @@ RSpec.describe 'Candidate edits published preference' do
     given_i_am_signed_in(funding_type: 'salary')
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     and_i_click('Change whether you would consider fee-funded courses')
     then_i_am_redirected_to_fee_funding_page
     and_the_funding_type_is_checked
@@ -93,7 +93,7 @@ RSpec.describe 'Candidate edits published preference' do
     and_candidate_preference_funding_type_is_nil
 
     given_i_am_on_the_invites_page
-    when_i_click('Update your preferences')
+    when_i_click('Change')
     and_i_click('Select whether you would consider fee-funded courses')
     then_i_am_redirected_to_fee_funding_page
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Candidate submits the application' do
 
   def and_i_am_redirected_to_pool_opt_in_page
     expect(page).to have_content(
-      'Do you want to make your application details visible to other training providers?',
+      'Do you want to be invited to similar courses?',
     )
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -261,6 +261,6 @@ RSpec.describe 'Candidate submits the application' do
     expect(page).to have_current_path(new_candidate_interface_pool_opt_in_path(submit_application: true))
 
     expect(page).to have_content('Application submitted')
-    expect(page).to have_content('Do you want to make your application details visible to other training providers?')
+    expect(page).to have_content('Do you want to be invited to similar courses?')
   end
 end


### PR DESCRIPTION
## Context

Content improvements following recent UR round.

## Changes proposed in this pull request

- Add the caption ‘Application settings’ to the H1 of all screens in Application settings
- Update content on opt-in page and application sharing homepage (plus variants)

## Guidance to review

- Log in as Jeffrey Wisozk (https://apply-review-11250.test.teacherservices.cloud/support/applications/74)
- Go to the Application Sharing tab
- Review the text and make sure it is accurate to your circumstances - I have included some screenshots below of text that will appear if opted in and visible to providers, if opted in and invisible to providers, and if opted out.
- Go through the journey to edit your preferences and check that the 'Application sharing' caption appears above the header on every page
- Review invites and make sure the caption text appears on each screen, including the decline flow (if no invites are present, please impersonate a provider to invite him to a course)

_Opted in and visible to providers_

<img width="497" height="280" alt="Screenshot 2025-09-30 at 16 29 19" src="https://github.com/user-attachments/assets/a4165215-2c2a-47bc-bdde-987969303d0e" />

_Opted in and invisible to providers (i.e. has a choice pending decision or in interviewing)_

<img width="490" height="277" alt="Screenshot 2025-09-30 at 16 31 16" src="https://github.com/user-attachments/assets/a03ddefa-a9ce-4c2b-85ff-27317dbe4a2b" />

_Opted out_

<img width="506" height="216" alt="Screenshot 2025-09-30 at 16 30 03" src="https://github.com/user-attachments/assets/97e52e39-cbd7-4374-8c6d-00af390789e9" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
