### PR TITLE
Update api to use the published_english_proficiency if flag on

### DIFF
--- a/app/components/shared/efl_qualification_card_component.rb
+++ b/app/components/shared/efl_qualification_card_component.rb
@@ -22,11 +22,7 @@ class EflQualificationCardComponent < ApplicationComponent
   end
 
   def english_proficiency
-    @english_proficiency ||= if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
-                               application_form.published_english_proficiency
-                             else
-                               application_form.english_proficiency
-                             end
+    @english_proficiency ||= application_form.english_proficiency
   end
 
   def efl_qualification

--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -48,6 +48,8 @@ module APIDocs
           api_docs_spec_1_6_url
         when '1.7'
           api_docs_spec_1_7_url
+        when '1.8'
+          api_docs_spec_1_8_url
         end
       end
       helper_method :spec_url_for_current_version

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -9,7 +9,9 @@ module VendorAPI
   VERSION_1_5 = '1.5'.freeze
   VERSION_1_6 = '1.6'.freeze
   VERSION_1_7 = '1.7'.freeze
-  VERSION = VERSION_1_7
+  VERSION_1_8 = '1.8pre'.freeze # the pre suffix should make v1.8 available to dev envs and sandbox only
+
+  VERSION = '1.8'.freeze
 
   VERSIONS = {
     '1.0' => [
@@ -73,6 +75,9 @@ module VendorAPI
     ],
     '1.7' => [
       Changes::V17::AddPossibleUndeclaredPreviousTeacherTrainingUrl,
+    ],
+    '1.8pre' => [
+      Changes::V18::EnglishAsAForeignLanguageCandidateResponse,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/v18/english_as_a_foreign_language_candidate_response.rb
+++ b/app/lib/vendor_api/changes/v18/english_as_a_foreign_language_candidate_response.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V18
+      class EnglishAsAForeignLanguageCandidateResponse < VersionChange
+        description 'Does the candidate intend to take an English as a foreign language assessment?'
+
+        resource ApplicationPresenter, [ApplicationPresenter::EnglishAsAForeignLanguageCandidateResponse]
+      end
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -69,14 +69,8 @@ class ApplicationForm < ApplicationRecord
 
   belongs_to :previous_application_form, class_name: 'ApplicationForm', optional: true, inverse_of: 'subsequent_application_form'
   has_one :subsequent_application_form, class_name: 'ApplicationForm', foreign_key: 'previous_application_form_id', inverse_of: 'previous_application_form', dependent: :destroy
-  has_one :english_proficiency, -> { where(draft: false).order(:created_at) }, class_name: 'EnglishProficiency', dependent: :destroy
+  has_one :english_proficiency, -> { where(draft: false).order(created_at: :desc) }, class_name: 'EnglishProficiency', dependent: :destroy
   has_many :english_proficiencies, dependent: :destroy
-  has_one(
-    :published_english_proficiency,
-    -> { where(draft: false).order(created_at: :desc) },
-    dependent: :destroy,
-    class_name: 'EnglishProficiency',
-  )
 
   has_many :application_feedback
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -522,7 +522,12 @@ class ApplicationForm < ApplicationRecord
 
     if self[:english_main_language].nil?
       return true if british_or_irish?
-      return true if english_proficiency&.qualification_not_needed?
+
+      if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
+        return published_english_proficiency&.qualification_not_needed
+      elsif english_proficiency&.qualification_not_needed?
+        return true
+      end
 
       false
     else
@@ -530,12 +535,21 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  def reset_form
+    application_choices.destroy_all
+    update(submitted_at: nil)
+  end
+
   def english_language_details
     self[:english_language_details].presence || english_proficiency&.formatted_qualification_description
   end
 
   def english_language_qualification_details
-    english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
+    if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
+      published_english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
+    else
+      english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
+    end
   end
 
   def selected_enough_references?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -522,12 +522,7 @@ class ApplicationForm < ApplicationRecord
 
     if self[:english_main_language].nil?
       return true if british_or_irish?
-
-      if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
-        return published_english_proficiency&.qualification_not_needed
-      elsif english_proficiency&.qualification_not_needed?
-        return true
-      end
+      return true if english_proficiency&.qualification_not_needed?
 
       false
     else
@@ -535,21 +530,12 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  def reset_form
-    application_choices.destroy_all
-    update(submitted_at: nil)
-  end
-
   def english_language_details
     self[:english_language_details].presence || english_proficiency&.formatted_qualification_description
   end
 
   def english_language_qualification_details
-    if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
-      published_english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
-    else
-      english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
-    end
+    english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
   end
 
   def selected_enough_references?

--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -19,6 +19,6 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
   end
 
   def obtaining_english_language_qualification_details
-    published_english_proficiency.no_qualification_details
+    published_english_proficiency&.no_qualification_details
   end
 end

--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -1,0 +1,24 @@
+module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateResponse
+  def schema
+    super.deep_merge!({
+      attributes: {
+        candidate: {
+          will_obtain_english_language_qualifications:,
+          obtaining_english_language_qualification_details:,
+        },
+      },
+    })
+  end
+
+  def published_english_proficiency
+    @published_english_proficiency ||= application_form&.published_english_proficiency
+  end
+
+  def will_obtain_english_language_qualifications
+    published_english_proficiency&.no_qualification_details.present?
+  end
+
+  def obtaining_english_language_qualification_details
+    published_english_proficiency.no_qualification_details
+  end
+end

--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -10,15 +10,15 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
     })
   end
 
