### PR TITLE
Fix recruitment report bug in provider interface

### DIFF
--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -8,7 +8,7 @@
 
     <h2 class="govuk-heading-m"><%= @current_timetable.cycle_range_name %> recruitment cycle</h2>
 
-    <% unless @performance_reports && RecruitmentPerformanceReportTimetable.report_season? %>
+    <% unless RecruitmentPerformanceReportTimetable.report_season? %>
       <%= t(
         '.available_in_the_future_html',
         current_cycle_range: @current_timetable.cycle_range_name,


### PR DESCRIPTION
## Context

Previously, we were showing some content that is meant for the period outside of the report season when the report for a provider wasn't generated. This is not correct.

We should only show this content when we are not in report season. This commit fixes this bug

We do have separate content/behaviour for when a report wasn't generated

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This is the content that was shown when a report wasn't generated 
<img width="1238" height="369" alt="image" src="https://github.com/user-attachments/assets/e7bc4c68-d00c-422a-ba64-a153697c633b" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
