### PR TITLE
Add course start dates to application components

### DIFF
--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -22,6 +22,7 @@ module CandidateInterface
         course_fee_row(application_choice, current_course),
         qualifications_row,
         course_length_row,
+        start_date_row,
         study_mode_row,
         location_row,
         personal_statement_row,
@@ -79,6 +80,13 @@ module CandidateInterface
       {
         key: 'Course length',
         value: DisplayCourseLength.call(course_length: current_course.course_length),
+      }
+    end
+
+    def start_date_row
+      {
+        key: 'Date course starts',
+        value: current_course.start_date.to_fs(:month_and_year),
       }
     end
 

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -45,6 +45,10 @@ module ProviderInterface
           },
         },
         {
+          key: 'Date course starts',
+          value: course.start_date.to_fs(:month_and_year),
+        },
+        {
           key: 'Full time or part time',
           value: study_mode,
           action: {

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -5,6 +5,7 @@ module ProviderInterface
         { key: 'Training provider', value: provider_name },
         { key: 'Course', value: course_name_and_code },
         { key: 'Cycle', value: cycle },
+        { key: 'Date course starts', value: course.start_date.to_fs(:month_and_year) },
         { key: 'Full time or part time', value: study_mode },
         { key: location_key, value: preferred_location },
         { key: 'Accredited body', value: accredited_body },

--- a/app/components/support_interface/course_option_details_component.rb
+++ b/app/components/support_interface/course_option_details_component.rb
@@ -16,6 +16,7 @@ module SupportInterface
         { key: 'Course', value: render(SupportInterface::CourseNameAndStatusComponent.new(course_option:)) },
         { key: 'Course type', value: course_option.course.course_type.capitalize },
         { key: 'Cycle', value: course_option.course.recruitment_cycle_year },
+        { key: 'Date course starts', value: course_option.course.start_date.to_fs(:month_and_year) },
         { key: 'Full time or part time', value: course_option.study_mode.humanize },
         { key: location_key, value: course_option.site.name_and_code },
       ]

--- a/spec/components/candidate_interface/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/application_review_component_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe CandidateInterface::ApplicationReviewComponent do
     end
   end
 
+  shared_examples_for 'course start date row' do
+    it 'shows the course start date' do
+      expect(result.text).to include("Date course starts#{course.start_date.to_fs(:month_and_year)}")
+    end
+  end
+
   subject(:result) do
     render_inline(component)
   end
@@ -111,6 +117,7 @@ RSpec.describe CandidateInterface::ApplicationReviewComponent do
 
     it_behaves_like 'course length row'
     it_behaves_like 'course fee row'
+    it_behaves_like 'course start date row'
 
     it 'shows change course link' do
       expect(links).to include("Change course for #{application_choice.current_course.name_and_code}")
@@ -181,6 +188,7 @@ RSpec.describe CandidateInterface::ApplicationReviewComponent do
 
   context 'when application is submitted (awaiting_provider_decision)' do
     it_behaves_like 'course length row'
+    it_behaves_like 'course start date row'
 
     it 'shows the application status' do
       expect(result.text).to include('StatusAwaiting decision')

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                   name: 'Geography',
                   code: 'H234',
                   recruitment_cycle_year: 2020,
+                  start_date: Date.new(2020, 1, 1),
                   accredited_provider: nil,
                   qualifications: %w[qts pgce],
                   funding_type: 'fee',
@@ -55,6 +56,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                   name: 'Geography',
                   code: 'H234',
                   recruitment_cycle_year: 2020,
+                  start_date: Date.new(2020, 2, 1),
                   accredited_provider: nil,
                   qualifications: %w[qts pgce],
                   funding_type: 'fee')
@@ -89,11 +91,12 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   def row_text_selector(row_name, render)
     rows = { provider: 0,
              course: 1,
-             full_or_part_time: 2,
-             location: 3,
-             accredited_body: 4,
-             qualification: 5,
-             funding_type: 6 }
+             start_date: 2,
+             full_or_part_time: 3,
+             location: 4,
+             accredited_body: 5,
+             qualification: 6,
+             funding_type: 7 }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
   end
@@ -134,6 +137,13 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
       expect(render_text).to include('Geography (H234)')
       expect(render_text).to include('Change')
     end
+
+    it 'renders the course start date' do
+      render_text = row_text_selector(:start_date, render)
+
+      expect(render_text).to include('Date course starts')
+      expect(render_text).to include('January 2020')
+    end
   end
 
   context 'when only one course' do
@@ -143,6 +153,13 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
       expect(render_text).to include('Course')
       expect(render_text).to include('Geography (H234)')
       expect(render_text).not_to include('Change')
+    end
+
+    it 'renders the course start date' do
+      render_text = row_text_selector(:start_date, render)
+
+      expect(render_text).to include('Date course starts')
+      expect(render_text).to include('January 2020')
     end
   end
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
            code: 'H234',
            recruitment_cycle_year: 2020,
            accredited_provider: nil,