-  def published_english_proficiency
-    @published_english_proficiency ||= application_form&.published_english_proficiency
+  def english_proficiency
+    @english_proficiency ||= application_form&.english_proficiency
   end
 
   def will_obtain_english_language_qualifications
-    published_english_proficiency&.no_qualification_details.present?
+    english_proficiency&.no_qualification_details.present?
   end
 
   def obtaining_english_language_qualification_details
-    published_english_proficiency&.no_qualification_details
+    english_proficiency&.no_qualification_details
   end
 end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l" id="important">Version 1.8 changes</h2>
 
-<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intension of taking an English as a foreign language assessment if they don't have one</p>
+<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intention of taking an English as a foreign language assessment if they don't have one</p>
 
 <p class="govuk-body">
   A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
@@ -10,11 +10,11 @@
 </p>
 
 <p class="govuk-body">
-  If a candidate does not have an English language qualification, they can state their intension of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+  If a candidate does not have an English language qualification, they can state their intention of gaining one or not. If they do intend to gain this qualification they can add further details about their plans
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
 </p>
 <p class="govuk-body">
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
 </p>
 
 <p class="govuk-body">

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
@@ -1,0 +1,25 @@
+<h2 class="govuk-heading-l" id="important">Version 1.8 changes</h2>
+
+<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intension of taking an English as a foreign language assessment if they don't have one</p>
+
+<p class="govuk-body">
+  A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
+</p>
+<p class="govuk-body">
+  A new attribute, <code>obtaining_english_language_qualification_details</code>, has been added to the candidate object.
+</p>
+
+<p class="govuk-body">
+  If a candidate does not have an English language qualification, they can state their intension of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+</p>
+<p class="govuk-body">
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+</p>
+
+<p class="govuk-body">
+  If a candidate does not have an English language qualification and they don't intend to gain one the attribute <code>will_obtain_english_language_qualifications</code> will be <code>false</code> and <code>obtaining_english_language_qualification_details</code> will be <code>nil</code>.
+</p>
+<p class=">govuk-body">
+  If a candidate has an English language qualifications both attributes will be <code>nil</code>.
+</p>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -72,7 +72,7 @@
 
 <h2 class="govuk-heading-l" id="changes">Version 1.8 changes</h2>
 
-<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intension of taking an English as a foreign language assessment if they don't have one</p>
+<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intention of taking an English as a foreign language assessment if they don't have one</p>
 
 <p class="govuk-body">
   A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
@@ -82,11 +82,11 @@
 </p>
 
 <p class="govuk-body">
-  If a candidate does not have an English language qualification, they can state their intension of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+  If a candidate does not have an English language qualification, they can state their intention of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
 </p>
 <p class="govuk-body">
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
 </p>
 
 <p class="govuk-body">

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -10,7 +10,7 @@
 <ol class="app-contents-list__list">
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'API Versions', '#versions', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Testing draft changes', '#testing-draft', class: 'app-contents-list__link' %></li>
-  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.7 changes', '#changes', class: 'app-contents-list__link' %></li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.8 changes', '#changes', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent">
     <%= govuk_link_to 'Endpoints', '#endpoints', class: 'app-contents-list__link' %>
