### PR TITLE
Remove offest for when find opens

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -148,7 +148,7 @@ jobs:
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
-        offset-date: [real_world, before_apply_reopens, after_apply_reopens]
+        offset-date: [real_world, after_apply_reopens]
         # Use these offsets through mid-cycle
         # offset-date: [real_world]
 


### PR DESCRIPTION
## Context

We use the offsets to make sure our test suite is not going to fail as we move through the end of cycle period. Now that we are in the 'before apply opens' phase, we no longer need this offset. 

## Changes proposed in this pull request

Remove one of the offsets.

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
