### PR TITLE
Fix flaky expiry test

### DIFF
--- a/spec/system/support_interface/editing_visa_expiry_spec.rb
+++ b/spec/system/support_interface/editing_visa_expiry_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Editing visa exipiry' do
+RSpec.describe 'Editing visa expiry' do
   include DfESignInHelpers
 
   before do
@@ -24,7 +24,13 @@ RSpec.describe 'Editing visa exipiry' do
   end
 
   def and_an_application_exists
-    @form = create(:completed_application_form, first_nationality: 'Canadian', second_nationality: nil, right_to_work_or_study: 'yes')
+    @form = create(
+      :completed_application_form,
+      first_nationality: 'Canadian',
+      second_nationality: nil,
+      right_to_work_or_study: 'yes',
+      immigration_status: ApplicationForm::TEMPORARY_IMMIGRATION_STATUSES.sample,
+    )
   end
 
   def and_i_visit_the_application_page


### PR DESCRIPTION
## Context

- Fix flaky test with visa expiry (see https://github.com/DFE-Digital/apply-for-teacher-training/pull/11846)

## Changes proposed in this pull request

- Application form in test `immigration_status` attribute is now set to a status where `temporary_immigration_status?` is `true`

## Guidance to review

- Test should no longer fail intermittently.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
