### PR TITLE
Destroy withdrawal reason with RevertWithdrawal service

### DIFF
--- a/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
+++ b/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
@@ -17,7 +17,6 @@ module SupportInterface
         return false if errors.any?
 
         ActiveRecord::Base.transaction do
-          revert_withdrawal_service.withdrawal_reasons.destroy_all
           revert_withdrawal_service.save
         end
       end

--- a/app/services/support_interface/revert_withdrawal.rb
+++ b/app/services/support_interface/revert_withdrawal.rb
@@ -7,6 +7,10 @@ module SupportInterface
       assign_revert_attrs
     end
 
+    def save
+      super && destroy_withdrawal_reasons
+    end
+
   private
 
     attr_reader :application_choice, :zendesk_ticket
@@ -22,6 +26,11 @@ module SupportInterface
           structured_withdrawal_reasons: [],
         )
       end
+    end
+
+    def destroy_withdrawal_reasons
+      @application_choice.withdrawal_reasons.destroy_all
+      true
     end
   end
 end

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -443,7 +443,7 @@ You should use an adapted version of the revert rejection service to set the sta
       )
 ```
 
-### Revert a withdrawn offer
+### Revert a provider withdrawn offer
 
 This must be done manually via the console.
 
@@ -454,7 +454,16 @@ choice.update!(status: "awaiting_provider_decision", offer_withdrawal_reason: ni
 
 ### Revert a candidate withdrawn application
 
-If a candidate accidentally withdraws their application, it can be reverted via the Support UI
+If a candidate accidentally withdraws their application, it can be reverted via the Support UI.
+
+Alternatively, you can use the SupportInterface::RevertWithdrawal service.
+
+```ruby
+application_choice = ApplicationChoice.find(id)
+SupportInterface::RevertWithdrawal.new(application_choice:, zendesk_ticket: ZENDESK_URL)
+```
+
+This will revert the application to the `awaiting_provider_decision` status, and delete any associated WithdrawalReason records.
 
 ### Accept offer declined by default
 

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -460,7 +460,7 @@ Alternatively, you can use the SupportInterface::RevertWithdrawal service.
 
 ```ruby
 application_choice = ApplicationChoice.find(id)
-SupportInterface::RevertWithdrawal.new(application_choice:, zendesk_ticket: ZENDESK_URL)
+SupportInterface::RevertWithdrawal.new(application_choice:, zendesk_ticket: ZENDESK_URL).save
 ```
 
 This will revert the application to the `awaiting_provider_decision` status, and delete any associated WithdrawalReason records.

--- a/spec/services/support_interface/revert_withdrawal_spec.rb
+++ b/spec/services/support_interface/revert_withdrawal_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::RevertWithdrawal, :with_audited do
-  describe '#save!' do
+  describe '#save' do
     it 'reverts the application choice status back to `awaiting_provider_decision` and sets an audit comment' do
       application_choice = create(:application_choice, :awaiting_provider_decision, structured_withdrawal_reasons: %w[reason1 reason2 reason3])
       original_application_choice = application_choice.clone
@@ -10,19 +10,24 @@ RSpec.describe SupportInterface::RevertWithdrawal, :with_audited do
 
       WithdrawApplication.new(
         application_choice:,
+        accepted_offer: true,
       ).save!
+      expect(application_choice.withdrawal_reasons.exists?).to be(true)
+
       described_class.new(application_choice:, zendesk_ticket:).save
 
       expect(application_choice).to eq(original_application_choice)
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
       expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to be_nil
       expect(application_choice.structured_withdrawal_reasons).to eq []
+      expect(application_choice.withdrawal_reasons.exists?).to be(false)
     end
   end
 
   describe 'when reverting application results in duplicate course selection' do
     it 'adds errors to the application choice' do
       application_choice = create(:application_choice, :withdrawn)
+      _withdrawal_reason = create(:withdrawal_reason, :published, application_choice:)
       course_option = application_choice.course_option
       application_form = application_choice.application_form
       create(:application_choice, :unsubmitted, application_form:, course_option:)
@@ -32,6 +37,7 @@ RSpec.describe SupportInterface::RevertWithdrawal, :with_audited do
       described_class.new(application_choice:, zendesk_ticket:).save
 
       expect(application_choice.errors.full_messages).to include('cannot apply to the same course when an open application exists')
+      expect(application_choice.withdrawal_reasons.exists?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Context

- RevertWithdrawal service now deletes associated `WithdrawalReason` records

## Changes proposed in this pull request

- Overwrite `save` method to `destroy_all` deletes associated `WithdrawalReason` records.

## Guidance to review

- Review the code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/iHyzfgc3/1426-tech-debt-update-revert-withdrawal-service-to-bring-in-line-with-current-withdrawal-reasons-logic-and-update-support-playbook