### PR TITLE
Remove candidate_preferences feature flag

### DIFF
--- a/app/components/candidate_interface/manage_preferences_component.rb
+++ b/app/components/candidate_interface/manage_preferences_component.rb
@@ -7,7 +7,7 @@ class CandidateInterface::ManagePreferencesComponent < ViewComponent::Base
   end
 
   def render?
-    FeatureFlag.active?(:candidate_preferences) && application_form.submitted_applications?
+    application_form.submitted_applications?
   end
 
   def pool_opt_in?

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -51,7 +51,7 @@ module CandidateInterface
       CandidateInterface::SubmitApplicationChoice.new(@application_choice).call
       flash[:success] = t('application_form.submit_application_success.title')
 
-      if FeatureFlag.active?(:candidate_preferences) && current_candidate.published_preferences.blank?
+      if current_candidate.published_preferences.blank?
         redirect_to new_candidate_interface_pool_opt_in_path(submit_application: true)
       else
         redirect_to candidate_interface_application_choices_path

--- a/app/controllers/candidate_interface/draft_preferences_controller.rb
+++ b/app/controllers/candidate_interface/draft_preferences_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class DraftPreferencesController < CandidateInterfaceController
     before_action :set_preference, only: %i[show update]
-    before_action :redirect_to_root_path_if_flag_is_inactive
 
     def show
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
@@ -50,10 +49,6 @@ module CandidateInterface
       if @preference.blank?
         redirect_to candidate_interface_invites_path
       end
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
     end
   end
 end

--- a/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/dynamic_location_preferences_controller.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class DynamicLocationPreferencesController < CandidateInterfaceController
     before_action :set_preference
     before_action :set_back_path, only: :new
-    before_action :redirect_to_root_path_if_flag_is_inactive
 
     def new
       if @preference.published?
@@ -53,10 +52,6 @@ module CandidateInterface
       params.fetch(:candidate_interface_dynamic_location_preferences_form, {}).permit(
         :dynamic_location_preferences,
       )
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
     end
   end
 end

--- a/app/controllers/candidate_interface/funding_type_preferences_controller.rb
+++ b/app/controllers/candidate_interface/funding_type_preferences_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class FundingTypePreferencesController < CandidateInterfaceController
     before_action :set_preference
-    before_action :redirect_to_root_path_if_flag_is_inactive
     before_action :set_back_path
 
     def new
@@ -42,10 +41,6 @@ module CandidateInterface
       if @preference.blank?
         redirect_to candidate_interface_invites_path
       end
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
     end
 
     def set_back_path

--- a/app/controllers/candidate_interface/invites_controller.rb
+++ b/app/controllers/candidate_interface/invites_controller.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class InvitesController < CandidateInterfaceController
     before_action CarryOverFilter
     before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
-    before_action :redirect_if_feature_off_and_no_submitted_application
     before_action :set_invite, only: %i[edit update]
 
     def index
@@ -39,12 +38,6 @@ module CandidateInterface
 
     def invite_response_form_params
       params.fetch(:candidate_interface_fac_invite_response_form, {}).permit(:apply_for_this_course)
-    end
-
-    def redirect_if_feature_off_and_no_submitted_application
-      unless FeatureFlag.active?(:candidate_preferences) && current_application.submitted_applications?
-        redirect_to root_path
-      end
     end
   end
 end

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -3,7 +3,6 @@ module CandidateInterface
     before_action :set_preference
     before_action :set_location_preference, only: %i[edit update show destroy]
     before_action :set_back_path, only: %i[index]
-    before_action :redirect_to_root_path_if_flag_is_inactive
 
     def index
       if @preference.published?
@@ -90,10 +89,6 @@ module CandidateInterface
       if params[:return_to] == 'review'
         @back_path = candidate_interface_draft_preference_path(@preference)
       end
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences) && current_application.submitted_applications?
     end
   end
 end

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -3,7 +3,6 @@ module CandidateInterface
     before_action :redirect_to_review_for_duplicate_preferences, only: :new
     before_action :set_preference, only: %i[edit update]
     before_action :set_back_path, only: %i[edit update]
-    before_action :redirect_to_root_path_if_flag_is_inactive
 
     def show; end
 
