### PR TITLE
Go to next step if type is not valid step for degree level

### DIFF
--- a/app/controllers/candidate_interface/degrees/degree_types_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree_types_controller.rb
@@ -6,6 +6,8 @@ module CandidateInterface
         @form = Degrees::TypeForm.new(degree_store, degree_attrs)
 
         @form.save_state!
+
+        next_step! if @form.skips_type_step?
       end
 
       def update

--- a/app/forms/candidate_interface/degrees/base_form.rb
+++ b/app/forms/candidate_interface/degrees/base_form.rb
@@ -18,6 +18,10 @@ module CandidateInterface
       uk? || (country_with_compatible_degrees? && bachelors?)
     end
 
+    def skips_type_step?
+      other_uk_qualification? || degree_level == 'Level 6 Diploma'
+    end
+
     def reviewing_and_unchanged_country?
       reviewing? && existing_degree&.institution_country == country
     end

--- a/app/forms/candidate_interface/degrees/level_form.rb
+++ b/app/forms/candidate_interface/degrees/level_form.rb
@@ -28,10 +28,6 @@ module CandidateInterface
       end
     end
 
-    def skips_type_step?
-      other_uk_qualification? || degree_level == 'Level 6 Diploma'
-    end
-
     def next_step
       if reviewing_and_unchanged_country?
         if skips_type_step?


### PR DESCRIPTION
## Context

Sentry error raised because a translation was missing on the degree types page for Level 6 Diploma. But if Level 6 diploma has been chosen for the level, the user shouldn't see the type page. They must have come to this page directly as I couldn't recreate it by stepping through the form. 

## Changes proposed in this pull request

If a user does happen to land on the types page having chosen a level of 'Level 6 Diploma', they will be moved forward to the next step. 

## Guidance to review

- Create a UK degree and choose 'Level 6 Diploma' on the level option. 
- Try to visit "/candidate/application/degrees/types". You should be directed to the next step (subject).


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
