### PR TITLE
Remove CandidatePoolProviderOptIn model

### DIFF
--- a/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/candidates_controller.rb
@@ -3,7 +3,6 @@ module ProviderInterface
     class CandidatesController < ProviderInterfaceController
       include Pagy::Backend
 
-      before_action :redirect_to_applications_unless_provider_opted_in
       before_action :set_policy
       before_action :set_back_link, only: [:show]
 
@@ -50,12 +49,6 @@ module ProviderInterface
 
       def set_policy
         @policy = ProviderInterface::Policies::CandidatePoolInvitesPolicy.new(current_provider_user)
-      end
-
-      def redirect_to_applications_unless_provider_opted_in
-        invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
-
-        redirect_to provider_interface_applications_path if invites.blank?
       end
 
       def apply_filters

--- a/app/controllers/provider_interface/candidate_pool/invites_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/invites_controller.rb
@@ -3,7 +3,6 @@ module ProviderInterface
     class InvitesController < ProviderInterfaceController
       include Pagy::Backend
 
-      before_action :redirect_to_applications_unless_provider_opted_in
       before_action :set_invite, only: :show
       before_action :redirect_if_candidate_in_pool, only: :show
       before_action :set_back_link, only: :show
@@ -43,12 +42,6 @@ module ProviderInterface
         pool_candidate = Pool::Candidates.application_forms_for_provider.find_by(candidate_id: @invite.candidate_id)
 
         redirect_to provider_interface_candidate_pool_candidate_path(@invite.candidate_id) if pool_candidate.present?
-      end
-
-      def redirect_to_applications_unless_provider_opted_in
-        opt_in = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
-
-        redirect_to provider_interface_applications_path if opt_in.blank?
       end
 
       def filter_params

--- a/app/controllers/provider_interface/candidate_pool/shares_controller.rb
+++ b/app/controllers/provider_interface/candidate_pool/shares_controller.rb
@@ -1,7 +1,6 @@
 module ProviderInterface
   module CandidatePool
     class SharesController < ProviderInterfaceController
-      before_action :redirect_to_applications_unless_provider_opted_in
       before_action :set_candidate
       before_action :set_back_link
 
@@ -29,12 +28,6 @@ module ProviderInterface
                        else
                          provider_interface_candidate_pool_candidate_url(@candidate)
                        end
-      end
-
-      def redirect_to_applications_unless_provider_opted_in
-        invites = CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids)
-
-        redirect_to provider_interface_applications_path if invites.blank?
       end
     end
   end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -136,13 +136,11 @@ class NavigationItems
           ),
         }
 
-        if CandidatePoolProviderOptIn.find_by(provider_id: current_provider_user.provider_ids).present?
-          items << {
-            text: 'Find candidates',
-            href: provider_interface_candidate_pool_root_path,
-            active: active?(current_controller, %w[candidates draft_invites invites not_seen shares]),
-          }
-        end
+        items << {
+          text: 'Find candidates',
+          href: provider_interface_candidate_pool_root_path,
+          active: active?(current_controller, %w[candidates draft_invites invites not_seen shares]),
+        }
 
         items << {
           text: 'Interview schedule',

--- a/app/models/candidate_pool_provider_opt_in.rb
+++ b/app/models/candidate_pool_provider_opt_in.rb
@@ -1,3 +1,0 @@
-class CandidatePoolProviderOptIn < ApplicationRecord
-  belongs_to :provider
-end

--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -6,10 +6,6 @@ class GenerateCandidatePoolData
   def call
     return if HostingEnvironment.production?
 
-    CandidatePoolProviderOptIn.insert_all(
-      Provider.ids.map { |provider_id| { provider_id: } },
-    )
-
     application_forms = Pool::Candidates.new.curated_application_forms
 
     locations = [

--- a/spec/factories/candidate_pool_provider_opt_in.rb
+++ b/spec/factories/candidate_pool_provider_opt_in.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :candidate_pool_provider_opt_in do
-    provider
-  end
-end

--- a/spec/models/candidate_pool_provider_opt_in_spec.rb
+++ b/spec/models/candidate_pool_provider_opt_in_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CandidatePoolProviderOptIn do
-  describe 'associations' do
-    it { is_expected.to belong_to(:provider) }
-  end
-end

--- a/spec/services/generate_candidate_pool_data_spec.rb
+++ b/spec/services/generate_candidate_pool_data_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe GenerateCandidatePoolData do
       create(:application_choice, :declined, application_form: declined_application_form)
 
       expect { described_class.call }.to change(CandidatePreference, :count).from(0).to(2)
-        .and change(CandidatePoolProviderOptIn, :count).from(0).to(2)
         .and change(CandidatePoolApplication, :count).from(0).to(2)
     end
 
@@ -28,7 +27,6 @@ RSpec.describe GenerateCandidatePoolData do
         create(:application_choice, :declined, application_form: declined_application_form)
 
         expect { described_class.call }.to not_change(CandidatePreference, :count)
-          .and not_change(CandidatePoolProviderOptIn, :count)
           .and not_change(CandidatePoolApplication, :count)
       end
     end

--- a/spec/system/provider_interface/candidate_pool/errors_on_candidate_number_search_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/errors_on_candidate_number_search_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Providers views candidate pool list' do
 
   scenario 'Provider enters invalid data into candidate number search' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
@@ -26,10 +25,6 @@ private
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database(provider_code: current_provider.code)
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_find_candidates_page

--- a/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_cannot_send_invites_spec.rb
@@ -79,7 +79,6 @@ private
   def and_those_providers_have_courses_for_the_pool
     @provider_user.providers.each do |provider|
       create_list(:course, 3, :open, provider:)
-      create(:candidate_pool_provider_opt_in, provider:)
     end
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_invites_candidate_to_apply_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_user_exists
     and_provider_has_courses(3)
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_candidate_pool_show_page
@@ -60,7 +59,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_user_exists
     and_provider_has_courses(3)
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_not_seen_page
@@ -87,7 +85,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_has_courses(3)
     and_there_are_candidates_for_candidate_pool
     and_provider_has_invites
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_invited_page
@@ -113,7 +110,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_user_exists
     and_provider_has_courses(21)
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_candidate_pool_show_page
@@ -139,7 +135,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_user_exists
     and_provider_has_courses(3)
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_candidate_pool_show_page
@@ -176,7 +171,6 @@ RSpec.describe 'Providers invites candidates' do
     and_provider_user_exists
     and_provider_has_courses(3)
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_candidate_pool_show_page
@@ -248,10 +242,6 @@ RSpec.describe 'Providers invites candidates' do
       submitted_at: 1.day.ago,
     )
     create(:candidate_pool_application, application_form: rejected_candidate_form)
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_candidate_pool_show_page

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Provider shares candiate profile' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
@@ -43,10 +42,6 @@ RSpec.describe 'Provider shares candiate profile' do
       submitted_at: 1.day.ago,
     )
     create(:candidate_pool_application, application_form: @rejected_candidate_form)
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_find_candidates_page

