### PR TITLE
Optimise the Provider edi report generating query

### DIFF
--- a/app/lib/dfe/bigquery/national_edi_metrics.rb
+++ b/app/lib/dfe/bigquery/national_edi_metrics.rb
@@ -44,19 +44,16 @@ module DfE
                   :recruitment_cycle_year,
                   :nonprovider_filter,
                   :provider_filter,
-                  :provider_filter_category,
-                  :category
+                  :provider_filter_category
 
       def initialize(
         cycle_week:,
-        category:,
         provider_id: nil,
         recruitment_cycle_year: RecruitmentCycleTimetable.current_year
       )
         @provider_id = provider_id&.to_s
         @cycle_week = cycle_week
         @recruitment_cycle_year = recruitment_cycle_year
-        @category = category
       end
 
       def table_name
@@ -74,7 +71,6 @@ module DfE
           teach_first_or_iot_filter: 'All',
           cycle_week:,
           recruitment_cycle_year:,
-          nonprovider_filter_category: category.downcase == 'disability' ? 'HESA disability' : category,
         ).to_sql
       end
 
@@ -89,7 +85,6 @@ module DfE
             provider_filter_category: 'All',
             cycle_week:,
             recruitment_cycle_year:,
-            nonprovider_filter_category: category.downcase == 'disability' ? 'HESA disability' : category,
           ).to_sql
       end
 

--- a/app/lib/dfe/bigquery/regional_edi_metrics.rb
+++ b/app/lib/dfe/bigquery/regional_edi_metrics.rb
@@ -34,14 +34,12 @@ module DfE
       ].freeze
 
       attr_reader :cycle_week,
-                  :category,
                   :region,
                   :recruitment_cycle_year
 