@@ -109,10 +108,6 @@ module CandidateInterface
       if params[:return_to] == 'review'
         @back_path = candidate_interface_draft_preference_path(@preference)
       end
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences) && current_application.submitted_applications?
     end
   end
 end

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class PublishPreferencesController < CandidateInterfaceController
     before_action :set_preference
-    before_action :redirect_to_root_path_if_flag_is_inactive
 
     def show
       @location_preferences = @preference.location_preferences.order(:created_at).map do |location|
@@ -34,10 +33,6 @@ module CandidateInterface
       if @preference.blank?
         redirect_to candidate_interface_invites_path
       end
-    end
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences)
     end
   end
 end

--- a/app/controllers/candidate_interface/share_details_controller.rb
+++ b/app/controllers/candidate_interface/share_details_controller.rb
@@ -1,13 +1,5 @@
 module CandidateInterface
   class ShareDetailsController < CandidateInterfaceController
-    before_action :redirect_to_root_path_if_flag_is_inactive
-
     def index; end
-
-  private
-
-    def redirect_to_root_path_if_flag_is_inactive
-      redirect_to root_path unless FeatureFlag.active?(:candidate_preferences) && current_application.submitted_applications?
-    end
   end
 end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -38,7 +38,7 @@ class NavigationItems
           },
         ]
 
-        if FeatureFlag.active?(:candidate_preferences) && current_candidate.current_application.submitted_applications?
+        if current_candidate.current_application.submitted_applications?
           items << {
             text: t('page_titles.application_sharing'),
             href: candidate_interface_invites_path,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,7 +27,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
-    [:candidate_preferences, 'Allow candidates to add their preferences for providers to find them', 'Apply team'],
     [:api_token_management, 'Allow provider users to manage their own api tokens', 'Apply team'],
   ].freeze
 

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -53,7 +53,7 @@
              <%= simple_format(t('.start_applying', max_courses: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES)) %>
 
               <% if current_candidate.present? %>
-                <% if current_application.submitted_applications? && FeatureFlag.active?(:candidate_preferences) %>
+                <% if current_application.submitted_applications? %>
                   <%= t('.if_unsuccessful_html', link: govuk_link_to('choose to share your details', candidate_interface_share_details_path)) %>
                 <% else %>
                   <%= t('.if_unsuccessful_html', link: 'choose to share your details') %>

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
   describe '#render' do
     context 'when candidate preference feature flag is enabled' do
       it 'renders the component' do
-        FeatureFlag.activate(:candidate_preferences)
         application_form = create(:application_form, :with_accepted_offer)
 
         component = described_class.new(current_candidate: application_form.candidate, application_form:)
@@ -18,7 +17,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
     context 'when candidate preference feature flag is not enabled' do
       it 'renders the component' do
-        FeatureFlag.deactivate(:candidate_preferences)
         application_form = create(:application_form, :with_accepted_offer)
 
         component = described_class.new(current_candidate: application_form.candidate, application_form:)
@@ -30,7 +28,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
     context 'when candidate preference feature flag is enabled but no sent applications' do
       it 'renders the component' do
-        FeatureFlag.activate(:candidate_preferences)
         application_form = create(:application_form)
 
         component = described_class.new(current_candidate: application_form.candidate, application_form:)
@@ -73,7 +70,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
 
   describe '#path_to_change_preferences' do
     it 'returns the published show path if the candidate has a published preference' do
