### PR TITLE
Move scheduled backup an hour earlier

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -24,7 +24,7 @@ on:
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
   schedule:
-    - cron: "50 6 * * *" # 06:50 UTC
+    - cron: "50 5 * * *" # 05:50 UTC
 
 env:
   SERVICE_NAME: apply


### PR DESCRIPTION
## Context

Daily backup has started failing since the clocks changed for BST, as the schedule is UTC.
It runs fine if I start it manually at the original time.

## Changes proposed in this pull request

Move the backup time back 1 hour

## Guidance to review

see https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/24550518622 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
