### PR TITLE
[lb/1711] Implement application caps mid cycle

### DIFF
--- a/app/components/candidate_interface/applications_left_message_component.rb
+++ b/app/components/candidate_interface/applications_left_message_component.rb
@@ -18,7 +18,9 @@ module CandidateInterface
   private
 
     def inactive_application_message
-      t('candidate_interface.applications_left_message.inactive_application_message')
+      return nil if application_form.unsuccessful_retry_limit.zero?
+
+      t('candidate_interface.applications_left_message.inactive_application_message', count: application_form.unsuccessful_retry_limit)
     end
 
     def maximum_number_of_applications_message
@@ -26,7 +28,7 @@ module CandidateInterface
 
       if cannot_add_more_choices?
         [
-          t('candidate_interface.applications_left_message.can_not_add_more_heading', maximum_number_of_course_choices: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES),
+          t('candidate_interface.applications_left_message.can_not_add_more_heading', maximum_number_of_course_choices: application_form.in_progress_limit),
           t('candidate_interface.applications_left_message.can_not_add_more_message'),
         ]
       else
@@ -35,7 +37,7 @@ module CandidateInterface
     end
 
     def default_message
-      t('candidate_interface.applications_left_message.default_message', maximum_number_of_course_choices: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES)
+      t('candidate_interface.applications_left_message.default_message', maximum_number_of_course_choices: application_form.in_progress_limit)
     end
   end
 end

--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-xl">
   <%= t('mid_cycle_content_component.title') %>
 </h1>
-<% if application_form_presenter.application_limit_reached? %>
+<% if application_form_presenter.unsuccessful_limit_reached? %>
   <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_submit_more')) %>
   <p class="govuk-body">This is because you have a total of 15 applications that have been either:</p>
   <%= govuk_list(

--- a/app/components/candidate_interface/mid_cycle_content_component.rb
+++ b/app/components/candidate_interface/mid_cycle_content_component.rb
@@ -51,7 +51,7 @@ module CandidateInterface
     end
 
     def max_number_of_applications
-      ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
+      [application_form.unsuccessful_retry_limit, application_form.in_progress_limit].max
     end
 
     def apply_reopens_date

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -14,11 +14,11 @@ module CandidateInterface
       elsif choices_with_course.any?
         flash[:warning] = "You have already added an application for #{course_from_find.name}. #{view_context.link_to('Find a different course to apply to', find_url, class: 'govuk-link')}."
         redirect_to course_choices_page
-      elsif current_application.cannot_add_more_choices?
-        flash[:warning] = I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name)
+      elsif current_application.unsuccessful_limit_reached?
+        flash[:warning] = I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: current_application.unsuccessful_retry_limit)
         redirect_to course_choices_page
-      elsif current_application.application_limit_reached?
-        flash[:warning] = I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
+      elsif current_application.cannot_add_more_choices?
+        flash[:warning] = I18n.t('errors.messages.too_many_course_choices', max_applications: current_application.in_progress_limit, course_name: course_from_find.name)
 
         redirect_to course_choices_page
       else

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -104,7 +104,7 @@ module CandidateInterface
       end
 
       def redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached
-        redirect_to candidate_interface_application_choices_path if current_application.application_limit_reached?
+        redirect_to candidate_interface_application_choices_path if current_application.unsuccessful_limit_reached?
       end
     end
   end

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -38,7 +38,7 @@ module CandidateInterface
 
       error_key = 'errors.messages.too_many_course_choices'
 
-      errors.add(:base, I18n.t!(error_key, max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_option.course.name_and_code))
+      errors.add(:base, I18n.t!(error_key, max_applications: application_form.in_progress_limit, course_name: course_option.course.name_and_code))
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,7 +65,7 @@ module ApplicationHelper
   end
 
   def max_course_choices
-    ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES
+    ApplicationForm::IN_PROGRESS_LIMIT
   end
 
   def markdown(source)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -1,5 +1,3 @@
