### PR TITLE
Fix gsce Country or territory options

### DIFF
--- a/app/views/candidate_interface/gcse/institution_country/_form.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 <%= f.govuk_collection_select(
   :institution_country,
-  select_country_options,
+  select_degree_country_options,
   :id,
   :name,
   label: { text: t('gcse_edit_institution_country.page_title', subject: @subject.capitalize), size: 'l', tag: 'h1' },

--- a/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
+++ b/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
@@ -42,7 +42,7 @@
 
   <%= f.govuk_radio_button :qualification_type, :non_uk, label: { text: t('application_form.gcse.qualification_types.non_uk') } do %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text_english') } %>
-    <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
+    <%= f.govuk_collection_select :institution_country, select_degree_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
     <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.label'), size: 's' } do %>
       <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
         <%= f.govuk_radio_button(


### PR DESCRIPTION
## Context

The gsce country institution_country field was using an old helper which included Taiwan in the options, along with Puerto Rico and others.

We recently changed forms to not allow these options to be selected by candidates. This PR brings the gsce country options in line with the degree country options.

This also solves a bug in our application where a candidate could choose an option like Taiwan but the validation would not let them submit. Because it was comparing the option against the updated COUNTRIES_AND_TERRITORIES values, that have recently been updated.

This should unblock the candidates that are stuck with this validation error.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and when adding gcse, select `Qualification from outside the UK`
Then try to input Puerto Rico or Taiwan.
It should not allow you to choose this option. 

<img width="1923" height="1057" alt="image" src="https://github.com/user-attachments/assets/7f916ad1-1925-4739-b803-c4773bfe7439" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
