### PR TITLE
Prevent NonDisclosureTraineeWithdrawalWorker on unless on production …

### DIFF
--- a/app/workers/non_disclosure_trainee_withdrawal_worker.rb
+++ b/app/workers/non_disclosure_trainee_withdrawal_worker.rb
@@ -4,6 +4,8 @@ class NonDisclosureTraineeWithdrawalWorker
   sidekiq_options retry: 3, queue: :default
 
   def perform(candidate_id)
+    return unless HostingEnvironment.production? || HostingEnvironment.qa? || HostingEnvironment.test_environment?
+
     candidate = Candidate.find(candidate_id)
     GeneratePossiblePreviousTeacherTraining.new(candidate).call
   end


### PR DESCRIPTION
…QA or test

## Context

- Prevent the NonDisclosureTraineeWithdrawalWorker from triggering unless on Production, QA or Test environments.
- Stop the amount of Sentry errors caused by this worker on sandbox. https://dfe-teacher-services.sentry.io/issues/7276116258/?project=1765973&query=is%3Aunresolved&referrer=issue-stream


## Changes proposed in this pull request

- `return` unless on the Production, QA or Test environments.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