-# The Application Form is filled in and submitted by the Candidate. Candidates
-# can initially apply to 3 different courses, represented by an Application Choice.
 class ApplicationForm < ApplicationRecord
   audited
   has_associated_audits
@@ -11,6 +9,7 @@ class ApplicationForm < ApplicationRecord
   include Chased
   include AdviserEligibility
   include HasApplicableDegreeForAdviser
+  include ChoiceLimitsCalculator
 
   has_one :recruitment_cycle_timetable, primary_key: :recruitment_cycle_year, foreign_key: :recruitment_cycle_year
   delegate :apply_deadline_at,
@@ -112,8 +111,6 @@ class ApplicationForm < ApplicationRecord
   MAXIMUM_REFERENCES = 10
   EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze
   BRITISH_OR_IRISH_NATIONALITIES = %w[GB IE].freeze
-  MAXIMUM_NUMBER_OF_COURSE_CHOICES = 4
-  MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS = 15
   RECOMMENDED_PERSONAL_STATEMENT_WORD_COUNT = 500
 
   BEGINNING_OF_FREE_SCHOOL_MEALS = Date.new(1964, 9, 1)
@@ -389,56 +386,6 @@ class ApplicationForm < ApplicationRecord
   def unsuccessful_and_apply_deadline_has_passed?
     ended_without_success? && after_apply_deadline?
   end
-
-  ##########################################
-  #
-  # Limiting choices on applications form
-  #
-  ##########################################
-
-  def maximum_number_of_choices_reached?
-    application_limit_reached? || cannot_add_more_choices?
-  end
-
-  def application_limit_reached?
-    application_choices.count(&:application_unsuccessful?) >= MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
-  end
-
-  ## A slot represents the availability of one course choice
-
-  def can_add_more_choices?
-    number_of_slots_left.positive?
-  end
-
-  def can_submit_more_choices?
-    number_of_in_progress_slots_left.positive?
-  end
-
-  def cannot_add_more_choices?
-    number_of_slots_left.zero?
-  end
-
-  def number_of_slots_left
-    MAXIMUM_NUMBER_OF_COURSE_CHOICES - number_of_slots_taken
-  end
-
-  def number_of_in_progress_slots_left
-    MAXIMUM_NUMBER_OF_COURSE_CHOICES - number_of_in_progress_slots_taken
-  end
-
-  def number_of_slots_taken
-    slots_taken.count
-  end
-
-  def number_of_in_progress_slots_taken
-    application_choices.count(&:application_in_progress?)
-  end
-
-  def slots_taken
-    application_choices.reject(&:application_unsuccessful?)
-  end
-
-  ## End Limiting choices on applications form
 
   def recruited?
     application_choices.recruited.any?

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -1,0 +1,88 @@
+module ChoiceLimitsCalculator
+  extend ActiveSupport::Concern
+
+  IN_PROGRESS_LIMIT = 4
+  UNSUCCESSFUL_RETRY_LIMIT = 15
+  MID_CYCLE_UNSUCCESSFUL_RETRY_LIMIT = 0
+
+  delegate :unsuccessful_retry_limit, :in_progress_limit, :total_application_limit, to: :limits
+
+  Limits = Data.define(:in_progress_limit, :unsuccessful_retry_limit) do
+    def total_application_limit = unsuccessful_retry_limit + in_progress_limit
+  end
+
+  def limits
+    @limits ||= if mid_cycle_cap_applies?
+                  Limits.new(
+                    unsuccessful_retry_limit: MID_CYCLE_UNSUCCESSFUL_RETRY_LIMIT,
+                    in_progress_limit: IN_PROGRESS_LIMIT,
+                  )
+                else
+                  Limits.new(
+                    unsuccessful_retry_limit: UNSUCCESSFUL_RETRY_LIMIT,
+                    in_progress_limit: IN_PROGRESS_LIMIT,
+                  )
+                end
+  end
+
+  def unsuccessful_count
+    application_choices.count(&:application_unsuccessful?)
+  end
+
+  def in_progress_count
+    application_choices.count(&:application_in_progress?)
+  end
+
+  def total_submitted_count
+    unsuccessful_count + in_progress_count
+  end
+
+  def draft_count
+    application_choices.count(&:unsubmitted?)
+  end
+
+  def cannot_submit_more_choices?
+    unsuccessful_limit_reached? || in_progress_limit_reached?
+  end
+
+  def can_submit_more_choices?
+    !cannot_submit_more_choices?
+  end
+
+  def unsuccessful_limit_reached?
+    if unsuccessful_retry_limit >= in_progress_limit
+      unsuccessful_count >= unsuccessful_retry_limit
+    else
+      total_submitted_application_limit_reached? && unsuccessful_count > unsuccessful_retry_limit
+    end
+  end
+
+  def total_submitted_application_limit_reached?
+    total_submitted_count >= total_application_limit
+  end
+
+  def in_progress_limit_reached?
+    in_progress_count >= in_progress_limit
+  end
+
+  def mid_cycle_cap_applies?
+    FeatureFlag.active?(:mid_cycle_cap) &&
+      # The cap only applies to people who were unsubmitted at the time the cap was introduced
+      (submitted_at.nil? || submitted_at.after?(FeatureFlag.activated_at(:mid_cycle_cap)))
+  end
+
+  def can_add_more_choices?
+    can_submit_more_choices? && number_of_slots_left.positive?
+  end
+
+  def cannot_add_more_choices?
+    !can_add_more_choices?
+  end
+
+  def number_of_slots_left
+    slots_left = in_progress_limit - in_progress_count # in progress take up a slot
+    slots_left -= draft_count # drafts take up a slot
+    slots_left -= [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
+    [slots_left, 0].max
+  end
+end

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -73,7 +73,7 @@ class Pool::Candidates
                            status: ApplicationStateChange::UNSUCCESSFUL_STATES,
                          })
                          .group(:id)