@@ -52,37 +52,48 @@
   <li>using the correct version of the API</li>
 </ul>
 
-<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.7</h3>
+<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.8</h3>
 
 <p class="govuk-body">
   When an API version is in draft, you can test it using our sandbox test environment.
 </p>
 
 <p class="govuk-body">
-  You can test draft version <code>1.7</code> by using:
+  You can test draft version <code>1.8</code> by using:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.7', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.7' %></li>
+  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8' %></li>
   <li>your sandbox API token - email <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %> if you do not have one</li>
 </ul>
 
 <p class="govuk-body">
-  After version <code>1.7</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
+  After version <code>1.8</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
 </p>
 
-<h2 class="govuk-heading-l" id="changes">Version 1.7 changes</h2>
+<h2 class="govuk-heading-l" id="changes">Version 1.8 changes</h2>
 
-<p class="govuk-heading-s">New attribute added to the application object for viewing data on possible undeclared previous ITT</p>
+<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intension of taking an English as a foreign language assessment if they don't have one</p>
 
 <p class="govuk-body">
-  A new attribute, <code>possible_undeclared_previous_teacher_training_url</code>, has been added to the application object.
+  A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
 </p>
 <p class="govuk-body">
-  If we have identified possible undeclared previous teacher training, this attribute provides a URL that can be used to view possible undeclared previous teacher training details associated with an application.
-  If no undeclared previous training experiences have been found, the value of the attribute will be `null`.
+  A new attribute, <code>obtaining_english_language_qualification_details</code>, has been added to the candidate object.
+</p>
+
+<p class="govuk-body">
+  If a candidate does not have an English language qualification, they can state their intension of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+</p>
+<p class="govuk-body">
+  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intension.
+</p>
+
+<p class="govuk-body">
+  If a candidate does not have an English language qualification and they don't intend to gain one the attribute <code>will_obtain_english_language_qualifications</code> will be <code>false</code> and <code>obtaining_english_language_qualification_details</code> will be <code>nil</code>.
 </p>
 <p class=">govuk-body">
-  This is speculative data based on the comparison of records with some matching attributes. More information on how to use this information and providers’ duties with regard to it is provided at the link destination.
+  If a candidate has an English language qualifications both attributes will be <code>nil</code>.
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -101,10 +112,10 @@
 
 <p class="govuk-body">
   We have a production environment and a sandbox environment.
-  When version 1.7 is launched initially for testing, it will only be accessible
+  When version 1.8 is launched initially for testing, it will only be accessible
   in the sandbox environment by determining the version in the URL as so:
-  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.7',
-                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.7' %>.
+  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8',
+                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8' %>.
   Only after testing is complete, the production environment will automatically upgrade
   to the latest minor version without the need to update the URL.
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,7 +331,7 @@ en:
         release_notes: Release notes
         lifecycle: Lifecycle
         alpha_release_notes: Alpha release notes
-        draft: Draft Version 1.7
+        draft: Draft Version 1.8
       register_api_docs:
         reference: Apply for teacher training - Register API
     provider:

--- a/config/routes/api/docs.rb
+++ b/config/routes/api/docs.rb
@@ -22,6 +22,7 @@ namespace :api_docs, path: nil do
     get '/spec-1.5.yml' => 'openapi#spec_1_5', as: :spec_1_5
     get '/spec-1.6.yml' => 'openapi#spec_1_6', as: :spec_1_6
     get '/spec-1.7.yml' => 'openapi#spec_1_7', as: :spec_1_7
+    get '/spec-1.8.yml' => 'openapi#spec_1_8', as: :spec_1_8
   end
 
   namespace :data_api_docs, path: '/data-api' do

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.7
+  version: v1.8
   title: Apply API
   contact:
     name: DfE

--- a/config/vendor_api/v1.8.yml
+++ b/config/vendor_api/v1.8.yml
@@ -21,11 +21,11 @@ components:
       properties:
         will_obtain_english_language_qualifications:
           type: boolean