--- a/spec/system/provider_interface/candidate_pool/provider_switches_tabs_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_switches_tabs_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Provider user navigates the FAC tabs' do
 
   before do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_provider_is_opted_in_to_candidate_pool
     and_provider_has_open_course
     set_viewed_application_form
     set_not_seen_application_form
@@ -124,12 +123,6 @@ RSpec.describe 'Provider user navigates the FAC tabs' do
       dfe_sign_in_uid: @provider_user.dfe_sign_in_uid,
     )
     @provider_user.provider_permissions.update_all(make_decisions: true)
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    @provider_user.providers.each do |provider|
-      create(:candidate_pool_provider_opt_in, provider:)
-    end
   end
 
   def and_provider_has_open_course

--- a/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_a_candidate_on_candidate_pool_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Providers views candidate pool details' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
@@ -31,7 +30,6 @@ RSpec.describe 'Providers views candidate pool details' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page_with_bad_pagination
@@ -80,10 +78,6 @@ RSpec.describe 'Providers views candidate pool details' do
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_find_candidates_page

--- a/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_candidate_pool_list_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Providers views candidate pool list' do
   scenario 'View candidates' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_find_candidates_page
@@ -68,7 +67,6 @@ RSpec.describe 'Providers views candidate pool list' do
     scenario 'Provider inputs a wrong location in the filters' do
       given_i_am_a_provider_user_with_dfe_sign_in
       and_provider_user_exists
-      and_provider_is_opted_in_to_candidate_pool
       and_i_sign_in_to_the_provider_interface
 
       when_i_visit_the_find_candidates_page
@@ -76,17 +74,6 @@ RSpec.describe 'Providers views candidate pool list' do
 
       then_i_see_an_error
     end
-  end
-
-  scenario 'Provider cannot view candidates if not invited' do
-    given_i_am_a_provider_user_with_dfe_sign_in
-    and_provider_user_exists
-    and_i_sign_in_to_the_provider_interface
-
-    when_i_visit_the_find_candidates_page
-
-    then_i_am_redirected_to_the_applications_page
-    and_find_candidates_is_not_in_my_navigation
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -143,10 +130,6 @@ RSpec.describe 'Providers views candidate pool list' do
       needs_visa: true,
       course_funding_type_fee: true,
     )
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_find_candidates_page

--- a/spec/system/provider_interface/candidate_pool/provider_views_invited_candidates_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_invited_candidates_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe 'Invited candidate list' do
   scenario 'I can navigate to a candidate that is currently in the pool' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_invited_candidates_page
@@ -74,7 +73,6 @@ RSpec.describe 'Invited candidate list' do
   scenario 'Provider user with existing filters views list of candidates' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
     and_i_have_an_existing_filter
 
@@ -85,7 +83,6 @@ RSpec.describe 'Invited candidate list' do
   scenario 'Visiting a page that is out of range' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_invited_candidates_page_with_bad_pagination
@@ -100,10 +97,6 @@ private
 
   def and_provider_user_exists
     provider_user_exists_in_apply_database(provider_code: current_provider.code)
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_invited_candidates_page

--- a/spec/system/provider_interface/candidate_pool/provider_views_new_candidate_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_new_candidate_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Providers views new candidate in pool' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool
-    and_provider_is_opted_in_to_candidate_pool
     and_i_sign_in_to_the_provider_interface
   end
 
@@ -73,10 +72,6 @@ private
       submitted_at: 1.year.ago,
       candidate: declined_candidate,
     )
-  end
-
-  def and_provider_is_opted_in_to_candidate_pool
-    create(:candidate_pool_provider_opt_in, provider: current_provider)
   end
 
   def when_i_visit_the_find_candidates_new_tab


### PR DESCRIPTION
We don't need this anymore

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Can go on review app and impersonate a provider, you should still have access to the FAC feature.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