-                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
+                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
                          .select(:id)
 
     # Final query

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -12,7 +12,7 @@ module CandidateInterface
              :can_add_more_choices?,
              :can_add_course_choice?,
              :english_main_language,
-             :application_limit_reached?,
+             :unsuccessful_limit_reached?,
              :first_name,
              :first_nationality,
              :previous_application_form,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:ms_clarity, 'Record sessions with MS Clarity'],
     [:import_non_disclosure_trainee_withdrawals, 'Import Non-disclosure data from BigQuery to generate Possible Previous Teacher Training records', 'Apply team'],
     [:provider_edi_report, 'Regional edi reports for providers', 'Apply team'],
+    [:mid_cycle_cap, 'For implementing a cap on applications', 'Apply team'],
     ['2027_application_form_has_many_english_proficiencies', 'Change application form association from has one english proficiency to has many english proficiencies', 'Apply team'],
     ['2027_visa_expiry', 'Collect visa expiry dates for candidates', 'Apply team'],
     ['2027_application_form_contact_details_residency_questions', 'Add residency questions to contact details flow in candidate interface', 'Apply team'],
@@ -75,6 +76,13 @@ class FeatureFlag
     raise unless feature_name.in?(FEATURES)
 
     feature_statuses[feature_name].presence || false
+  end
+
+  def self.activated_at(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    feature = Feature.find_or_initialize_by(name: feature_name)
+    feature.updated_at if feature.active?
   end
 
   def self.inactive?(feature_name)

--- a/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
@@ -1,6 +1,6 @@
 class SendApplyToAnotherCourseWhenInactiveEmailToCandidate
   def self.call(application_form)
-    return if application_form.maximum_number_of_choices_reached?
+    return if application_form.cannot_submit_more_choices?
     return if already_sent_to?(application_form)
 
     CandidateMailer.apply_to_another_course_after_30_working_days(application_form).deliver_later

--- a/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
@@ -1,6 +1,6 @@
 class SendApplyToMultipleCoursesWhenInactiveEmailToCandidate
   def self.call(application_form)
-    return if application_form.maximum_number_of_choices_reached?
+    return if application_form.cannot_submit_more_choices?
     return if already_sent_to?(application_form)
 
     CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_form).deliver_later