-          description: The candidate’s intension to gain english language qualification
+          description: The candidate’s intention to gain english language qualification
           example: true
         obtaining_english_language_qualification_details:
           type: string
-          description: If the candidate intends to gain this qualification they can explain their intension
+          description: If the candidate intends to gain this qualification they can explain their intention
           example: "I will gain it next year"
       required:
         - will_obtain_english_language_qualifications

--- a/config/vendor_api/v1.8.yml
+++ b/config/vendor_api/v1.8.yml
@@ -1,0 +1,32 @@
+---
+openapi: 3.0.0
+info:
+  version: v1.8
+  title: Apply API
+  contact:
+    name: DfE
+    email: becomingateacher@digital.education.gov.uk
+  description: |
+    API for DfE’s Apply for teacher training service.
+    Endpoints with the `/applications` prefix are considered stable.
+    Experimental endpoints prefixed with `/test-data` may change or be removed.
+servers:
+- description: Sandbox (test environment for vendors)
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8
+- description: Production
+  url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.8
+components:
+  schemas:
+    Candidate:
+      properties:
+        will_obtain_english_language_qualifications:
+          type: boolean
+          description: The candidate’s intension to gain english language qualification
+          example: true
+        obtaining_english_language_qualification_details:
+          type: string
+          description: If the candidate intends to gain this qualification they can explain their intension
+          example: "I will gain it next year"
+      required:
+        - will_obtain_english_language_qualifications
+        - obtaining_english_language_qualification_details

--- a/spec/lib/concerns/versioning_helpers_spec.rb
+++ b/spec/lib/concerns/versioning_helpers_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe VersioningHelpers do
       before { allow(HostingEnvironment).to receive(:sandbox_mode?).and_return true }
 
       it 'returns the release' do
-        expect(released_version).to eq '1.7'
+        expect(released_version).to eq '1.8'
       end
     end
 
     context 'development environments' do
       it 'returns the release' do
-        expect(released_version).to eq '1.7'
+        expect(released_version).to eq '1.8'
       end
     end
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -825,6 +825,48 @@ RSpec.describe ApplicationForm do
       end
     end
 
+    context 'when english_proficiency flag is on' do
+      let(:application_form) { build(:application_form, english_main_language: nil) }
+
+      before do
+        FeatureFlag.activate('2027_application_form_has_many_english_proficiencies')
+      end
+
+      context 'when british_or_irish? is true' do
+        it 'returns true' do
+          application_form.first_nationality = 'British'
+
+          expect(application_form.english_main_language).to be true
+        end
+      end
+
+      context 'when the english_proficiency record declares that a qualification is not needed' do
+        it 'returns true' do
+          create(
+            :english_proficiency,
+            :qualification_not_needed,
+            draft: false,
+            application_form:,
+          )
+
+          expect(application_form.english_main_language).to be true
+        end
+      end
+
+      context 'when the english_proficiency record does not declare that a qualification is not needed' do
+        it 'returns false' do
+          create(
+            :english_proficiency,
+            :no_qualification,
+            draft: false,
+            application_form:,
+          )
+
+          expect(application_form.english_main_language).to be false
+        end
+      end
+    end
+
     context 'database value is true' do
       let(:application_form) { build(:application_form, english_main_language: true) }
 
@@ -838,6 +880,69 @@ RSpec.describe ApplicationForm do
 
       it 'returns false' do
         expect(application_form.english_main_language).to be false