-      FeatureFlag.activate(:candidate_preferences)
       candidate = create(:candidate)
       preference = create(
         :candidate_preference,
@@ -93,7 +89,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
     end
 
     it 'returns the new opt in path if the candidate does not have a published preference' do
-      FeatureFlag.activate(:candidate_preferences)
       candidate = create(:candidate)
       _preference = create(
         :candidate_preference,
@@ -113,7 +108,6 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
     end
 
     it 'returns the edit opt in path if the published preference is opted out' do
-      FeatureFlag.activate(:candidate_preferences)
       candidate = create(:candidate)
       preference = create(
         :candidate_preference,

--- a/spec/components/candidate_interface/manage_preferences_component_spec.rb
+++ b/spec/components/candidate_interface/manage_preferences_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
   include Rails.application.routes.url_helpers
 
   describe '#render' do
-    context 'when candidate preference feature flag is enabled' do
+    context 'when sent applications' do
       it 'renders the component' do
         application_form = create(:application_form, :with_accepted_offer)
 
@@ -15,18 +15,7 @@ RSpec.describe CandidateInterface::ManagePreferencesComponent, type: :component 
       end
     end
 
-    context 'when candidate preference feature flag is not enabled' do
-      it 'renders the component' do
-        application_form = create(:application_form, :with_accepted_offer)
-
-        component = described_class.new(current_candidate: application_form.candidate, application_form:)
-        result = render_inline(component)
-
-        expect(result.to_html).to be_blank
-      end
-    end
-
-    context 'when candidate preference feature flag is enabled but no sent applications' do
+    context 'when no sent applications' do
       it 'renders the component' do
         application_form = create(:application_form)
 

--- a/spec/helpers/navigation_items_spec.rb
+++ b/spec/helpers/navigation_items_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe NavigationItems do
-  before { FeatureFlag.activate(:candidate_preferences) }
-  after { FeatureFlag.deactivate(:candidate_preferences) }
-
   let(:current_application) { current_candidate.current_application }
 
   describe '.candidate_primary_navigation' do

--- a/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
@@ -45,8 +45,6 @@ RSpec.describe 'Block submission from blocked candidates' do
 
     context 'when tries to submit' do
       it 'redirects to your applications' do
-        FeatureFlag.activate(:candidate_preferences)
-
         post candidate_interface_course_choices_submit_course_choice_path(choice.id),
              params: {
                candidate_interface_course_choices_submit_application_form: {
@@ -62,8 +60,6 @@ RSpec.describe 'Block submission from blocked candidates' do
     context 'when candidate_preferences feature flag is off' do
       context 'when tries to submit' do
         it 'redirects to your applications' do
-          FeatureFlag.deactivate(:candidate_preferences)
-
           post candidate_interface_course_choices_submit_course_choice_path(choice.id),
                params: {
                  candidate_interface_course_choices_submit_application_form: {

--- a/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
@@ -56,21 +56,5 @@ RSpec.describe 'Block submission from blocked candidates' do
         expect(response.body).to include(t('application_form.submit_application_success.title'))
       end
     end
-
-    context 'when candidate_preferences feature flag is off' do
-      context 'when tries to submit' do
-        it 'redirects to your applications' do
-          post candidate_interface_course_choices_submit_course_choice_path(choice.id),
-               params: {
-                 candidate_interface_course_choices_submit_application_form: {
-                   submit_answer: true,
-                 },
-               }
-          expect(response).to redirect_to(candidate_interface_application_choices_path)
-          follow_redirect!
-          expect(response.body).to include(t('application_form.submit_application_success.title'))
-        end
-      end
-    end
   end
 end

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'Submit to continuous apps' do
     let(:application_form) { create(:application_form, :completed, :with_degree, submitted_at: nil) }
 
     before do
-      FeatureFlag.activate(:candidate_preferences)
       post candidate_interface_course_choices_submit_course_choice_path(choice.id)
     end
 
@@ -28,7 +27,6 @@ RSpec.describe 'Submit to continuous apps' do
 
     context 'when candidate preferences FeatureFlag is off' do
       before do
-        FeatureFlag.deactivate(:candidate_preferences)
         post candidate_interface_course_choices_submit_course_choice_path(choice.id)
       end
 

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -166,6 +166,14 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
     click_on 'Review application'
     click_on 'Confirm and submit application'
 
+    expect(page).to have_content(
+      'Do you want to make your application details visible to other training providers?',
+    )
+    choose 'No'
+    click_on 'Continue'
+
+    click_on 'Your applications'
+
     expect(page).to have_content('You can add 3 more applications')
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
   include CandidateHelper
 
   context 'candidate preferences feature flag is activated' do
-    before do
-      FeatureFlag.activate(:candidate_preferences)
-    end
-
     it 'candidate can submit in next cycle after dismissing candidate preferences' do
       given_i_am_signed_in_with_one_login
       when_i_have_an_unsubmitted_application_without_a_course
@@ -35,10 +31,6 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
   end
 
   context 'candidate preferences feature flag is deactivated' do
-    before do
-      FeatureFlag.deactivate(:candidate_preferences)
-    end
-
     it 'Candidate can submit in next cycle with cycle switcher after apply opens', time: mid_cycle do
       given_i_am_signed_in_with_one_login
       when_i_have_an_unsubmitted_application_without_a_course

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Carry over application and submit new application choices' do
   include CandidateHelper
 
-  before do
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
   it 'Candidate carries over unsubmitted application with a course to new cycle', time: mid_cycle do
     given_i_am_signed_in_with_one_login
     when_i_have_an_unsubmitted_application

--- a/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits application with feedback form previously completed' do
   include CandidateHelper
 
-  before do
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
   it 'Candidate submits application, skips feedback and goes straight to the application dashboard' do
     given_i_complete_my_application
     and_the_feedback_form_was_previously_submitted

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Candidate responds to an invite' do
   include CandidateHelper
 
-  before { FeatureFlag.activate(:candidate_preferences) }
-  after { FeatureFlag.deactivate(:candidate_preferences) }
-
   scenario 'After apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_respond_to_invite

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Candidate views their invites' do
   include CandidateHelper
 
-  before { FeatureFlag.activate(:candidate_preferences) }
-  after { FeatureFlag.deactivate(:candidate_preferences) }
-
   scenario 'after apply deadline', time: after_apply_deadline do
     given_i_am_signed_in_without_in_flight_applications
     when_i_go_to_application_sharing

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_after_carrying_over_application_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   let(:provider) { create(:provider) }
 
-  before { FeatureFlag.activate(:candidate_preferences) }
-
   scenario 'Candidate opts in to find a candidate with specific locations' do
     given_i_am_signed_in
     given_i_have_a_duplicate_preference_form

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -23,11 +23,8 @@ RSpec.describe 'Candidate adds preferences' do
     allow(client).to receive(:autocomplete).and_return(api_response)
   end
 
-  after { FeatureFlag.deactivate(:candidate_preferences) }
-
   scenario 'Candidate opts in to find a candidate with specific locations' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
@@ -106,7 +103,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   scenario 'Candidate opts in to find a candidate with specific locations and applied to fee funded courses' do
     given_i_am_signed_in(funding_type: 'fee')
-    and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
@@ -142,7 +138,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   scenario 'Candidate opts in to find a candidate for anywhere in England' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
@@ -169,7 +164,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   scenario 'Candidate opts in to find a candidate for anywhere in England and applied to fee funded courses' do
     given_i_am_signed_in(funding_type: 'fee')
-    and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
@@ -201,7 +195,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   scenario 'Candidate opts out of find a candidate' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     visit new_candidate_interface_pool_opt_in_path
     and_i_opt_out_to_find_a_candidate
@@ -212,7 +205,6 @@ RSpec.describe 'Candidate adds preferences' do
 
   scenario 'Candidate opts out of find a candidate and gives a reason' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     visit new_candidate_interface_pool_opt_in_path
     and_i_opt_out_to_find_a_candidate
@@ -258,7 +250,6 @@ RSpec.describe 'Candidate adds preferences' do
   def given_i_am_a_candidate_who_has_opted_in_with_a_dynamic_location
     given_i_am_signed_in
     given_courses_exist
-    and_feature_flag_is_enabled
     given_i_am_on_the_share_details_page
     and_i_click('Back')
 
@@ -469,10 +460,6 @@ RSpec.describe 'Candidate adds preferences' do
   def and_i_edit_a_location
     fill_in('I can travel up to', with: updated_location[:within])
     fill_in('from city, town or postcode', with: updated_location[:name])
-  end
-
-  def and_feature_flag_is_enabled
-    FeatureFlag.activate(:candidate_preferences)
   end
 
   def given_i_am_on_the_share_details_page

--- a/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_edits_published_preference_spec.rb
@@ -1,13 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate edits published preference' do
-  after { FeatureFlag.deactivate(:candidate_preferences) }
-
   let(:provider) { create(:provider) }
 
   scenario 'Candidate edits share preferences' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -23,7 +20,6 @@ RSpec.describe 'Candidate edits published preference' do
 
   scenario 'Candidate adds a reason for opting out' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -40,7 +36,6 @@ RSpec.describe 'Candidate edits published preference' do
 
   scenario 'Candidate edits dynamic location preferences' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -58,7 +53,6 @@ RSpec.describe 'Candidate edits published preference' do
 
   scenario 'Candidate edits training locations' do
     given_i_am_signed_in
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -77,7 +71,6 @@ RSpec.describe 'Candidate edits published preference' do
 
   scenario 'Candidate edits funding_type' do
     given_i_am_signed_in(funding_type: 'salary')
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -98,7 +91,6 @@ RSpec.describe 'Candidate edits published preference' do
   scenario 'Candidate edits funding_type without setting it in the first place' do
     given_i_am_signed_in(funding_type: 'salary')
     and_candidate_preference_funding_type_is_nil
-    and_feature_flag_is_enabled
 
     given_i_am_on_the_invites_page
     when_i_click('Update your preferences')
@@ -137,10 +129,6 @@ RSpec.describe 'Candidate edits published preference' do
       :candidate_location_preference,
       candidate_preference: @existing_candidate_preference,
     )
-  end
-
-  def and_feature_flag_is_enabled
-    FeatureFlag.activate(:candidate_preferences)
   end
 
   def given_i_am_on_the_invites_page

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe 'Candidate submits the application' do
     and_i_continue_with_my_application
     and_i_choose_to_submit
     then_i_can_see_my_application_has_been_successfully_submitted
+
+    and_i_am_redirected_to_pool_opt_in_page
+    and_i_say_no_to_sharing_details
+    then_i_am_redirected_to_invites
+
+    when_i_click_on_your_applications
     and_i_am_redirected_to_the_application_dashboard
     and_my_application_is_submitted
     then_i_can_see_my_submitted_application
@@ -150,6 +156,25 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_can_see_my_application_has_been_successfully_submitted
     expect(page).to have_content 'Application submitted'
+  end
+
+  def and_i_am_redirected_to_pool_opt_in_page
+    expect(page).to have_content(
+      'Do you want to make your application details visible to other training providers?',
+    )
+  end
+
+  def and_i_say_no_to_sharing_details
+    choose 'No'
+    click_link_or_button('Continue')
+  end
+
+  def then_i_am_redirected_to_invites
+    expect(page).to have_content('You are not sharing your application details with providers you have not applied to')
+  end
+
+  def when_i_click_on_your_applications
+    click_link_or_button('Your applications')
   end
 
   def and_i_am_redirected_to_the_application_dashboard

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
 
   scenario 'Candidate with a completed application', :with_audited do
-    given_the_candidate_preferences_feature_flag_is_not_activated
     given_i_am_signed_in_with_one_login
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
@@ -51,7 +50,6 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate with a primary application missing the science GCSE' do
-    given_the_candidate_preferences_feature_flag_is_not_activated
     given_i_am_signed_in_with_one_login
 
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
@@ -65,7 +63,6 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate with a primary application missing the science GCSE and missing other sections' do
-    given_the_candidate_preferences_feature_flag_is_not_activated
     given_i_am_signed_in_with_one_login
 
     when_i_have_an_incomplete_application_and_have_added_primary_as_a_course_choice
@@ -79,7 +76,6 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   scenario 'Candidate views the share details page after submission' do
-    given_the_candidate_preferences_feature_flag_is_activated
     given_i_am_signed_in_with_one_login
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
@@ -234,14 +230,6 @@ RSpec.describe 'Candidate submits the application' do
     expect(
       @application_choice.audits.where(user_id: @current_candidate.id).any?,
     ).to be_truthy
-  end
-
-  def given_the_candidate_preferences_feature_flag_is_activated
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
-  def given_the_candidate_preferences_feature_flag_is_not_activated
-    FeatureFlag.deactivate(:candidate_preferences)
   end
 
   def then_i_am_redirected_to_preference_opt_in_form

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
 
-  before do
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in_with_one_login
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate submits an application up to 4 choices' do
 
   before do
     given_courses_exist
-    FeatureFlag.activate(:candidate_preferences)
   end
 
   scenario 'when candidate has a conditions not met and only one free slot' do

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
 
-  before do
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
   scenario 'Candidate with more than the max unsuccessful apps' do
     given_i_am_signed_in_with_one_login
     and_i_have_19_unsuccessful_applications

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'International candidate submits the application' do
   include CandidateHelper
   include EFLHelper
 
-  before do
-    FeatureFlag.activate(:candidate_preferences)
-  end
-
   it 'International candidate completes and submits an application' do
     given_i_am_signed_in_with_one_login
 


### PR DESCRIPTION
## Context

Removed the feature flag for candidate preferences, including in specs. Migration to remove the data will follow.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/7d491ce1-142b-4cb2-be0d-b1996989cc1c



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