--- a/app/validators/can_add_more_choices_validator.rb
+++ b/app/validators/can_add_more_choices_validator.rb
@@ -4,8 +4,13 @@ class CanAddMoreChoicesValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications')
     end
 
-    if application_choice.application_form.application_limit_reached?
-      record.errors.add(attribute, :max_course_choices, message: "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications")
+    if application_choice.application_form.unsuccessful_limit_reached?
+      max_unsuccessful_attempts = [application_choice.application_form.unsuccessful_retry_limit, application_choice.application_form.in_progress_limit].max
+      record.errors.add(
+        attribute,
+        :max_course_choices,
+        message: "You cannot submit this application because you have #{max_unsuccessful_attempts} unsuccessful applications",
+      )
     end
   end
 end

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -1,20 +1,21 @@
 <%= render 'banners' %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render CandidateInterface::ApplicationChoices::IndexContentComponent.new(application_form: current_application) %>
-  <div>
-    <%= render CandidateInterface::ApplicationChoiceListComponent.new(
-      application_form: current_application,
-      application_choices: @application_choices,
-      current_tab_name: params[:current_tab_name],
-    ) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render CandidateInterface::ApplicationChoices::IndexContentComponent.new(application_form: current_application) %>
+    <div>
+      <%= render CandidateInterface::ApplicationChoiceListComponent.new(
+        application_form: current_application,
+        application_choices: @application_choices,
+        current_tab_name: params[:current_tab_name],
+      ) %>
+    </div>
   </div>
-</div>
 
-<div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-  <%= render 'candidate_interface/details/support', support_reference: @application_form_presenter.support_reference %>
-  <% if @application_form_presenter.candidate_has_previously_applied? %>
-    <%= render 'candidate_interface/application_choices/previous_applications_link', application_form_presenter: @application_form_presenter %>
-  <% end %>
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+    <%= render 'candidate_interface/details/support', support_reference: @application_form_presenter.support_reference %>
+    <% if @application_form_presenter.candidate_has_previously_applied? %>
+      <%= render 'candidate_interface/application_choices/previous_applications_link', application_form_presenter: @application_form_presenter %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/candidate_interface/details/index.html.erb
+++ b/app/views/candidate_interface/details/index.html.erb
@@ -110,7 +110,7 @@
     <% if @application_form_presenter.application_form.candidate&.submission_blocked? %>
       <p class='govuk-body'>You have created more than one account.</p>
       <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
-      <p class='govuk-body'>You can apply for up to <%= max_course_choices %> courses at a time.</p>
+      <p class='govuk-body'>You can apply for up to <%= application_form.in_progress_limit %> courses at a time.</p>
       <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
     <% elsif @application_form_presenter.can_submit_more_applications? %>
       <div class="app-grid-column--grey">

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -50,7 +50,7 @@
           <div class="app-timeline__log-card">
             <div class="app-timeline__log-card__note">
               <div class="app-timeline__log-card__note--title govuk-body">
-             <%= simple_format(t('.start_applying', max_courses: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES)) %>
+             <%= simple_format(t('.start_applying', max_courses: ApplicationForm::IN_PROGRESS_LIMIT)) %>
 
               <% if current_candidate.present? %>
                 <% if current_application.submitted_applications? %>

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -49,7 +49,7 @@
       <li>you withdraw an application</li>
     </ul>
 
-    <p class="govuk-body">You will not be able to submit another application in the same recruitment cycle if you have already submitted more than <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> applications in that cycle that have a status of:</p>
+    <p class="govuk-body">You will not be able to submit another application in the same recruitment cycle if you have already submitted more than <%= ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT %> applications in that cycle that have a status of:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>withdrawn</li>