+      end
+    end
+  end
+
+  describe '#english_language_qualification_details' do
+    context 'when english_proficiency flag is on' do
+      let(:application_form) { build(:application_form, english_main_language: nil) }
+
+      before do
+        FeatureFlag.activate('2027_application_form_has_many_english_proficiencies')
+      end
+
+      context 'when published_english_proficiency is present' do
+        it 'returns formatted response from published record' do
+          create(
+            :english_proficiency,
+            :with_ielts_qualification,
+            draft: false,
+            application_form:,
+          )
+
+          expect(application_form.english_language_qualification_details).to eq(
+            'Name: IELTS, Grade: 6.5, Awarded: 1999, Reference: 123456',
+          )
+        end
+      end
+
+      context 'when legacy english_language_details is present' do
+        it 'returns formatted response from legacy column' do
+          application_form[:english_language_details] = 'test'
+
+          expect(application_form.english_language_qualification_details).to eq(
+            'test',
+          )
+        end
+      end
+    end
+
+    context 'when english_proficiency flag is off' do
+      let(:application_form) { build(:application_form, english_main_language: nil) }
+
+      context 'when published_english_proficiency is present' do
+        it 'returns formatted response from english proficiency record' do
+          create(
+            :english_proficiency,
+            :with_ielts_qualification,
+            application_form:,
+          )
+
+          expect(application_form.english_language_qualification_details).to eq(
+            'Name: IELTS, Grade: 6.5, Awarded: 1999, Reference: 123456',
+          )
+        end
+      end
+
+      context 'when legacy english_language_details is present' do
+        it 'returns formatted response from legacy column' do
+          application_form[:english_language_details] = 'test'
+
+          expect(application_form.english_language_qualification_details).to eq(
+            'test',
+          )
+        end
       end
     end
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -845,7 +845,7 @@ RSpec.describe ApplicationForm do
   describe '#english_language_qualification_details' do
     let(:application_form) { build(:application_form, english_main_language: nil) }
 
