### PR TITLE
Data migration for toggling english proficiency qualification status bool

### DIFF
--- a/app/services/data_migrations/toggle_english_proficiency_qualification_status_booleans.rb
+++ b/app/services/data_migrations/toggle_english_proficiency_qualification_status_booleans.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class ToggleEnglishProficiencyQualificationStatusBooleans
+    TIMESTAMP = 20260318102114
+    MANUAL_RUN = false
+
+    def change
+      EnglishProficiency.has_qualification.update_all(has_qualification: true)
+      EnglishProficiency.no_qualification.update_all(no_qualification: true)
+      EnglishProficiency.qualification_not_needed.update_all(qualification_not_needed: true)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ToggleEnglishProficiencyQualificationStatusBooleans',
   'DataMigrations::RemoveServiceInformationBannerFeatureFlag',
   'DataMigrations::DropDfEStatefulSessionFlags',
   'DataMigrations::DowncaseAllReferenceEmailAddresses',

--- a/spec/services/data_migrations/toggle_english_proficiency_qualification_status_booleans_spec.rb
+++ b/spec/services/data_migrations/toggle_english_proficiency_qualification_status_booleans_spec.rb
@@ -45,26 +45,26 @@ RSpec.describe DataMigrations::ToggleEnglishProficiencyQualificationStatusBoolea
 
     has_qualifications.each do |has_qualification_proficiency|
       has_qualification_proficiency.reload
-      expect(has_qualification_proficiency.has_qualification).to eq(true)
+      expect(has_qualification_proficiency.has_qualification).to be(true)
 
-      expect(has_qualification_proficiency.no_qualification).to eq(false)
-      expect(has_qualification_proficiency.qualification_not_needed).to eq(false)
+      expect(has_qualification_proficiency.no_qualification).to be(false)
+      expect(has_qualification_proficiency.qualification_not_needed).to be(false)
     end
 
     no_qualifications.each do |no_qualification_proficiency|
       no_qualification_proficiency.reload
-      expect(no_qualification_proficiency.no_qualification).to eq(true)
+      expect(no_qualification_proficiency.no_qualification).to be(true)
 
-      expect(no_qualification_proficiency.has_qualification).to eq(false)
-      expect(no_qualification_proficiency.qualification_not_needed).to eq(false)
+      expect(no_qualification_proficiency.has_qualification).to be(false)
+      expect(no_qualification_proficiency.qualification_not_needed).to be(false)
     end
 
     qualifications_not_needed.each do |qualifications_not_needed_proficiency|
       qualifications_not_needed_proficiency.reload
-      expect(qualifications_not_needed_proficiency.qualification_not_needed).to eq(true)
+      expect(qualifications_not_needed_proficiency.qualification_not_needed).to be(true)
 
-      expect(qualifications_not_needed_proficiency.has_qualification).to eq(false)
-      expect(qualifications_not_needed_proficiency.no_qualification).to eq(false)
+      expect(qualifications_not_needed_proficiency.has_qualification).to be(false)
+      expect(qualifications_not_needed_proficiency.no_qualification).to be(false)
     end
   end
 end

--- a/spec/services/data_migrations/toggle_english_proficiency_qualification_status_booleans_spec.rb
+++ b/spec/services/data_migrations/toggle_english_proficiency_qualification_status_booleans_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ToggleEnglishProficiencyQualificationStatusBooleans do
+  subject(:data_migration) { described_class.new.change }
+
+  let(:has_qualifications) do
+    create_list(
+      :english_proficiency,
+      3,
+      qualification_status: 'has_qualification',
+      has_qualification: false,
+      qualification_not_needed: false,
+      no_qualification: false,
+    )
+  end
+  let(:no_qualifications) do
+    create_list(
+      :english_proficiency,
+      3,
+      qualification_status: 'no_qualification',
+      no_qualification: false,
+      has_qualification: false,
+      qualification_not_needed: false,
+    )
+  end
+  let(:qualifications_not_needed) do
+    create_list(
+      :english_proficiency,
+      3,
+      qualification_status: 'qualification_not_needed',
+      no_qualification: false,
+      has_qualification: false,
+      qualification_not_needed: false,
+    )
+  end
+
+  before do
+    has_qualifications
+    no_qualifications
+    qualifications_not_needed
+  end
+
+  it 'updates english proficiencies with the correct booleans qualification statuses' do
+    data_migration
+
+    has_qualifications.each do |has_qualification_proficiency|
+      has_qualification_proficiency.reload
+      expect(has_qualification_proficiency.has_qualification).to eq(true)
+
+      expect(has_qualification_proficiency.no_qualification).to eq(false)
+      expect(has_qualification_proficiency.qualification_not_needed).to eq(false)
+    end
+
+    no_qualifications.each do |no_qualification_proficiency|
+      no_qualification_proficiency.reload
+      expect(no_qualification_proficiency.no_qualification).to eq(true)
+
+      expect(no_qualification_proficiency.has_qualification).to eq(false)
+      expect(no_qualification_proficiency.qualification_not_needed).to eq(false)
+    end
+
+    qualifications_not_needed.each do |qualifications_not_needed_proficiency|
+      qualifications_not_needed_proficiency.reload
+      expect(qualifications_not_needed_proficiency.qualification_not_needed).to eq(true)
+
+      expect(qualifications_not_needed_proficiency.has_qualification).to eq(false)
+      expect(qualifications_not_needed_proficiency.no_qualification).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Data migration for toggling english proficiency qualification status booleans

## Changes proposed in this pull request

- Data migration for toggling english proficiency qualification status booleans


## Guidance to review

- Review the migration

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [x] does the code safely backfill existing records for consistency
