### PR TITLE
Fix sql statement by using email_address method

### DIFF
--- a/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
+++ b/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
@@ -43,7 +43,7 @@ module DfE
       def sql_statement
         ActiveRecord::Base.send(
           :sanitize_sql_for_conditions,
-          ['email = ? OR (first_name IN (?) AND last_name IN (?) AND date_of_birth = ?)', candidate.email_address, first_names, last_names, date_of_birth],
+          ['email = ? OR (first_name IN (?) AND last_name IN (?) AND date_of_birth = ?)', email_address, first_names, last_names, date_of_birth],
         )
       end
 

--- a/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
+++ b/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
       expect(Google::Apis::BigqueryV2::QueryRequest).to have_received(:new).with(query: <<~SQL, timeout_ms: 10_000, use_legacy_sql: false)
         SELECT trainee_start_date, accredited_provider.name, accredited_provider.code, withdraw.date
         FROM `1_key_tables.non_disclosure_trainee_withdrawals`
-        WHERE email = 'john_doe@example.com' OR (first_name IN #{first_names_sql} AND last_name IN ('doe') AND date_of_birth = '1990-01-01')
+        WHERE email = 'john_doe%40example.com' OR (first_name IN #{first_names_sql} AND last_name IN ('doe') AND date_of_birth = '1990-01-01')
       SQL
     end
 


### PR DESCRIPTION
## Context

- `email_address` method was not being used in `sql_statement` method. Causing issues when the email address includes `'` character.

## Changes proposed in this pull request

- Use the `email_address` method, which `CGI.escape(candidate.email_address)` to fix issue passing `'` characters to BigQuery

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Sentry

https://dfe-teacher-services.sentry.io/issues/7276116258/events/b049ea77f4844ce1ad9fb85e1f530766/?project=1765973