### PR TITLE
Send pool_opt_in email after published! transaction

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -148,7 +148,7 @@ jobs:
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
-        offset-date: [real_world, after_apply_reopens]
+        offset-date: [real_world]
         # Use these offsets through mid-cycle
         # offset-date: [real_world]
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -18,7 +18,7 @@ module CandidateInterface
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
         current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
       end
-      if @preference.reload.publshed?
+      if @preference.reload.published?
         PreferencesEmail.call(preference: @preference)
       end
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -18,7 +18,7 @@ module CandidateInterface
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
         current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
       end
-      PreferencesEmail.call(preference: @preference)
+      PreferencesEmail.call(preference: @preference.reload)
 
       flash[:success] = t('.success_opt_out') if @preference.opt_out?
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -17,8 +17,8 @@ module CandidateInterface
         end
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
         current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
-        PreferencesEmail.call(preference: @preference)
       end
+      PreferencesEmail.call(preference: @preference)
 
       flash[:success] = t('.success_opt_out') if @preference.opt_out?
 

--- a/app/controllers/candidate_interface/publish_preferences_controller.rb
+++ b/app/controllers/candidate_interface/publish_preferences_controller.rb
@@ -18,7 +18,9 @@ module CandidateInterface
         current_candidate.published_preferences.where.not(id: @preference.id).destroy_all
         current_candidate.duplicated_preferences.where.not(id: @preference.id).destroy_all
       end
-      PreferencesEmail.call(preference: @preference.reload)
+      if @preference.reload.publshed?
+        PreferencesEmail.call(preference: @preference)
+      end
 
       flash[:success] = t('.success_opt_out') if @preference.opt_out?
 


### PR DESCRIPTION
## Context

This was a bug where the email was sent before the transaction was finished

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