-      def initialize(cycle_week:, region:, category:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
+      def initialize(cycle_week:, region:, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
         @cycle_week = cycle_week
         @region = region
-        @category = category
         @recruitment_cycle_year = recruitment_cycle_year
       end
 
@@ -57,7 +55,6 @@ module DfE
         select(SELECT_COLUMNS.join(', '))
         .where(
           region_filter: region,
-          nonregion_filter_category: category.downcase == 'disability' ? 'HESA disability' : category,
           region_filter_category: 'ITL1',
           cycle_week:,
           recruitment_cycle_year:,

--- a/app/models/publications/provider_edi_report_generator.rb
+++ b/app/models/publications/provider_edi_report_generator.rb
@@ -5,13 +5,11 @@ module Publications
                 :generation_date,
                 :publication_date,
                 :cycle_week,
-                :category,
                 :recruitment_cycle_year
 
     def initialize(
       provider_id:,
       cycle_week:,
-      category:,
       generation_date: Time.zone.today,
       publication_date: nil,
       recruitment_cycle_year: RecruitmentCycleTimetable.current_year
@@ -21,11 +19,9 @@ module Publications
       @publication_date = publication_date.presence || @generation_date
       @recruitment_cycle_year = recruitment_cycle_year
       @cycle_week = cycle_week
-      @category = category
 
       @client = DfE::Bigquery::NationalEdiMetrics.new(
         cycle_week:,
-        category: category.downcase == 'disability' ? 'HESA disability' : category,
         provider_id:,
         recruitment_cycle_year:,
       )
@@ -37,15 +33,24 @@ module Publications
         return
       end
 
-      Publications::ProviderEdiReport.create!(
-        provider_id:,
-        statistics: data,
-        cycle_week:,
-        category:,
-        publication_date:,
-        generation_date:,
-        recruitment_cycle_year:,
-      )
+      Publications::ProviderEdiReport.categories.each_value do |category|
+        filter_category = category.downcase == 'disability' ? 'HESA disability' : category
+
+        category_data = data.select do |datum|
+          datum['nonprovider_filter_category'] == filter_category
+        end
+        next if category_data.empty?
+
+        Publications::ProviderEdiReport.create!(
+          provider_id:,
+          statistics: category_data,
+          cycle_week:,
+          category:,
+          publication_date:,
+          generation_date:,
+          recruitment_cycle_year:,
+        )
+      end
     end
 
     def data

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -39,17 +39,15 @@ module Publications
 
     def schedule_regional_edi_report
       Publications::RegionalEdiReport.regions.each_value do |region|
-        Publications::RegionalEdiReport.categories.each_value do |category|
-          next if Publications::RegionalEdiReport.exists?(
-            cycle_week:,
-            recruitment_cycle_year:,
-            region:,
-            category:,
-          )
+        next if Publications::RegionalEdiReport.where(
+          cycle_week:,
+          recruitment_cycle_year:,
+          region:,
+          category: Publications::ProviderEdiReport.categories.values,
+        ).count == Publications::ProviderEdiReport.categories.count
 
-          Publications::RegionalEdiReportWorker
-            .perform_async(cycle_week, region, category, recruitment_cycle_year)
-        end
+        Publications::RegionalEdiReportWorker
+          .perform_async(cycle_week, region, recruitment_cycle_year)
       end
     end
 
@@ -57,15 +55,12 @@ module Publications
       ProvidersForRecruitmentPerformanceReportQuery
         .call(cycle_week:, recruitment_cycle_year:)
         .find_each do |provider|
-        Publications::ProviderEdiReport.categories.each_value do |category|
-          Publications::ProviderEdiReportWorker
-            .perform_async(
-              provider.id,
-              cycle_week,
-              category,
-              recruitment_cycle_year,
-            )
-        end
+        Publications::ProviderEdiReportWorker
+          .perform_async(
+            provider.id,
+            cycle_week,
+            recruitment_cycle_year,
+          )
       end
     end
 

--- a/app/models/publications/regional_edi_report_generator.rb
+++ b/app/models/publications/regional_edi_report_generator.rb
@@ -5,48 +5,65 @@ module Publications
                 :publication_date,
                 :cycle_week,
                 :region,
-                :category,
                 :recruitment_cycle_year
 
     def initialize(
       cycle_week:,
       region:,
-      category:,
       generation_date: Time.zone.now,
       publication_date: nil, recruitment_cycle_year: RecruitmentCycleTimetable.current_year
     )
       @cycle_week = cycle_week
       @region = region
-      @category = category
       @generation_date = generation_date
       @publication_date = publication_date.presence || @generation_date
       @recruitment_cycle_year = recruitment_cycle_year
       @client = if region == ReportSharedEnums.all_of_england_value
                   DfE::Bigquery::NationalEdiMetrics.new(
                     cycle_week:,
-                    category:,
                     recruitment_cycle_year:,
                   )
                 else
                   DfE::Bigquery::RegionalEdiMetrics.new(
                     cycle_week:,
                     region:,
-                    category:,
                     recruitment_cycle_year:,
                   )
                 end
     end
 
     def call
-      Publications::RegionalEdiReport.create!(
-        statistics: data,
-        region:,
-        category:,
-        cycle_week:,
-        publication_date:,
-        generation_date:,
-        recruitment_cycle_year:,
-      )
+      if data.empty?
+        Rails.logger.info('No recruitment performance data was received.')
+        return
+      end
+
+      Publications::ProviderEdiReport.categories.each_value do |category|
+        next if Publications::RegionalEdiReport.exists?(
+          cycle_week:,
+          recruitment_cycle_year:,
+          region:,
+          category:,
+        )
+
+        filter_category = category.downcase == 'disability' ? 'HESA disability' : category
+        filter = @client.is_a?(DfE::Bigquery::NationalEdiMetrics) ? 'nonprovider_filter_category' : 'nonregion_filter_category'
+
+        category_data = data.select do |datum|
+          datum[filter] == filter_category
+        end
+        next if category_data.empty?
+
+        Publications::RegionalEdiReport.create!(
+          statistics: data,
+          region:,
+          category:,
+          cycle_week:,
+          publication_date:,
+          generation_date:,
+          recruitment_cycle_year:,
+        )
+      end
     end
 
     def data

--- a/app/models/publications/regional_edi_report_generator.rb
+++ b/app/models/publications/regional_edi_report_generator.rb
@@ -55,7 +55,7 @@ module Publications
         next if category_data.empty?
 
         Publications::RegionalEdiReport.create!(
-          statistics: data,
+          statistics: category_data,
           region:,
           category:,
           cycle_week:,

--- a/app/workers/publications/provider_edi_report_worker.rb
+++ b/app/workers/publications/provider_edi_report_worker.rb
@@ -4,13 +4,12 @@ module Publications
 
     sidekiq_options retry: 3, queue: :default
 
-    def perform(provider_id, cycle_week, category, recruitment_cycle_year)
+    def perform(provider_id, cycle_week, recruitment_cycle_year)
       ProviderEdiReportGenerator.new(
         provider_id:,
         cycle_week:,
         generation_date:,
         publication_date:,
-        category:,
         recruitment_cycle_year:,
       ).call
     end

--- a/app/workers/publications/regional_edi_report_worker.rb
+++ b/app/workers/publications/regional_edi_report_worker.rb
@@ -4,11 +4,10 @@ module Publications
 
     sidekiq_options retry: 3, queue: :default
 
-    def perform(cycle_week, region, category, recruitment_cycle_year)
+    def perform(cycle_week, region, recruitment_cycle_year)
       Publications::RegionalEdiReportGenerator.new(
         cycle_week:,
         region:,
-        category:,
         generation_date:,
         publication_date:,
         recruitment_cycle_year:,

--- a/spec/lib/dfe/bigquery/national_edi_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/national_edi_metrics_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
 
   describe '.data' do
     subject(:national_statistics) do
-      described_class.new(cycle_week: 18, category: 'Sex').data
+      described_class.new(cycle_week: 18).data
     end
 
     let(:rows) do
@@ -96,7 +96,6 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
         AND provider_filter_category = "All"
         AND cycle_week = 18
         AND recruitment_cycle_year = 2024
-        AND nonprovider_filter_category = "Sex"
       SQL
     end
 
@@ -142,7 +141,7 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
 
   describe '.provider_data' do
     subject(:provider_statistics) do
-      described_class.new(cycle_week: 18, provider_id: 1, category: 'Sex').provider_data
+      described_class.new(cycle_week: 18, provider_id: 1).provider_data
     end
 
     let(:rows) do
@@ -229,7 +228,6 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
         AND teach_first_or_iot_filter = "All"
         AND cycle_week = 18
         AND recruitment_cycle_year = 2024
-        AND nonprovider_filter_category = "Sex"
       SQL
     end
 
@@ -292,7 +290,7 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
 
   describe 'when the query returns nil for rows' do
     subject(:national_statistics) do
-      described_class.new(cycle_week: 18, category: 'Sex').data
+      described_class.new(cycle_week: 18).data
     end
 
     let(:stub_bigquery_response) do
@@ -310,7 +308,7 @@ RSpec.describe DfE::Bigquery::NationalEdiMetrics do
 
   describe 'when there is an error' do
     subject(:national_statistics) do
-      described_class.new(cycle_week: 7, category: 'Sex').data
+      described_class.new(cycle_week: 7).data
     end
 
     context 'when there is more than one page' do

--- a/spec/lib/dfe/bigquery/regional_edi_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/regional_edi_metrics_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DfE::Bigquery::RegionalEdiMetrics do
 
   describe '.data' do
     subject(:region_statistics) do
-      described_class.new(cycle_week: 18, region: 'London', category: 'Sex').data
+      described_class.new(cycle_week: 18, region: 'London').data
     end
 
     let(:rows) do
@@ -93,7 +93,6 @@ RSpec.describe DfE::Bigquery::RegionalEdiMetrics do
         SELECT nonregion_filter, nonregion_filter_category, cycle_week, recruitment_cycle_year, region_filter, number_of_candidates_submitted_to_date, number_of_candidates_submitted_to_same_date_previous_cycle, number_of_candidates_submitted_to_date_as_proportion_of_last_cycle, number_of_candidates_with_offers_to_date, number_of_candidates_with_offers_to_same_date_previous_cycle, number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle, offer_rate_to_date, offer_rate_to_same_date_previous_cycle, number_of_candidates_accepted_to_date, number_of_candidates_accepted_to_same_date_previous_cycle, number_of_candidates_accepted_to_date_as_proportion_of_last_cycle, number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date, number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle, number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle, number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date, number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle, number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle, number_of_candidates_who_had_an_inactive_application_this_cycle_to_date, number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates, number_of_candidates_who_had_an_inactive_application_last_cycle_to_date_as_proportion_of_submitted_candidates_last_cycle, recruited_rate_to_date, recruited_rate_to_same_date_previous_cycle
         FROM `1_key_tables.application_metrics_by_region`
         WHERE region_filter = "London"
-        AND nonregion_filter_category = "Sex"
         AND region_filter_category = "ITL1"
         AND cycle_week = 18
         AND recruitment_cycle_year = 2024
@@ -160,7 +159,7 @@ RSpec.describe DfE::Bigquery::RegionalEdiMetrics do
 
   describe 'when the query returns nil for rows' do
     subject(:region_statistics) do
-      described_class.new(cycle_week: 18, region: 'London', category: 'Sex').data
+      described_class.new(cycle_week: 18, region: 'London').data
     end
 
     let(:stub_bigquery_response) do
@@ -178,7 +177,7 @@ RSpec.describe DfE::Bigquery::RegionalEdiMetrics do
 
   describe 'when there is an error' do
     subject(:region_statistics) do
-      described_class.new(cycle_week: 7, region: 'London', category: 'Sex').data
+      described_class.new(cycle_week: 7, region: 'London').data
     end
 
     context 'when there is more than one page' do

--- a/spec/models/publications/provider_edi_report_generator_spec.rb
+++ b/spec/models/publications/provider_edi_report_generator_spec.rb
@@ -113,5 +113,36 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
         })
       end
     end
+
+    context 'when the response from BigQuery contains multiple category data' do
+      before do
+        stub_bigquery_provider_edi_request(
+          rows: [
+            [
+              { name: 'nonprovider_filter', type: 'STRING', value: 'Prefer not to say' },
+              { name: 'nonprovider_filter_category', type: 'STRING', value: category },
+              { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              { name: 'id', type: 'STRING', value: provider.id },
+            ],
+            [
+              { name: 'nonprovider_filter', type: 'STRING', value: '60 to 64' },
+              { name: 'nonprovider_filter_category', type: 'STRING', value: 'Age group' },
+              { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              { name: 'id', type: 'STRING', value: provider.id },
+            ],
+            [
+              { name: 'nonprovider_filter', type: 'STRING', value: 'Female' },
+              { name: 'nonprovider_filter_category', type: 'STRING', value: category },
+              { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              { name: 'id', type: 'STRING', value: provider.id },
+            ],
+          ],
+        )
+      end
+
+      it 'creates a new report' do
+        expect { generator.call }.to change(Publications::ProviderEdiReport, :count).by(1)
+      end
+    end
   end
 end

--- a/spec/models/publications/provider_edi_report_generator_spec.rb
+++ b/spec/models/publications/provider_edi_report_generator_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
       end
 
       it 'creates a new report' do
-        expect { generator.call }.to change(Publications::ProviderEdiReport, :count).by(1)
+        expect { generator.call }.to change(Publications::ProviderEdiReport, :count).by(2)
       end
     end
   end

--- a/spec/models/publications/provider_edi_report_generator_spec.rb
+++ b/spec/models/publications/provider_edi_report_generator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Publications::ProviderEdiReportGenerator do
   include DfE::Bigquery::TestHelper
 
-  subject(:generator) { described_class.new(provider_id: provider.id, cycle_week:, category:) }
+  subject(:generator) { described_class.new(provider_id: provider.id, cycle_week:) }
 
   before do
     stub_bigquery_provider_edi_request(
@@ -18,7 +18,7 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
 
   let(:provider) { create(:provider) }
   let(:cycle_week) { 11 }
-  let(:category) { 'sex' }
+  let(:category) { 'Sex' }
   let(:generation_date) { Time.zone.today }
   let(:provider_attributes) do
     [
@@ -73,7 +73,6 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
           'publication_date' => Time.zone.today,
           'generation_date' => Time.zone.today,
           'cycle_week' => cycle_week,
-          'category' => category,
           'statistics' => provider_attributes,
         })
       end
@@ -91,14 +90,13 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
           'publication_date' => generation_date,
           'generation_date' => generation_date,
           'cycle_week' => 15,
-          'category' => category,
           'statistics' => provider_attributes,
         })
       end
     end
 
     context 'when setting a future generation date' do
-      subject(:generator) { described_class.new(provider_id: provider.id, cycle_week:, generation_date:, category:) }
+      subject(:generator) { described_class.new(provider_id: provider.id, cycle_week:, generation_date:) }
 
       let(:generation_date) { 1.week.from_now.to_date }
 
@@ -110,7 +108,6 @@ RSpec.describe Publications::ProviderEdiReportGenerator do
         expect(model).to have_attributes({
           'publication_date' => generation_date,
           'generation_date' => generation_date,
-          'category' => category,
           'cycle_week' => cycle_week,
           'statistics' => provider_attributes,
         })

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -218,14 +218,11 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       described_class.new.call
 
       Publications::RegionalEdiReport.regions.each_value do |region|
-        Publications::RegionalEdiReport.categories.each_value do |category|
-          expect(regional_edi_worker).to have_received(:perform_async).with(
-            cycle_week,
-            region,
-            category,
-            recruitment_cycle_year,
-          )
-        end
+        expect(regional_edi_worker).to have_received(:perform_async).with(
+          cycle_week,
+          region,
+          recruitment_cycle_year,
+        )
       end
     end
 
@@ -239,19 +236,18 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         expect(regional_edi_worker).to have_received(:perform_async).with(
           cycle_week,
           'London',
-          'Sex',
           recruitment_cycle_year,
         )
       end
 
       it 'does not create a Regional edi report worker when a report already exists' do
         create(:regional_edi_report, recruitment_cycle_year: current_year, region: :london)
+        allow(Publications::ProviderEdiReport).to receive(:categories).and_return({ 'sex' => 'Sex' })
         described_class.new(cycle_week:).call
 
         expect(regional_edi_worker).not_to have_received(:perform_async).with(
           cycle_week,
           'London',
-          'Sex',
           recruitment_cycle_year,
         )
       end
@@ -260,14 +256,11 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         described_class.new(cycle_week:).call
 
         Publications::RegionalEdiReport.regions.each_value do |region|
-          Publications::RegionalEdiReport.categories.each_value do |category|
-            expect(regional_edi_worker).to have_received(:perform_async).with(
-              cycle_week,
-              region,
-              category,
-              recruitment_cycle_year,
-            )
-          end
+          expect(regional_edi_worker).to have_received(:perform_async).with(
+            cycle_week,
+            region,
+            recruitment_cycle_year,
+          )
         end
       end
     end
@@ -283,14 +276,11 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
     it 'creates a Provider edi report' do
       described_class.new.call
 
-      Publications::ProviderEdiReport.categories.each_value do |category|
-        expect(provider_edi_worker).to have_received(:perform_async).with(
-          provider.id,
-          cycle_week,
-          category,
-          recruitment_cycle_year,
-        )
-      end
+      expect(provider_edi_worker).to have_received(:perform_async).with(
+        provider.id,
+        cycle_week,
+        recruitment_cycle_year,
+      )
     end
 
     context 'explicit cycle_week is passed' do
@@ -303,7 +293,6 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         expect(provider_edi_worker).to have_received(:perform_async).with(
           provider.id,
           cycle_week,
-          'Sex',
           recruitment_cycle_year,
         )
       end
@@ -315,7 +304,6 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         expect(provider_edi_worker).not_to have_received(:perform_async).with(
           provider.id,
           cycle_week,
-          'Sex',
           recruitment_cycle_year,
         )
       end
@@ -323,14 +311,11 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       it 'creates a Provider edi report for the cycle_week value' do
         described_class.new(cycle_week:).call
 
-        Publications::ProviderEdiReport.categories.each_value do |category|
-          expect(provider_edi_worker).to have_received(:perform_async).with(
-            provider.id,
-            cycle_week,
-            category,
-            recruitment_cycle_year,
-          )
-        end
+        expect(provider_edi_worker).to have_received(:perform_async).with(
+          provider.id,
+          cycle_week,
+          recruitment_cycle_year,
+        )
       end
     end
   end

--- a/spec/models/publications/regional_edi_report_generator_spec.rb
+++ b/spec/models/publications/regional_edi_report_generator_spec.rb
@@ -179,6 +179,37 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
           })
         end
       end
+
+      context 'when the response from BigQuery contains multiple category data' do
+        before do
+          stub_bigquery_regional_edi_request(
+            rows: [
+              [
+                { name: 'nonregion_filter', type: 'STRING', value: 'Prefer not to say' },
+                { name: 'nonregion_filter_category', type: 'STRING', value: category },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+                { name: 'region_filter', type: 'STRING', value: region },
+              ],
+              [
+                { name: 'nonregion_filter', type: 'STRING', value: '60 to 64' },
+                { name: 'nonregion_filter_category', type: 'STRING', value: 'Age group' },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+                { name: 'region_filter', type: 'STRING', value: region },
+              ],
+              [
+                { name: 'nonregion_filter', type: 'STRING', value: 'Female' },
+                { name: 'nonregion_filter_category', type: 'STRING', value: category },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+                { name: 'region_filter', type: 'STRING', value: region },
+              ]
+            ],
+          )
+        end
+
+        it 'creates a new report per category' do
+          expect { generator.call }.to change(Publications::RegionalEdiReport, :count).by(2)
+        end
+      end
     end
 
     context 'when region is national' do
@@ -246,6 +277,34 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
             'cycle_week' => cycle_week,
             'statistics' => national_attributes,
           })
+        end
+      end
+
+      context 'when the response from BigQuery contains multiple category data' do
+        before do
+          stub_bigquery_regional_edi_request(
+            rows: [
+              [
+                { name: 'nonprovider_filter', type: 'STRING', value: 'Prefer not to say' },
+                { name: 'nonprovider_filter_category', type: 'STRING', value: category },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              ],
+              [
+                { name: 'nonprovider_filter', type: 'STRING', value: '60 to 64'  },
+                { name: 'nonprovider_filter_category', type: 'STRING', value: 'Age group' },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              ],
+              [
+                { name: 'nonprovider_filter', type: 'STRING', value: 'Female' },
+                { name: 'nonprovider_filter_category', type: 'STRING', value: category },
+                { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
+              ]
+            ],
+            )
+        end
+
+        it 'creates a new report per category' do
+          expect { generator.call }.to change(Publications::RegionalEdiReport, :count).by(2)
         end
       end
     end

--- a/spec/models/publications/regional_edi_report_generator_spec.rb
+++ b/spec/models/publications/regional_edi_report_generator_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
                 { name: 'nonregion_filter_category', type: 'STRING', value: category },
                 { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
                 { name: 'region_filter', type: 'STRING', value: region },
-              ]
+              ],
             ],
           )
         end