-    context 'when published_english_proficiency is present' do
+    context 'when english_proficiency is present' do
       it 'returns formatted response from english proficiency record' do
         create(
           :english_proficiency,

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -803,6 +803,10 @@ RSpec.describe ApplicationForm do
     context 'database value is nil' do
       let(:application_form) { build(:application_form, english_main_language: nil) }
 
+      before do
+        FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+      end
+
       it 'returns false by default' do
         expect(application_form.english_main_language).to be false
       end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -803,10 +803,6 @@ RSpec.describe ApplicationForm do
     context 'database value is nil' do
       let(:application_form) { build(:application_form, english_main_language: nil) }
 
-      before do
-        FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
-      end
-
       it 'returns false by default' do
         expect(application_form.english_main_language).to be false
       end
@@ -829,48 +825,6 @@ RSpec.describe ApplicationForm do
       end
     end
 
-    context 'when english_proficiency flag is on' do
-      let(:application_form) { build(:application_form, english_main_language: nil) }
-
-      before do
-        FeatureFlag.activate('2027_application_form_has_many_english_proficiencies')
-      end
-
-      context 'when british_or_irish? is true' do
-        it 'returns true' do
-          application_form.first_nationality = 'British'
-
-          expect(application_form.english_main_language).to be true
-        end
-      end
-
-      context 'when the english_proficiency record declares that a qualification is not needed' do
-        it 'returns true' do
-          create(
-            :english_proficiency,
-            :qualification_not_needed,
-            draft: false,
-            application_form:,
-          )
-
-          expect(application_form.english_main_language).to be true
-        end
-      end
-
-      context 'when the english_proficiency record does not declare that a qualification is not needed' do
-        it 'returns false' do
-          create(
-            :english_proficiency,
-            :no_qualification,
-            draft: false,
-            application_form:,
-          )
-
-          expect(application_form.english_main_language).to be false
-        end
-      end
-    end
-
     context 'database value is true' do
       let(:application_form) { build(:application_form, english_main_language: true) }
 
@@ -889,64 +843,29 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#english_language_qualification_details' do
-    context 'when english_proficiency flag is on' do
-      let(:application_form) { build(:application_form, english_main_language: nil) }
+    let(:application_form) { build(:application_form, english_main_language: nil) }
 
-      before do
-        FeatureFlag.activate('2027_application_form_has_many_english_proficiencies')
-      end
+    context 'when published_english_proficiency is present' do
+      it 'returns formatted response from english proficiency record' do
+        create(
+          :english_proficiency,
+          :with_ielts_qualification,
+          application_form:,
+        )
 
-      context 'when published_english_proficiency is present' do
-        it 'returns formatted response from published record' do
-          create(
-            :english_proficiency,
-            :with_ielts_qualification,
-            draft: false,
-            application_form:,
-          )
-
-          expect(application_form.english_language_qualification_details).to eq(
-            'Name: IELTS, Grade: 6.5, Awarded: 1999, Reference: 123456',
-          )
-        end
-      end
-
-      context 'when legacy english_language_details is present' do
-        it 'returns formatted response from legacy column' do
-          application_form[:english_language_details] = 'test'
-
-          expect(application_form.english_language_qualification_details).to eq(
-            'test',
-          )
-        end
+        expect(application_form.english_language_qualification_details).to eq(
+          'Name: IELTS, Grade: 6.5, Awarded: 1999, Reference: 123456',
+        )
       end
     end
 
-    context 'when english_proficiency flag is off' do
-      let(:application_form) { build(:application_form, english_main_language: nil) }
+    context 'when legacy english_language_details is present' do
+      it 'returns formatted response from legacy column' do
+        application_form[:english_language_details] = 'test'
 
-      context 'when published_english_proficiency is present' do
-        it 'returns formatted response from english proficiency record' do
-          create(
-            :english_proficiency,
-            :with_ielts_qualification,
-            application_form:,
-          )
-
-          expect(application_form.english_language_qualification_details).to eq(
-            'Name: IELTS, Grade: 6.5, Awarded: 1999, Reference: 123456',
-          )
-        end
-      end
-
-      context 'when legacy english_language_details is present' do
-        it 'returns formatted response from legacy column' do
-          application_form[:english_language_details] = 'test'
-
-          expect(application_form.english_language_qualification_details).to eq(
-            'test',
-          )
-        end
+        expect(application_form.english_language_qualification_details).to eq(
+          'test',
+        )
       end
     end
   end

--- a/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::ApplicationPresenter do
+  context 'candidate intends to gain english language qualification' do
+    describe '#attributes' do
+      it 'returns correct response' do
+        application_form = create(:application_form, :submitted)
+        _english_proficiency = create(
+          :english_proficiency,
+          :no_qualification,
+          no_qualification_details: 'I will take it next year',
+          draft: false,
+          application_form:,
+        )
+        application_choice = create(:application_choice, application_form:)
+        result = described_class.new('1.8', application_choice).as_json
+
+        expect(result.dig(:attributes, :candidate, :will_obtain_english_language_qualifications)).to be(true)
+        expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to eq(
+          'I will take it next year',
+        )
+      end
+    end
+  end
+
+  context 'candidate does not intend to gain english language qualification' do
+    describe '#attributes' do
+      it 'returns correct response' do
+        application_form = create(:application_form, :submitted)
+        _english_proficiency = create(
+          :english_proficiency,
+          :no_qualification,
+          draft: false,
+          application_form:,
+        )
+        application_choice = create(:application_choice, application_form:)
+        result = described_class.new('1.8', application_choice).as_json
+
+        expect(result.dig(:attributes, :candidate, :will_obtain_english_language_qualifications)).to be(false)
+        expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The recent change to the english proficiency flow, where we allow the candidate to choose any or all of these options:
- English is my first language
- My degree was taught in English
- I have an English as a foreign language (EFL) assessment
- None

<img width="1229" height="742" alt="image" src="https://github.com/user-attachments/assets/25ab6f90-2375-456a-a879-8bcb29651f40" />


Will not change the vendor api too much. The format of the response doesn't change

The existing response format can display all the information that we ask the candidate
<img width="1444" height="78" alt="image" src="https://github.com/user-attachments/assets/469c6723-2ccd-4119-b3e8-1edc32758396" />

But the new flow allows the candidate to explain that they will pursue a qualification if they don't have one.

To accommodate this, these two attributes will be available in 1.8. On the candidate object
```
will_obtain_english_language_qualifications
obtaining_english_language_qualification_details
```
 

## Changes proposed in this pull request
- api 1.8 pre release version with new attributes exposing the candidate's intention to get an English qualification.
- removed duplicated association


## Guidance to review

I've created an api token and a few candidates.
Candidate who will get an English language qualification
```
curl https://apply-review-11851.test.teacherservices.cloud/api/v1.8/applications/160 -H "Authorization: Bearer knmER187SyRyCrJn_smZ"
```

Candidate who will not get an English language qualification

```
curl https://apply-review-11851.test.teacherservices.cloud/api/v1.8/applications/161 -H "Authorization: Bearer knmER187SyRyCrJn_smZ"
```

Candidate with an English language qualification
```
curl https://apply-review-11851.test.teacherservices.cloud/api/v1.8/applications/162 -H "Authorization: Bearer knmER187SyRyCrJn_smZ"
```




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
