### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -295,7 +295,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: success()
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           header: review-app-v2
           message: |
@@ -317,7 +317,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Merge minor dependency updates
-        uses: fastify/github-action-merge-dependabot@v3
+        uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 #Pinned at v3.12.0
         with:
           github-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           target: minor

--- a/.github/workflows/delete-v2-review-app.yml
+++ b/.github/workflows/delete-v2-review-app.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: env.TF_STATE_EXISTS == 'true'
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # Pinned at v3.0.4
         with:
           header: review-app-v2
           message: |

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -98,7 +98,7 @@ jobs:
       # Comment on the PR if enums have changed
       - name: Comment on PR if enums have changed
         if: contains(steps.changed-enums.outputs.data, 'enum')
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@64b8e914979889d746c99dea15a76e77ef64580a # Pinned at v3.10.0
         with:
           message: |
             **Database-level enum changes detected**


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR