### PR TITLE
Data migration to remove provider_edi_report feature flag

### DIFF
--- a/app/services/data_migrations/remove_provider_edi_report_feature_flag.rb
+++ b/app/services/data_migrations/remove_provider_edi_report_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveProviderEdiReportFeatureFlag
+    TIMESTAMP = 20260416154158
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :provider_edi_report)&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveProviderEdiReportFeatureFlag',
   'DataMigrations::PublishEnglishProficiencies',
   'DataMigrations::RemoveServiceInformationBannerFeatureFlag',
   'DataMigrations::DropDfEStatefulSessionFlags',

--- a/spec/services/data_migrations/remove_provider_edi_report_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_provider_edi_report_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveProviderEdiReportFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'provider_edi_report')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'provider_edi_report')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add data migration to remove `provider_edi_report` feature flag

## Changes proposed in this pull request

- Add data migration to remove `provider_edi_report` feature flag

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/FMBC0sG0/1768-data-migration-to-remove-the-provideredireport-feature-flag