@@ -290,7 +290,7 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
                 { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
               ],
               [
-                { name: 'nonprovider_filter', type: 'STRING', value: '60 to 64'  },
+                { name: 'nonprovider_filter', type: 'STRING', value: '60 to 64' },
                 { name: 'nonprovider_filter_category', type: 'STRING', value: 'Age group' },
                 { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
               ],
@@ -298,9 +298,9 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
                 { name: 'nonprovider_filter', type: 'STRING', value: 'Female' },
                 { name: 'nonprovider_filter_category', type: 'STRING', value: category },
                 { name: 'cycle_week', type: 'INTEGER', value: cycle_week.to_s },
-              ]
+              ],
             ],
-            )
+          )
         end
 
         it 'creates a new report per category' do

--- a/spec/models/publications/regional_edi_report_generator_spec.rb
+++ b/spec/models/publications/regional_edi_report_generator_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Publications::RegionalEdiReportGenerator do
   include DfE::Bigquery::TestHelper
 
-  subject(:generator) { described_class.new(cycle_week:, region:, category:) }
+  subject(:generator) { described_class.new(cycle_week:, region:) }
 
   let(:cycle_week) { 11 }
   let(:region) { 'London' }
-  let(:category) { 'sex' }
+  let(:category) { 'Sex' }
   let(:generation_date) { Time.zone.today }
   let(:regional_attributes) do
     [
@@ -139,7 +139,6 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
             'publication_date' => Time.zone.today,
             'generation_date' => Time.zone.today,
             'cycle_week' => cycle_week,
-            'category' => category,
             'statistics' => regional_attributes,
           })
         end
