### PR TITLE
[lb/1385] Select main site where available

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -13,6 +13,10 @@ class Site < ApplicationRecord
     "#{name} (#{code})"
   end
 
+  def main_site?
+    code == '-'
+  end
+
   def self.for_recruitment_cycle_years(recruitment_cycle_years)
     joins(:courses)
     .where(courses: { recruitment_cycle_year: recruitment_cycle_years })

--- a/app/services/candidate_interface/course_choices/course_selection_store.rb
+++ b/app/services/candidate_interface/course_choices/course_selection_store.rb
@@ -32,7 +32,9 @@ module CandidateInterface
         when :course_site
           available_course_options.find(current_step.course_option_id)
         else
-          available_course_options.first
+          available_course_options.find do |course_option|
+            course_option.site.main_site?
+          end.presence || available_course_options.first
         end
       end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -116,4 +116,20 @@ RSpec.describe Site do
       expect(site.geocoded?).to be false
     end
   end
+
+  describe 'main_site?' do
+    context 'when code is "-"' do
+      it 'returns true' do
+        site = create(:site, code: '-')
+        expect(site.main_site?).to be true
+      end
+    end
+
+    context 'when code is not "-"' do
+      it 'returns false' do
+        site = create(:site, code: 'blah')
+        expect(site.main_site?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -3,20 +3,42 @@ require 'rails_helper'
 RSpec.describe 'Selecting a course with multiple sites when the provider is not selectable_school', time: CycleTimetableHelper.mid_cycle(2025) do
   include CandidateHelper
 
-  it 'Candidate skips the school selection' do
-    given_i_am_signed_in_with_one_login
-    and_there_are_course_options
+  describe 'when there is a main site' do
+    it 'Candidate skips the school selection, main site is selected automatically' do
+      given_i_am_signed_in_with_one_login
+      and_there_are_course_options
 
-    when_i_visit_the_site
-    and_i_click_on_course_choices
+      when_i_visit_the_site
+      and_i_click_on_course_choices
 
-    and_i_choose_that_i_know_where_i_want_to_apply
-    and_i_click_continue
-    and_i_choose_a_provider
-    and_i_choose_a_course
+      and_i_choose_that_i_know_where_i_want_to_apply
+      and_i_click_continue
+      and_i_choose_a_provider
+      and_i_choose_a_course
 
-    then_i_am_on_the_application_choice_review_page
-    and_the_application_is_school_placement_auto_selected
+      then_i_am_on_the_application_choice_review_page
+      and_the_application_is_school_placement_auto_selected
+      and_the_site_is_the_main_site
+    end
+  end
+
+  describe 'when there is no main site' do
+    it 'Candidate skips the school selection, first site is selected automatically' do
+      given_i_am_signed_in_with_one_login
+      and_there_are_course_options_without_main_site
+
+      when_i_visit_the_site
+      and_i_click_on_course_choices
+
+      and_i_choose_that_i_know_where_i_want_to_apply
+      and_i_click_continue
+      and_i_choose_a_provider
+      and_i_choose_a_course
+
+      then_i_am_on_the_application_choice_review_page
+      and_the_application_is_school_placement_auto_selected
+      and_the_site_is_the_first_site
+    end
   end
 
   def when_i_visit_the_site
@@ -59,20 +81,9 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
     current_candidate.current_application.application_choices.last
   end
 
-  def and_there_are_course_options
+  def and_there_are_course_options_without_main_site
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', selectable_school: false)
     first_site = create(
-      :site,
-      name: 'Main site',
-      code: '-',
-      provider: @provider,
-      address_line1: 'Gorse SCITT',
-      address_line2: 'C/O The Bruntcliffe Academy',
-      address_line3: 'Bruntcliffe Lane',
-      address_line4: 'MORLEY, lEEDS',
-      postcode: 'LS27 0LZ',
-    )
-    second_site = create(
       :site,
       name: 'Harehills Primary School',
       code: '1',
@@ -83,6 +94,46 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
       address_line4: 'West Yorkshire',
       postcode: 'LS8 5DQ',
     )
+    second_site = create(
+      :site,
+      name: 'Another site',
+      code: 'ABC',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    @multi_site_course = create(:course, :open, :with_both_study_modes, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, site: first_site, course: @multi_site_course)
+    create(:course_option, site: second_site, course: @multi_site_course)
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', selectable_school: false)
+    first_site = create(
+      :site,
+      name: 'Harehills Primary School',
+      code: '1',
+      provider: @provider,
+      address_line1: 'Darfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DQ',
+    )
+    second_site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
     @multi_site_course = create(:course, :open, :with_both_study_modes, name: 'Primary', code: '2XT2', provider: @provider)
     create(:course_option, site: first_site, course: @multi_site_course)
     create(:course_option, site: second_site, course: @multi_site_course)
@@ -90,5 +141,14 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
 
   def and_the_application_is_school_placement_auto_selected
     expect(page).to have_no_content('Location')
+  end
+
+  def and_the_site_is_the_main_site
+    expect(application_choice.current_course_option.site.main_site?).to be true
+  end
+
+  def and_the_site_is_the_first_site
+    expect(application_choice.current_course_option.site.main_site?).to be false
+    expect(application_choice.current_course_option.site.code).to eq '1'
   end
 end


### PR DESCRIPTION
## Context

When a provider has said they do not want schools to be selectable by the candidate, then we want to select the 'Main site' if that is available, rather than just selecting the first available.

## Changes proposed in this pull request

- Method on the site model for determining if it is a main site
- Setting the option with a main site if available, otherwise using the first.

## Guidance to review

On the review app, sign in as a candidate and create an application choice for UCL (does not allow candidates to choose school)
Sign in as a support user and view the application choice -- the main site should be chose. 

On the review app, sign in as a candidate and create an application choice for GORSE SCITT (_does_ allow candidates to choose school). 
Sign in as a support user and view the application choice -- it should be the site you chose as a candidate.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
