### PR TITLE
Fix pool opt in confirmation page

### DIFF
--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -4,12 +4,9 @@ module CandidateInterface
     before_action :set_preference, only: %i[edit update]
     before_action :set_back_path, only: %i[edit update]
     before_action :redirect_to_root_path_if_submitted_applications
+    before_action :redirect_to_invites_page_if_preference_is_blank_or_opt_out, only: :show
 
-    def show
-      if current_application.published_preference.nil? || current_application.published_preference.opt_out?
-        redirect_to candidate_interface_invites_path
-      end
-    end
+    def show; end
 
     def new
       @back_path = if just_submitted?
@@ -117,6 +114,12 @@ module CandidateInterface
 
     def redirect_to_root_path_if_submitted_applications
       redirect_to root_path unless current_application.submitted_applications?
+    end
+
+    def redirect_to_invites_page_if_preference_is_blank_or_opt_out
+      if current_application.published_preference.nil? || current_application.published_preference.opt_out?
+        redirect_to candidate_interface_invites_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/pool_opt_ins_controller.rb
+++ b/app/controllers/candidate_interface/pool_opt_ins_controller.rb
@@ -5,7 +5,11 @@ module CandidateInterface
     before_action :set_back_path, only: %i[edit update]
     before_action :redirect_to_root_path_if_submitted_applications
 
-    def show; end
+    def show
+      if current_application.published_preference.nil? || current_application.published_preference.opt_out?
+        redirect_to candidate_interface_invites_path
+      end
+    end
 
     def new
       @back_path = if just_submitted?

--- a/spec/factories/one_login_auth.rb
+++ b/spec/factories/one_login_auth.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
     token { SecureRandom.hex(10) }
     email_address { "#{SecureRandom.hex(5)}@example.com" }
   end
+
+  trait :dev_candidate do
+    token { 'dev-candidate' }
+  end
 end

--- a/spec/requests/candidate_interface/pool_opt_ins_spec.rb
+++ b/spec/requests/candidate_interface/pool_opt_ins_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'pool opt ins' do
+  before do
+    sign_in_request_bypass(candidate)
+  end
+
+  let(:candidate) { create(:candidate) }
+
+  describe 'GET /candidate/preferences-opt-in/show' do
+    context 'published_preference exists' do
+      it 'returns ok' do
+        application_form = create(
+          :application_form,
+          :completed,
+          candidate:,
+          submitted_application_choices_count: 1,
+        )
+        create(:candidate_preference, application_form:)
+
+        get auth_one_login_developer_callback_path
+        get show_candidate_interface_pool_opt_ins_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'published_preference is opt_out' do
+      it 'redirects to candidate invites page' do
+        application_form = create(
+          :application_form,
+          :completed,
+          candidate:,
+          submitted_application_choices_count: 1,
+        )
+        create(:candidate_preference, :opt_out, application_form:)
+
+        get auth_one_login_developer_callback_path
+        get show_candidate_interface_pool_opt_ins_path
+
+        expect(response).to redirect_to(candidate_interface_invites_path)
+      end
+    end
+
+    context 'no published_preference' do
+      it 'redirects to candidate invites page' do
+        create(
+          :application_form,
+          :completed,
+          candidate:,
+          submitted_application_choices_count: 1,
+        )
+
+        get auth_one_login_developer_callback_path
+        get show_candidate_interface_pool_opt_ins_path
+
+        expect(response).to redirect_to(candidate_interface_invites_path)
+      end
+    end
+  end
+end

--- a/spec/support/test_helpers/one_login_helper.rb
+++ b/spec/support/test_helpers/one_login_helper.rb
@@ -35,4 +35,23 @@ module OneLoginHelper
     click_link_or_button 'Continue'
   end
   alias i_am_signed_in_with_one_login :given_i_am_signed_in_with_one_login
+
+  def sign_in_request_bypass(candidate)
+    if FeatureFlag.inactive?(:one_login_candidate_sign_in)
+      FeatureFlag.activate(:one_login_candidate_sign_in)
+    end
+
+    OmniAuth.config.test_mode = true
+    Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:one_login_developer] = OmniAuth::AuthHash.new(
+      {
+        provider: :one_login_developer,
+        uid: 'dev-candidate',
+        credentials: {
+          id_token: 'id_token',
+        },
+      },
+    )
+
+    create(:one_login_auth, candidate:, token: 'dev-candidate')
+  end
 end


### PR DESCRIPTION
## Context

This page can be technically accessed at any time. Even when candidates don't have a published preference.

Not through the UI directly but through back links or if the candidate knows the url.

A small number of users do this and get an error. This commit redirects the user to the application_sharing page if the state of the preference is not correct.

Sentry issues
https://dfe-teacher-services.sentry.io/issues/6928001933/?environment=production&project=1765973&query=is%3Aunresolved&referrer=issue-stream

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


https://github.com/user-attachments/assets/66cc59e2-0769-478a-8eec-0d85cb8cc8f0



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