--- a/app/views/shared/publications/monthly_statistics/_v2.html.erb
+++ b/app/views/shared/publications/monthly_statistics/_v2.html.erb
@@ -144,9 +144,9 @@
     <% if @presenter.first_year_of_continuous_applications? %>
       <p class="govuk-body">New definitions and methodology have been introduced for the 2024 to 2025 academic year
         because candidates can now submit applications to courses individually up to a maximum
-        of <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> open applications at a time. Previously, candidates
-        submitted one application form with up to <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> course
-        choices at the same time. All <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> course choices had to
+        of <%= ApplicationForm::IN_PROGRESS_LIMIT %> open applications at a time. Previously, candidates
+        submitted one application form with up to <%= ApplicationForm::IN_PROGRESS_LIMIT %> course
+        choices at the same time. All <%= ApplicationForm::IN_PROGRESS_LIMIT %> course choices had to
         receive a decision before the candidate could submit another application form in the same recruitment cycle.
       </p>
 
@@ -187,7 +187,7 @@
 
     <p class="govuk-body">Candidates can apply for different courses. On later dates they may then apply for further courses. Any of their applications may change status throughout their lifecycle. This means that over time, some statistics may go up or down.</p>
 
-    <p class="govuk-body">For example, if a candidate’s initial <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> applications had been rejected, they may have submitted a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again. </p>
+    <p class="govuk-body">For example, if a candidate’s initial <%= ApplicationForm::IN_PROGRESS_LIMIT %> applications had been rejected, they may have submitted a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again. </p>
 
     <p class="govuk-body">
       The data is collected throughout the recruitment cycle which runs a year before the academic year that the applicants will start training in. The data is from the <%= @presenter.current_cycle_name %> recruitment cycle which covers application for courses starting in the <%= @presenter.academic_year_name %> academic year.

--- a/config/locales/candidate_interface/applications_left_message.yml
+++ b/config/locales/candidate_interface/applications_left_message.yml
@@ -7,4 +7,4 @@ en:
         other: 'You can submit %{count} more applications.'
       can_not_add_more_heading: 'You cannot add any more applications because you are waiting for decisions on %{maximum_number_of_course_choices} others.'
       can_not_add_more_message: 'If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.'
-      inactive_application_message: 'If an application becomes inactive, is withdrawn or rejected you can add another, up to a maximum of 15 in a single recruitment cycle.'
+      inactive_application_message: If an application becomes inactive, is withdrawn or rejected you can add another, up to a maximum of %{count} in a single recruitment cycle.'

--- a/spec/components/candidate_interface/applications_left_message_component_spec.rb
+++ b/spec/components/candidate_interface/applications_left_message_component_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent do
   let(:application_form) { create(:application_form) }
 
+  before { FeatureFlag.activate(:mid_cycle_cap) }
+
   subject(:message) do
     render_inline(described_class.new(application_form)).text
   end
@@ -30,7 +32,11 @@ RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent do
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :rejected, application_form:)
         create(:application_choice, :inactive, application_form:)
-        expect(message).to include('You can submit 2 more applications.')
+        if application_form.mid_cycle_cap_applies?
+          expect(message).to include('You cannot add any more applications')
+        else
+          expect(message).to include('You can submit 2 more applications.')
+        end
       end
     end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
@@ -48,19 +48,8 @@ RSpec.describe CandidateMailer do
     context 'mid cycle', time: mid_cycle do
       let(:recruitment_cycle_year) { current_year }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Offer withdrawn by Arithmetic College',
