### PR TITLE
Add international application to test application generator

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -339,8 +339,7 @@ private
   end
 
   def accept_offer(choice, incomplete_references)
-    application_form = choice.application_form
-    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+    return if unable_to_change_state(choice)
 
     fast_forward
     AcceptOffer.new(application_choice: choice).save!
@@ -382,8 +381,7 @@ private
   end
 
   def make_offer(choice, conditions: ['Complete DBS'])
-    application_form = choice.application_form
-    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+    return if unable_to_change_state(choice)
 
     as_provider_user(choice) do
       fast_forward
@@ -461,8 +459,7 @@ private
   end
 
   def defer_offer(choice)
-    application_form = choice.application_form
-    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+    return if unable_to_change_state(choice)
 
     as_provider_user(choice) do
       fast_forward
@@ -601,6 +598,11 @@ private
         created_at: time,
       )
     end
+  end
+
+  def unable_to_change_state(application_choice)
+    application_form = application_choice.application_form
+    application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
   end
 
   def internationalize_application(application_form)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -161,7 +161,7 @@ private
 
       fast_forward
 
-      application_choices = courses.map do |course|
+      courses.each_with_index do |course, i|
         FactoryBot.create(
           :application_choice,
           status: 'unsubmitted',
@@ -170,12 +170,19 @@ private
           created_at: time,
           updated_at: time,
         )
+
+        if @application_form.efl_completed ||
+           ((course.can_sponsor_skilled_worker_visa || course.can_sponsor_student_visa) && i.even?)
+          internationalize_application(@application_form)
+        end
       end
+
+      application_choices = @application_form.application_choices
 
       if states == [:cancelled]
         # The cancelled state doesn't exist anymore in the current system,
         # so we have to set this manually.
-        @application_form.application_choices.each do |application_choice|
+        application_choices.each do |application_choice|
           application_choice.update!(
             status: 'cancelled',
           )
@@ -585,5 +592,47 @@ private
         created_at: time,
       )
     end
+  end
+
+  def internationalize_application(application_form)
+    unless application_form.efl_completed
+      application_form.update!(
+        first_nationality: 'American',
+        second_nationality: nil,
+        address_type: :international,
+        country: Faker::Address.country_code,
+        right_to_work_or_study: 'yes',
+        immigration_status: 'student_visa',
+        region_code: 'rest_of_the_world',
+        efl_completed_at: Time.zone.now,
+        efl_completed: true,
+        visa_expired_at: if FeatureFlag.active?('2027_visa_expiry')
+                           2.years.from_now
+                         end,
+      )
+    end
+
+    if FeatureFlag.active?('2027_visa_expiry')
+      application_form.application_choices.update_all(
+        visa_explanation: 'expires_after_course',
+        visa_explanation_details: Faker::Lorem.paragraph(sentence_count: 10),
+      )
+    end
+
+    return if application_form.english_proficiency.present?
+
+    qualification_status = EnglishProficiency.qualification_statuses.values.sample
+    EnglishProficiency.create!(
+      application_form:,
+      qualification_status:,
+      qualification_status.to_s => true,
+      draft: false,
+      no_qualification_details: if %w[no_qualification degree_taught_in_english].include?(qualification_status.to_s.downcase)
+                                  Faker::Lorem.paragraph(sentence_count: 10)
+                                end,
+      efl_qualification: if qualification_status == 'has_qualification'
+                           FactoryBot.build(:ielts_qualification)
+                         end,
+    )
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -459,7 +459,7 @@ private
   end
 
   def defer_offer(choice)
-    return if unable_to_change_state(choice)
+    return if choice.application_form.application_choices.exists?(status: 'withdrawn')
 
     as_provider_user(choice) do
       fast_forward

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -339,6 +339,9 @@ private
   end
 
   def accept_offer(choice, incomplete_references)
+    application_form = choice.application_form
+    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+
     fast_forward
     AcceptOffer.new(application_choice: choice).save!
     @application_form.reload
@@ -379,6 +382,9 @@ private
   end
 
   def make_offer(choice, conditions: ['Complete DBS'])
+    application_form = choice.application_form
+    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+
     as_provider_user(choice) do
       fast_forward
       update_conditions_service = SaveOfferConditionsFromText.new(application_choice: choice, conditions:)
@@ -455,6 +461,9 @@ private
   end
 
   def defer_offer(choice)
+    application_form = choice.application_form
+    return if application_form.any_offer_accepted? || application_form.application_choices.exists?(status: 'withdrawn')
+
     as_provider_user(choice) do
       fast_forward
       confirm_offer_conditions(choice) if rand > 0.5 # 'recruited' can also be deferred

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -626,7 +626,6 @@ private
     if FeatureFlag.active?('2027_visa_expiry')
       application_form.application_choices.update_all(
         visa_explanation: 'expires_after_course',
-        visa_explanation_details: Faker::Lorem.paragraph(sentence_count: 10),
       )
     end
 

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -35,8 +35,12 @@ private
     elsif previous_cycle
       states_for_previous_cycle(courses_per_application)
     else
-      [:awaiting_provider_decision] * courses_per_application
+      [states_for_this_cycle.sample] * courses_per_application
     end
