### PR TITLE
Fix sentry error occurring before reports are scheduled

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -19,7 +19,9 @@ class DetectInvariantsDailyCheck
                                            .new
                                            .generated_schedules
                                            .last
-                                           .generation_date
+                                            &.generation_date
+
+    return if latest_past_generation_date.nil? # We don't have any generation dates in the past.
 
     report = Publications::MonthlyStatistics::MonthlyStatisticsReport.find_by(
       generation_date: latest_past_generation_date,

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -217,6 +217,17 @@ RSpec.describe DetectInvariantsDailyCheck do
           end
         end
       end
+
+      context 'when it is before reports are generated' do
+        it 'does not send an alert' do
+          first_generation_date = Publications::MonthlyStatistics::Timetable.new.schedules.first.generation_date
+          travel_temporarily_to(first_generation_date - 1.day) do
+            described_class.new.perform
+
+            expect(Sentry).not_to have_received(:capture_exception).with(exception)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

[Sentry Error](https://dfe-teacher-services.sentry.io/issues/6914584980/?alert_rule_id=853774&alert_type=issue&notification_uuid=18db4b54-e5c2-4689-a013-5693badc8ce6&project=1765973&referrer=slack)

## Changes proposed in this pull request

Check to see if we are before the first publication date before checking to see if there is a report.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
