### PR TITLE
[lb/1751] Capping applications, implement changes to FAC queries

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -67,14 +67,35 @@ class Pool::Candidates
                                                                 .where('pool_invite_decline_reasons.reason ILIKE ?', '%no_longer_interested%')
 
     # Subquery: To include only those forms who have not used all their application slows
-    forms_with_available_slots = current_cycle_forms
-                         .joins(:application_choices)
-                         .where(application_choices: {
-                           status: ApplicationStateChange::UNSUCCESSFUL_STATES,
-                         })
-                         .group(:id)
-                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-                         .select(:id)
+    if FeatureFlag.active?(:mid_cycle_cap)
+      active_date = FeatureFlag.activated_at(:mid_cycle_cap)
+      forms_with_available_slots_with_restriction = current_cycle_forms
+                                                      .where('submitted_at > ?', active_date)
+                                                      .joins(:application_choices)
+                                                      .group(:id)
+                                                      .having("COUNT(DISTINCT application_choices.id) < #{ApplicationForm::IN_PROGRESS_LIMIT}")
+                                                      .select(:id)
+
+      forms_with_available_slots_without_restriction = current_cycle_forms
+                                                         .where('submitted_at < ?', active_date)
+                                                         .joins(:application_choices)
+                                                         .where(application_choices: {
+                                                           status: ApplicationStateChange::UNSUCCESSFUL_STATES,
+                                                         })
+                                                         .group(:id)
+                                                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
+                                                         .select(:id)
+      forms_with_available_slots = forms_with_available_slots_with_restriction + forms_with_available_slots_without_restriction
+    else
+      forms_with_available_slots = current_cycle_forms
+                           .joins(:application_choices)
+                           .where(application_choices: {
+                             status: ApplicationStateChange::UNSUCCESSFUL_STATES,
+                           })
+                           .group(:id)
+                           .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
+                           .select(:id)
+    end
 
     # Final query
     current_cycle_forms

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -172,4 +172,23 @@ RSpec.describe Pool::Candidates do
       expect(application_forms).to be_empty
     end
   end
+
+  describe '#application_forms_in_the_pool, when mid_cycle_cap has applied' do
+    it 'applies different application choices limits based on submission date' do
+      FeatureFlag.deactivate(:mid_cycle_cap)
+      no_mid_cycle_cap = create(:application_form, :submitted, submitted_at: 2.minutes.ago)
+      create(:candidate_preference, application_form: no_mid_cycle_cap)
+      create_list(:application_choice, 4, :rejected, application_form: no_mid_cycle_cap)
+
+      FeatureFlag.activate(:mid_cycle_cap)
+      yes_mid_cycle_cap = create(:application_form, :submitted, submitted_at: 1.minute.from_now)
+      create(:candidate_preference, application_form: yes_mid_cycle_cap)
+      create_list(:application_choice, 4, :rejected, application_form: yes_mid_cycle_cap)
+
+      application_forms = described_class.new.application_forms_in_the_pool
+
+      expect(application_forms).to include(no_mid_cycle_cap)
+      expect(application_forms).not_to include(yes_mid_cycle_cap)
+    end
+  end
 end


### PR DESCRIPTION
## Context

See [this ticket](https://trello.com/c/qhdnciI4) 

## Guidance to review
In the review app
Create a candidate (candidate one) who has opted in, and has used up 4 slots, at least one rejected or withdrawn application. 
Switch on the feature flag
Create another candidate (candidate two) same as the one above. 
Populate the pool
Candidate one should be in the pool, but candidate two should not be.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