@@ -157,14 +156,13 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
             'publication_date' => generation_date,
             'generation_date' => generation_date,
             'cycle_week' => 15,
-            'category' => category,
             'statistics' => regional_attributes,
           })
         end
       end
 
       context 'when setting a future generation date' do
-        subject(:generator) { described_class.new(cycle_week:, generation_date:, region:, category:) }
+        subject(:generator) { described_class.new(cycle_week:, generation_date:, region:) }
 
         let(:generation_date) { 1.week.from_now.to_date }
 
@@ -176,7 +174,6 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
           expect(model).to have_attributes({
             'publication_date' => generation_date,
             'generation_date' => generation_date,
-            'category' => category,
             'cycle_week' => cycle_week,
             'statistics' => regional_attributes,
           })
@@ -211,7 +208,6 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
             'publication_date' => Time.zone.today,
             'generation_date' => Time.zone.today,
             'cycle_week' => cycle_week,
-            'category' => category,
             'statistics' => national_attributes,
           })
         end
@@ -229,14 +225,13 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
             'publication_date' => generation_date,
             'generation_date' => generation_date,
             'cycle_week' => 15,
-            'category' => category,
             'statistics' => national_attributes,
           })
         end
       end
 
       context 'when setting a future generation date' do
-        subject(:generator) { described_class.new(cycle_week:, generation_date:, region:, category:) }
+        subject(:generator) { described_class.new(cycle_week:, generation_date:, region:) }
 
         let(:generation_date) { 1.week.from_now.to_date }
 
