### PR TITLE
Set candidate_id to not_null on candidate_preferences

### DIFF
--- a/db/migrate/20251006125828_set_candidate_not_null_candidate_preferences.rb
+++ b/db/migrate/20251006125828_set_candidate_not_null_candidate_preferences.rb
@@ -1,0 +1,10 @@
+class SetCandidateNotNullCandidatePreferences < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint(
+      :candidate_preferences,
+      'candidate_id IS NOT NULL',
+      name: 'candidate_preferences_candidate_id_null',
+      validate: false,
+    )
+  end
+end

--- a/db/migrate/20251006125919_validate_candidate_column_not_null_candidate_preferences.rb
+++ b/db/migrate/20251006125919_validate_candidate_column_not_null_candidate_preferences.rb
@@ -1,0 +1,17 @@
+class ValidateCandidateColumnNotNullCandidatePreferences < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint(
+      :candidate_preferences,
+      name: 'candidate_preferences_candidate_id_null',
+    )
+    change_column_null :candidate_preferences, :candidate_id, true
+    remove_check_constraint(
+      :candidate_preferences,
+      name: 'candidate_preferences_candidate_id_null',
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_02_162146) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_06_125919) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -445,7 +445,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_02_162146) do
     t.string "pool_status"
     t.string "status", default: "draft", null: false
     t.boolean "dynamic_location_preferences"
-    t.bigint "candidate_id", null: false
+    t.bigint "candidate_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "opt_out_reason"


### PR DESCRIPTION
## Context

This is needed to start using the application_form when when querying candidate_preferences. Rather than candidate_id

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