+  end
+
+  def states_for_this_cycle
+    ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - [:inactive]
   end
 
   def states_for_next_cycle

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe TestApplications do
+  let(:courses_to_apply_to) { create_list(:course, 1, :with_a_course_option, recruitment_cycle_year:) }
+  let(:states) { [:awaiting_provider_decision] }
+  let(:recruitment_cycle_year) { 2026 }
+  let(:test_applications) { described_class.new }
+
+  describe '.create_application' do
+    subject(:create_application) do
+      test_applications.create_application(recruitment_cycle_year:, states:, courses_to_apply_to:)
+    end
+
+    it 'creates a test application' do
+      expect { create_application }.to change{ ApplicationForm.count }.by(1)
+      application_form = ApplicationForm.last
+      application_choice = application_form.application_choices.first
+      expect(application_choice.course).to eq(courses_to_apply_to.last)
+      expect(application_form.recruitment_cycle_year).to eq(recruitment_cycle_year)
+    end
+
+    context 'when the course accepts visas' do
+      let(:courses_to_apply_to) {
+        create_list(
+          :course,
+          2,
+          :with_a_course_option,
+          recruitment_cycle_year:,
+          can_sponsor_skilled_worker_visa: true,
+          can_sponsor_student_visa: true,
+        )
+      }
+      let(:states) { %i[awaiting_provider_decision awaiting_provider_decision] }
+
+      it 'creates an international application' do
+        expect { create_application }.to change{ ApplicationChoice.count }.by(2)
+        application_form = ApplicationForm.last
+        expect(application_form.english_proficiency.present?).to be(true)
+        expect(application_form.first_nationality).to eq('American')
+        expect(application_form.second_nationality).to be_nil
+        expect(application_form.address_type).to eq('international')
+        expect(application_form.right_to_work_or_study).to eq('yes')
+        expect(application_form.immigration_status).to eq('student_visa')
+        expect(application_form.region_code).to eq('rest_of_the_world')
+        expect(application_form.efl_completed).to be(true)
+      end
+
+      context 'when 2027_visa_expiry feature flag is on', feature_flag: '2027_visa_expiry' do
+        it 'assigns visa expiry details to the application' do
+          expect { create_application }.to change{ ApplicationChoice.count }.by(2)
+          application_form = ApplicationForm.last
+          expect(application_form.visa_expired_at).to eq(2.years.from_now)
+
+          application_choices = application_form.application_choices
+          expect(application_choices.pluck(:visa_explanation).uniq).to contain_exactly('expires_after_course')
+          expect(application_choices.map { |ac| ac.visa_explanation_details.present? }.uniq).to contain_exactly(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe TestApplications do
 
           application_choices = application_form.application_choices
           expect(application_choices.pluck(:visa_explanation).uniq).to contain_exactly('expires_after_course')
-          expect(application_choices.map { |ac| ac.visa_explanation_details.present? }.uniq).to contain_exactly(true)
         end
       end
     end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TestApplications do
     end
 
     it 'creates a test application' do
-      expect { create_application }.to change{ ApplicationForm.count }.by(1)
+      expect { create_application }.to change { ApplicationForm.count }.by(1)
       application_form = ApplicationForm.last
       application_choice = application_form.application_choices.first
       expect(application_choice.course).to eq(courses_to_apply_to.last)
@@ -33,7 +33,7 @@ RSpec.describe TestApplications do
       let(:states) { %i[awaiting_provider_decision awaiting_provider_decision] }
 
       it 'creates an international application' do
-        expect { create_application }.to change{ ApplicationChoice.count }.by(2)
+        expect { create_application }.to change { ApplicationChoice.count }.by(2)
         application_form = ApplicationForm.last
         expect(application_form.english_proficiency.present?).to be(true)
         expect(application_form.first_nationality).to eq('American')
@@ -47,9 +47,9 @@ RSpec.describe TestApplications do
 
       context 'when 2027_visa_expiry feature flag is on', feature_flag: '2027_visa_expiry' do
         it 'assigns visa expiry details to the application' do
-          expect { create_application }.to change{ ApplicationChoice.count }.by(2)
+          expect { create_application }.to change { ApplicationChoice.count }.by(2)
           application_form = ApplicationForm.last
-          expect(application_form.visa_expired_at).to eq(2.years.from_now)
+          expect(application_form.visa_expired_at.to_date).to eq(2.years.from_now.to_date)
 
           application_choices = application_form.application_choices
           expect(application_choices.pluck(:visa_explanation).uniq).to contain_exactly('expires_after_course')

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(2)
-    expect(ApplicationChoice.all.map(&:status).uniq).to eq(%w[awaiting_provider_decision])
+    expect(ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER).to include(
+      *ApplicationChoice.all.map { |ac| ac.status.to_sym }.uniq,
+    )
   end
 
   it 'does not generate more than three application_choices per application' do


### PR DESCRIPTION
## Context

- Test applications generated for providers include all statuses that providers can see, and international candidates.

## Changes proposed in this pull request

- Applications are generated with all statuses that providers can see.
- Applications are generated for international candidates.

## Guidance to review

⚠️ Can be tested locally if you change the following lines of code ⚠️ 
- `app/views/support_interface/providers/applications.html.erb` line 2 (remove `HostingEnvironment.sandbox_mode?`)
- `app/controllers/support_interface/provider_test_data_controller.rb` line 22 (add a line about `return`)
----------
- Visit http://localhost:3000/support/providers
- Select a provider (a provider with courses (which accept visas), perhaps with no applications)
- Navigate to "Applications"
- Click on "Generate test applications"
- 100 applications should be generated for that provider, with different statuses and some international candidates

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/zsL2JldU/1465-improve-automatically-generated-application-data