+           start_date: Date.new(2020, 1, 1),
            qualifications: %w[qts pgce],
            funding_type: 'fee',
            provider:)
@@ -68,6 +69,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
            recruitment_cycle_year: 2020,
            provider: accredited_provider,
            accredited_provider:,
+           start_date: Date.new(2020, 1, 1),
            qualifications: ['qts'],
            funding_type: 'fee')
   end
@@ -102,11 +104,12 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     rows = { provider: 0,
              course: 1,
              cycle: 2,
-             full_or_part_time: 3,
-             location: 4,
-             accredited_body: 5,
-             qualification: 6,
-             funding_type: 7 }
+             start_date: 3,
+             full_or_part_time: 4,
+             location: 5,
+             accredited_body: 6,
+             qualification: 7,
+             funding_type: 8 }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
   end
@@ -143,6 +146,13 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
     expect(render_text).to include('Course')
     expect(render_text).to include('Geography (H234)')
+  end
+
+  it 'renders the course start date' do
+    render_text = row_text_selector(:start_date, render)
+
+    expect(render_text).to include('Date course starts')
+    expect(render_text).to include('January 2020')
   end
 
   it 'renders the recruitment cycle year' do

--- a/spec/components/support_interface/course_option_details_component_spec.rb
+++ b/spec/components/support_interface/course_option_details_component_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe SupportInterface::CourseOptionDetailsComponent do
     end
   end
 
+  describe 'Course start date' do
+    it 'renders the course start date' do
+      @application_choice = build_stubbed(:application_choice)
+      @course_option = @application_choice.course_option
+      @course = @course_option.course
+
+      expect(render_component.css('.govuk-summary-list__key').text).to include('Date course starts')
+      expect(render_component.css('.govuk-summary-list__value').text).to include(@course.start_date.to_fs(:month_and_year))
+    end
+  end
+
   describe 'Location' do
     context 'when it is the applications original course option and the location is auto selected' do
       it 'renders auto selected Location' do


### PR DESCRIPTION
## Context

- Add the course start date to the following components:
  - app/components/candidate_interface/application_review_component.rb
  - app/components/provider_interface/change_course_details_component.rb
  - app/components/provider_interface/course_details_component.rb
  - app/components/support_interface/course_option_details_component.rb

## Changes proposed in this pull request

- Add the course start date to the following components:
  - app/components/candidate_interface/application_review_component.rb
  - app/components/provider_interface/change_course_details_component.rb
  - app/components/provider_interface/course_details_component.rb
  - app/components/support_interface/course_option_details_component.rb

## Guidance to review
- Visit https://apply-review-11857.test.teacherservices.cloud/support
- Sign in as a Support user
-------
_Support user views_
- Click on any application
- Scroll down to "Course choices"
- Check that the "Date course starts" row appears
-------
_Candidate views_
(Candidate with draft application)
- Visit https://apply-review-11857.test.teacherservices.cloud/support/applications/11
- Click on "Sign in as candidate"
- Visit https://apply-review-11857.test.teacherservices.cloud/candidate/application/course-choices/12/review (or click to view the draft application)
- Check that the "Date course starts" row appears
- Click on "Review application"
- Check that the "Date course starts" row appears
(Candidate with accepted application)
- Visit https://apply-review-11857.test.teacherservices.cloud/support/applications/46
- Click on "Sign in as candidate"
- Visit https://apply-review-11857.test.teacherservices.cloud/candidate/application/review/submitted (or click on "View application")
- Check that the "Date course starts" row appears
-------
_Provider_
- Visit https://apply-review-11857.test.teacherservices.cloud/support/users/provider/15
- Click on "Sign in as a provider user"
- Click on "Visit manage"
- Click on any application
- Scroll down to "Course"
- Check that the "Date course starts" row appears

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

- https://trello.com/c/xplh3x94/1772-add-course-start-date-to-page-in-support-for-course-details
- https://trello.com/c/pWHFY29b/1773-add-course-start-date-to-page-in-apply-for-course-details
- https://trello.com/c/8AvJwBUX/1771-add-course-start-date-to-page-in-manage-for-course-details

## Screenshots
_Candidate_
<img width="1517" height="1720" alt="screencapture-apply-review-11857-test-teacherservices-cloud-candidate-application-course-choices-12-review-2026-04-23-09_47_35" src="https://github.com/user-attachments/assets/a9aa3121-64f4-4d8c-99d0-76b7451b0b90" />

<img width="737" height="595" alt="Screenshot 2026-04-23 at 09 48 23" src="https://github.com/user-attachments/assets/a0526aaf-0461-424e-a86e-48b2212d1cae" />

_Support user_
<img width="988" height="526" alt="Screenshot 2026-04-23 at 09 46 52" src="https://github.com/user-attachments/assets/5280ddd0-1d5e-4ff8-98e5-7e1bea5d755c" />

_Provider_
<img width="678" height="582" alt="Screenshot 2026-04-23 at 09 51 48" src="https://github.com/user-attachments/assets/42a8f8e2-75be-47e6-91d0-5e235f572c37" />


