### PR TITLE
Drop candidate_preferences feature flag from DB

### DIFF
--- a/app/controllers/candidate_interface/invites_controller.rb
+++ b/app/controllers/candidate_interface/invites_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class InvitesController < CandidateInterfaceController
     before_action CarryOverFilter
     before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
+    before_action :redirect_if_no_submitted_application
     before_action :set_invite, only: %i[edit update]
 
     def index
@@ -38,6 +39,12 @@ module CandidateInterface
 
     def invite_response_form_params
       params.fetch(:candidate_interface_fac_invite_response_form, {}).permit(:apply_for_this_course)
+    end
+
+    def redirect_if_no_submitted_application
+      unless current_application.submitted_applications?
+        redirect_to root_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/location_preferences_controller.rb
+++ b/app/controllers/candidate_interface/location_preferences_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     before_action :set_preference
     before_action :set_location_preference, only: %i[edit update show destroy]
     before_action :set_back_path, only: %i[index]
+    before_action :redirect_to_root_path_if_submitted_application
 
     def index
       if @preference.published?
@@ -89,6 +90,10 @@ module CandidateInterface
       if params[:return_to] == 'review'
         @back_path = candidate_interface_draft_preference_path(@preference)
       end
+    end
+
+    def redirect_to_root_path_if_submitted_application
+      redirect_to root_path unless current_application.submitted_applications?
     end
   end
 end

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     before_action :redirect_to_review_for_duplicate_preferences, only: :new
     before_action :set_preference, only: %i[edit update]
     before_action :set_back_path, only: %i[edit update]
+    before_action :redirect_to_root_path_if_submitted_applications
 
     def show; end
 
@@ -108,6 +109,10 @@ module CandidateInterface
       if params[:return_to] == 'review'
         @back_path = candidate_interface_draft_preference_path(@preference)
       end
+    end
+
+    def redirect_to_root_path_if_submitted_applications
+      redirect_to root_path unless current_application.submitted_applications?
     end
   end
 end

--- a/app/controllers/candidate_interface/share_details_controller.rb
+++ b/app/controllers/candidate_interface/share_details_controller.rb
@@ -1,5 +1,13 @@
 module CandidateInterface
   class ShareDetailsController < CandidateInterfaceController
+    before_action :redirect_to_root_path_if_submitted_applications
+
     def index; end
+
+  private
+
+    def redirect_to_root_path_if_submitted_applications
+      redirect_to root_path unless current_application.submitted_applications?
+    end
   end
 end

--- a/app/services/data_migrations/remove_candidate_preferences_feature_flag.rb
+++ b/app/services/data_migrations/remove_candidate_preferences_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveCandidatePreferencesFeatureFlag
+    TIMESTAMP = 20251003133827
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :candidate_preferences)&.delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveCandidatePreferencesFeatureFlag',
   'DataMigrations::BackfillCourseOpenOnPoolInvite',
   'DataMigrations::BackfillApplicationFormOnCandidatePreferences',
   'DataMigrations::DropGroupedInviteEmailFeatureFlag',

--- a/spec/services/data_migrations/remove_candidate_preferences_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_candidate_preferences_feature_flag_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveCandidatePreferencesFeatureFlag do
+  context 'when the feature flag exist' do
+    it 'removes candidate_preference flag' do
+      create(:feature, name: 'candidate_preferences')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'candidate_preferences')).to be_blank
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We don't use this flag anymore

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