-        'greeting' => 'Dear Fred',
-        'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
-        'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
-        'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-        'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-      )
-
-      context 'with a course recommendation url' do
-        let(:email) { described_class.offer_withdrawn(application_form.application_choices.first, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
+      context 'without mid cycle cap' do
+        before { FeatureFlag.deactivate(:mid_cycle_cap) }
 
         it_behaves_like(
           'a mail with subject and content',
@@ -71,9 +60,60 @@ RSpec.describe CandidateMailer do
           'withdrawal reason' => 'You lied to us about secretly being Spiderman',
           'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-          'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
-          'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
         )
+      end
+
+      context 'with the mid cycle cap' do
+        before { FeatureFlag.activate(:mid_cycle_cap) }
+
+        it_behaves_like(
+          'a mail with subject and content',
+          'Offer withdrawn by Arithmetic College',
+          'greeting' => 'Dear Fred',
+          'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
+          'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
+          'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+          'realistic job preview' => 'Try the realistic job preview tool',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+        )
+      end
+
+      context 'with a course recommendation url' do
+        let(:email) { described_class.offer_withdrawn(application_form.application_choices.first, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
+
+        context 'without mid-cycle cap' do # rubocop:disable RSpec/NestedGroups
+          before { FeatureFlag.deactivate(:mid_cycle_cap) }
+
+          it_behaves_like(
+            'a mail with subject and content',
+            'Offer withdrawn by Arithmetic College',
+            'greeting' => 'Dear Fred',
+            'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
+            'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
+            'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+            'realistic job preview' => 'Try the realistic job preview tool',
+            'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+            'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
+            'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
+          )
+        end
+
+        context 'with mid-cycle cap' do # rubocop:disable RSpec/NestedGroups
+          before { FeatureFlag.activate(:mid_cycle_cap) }
+
+          it_behaves_like(
+            'a mail with subject and content',
+            'Offer withdrawn by Arithmetic College',
+            'greeting' => 'Dear Fred',
+            'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
+            'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
+            'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+            'realistic job preview' => 'Try the realistic job preview tool',
+            'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+            'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
+            'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
+          )
+        end
       end
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
-  describe '.withdraw_last_application_choice' do
+  describe '.withdraw_last_application_choice with mid_cycle_cap feature flag inactive' do
+    before { FeatureFlag.deactivate(:mid_cycle_cap) }
+
     let(:recruitment_cycle_year) { current_year }
     let(:application_form_with_references) do
       create(:application_form, first_name: 'Fred',
@@ -46,6 +48,81 @@ RSpec.describe CandidateMailer do
           'You have withdrawn your application',
           'heading' => 'Hello Fred',
           'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
+          'application_withdrawn' => 'You have withdrawn your application',
+          'realistic job preview' => 'Try the realistic job preview tool',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+          'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
+          'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
+        )
+      end
+    end
+
+    context 'between cycles, before find opens', time: after_apply_deadline(2024) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have withdrawn your application',
+        'heading' => 'Hello Fred',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am UK time on 8 October 2024',
+      )
+    end
+
+    context 'between cycles, before apply reopens', time: after_find_opens(2025) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have withdrawn your application',
+        'heading' => 'Hello Fred',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am UK time on 8 October 2024',
+      )
+    end
+  end
+
+  describe '.withdraw_last_application_choice mid_cycle_cap feature flag active' do
+    before { FeatureFlag.activate(:mid_cycle_cap) }
+
+    let(:recruitment_cycle_year) { current_year }
+    let(:application_form_with_references) do
+      create(:application_form, first_name: 'Fred',
+                                recruitment_cycle_year: recruitment_cycle_year,
+                                application_choices: application_choices,
+                                application_references: [referee1, referee2])
+    end
+    let(:referee1) { create(:reference, name: 'Jenny', feedback_status: :feedback_requested) }
+    let(:referee2) { create(:reference, name: 'Luke',  feedback_status: :feedback_requested) }
+    let(:email) { described_class.withdraw_last_application_choice(application_form_with_references) }
+
+    let(:application_choices) { [create(:application_choice, status: 'withdrawn')] }
+
+    context 'mid cycle', time: mid_cycle do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have withdrawn your application',
+        'heading' => 'Hello Fred',
+        'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
+        'application_withdrawn' => 'You have withdrawn your application',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+      )
+
+      context 'when a candidate has 2 or 3 offers that were withdrawn' do
+        let(:application_choices) { [create(:application_choice, :withdrawn), create(:application_choice, :withdrawn)] }
+
+        it_behaves_like(
+          'a mail with subject and content',
+          'You have withdrawn your applications',
+          'application_withdrawn' => 'You have withdrawn your application',
+        )
+      end
+
+      context 'with a course recommendation url' do
+        let(:email) { described_class.withdraw_last_application_choice(application_form_with_references, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
+
+        it_behaves_like(
+          'a mail with subject and content',
+          'You have withdrawn your application',
+          'heading' => 'Hello Fred',
+          'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
           'application_withdrawn' => 'You have withdrawn your application',
           'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+RSpec.describe ChoiceLimitsCalculator do
+  context 'midcycle feature flag on' do
+    before { FeatureFlag.activate(:mid_cycle_cap) }
+
+    describe '#limits' do
+      it 'the cap is applied to new applications' do
+        previously_submitted_limits = create(:application_form, submitted_at: 1.day.ago).limits
+        future_submitted_new_limits = create(:application_form, submitted_at: 1.day.from_now).limits
+        unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
+
+        expect(previously_submitted_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        expect(previously_submitted_limits.total_application_limit).to eq 19
+
+        expect(unsubmitted_new_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 0, in_progress_limit: 4 })
+        expect(unsubmitted_new_limits.total_application_limit).to eq 4
+
+        expect(future_submitted_new_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 0, in_progress_limit: 4 })
+        expect(future_submitted_new_limits.total_application_limit).to eq 4
+      end
+    end
+
+    describe '#maximum_number_of_choices_reached?' do
+      it 'only allows 4 unsuccessful applications' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :withdrawn, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create(:application_choice, :withdrawn, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+
+      it 'only allows 4 in progress applications' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create(:application_choice, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+
+      it 'only allows 4 total submitted applications, regardless of state' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create(:application_choice, :rejected, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+    end
+
+    describe '#number_of_slots_left' do
+      it 'only allows 4 draft slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'only allows 4 in progress slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :interviewing, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'only allows 4 unsuccessful slots total' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :withdrawn, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :rejected, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'only allows 4 submitted slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 2, :withdrawn, application_form:)
+        create(:application_choice, :interviewing, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'only allows more choices if the total of 4 slots in progress and draft' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 2, :awaiting_provider_decision, application_form:)
+        create(:application_choice, :interviewing, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+    end
+  end
+
+  context 'midcycle feature flag off' do
+    before { FeatureFlag.deactivate(:mid_cycle_cap) }
+
+    describe '#limits' do
+      it 'the cap is applied to all applications' do
+        previously_submitted_limits = create(:application_form, submitted_at: 1.day.ago).limits
+        future_submitted_new_limits = create(:application_form, submitted_at: 1.day.from_now).limits
+        unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
+
+        expect(previously_submitted_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        expect(unsubmitted_new_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        expect(future_submitted_new_limits.to_h)
+          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+      end
+    end
+
+    describe '#maximum_number_of_choices_reached?' do
+      it 'only allows 15 unsuccessful applications' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 14, :withdrawn, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create(:application_choice, :withdrawn, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+
+      it 'only allows 4 in progress applications' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create(:application_choice, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+
+      it 'only allows 19 total submitted applications, regardless of state' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        create_list(:application_choice, 14, :rejected, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create_list(:application_choice, 2, :rejected, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
+    end
+
+    describe '#number_of_slots_left' do
+      it 'only allows 4 draft slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'only allows 4 in progress slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :interviewing, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+
+      it 'allows 15 unsuccessful before reducing slots' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 15, :withdrawn, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 4
+
+        create(:application_choice, :rejected, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 3
+      end
+
+      it 'only allows more choices if the total of 4 slots in progress and draft' do
+        application_form = create(:application_form)
+        create_list(:application_choice, 2, :awaiting_provider_decision, application_form:)
+        create(:application_choice, :interviewing, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :unsubmitted, application_form:)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
+    end
+  end
+end

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -85,21 +85,22 @@ RSpec.describe 'After sign in redirects' do
 
   context 'when reaching maximum number of choices' do
     it 'redirects to your applications and shows a message to the candidate' do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
+      create_list(:application_choice, ApplicationForm::IN_PROGRESS_LIMIT, :awaiting_provider_decision, application_form:)
       get candidate_interface_interstitial_path
       expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
-      expect(response.body).to include(I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name))
+      expect(response.body).to include(I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::IN_PROGRESS_LIMIT, course_name: course_from_find.name))
     end
   end
 
   context 'when reaching maximum unsuccessful number of choices', time: mid_cycle do
     it 'redirects to your applications and shows a message to the candidate' do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :rejected, application_form:)
+      create_list(:application_choice, application_form.unsuccessful_retry_limit, :rejected, application_form:)
       get candidate_interface_interstitial_path
       expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
-      expect(response.body).to include(I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS))
+      message = I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: application_form.unsuccessful_retry_limit)
+      expect(response.body).to include(message)
     end
   end
 

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         it 'is valid' do
           application_form.application_choices << build_list(
             :application_choice,
-            ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS - 1,
+            ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT - 1,
             :rejected,
           )
           expect(application_choice_submission).to be_valid
@@ -438,13 +438,13 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         it 'adds error to application choice' do
           application_form.application_choices << build_list(
             :application_choice,
-            ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS,
+            ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT,
             :rejected,
           )
           expect(application_choice_submission).not_to be_valid
 
           expect(application_choice_submission.errors[:application_choice]).to include(
-            "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications",
+            "You cannot submit this application because you have #{ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT} unsuccessful applications",
           )
         end
       end

--- a/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
+      create_list(:application_choice, ApplicationForm::IN_PROGRESS_LIMIT, :awaiting_provider_decision, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
@@ -62,7 +62,7 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :withdrawn, application_form:)
+      create_list(:application_choice, ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT, :withdrawn, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)

--- a/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
+      create_list(:application_choice, ApplicationForm::IN_PROGRESS_LIMIT, :awaiting_provider_decision, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
@@ -69,7 +69,7 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :withdrawn, application_form:)
+      create_list(:application_choice, ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT, :withdrawn, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_am_informed_i_already_have_4_courses
-    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: @course_with_multiple_sites.name)
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::IN_PROGRESS_LIMIT, course_name: @course_with_multiple_sites.name)
   end
 
   def when_i_sign_out

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
   end
 
   def and_i_already_have_max_applications
-    create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES,
+    create_list(:application_choice, ApplicationForm::IN_PROGRESS_LIMIT,
                 :unsubmitted,
                 application_form: current_candidate.current_application)
   end

--- a/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
   end
 
   def when_i_add_the_maximum_number_of_choices
-    (ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES - 1).times do
+    (ApplicationForm::IN_PROGRESS_LIMIT - 1).times do
       create(:application_choice, :unsubmitted, application_form: @application_form)
     end
   end


### PR DESCRIPTION
## Context

See trello ticket.

## Changes proposed in this pull request

- Refactored the Limits / slots logic into it's own concern
- Added lots of unit tests for the limits / slots logic
- Made the limits specific to an application, not generalisable throughout the application. 

What I have _not_ done
- Updated the content. I will create a separate ticket for updating content .
- Updated the logic around FAC. There is some chat that this feature will just be turned off (ie, we stop populating the pool). If not, we'll have to update the logic in `app/models/pool/candidates.rb`, namely the `forms_with_available_slots` subquery.

## Guidance to review

- Sign into the review app
- Find a candidate who hasn't submitted any applications yet
- Try lots of combinations of submitting / withdrawing applications. You should only get to 4. 
- Look at someone who submitted before the cap was turned on 
- The normal 15 application limits should apply.



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
