### PR TITLE
Add tests to ensure carry over of new EFL flow

### DIFF
--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe DuplicateApplication do
       expect(result.efl_completed).to be true
       expect(result.english_proficiency.present?).to be(true)
       expect(result.english_proficiency.efl_qualification).to be_nil
+      expect(result.english_proficiency.qualification_not_needed).to be(true)
+      expect(result.english_proficiency.has_qualification).to be(false)
+      expect(result.english_proficiency.no_qualification).to be(false)
+      expect(result.english_proficiency.degree_taught_in_english).to be(false)
+      expect(result.english_proficiency.draft).to be(false)
     end
 
     it 'carries over english proficiency data with elf qualification' do
@@ -179,6 +184,31 @@ RSpec.describe DuplicateApplication do
       expect(result.english_proficiency.present?).to be(true)
       expect(result.english_proficiency.efl_qualification.present?).to be(true)
       expect(result.english_proficiency.efl_qualification_type).to eq 'ToeflQualification'
+      expect(result.english_proficiency.has_qualification).to be(true)
+      expect(result.english_proficiency.no_qualification).to be(false)
+      expect(result.english_proficiency.degree_taught_in_english).to be(false)
+      expect(result.english_proficiency.qualification_not_needed).to be(false)
+      expect(result.english_proficiency.draft).to be(false)
+    end
+
+    it 'carries over english proficiency with no qualification details' do
+      create(
+        :english_proficiency,
+        :qualification_not_needed,
+        degree_taught_in_english: true,
+        no_qualification_details: 'Work in progress',
+        application_form: @original_application_form,
+      )
+      result = duplicate_application_form
+
+      expect(result.efl_completed).to be true
+      expect(result.english_proficiency.present?).to be(true)
+      expect(result.english_proficiency.has_qualification).to be(false)
+      expect(result.english_proficiency.no_qualification).to be(false)
+      expect(result.english_proficiency.degree_taught_in_english).to be(true)
+      expect(result.english_proficiency.qualification_not_needed).to be(true)
+      expect(result.english_proficiency.draft).to be(false)
+      expect(result.english_proficiency.no_qualification_details).to eq('Work in progress')
     end
   end
 


### PR DESCRIPTION
## Context

- Add tests to ensure carry over of new EFL flow attributes.

## Changes proposed in this pull request

- Add and amend tests to ensure EFL flow attributes carry over.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/RsObXVTq/1669-english-as-a-foreign-language-flow-in-apply-carry-over-script