### PR TITLE
[lb/1349] Delay transactional mails related to application submission

### DIFF
--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -23,7 +23,7 @@ module CandidateInterface
         ApplicationStateChange.new(application_choice).send_to_provider!
 
         SendNewApplicationEmailToProvider.new(application_choice:).call
-        CandidateMailer.application_choice_submitted(application_choice).deliver_later
+        CandidateMailer.application_choice_submitted(application_choice).deliver_later(wait: wait_time)
 
         LocationPreferences.add_dynamic_location(
           preference: application_form.candidate.published_preferences.last,
@@ -38,5 +38,9 @@ module CandidateInterface
     alias effective_date current_time
     alias submitted_at current_time
     alias sent_to_provider_at current_time
+
+    def wait_time
+      rand(1..7).minutes
+    end
   end
 end

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -10,10 +10,16 @@ class SendNewApplicationEmailToProvider
 
     NotificationsList.for(application_choice, event: :application_submitted, include_ratifying_provider: true).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
-        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
+        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later(wait: wait_time)
       else
-        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
+        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later(wait: wait_time)
       end
     end
+  end
+
+private
+
+  def wait_time
+    @wait_time ||= rand(1..7).minutes
   end
 end


### PR DESCRIPTION
## Context

We are much less likely to hit the notify rate limit this year than we were last year because we no longer use magic link sign in, but there is still a possibility as multiple emails are sent out with each application and there are a lot of people hovering over the button, ready to submit as soon as 9:00 hits.

## Changes proposed in this pull request
 
Added a random wait time of 1-7 minutes for the candidate and provider emails that are sent when an application is submitted. 

## Guidance to review

Last year, we did 15 minutes, but I don't think we need to be as severe as that this time around since we aren't clobbering notify with the magic link emails. Also, we did have at least one support request last year because someone was rejected or withdrew before they received their submission email, which made things a bit confusing for them. 

[PR from last year](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9897/files)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