@@ -248,7 +243,6 @@ RSpec.describe Publications::RegionalEdiReportGenerator do
           expect(model).to have_attributes({
             'publication_date' => generation_date,
             'generation_date' => generation_date,
-            'category' => category,
             'cycle_week' => cycle_week,
             'statistics' => national_attributes,
           })

--- a/spec/workers/publications/provider_edi_report_worker_spec.rb
+++ b/spec/workers/publications/provider_edi_report_worker_spec.rb
@@ -12,20 +12,18 @@ RSpec.describe Publications::ProviderEdiReportWorker do
 
   let(:provider_id) { 1 }
   let(:cycle_week) { current_cycle_week.pred }
-  let(:category) { 'Sex' }
   let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:recruitment_cycle_year) { 2026 }
 
   describe '#perform' do
     it 'calls the provider edi report generator' do
-      described_class.new.perform(provider_id, cycle_week, category, recruitment_cycle_year)
+      described_class.new.perform(provider_id, cycle_week, recruitment_cycle_year)
 
       expect(@instance).to have_received(:call)
       expect(Publications::ProviderEdiReportGenerator).to have_received(:new).with(
         provider_id:,
         cycle_week:,
-        category:,
         generation_date:,
         publication_date:,
         recruitment_cycle_year:,

--- a/spec/workers/publications/regional_edi_report_worker_spec.rb
+++ b/spec/workers/publications/regional_edi_report_worker_spec.rb
@@ -12,20 +12,18 @@ RSpec.describe Publications::RegionalEdiReportWorker do
 
   let(:cycle_week) { current_cycle_week.pred }
   let(:region) { 'London' }
-  let(:category) { 'Sex' }
   let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
   let(:recruitment_cycle_year) { 2026 }
 
   describe '#perform' do
     it 'calls the regional edi report generator' do
-      described_class.new.perform(cycle_week, region, category, recruitment_cycle_year)
+      described_class.new.perform(cycle_week, region, recruitment_cycle_year)
 
       expect(@instance).to have_received(:call)
       expect(Publications::RegionalEdiReportGenerator).to have_received(:new).with(
         cycle_week:,
         region:,
-        category:,
         generation_date:,
         publication_date:,
         recruitment_cycle_year:,


### PR DESCRIPTION
## Context

- Reduce the number of requests to BigQuery when generating EDI reports
- Request EDI data per provider, NOT per provider AND category

## Changes proposed in this pull request

- Remove category as an argument in EDI flow
- Loop over categories in the report generation

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
