### PR TITLE
API 1.8 pre-release: Interviews, residency, visa expiry

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
@@ -45,6 +45,10 @@ module APIDocs
         spec(version: VendorAPI::VERSION_1_7)
       end
 
+      def spec_1_8
+        spec(version: VendorAPI::VERSION_1_8)
+      end
+
     private
 
       def spec(**)

--- a/app/controllers/vendor_api/interviews_controller.rb
+++ b/app/controllers/vendor_api/interviews_controller.rb
@@ -5,14 +5,18 @@ module VendorAPI
     rescue_from InterviewWorkflowConstraints::WorkflowError, with: :handle_as_validation_error
 
     def create
-      CreateInterview.new(
-        actor: audit_user,
-        application_choice:,
-        provider: provider_for_interview(interview_params[:provider_code]),
-        date_and_time: date_and_time(interview_params[:date_and_time]),
-        location: interview_params[:location],
-        additional_details: interview_params[:additional_details],
-      ).save!
+      if version_number.to_f >= 1.8 && interview_params.blank?
+        ApplicationStateChange.new(application_choice).interview!
+      else
+        CreateInterview.new(
+          actor: audit_user,
+          application_choice:,
+          provider: provider_for_interview(interview_params[:provider_code]),
+          date_and_time: date_and_time(interview_params[:date_and_time]),
+          location: interview_params[:location],
+          additional_details: interview_params[:additional_details],
+        ).save!
+      end
 
       render_application
     end
@@ -49,9 +53,9 @@ module VendorAPI
     end
 
     def provider_for_interview(code)
-      if code.present? # supporting partial updates
-        Provider.find_by(code:) || raise(ValidationException, ['Provider code is not valid'])
-      end
+      @provider_for_interview ||= if code.present? # supporting partial updates
+                                    Provider.find_by(code:) || raise(ValidationException, ['Provider code is not valid'])
+                                  end
     end
 
     def date_and_time(date_time_string)
@@ -69,6 +73,8 @@ module VendorAPI
     end
 
     def interview_params
+      return {} if params[:data].blank? && version_number.to_f >= 1.8
+
       params.require(:data).permit(:provider_code, :date_and_time, :location, :additional_details).tap do |data|
         data.require(%i[provider_code date_and_time location])
       end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -78,6 +78,9 @@ module VendorAPI
     ],
     '1.8pre' => [
       Changes::V18::EnglishAsAForeignLanguageCandidateResponse,
+      Changes::V18::VisaExpiry,
+      Changes::V18::LengthOfResidency,
+      Changes::V18::MarkInterviewObjectAsOptional,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/v18/length_of_residency.rb
+++ b/app/lib/vendor_api/changes/v18/length_of_residency.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V18
+      class LengthOfResidency < VersionChange
+        description 'Add country residency information to the application attributes'
+
+        resource ApplicationPresenter, [ApplicationPresenter::LengthOfResidency]
+      end
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/v18/mark_interview_object_as_optional.rb
+++ b/app/lib/vendor_api/changes/v18/mark_interview_object_as_optional.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V18
+      class MarkInterviewObjectAsOptional < VersionChange
+        description 'Mark interview object as optional'
+
+        action InterviewsController, :create
+      end
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/v18/visa_expiry.rb
+++ b/app/lib/vendor_api/changes/v18/visa_expiry.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V18
+      class VisaExpiry < VersionChange
+        description 'Add visa expiry to the application attributes'
+
+        resource ApplicationPresenter, [ApplicationPresenter::VisaExpiry]
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/application_state_api_data.rb
+++ b/app/presenters/concerns/application_state_api_data.rb
@@ -1,0 +1,17 @@
+module ApplicationStateAPIData
+  def api_application_states
+    if version >= '1.8'
+      {
+        offer_withdrawn: 'rejected',
+        inactive: 'awaiting_provider_decision',
+        interviewing: 'interviewing',
+      }.freeze
+    else
+      {
+        offer_withdrawn: 'rejected',
+        inactive: 'awaiting_provider_decision',
+        interviewing: 'awaiting_provider_decision',
+      }.freeze
+    end
+  end
+end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -7,17 +7,16 @@ module VendorAPI
     include WorkExperienceAPIData
     include DecisionsAPIData
     include HesaIttDataAPIData
+    include ApplicationStateAPIData
 
-    API_APPLICATION_STATES = { offer_withdrawn: 'rejected',
-                               inactive: 'awaiting_provider_decision',
-                               interviewing: 'awaiting_provider_decision' }.freeze
     CACHE_EXPIRES_IN = 1.day
 
-    attr_reader :application_choice
+    attr_reader :application_choice, :version
 
     def initialize(version, application_choice)
       super(version)
       @application_choice = ApplicationChoiceExportDecorator.new(application_choice)
+      @version = version
     end
 
     def serialized_json
@@ -93,7 +92,7 @@ module VendorAPI
     end
 
     def status
-      API_APPLICATION_STATES[application_choice.status.to_sym].presence || application_choice.status
+      api_application_states[application_choice.status.to_sym].presence || application_choice.status
     end
 
     def references

--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -3,7 +3,6 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
     super.deep_merge!({
       attributes: {
         candidate: {
-          will_obtain_english_language_qualifications:,
           obtaining_english_language_qualification_details:,
         },
       },
@@ -12,10 +11,6 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
 
   def english_proficiency
     @english_proficiency ||= application_form&.english_proficiency
-  end
-
-  def will_obtain_english_language_qualifications
-    english_proficiency&.no_qualification_details.present?
   end
 
   def obtaining_english_language_qualification_details

--- a/app/presenters/vendor_api/application_presenter/length_of_residency.rb
+++ b/app/presenters/vendor_api/application_presenter/length_of_residency.rb
@@ -1,0 +1,12 @@
+module VendorAPI::ApplicationPresenter::LengthOfResidency
+  def schema
+    super.deep_merge!({
+      attributes: {
+        candidate: {
+          country_residency_date_from: application_form.country_residency_date_from&.iso8601,
+          country_residency_since_birth: application_form.country_residency_since_birth,
+        },
+      },
+    })
+  end
+end

--- a/app/presenters/vendor_api/application_presenter/visa_expiry.rb
+++ b/app/presenters/vendor_api/application_presenter/visa_expiry.rb
@@ -1,0 +1,13 @@
+module VendorAPI::ApplicationPresenter::VisaExpiry
+  def schema
+    super.deep_merge!({
+      attributes: {
+        candidate: {
+          visa_expired_at: application_form.visa_expired_at&.iso8601,
+          visa_explanation: application_choice.visa_explanation,
+          visa_explanation_details: application_choice.visa_explanation_details,
+        },
+      },
+    })
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
@@ -1,25 +1,100 @@
-<h2 class="govuk-heading-l" id="important">Version 1.8 changes</h2>
+<span id="important">
+  <h2 class="govuk-heading-l" id="changes">Version 1.8 changes</h2>
+</span>
 
-<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intention of taking an English as a foreign language assessment if they don't have one</p>
-
-<p class="govuk-body">
-  A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
-</p>
-<p class="govuk-body">
-  A new attribute, <code>obtaining_english_language_qualification_details</code>, has been added to the candidate object.
-</p>
+<h3 class="govuk-heading-m">
+  Candidate object new attributes
+</h3>
 
 <p class="govuk-body">
-  If a candidate does not have an English language qualification, they can state their intention of gaining one or not. If they do intend to gain this qualification they can add further details about their plans
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
+  We have added attributes to <%= govuk_link_to 'the Candidate object', '#candidate-object' %> to help providers better understand an international candidate’s suitability for a course.
+  Candidates will not be asked to provide this data until the 2027 recruitment cycle.
 </p>
+
+<h4 class="govuk-heading-s">
+  Candidate object - English language qualification details
+</h4>
+
 <p class="govuk-body">
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
+  The following attribute has been added related to English language qualifications:
+  <ul class="govuk-list govuk-list--bullet">
+    <li><code>obtaining_english_language_qualification_details</code> (string)</li>
+  </ul>
 </p>
 
 <p class="govuk-body">
-  If a candidate does not have an English language qualification and they don't intend to gain one the attribute <code>will_obtain_english_language_qualifications</code> will be <code>false</code> and <code>obtaining_english_language_qualification_details</code> will be <code>nil</code>.
+  Starting in the 2027 recruitment cycle, international candidates who have not yet obtained an English language qualification may provide details about their future plans as free text.
+  This will be null for candidates who have English as a first language.
 </p>
-<p class=">govuk-body">
-  If a candidate has an English language qualifications both attributes will be <code>nil</code>.
+
+<h4 class="govuk-heading-s">
+  Candidate object - Residency details
+</h4>
+
+<p class="govuk-body">
+  The following attributes have been added related to a candidate’s residency:
+  <ul class="govuk-list govuk-list--bullet">
+    <li><code>country_residency_date_from</code> (date-time)</li>
+    <li><code>country_residency_since_birth</code> (boolean)</li>
+  </ul>
+</p>
+
+<p class="govuk-body">
+  Starting in the 2027 recruitment cycle, if the candidate has declared the date from when they began residing in their current country of residence, the <code>country_residency_date_from</code> attribute will contain a date.
+</p>
+
+<p class="govuk-body">
+  If the candidate has resided in their declared country of residence since birth, the <code>country_residency_since_birth</code>
+  attribute will be <code>true</code>.
+</p>
+
+<h4 class="govuk-heading-s">
+  Candidate object - Visa expiration
+</h4>
+
+<p class="govuk-body">
+  The following attributes have been added related to visa expiration:
+  <ul class="govuk-list govuk-list--bullet">
+    <li><code>visa_expired_at</code> (date-time)</li>
+    <li><code>visa_explanation</code> (string, enum)</li>
+    <li><code>visa_explanation_details</code> (string)</li>
+  </ul>
+</p>
+
+<p class="govuk-body">
+  Starting in the 2027 recruitment cycle, candidates who have a visa which allows them to work or study in the UK will be asked more information about when the visa expires.
+</p>
+
+<p class="govuk-body">
+  The visa expiry date, if given, will appear on the attribute <code>visa_expired_at</code>.
+</p>
+
+<p class="govuk-body">
+  If their visa is likely to expire before the end of the course, the <code>visa_explanation</code> attribute will contain some structured data about how the candidate plans to maintain their status for the duration of the course.
+  If the candidate has selected <code>other</code> as their <code>visa_explanation</code>,
+  the <code>visa_explanation_details</code> attribute will contain the candidate’s free-text explanation.
+</p>
+
+<h3 class="govuk-heading-m">
+  Interview status on the ApplicationAttributes object
+</h3>
+
+<p class="govuk-body">
+  In versions 1.7 and below, an application shows as <code>awaiting_provider_decision</code> until a decision is made, even if its status in the Manage User Interface is <code>interviewing</code>.
+</p>
+<p class="govuk-body">
+  In version 1.8, the possible statuses returned with the <%= govuk_link_to 'the ApplicationAttributes object', '#applicationattributes-object' %> now include <code>interviewing</code>. A candidate can transition to the <code>interviewing</code> state from <code>awaiting_provider_decision</code>.
+</p>
+
+<h3 class="govuk-heading-m">
+  CreateInterview object now optional
+</h3>
+
+<p class="govuk-body">
+  Sending a request to the <%= govuk_link_to 'create interview endpoint', '#post-applications-application_id-interviews-create' %> with a <%= govuk_link_to 'CreateInterview', '#createinterview-object' %> object
+  will update the application status to <code>interviewing</code> and schedule an interview on the service.
+</p>
+
+<p class="govuk-body">
+  Staring with version 1.8, sending a request to the endpoint without an interview object will update the status only.
 </p>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
@@ -62,7 +62,7 @@
 </p>
 
 <p class="govuk-body">
-  Starting in the 2027 recruitment cycle, candidates who have a visa which allows them to work or study in the UK will be asked more information about when the visa expires.
+  Starting in the 2027 recruitment cycle, candidates who have a visa which allows them to work or study in the UK will be asked for more information about their visa expiry.
 </p>
 
 <p class="govuk-body">
@@ -83,7 +83,7 @@
   In versions 1.7 and below, an application shows as <code>awaiting_provider_decision</code> until a decision is made, even if its status in the Manage User Interface is <code>interviewing</code>.
 </p>
 <p class="govuk-body">
-  In version 1.8, the possible statuses returned with the <%= govuk_link_to 'the ApplicationAttributes object', '#applicationattributes-object' %> now include <code>interviewing</code>. A candidate can transition to the <code>interviewing</code> state from <code>awaiting_provider_decision</code>.
+  In version 1.8, the possible statuses returned with the <%= govuk_link_to 'ApplicationAttributes object', '#applicationattributes-object' %> now include <code>interviewing</code>. A candidate can transition to the <code>interviewing</code> state from <code>awaiting_provider_decision</code>.
 </p>
 
 <h3 class="govuk-heading-m">
@@ -96,5 +96,5 @@
 </p>
 
 <p class="govuk-body">
-  Staring with version 1.8, sending a request to the endpoint without an interview object will update the status only.
+  Starting with version 1.8, sending a request to the endpoint without an interview object will update the status only.
 </p>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -70,31 +70,7 @@
   After version <code>1.8</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
 </p>
 
-<h2 class="govuk-heading-l" id="changes">Version 1.8 changes</h2>
-
-<p class="govuk-heading-s">New attributes added to the candidate object for viewing the candidates intention of taking an English as a foreign language assessment if they don't have one</p>
-
-<p class="govuk-body">
-  A new attribute, <code>will_obtain_english_language_qualifications</code>, has been added to the candidate object.
-</p>
-<p class="govuk-body">
-  A new attribute, <code>obtaining_english_language_qualification_details</code>, has been added to the candidate object.
-</p>
-
-<p class="govuk-body">
-  If a candidate does not have an English language qualification, they can state their intention of gaining one or not. If they express their intension of gaining such qualification they will be able to add more details about their intension.
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be true and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
-</p>
-<p class="govuk-body">
-  If a candidate intends to gain this qualification the <code>will_obtain_english_language_qualifications</code> attribute will be <code>true</code> and <code>obtaining_english_language_qualification_details</code> will contain more details about their intention.
-</p>
-
-<p class="govuk-body">
-  If a candidate does not have an English language qualification and they don't intend to gain one the attribute <code>will_obtain_english_language_qualifications</code> will be <code>false</code> and <code>obtaining_english_language_qualification_details</code> will be <code>nil</code>.
-</p>
-<p class=">govuk-body">
-  If a candidate has an English language qualifications both attributes will be <code>nil</code>.
-</p>
+<%= render('v1_8_changes') %>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
 

--- a/config/vendor_api/v1.8.yml
+++ b/config/vendor_api/v1.8.yml
@@ -15,18 +15,130 @@ servers:
   url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.8
 - description: Production
   url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.8
+paths:
+  /applications/{application_id}/interviews/create:
+    post:
+      tags:
+        - Interview management
+      summary: Create interview or update status to 'interviewing'
+      description: |
+        If a request body (CreateInterview object) is provided, it creates an interview for this application. If no request body is provided, it updates the application status to 'interviewing' without creating an interview.
+      parameters:
+        - "$ref": "#/components/parameters/application_id"
+      requestBody:
+        description: Interview details
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - meta
+              properties:
+                data:
+                  "$ref": "#/components/schemas/CreateInterview"
+                meta:
+                  "$ref": "#/components/schemas/MetaData"
+      responses:
+        '200':
+          description: An application
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SingleApplicationResponse"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
 components:
   schemas:
+    CreateInterview:
+      type: object
+      additionalProperties: false
+      required:
+        - provider_code
+        - date_and_time
+        - location
+      properties:
+        provider_code:
+          type: string
+          description: The provider’s code. This must correspond to either the training or the ratifying provider for the application and the course applied to.
+          example: 2FR
+          maxLength: 3
+        date_and_time:
+          type: string
+          format: date-time
+          description: Date and time of the interview
+          example: 2019-09-18T15:33:49.216Z
+        location:
+          type: string
+          description: |
+            A string describing where or how the interview will take place.
+          example: 'Zoom call'
+          maxLength: 10240
+        additional_details:
+          type: string
+          nullable: true
+          description: |
+            Optional string for additional notes.
+          example: 'Candidate requires a parking space'
+          maxLength: 10240
+    ApplicationAttributes:
+      properties:
+        status:
+          type: string
+          maxLength: 256
+          description: |
+            The status of this application. Refer to the [application
+            lifecycle diagram](/api-docs/lifecycle) for states and transitions.
+          enum:
+            - awaiting_provider_decision
+            - interviewing
+            - conditions_not_met
+            - declined
+            - offer
+            - offer_deferred
+            - pending_conditions
+            - recruited
+            - rejected
+            - withdrawn
+          example: awaiting_provider_decision
     Candidate:
       properties:
-        will_obtain_english_language_qualifications:
-          type: boolean
-          description: The candidate’s intention to gain english language qualification
-          example: true
         obtaining_english_language_qualification_details:
           type: string
+          maxLength: 256
           description: If the candidate intends to gain this qualification they can explain their intention
           example: "I will gain it next year"
+        visa_expired_at:
+          type: date-time
+          description: The date when the candidate’s visa will expire
+          example: "2019-06-13T10:44:31Z"
+        visa_explanation:
+          type: string
+          maxLength: 256
+          description: The candidate’s intention to resolve any issues with their visa expiring
+          enum:
+            - expires_after_course
+            - renew
+            - leads_to_permanent_visa
+            - switch_to_different_visa
+            - not_sure
+            - other
+          example: "expires_after_course"
+        visa_explanation_details:
+          type: string
+          maxLength: 256
+          description: Additional details regarding the candidate’s visa explanation, if the visa explanation is "other"
+          example: 'Details of renewing my visa'
+        country_residency_date_from:
+          type: date-time
+          description: The date when the candidate moved to their current country of residence
+          example: "2019-06-13T10:44:31Z"
+        country_residency_since_birth:
+          type: boolean
+          description: Whether or not the candidate has been a resident of their current country of residence since birth
+          example: true
       required:
-        - will_obtain_english_language_qualifications
         - obtaining_english_language_qualification_details

--- a/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
@@ -1,43 +1,162 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPI::ApplicationPresenter do
-  context 'candidate intends to gain english language qualification' do
-    describe '#attributes' do
-      it 'returns correct response' do
-        application_form = create(:application_form, :submitted)
-        _english_proficiency = create(
-          :english_proficiency,
-          :no_qualification,
-          no_qualification_details: 'I will take it next year',
-          draft: false,
-          application_form:,
-        )
-        application_choice = create(:application_choice, application_form:)
-        result = described_class.new('1.8', application_choice).as_json
+  describe 'english language qualification' do
+    context 'candidate intends to gain english language qualification' do
+      describe '#attributes' do
+        it 'returns correct response' do
+          application_form = create(:application_form, :submitted)
+          _english_proficiency = create(
+            :english_proficiency,
+            :no_qualification,
+            no_qualification_details: 'I will take it next year',
+            draft: false,
+            application_form:,
+          )
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
 
-        expect(result.dig(:attributes, :candidate, :will_obtain_english_language_qualifications)).to be(true)
-        expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to eq(
-          'I will take it next year',
-        )
+          expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to eq(
+            'I will take it next year',
+          )
+        end
+      end
+    end
+
+    context 'candidate does not intend to gain english language qualification' do
+      describe '#attributes' do
+        it 'returns correct response' do
+          application_form = create(:application_form, :submitted)
+          _english_proficiency = create(
+            :english_proficiency,
+            :no_qualification,
+            draft: false,
+            application_form:,
+          )
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to be_nil
+        end
       end
     end
   end
 
-  context 'candidate does not intend to gain english language qualification' do
-    describe '#attributes' do
-      it 'returns correct response' do
-        application_form = create(:application_form, :submitted)
-        _english_proficiency = create(
-          :english_proficiency,
-          :no_qualification,
-          draft: false,
-          application_form:,
-        )
-        application_choice = create(:application_choice, application_form:)
-        result = described_class.new('1.8', application_choice).as_json
+  describe 'visa expiry' do
+    let(:visa_expired_at) { 1.year.from_now }
 
-        expect(result.dig(:attributes, :candidate, :will_obtain_english_language_qualifications)).to be(false)
-        expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to be_nil
+    context 'candidate does not have a visa' do
+      describe '#attributes' do
+        it 'does not return the visa expiry date or details' do
+          application_form = create(:application_form, :submitted)
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :visa_expired_at)).to be_nil
+          expect(result.dig(:attributes, :candidate, :visa_explanation)).to be_nil
+          expect(result.dig(:attributes, :candidate, :visa_explanation_details)).to be_nil
+        end
+      end
+    end
+
+    context 'candidate has a visa which will expire' do
+      describe '#attributes' do
+        it 'returns the visa expiry date' do
+          application_form = create(:application_form, :submitted, visa_expired_at:)
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :visa_expired_at)).to eq(visa_expired_at.iso8601)
+        end
+      end
+    end
+
+    context 'candidate has explained their plan to review their visa' do
+      describe '#attributes' do
+        it 'returns the visa explanation' do
+          application_form = create(:application_form, :submitted, visa_expired_at:)
+          application_choice = create(:application_choice, application_form:, visa_explanation: 'expires_after_course')
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :visa_expired_at)).to eq(visa_expired_at.iso8601)
+          expect(result.dig(:attributes, :candidate, :visa_explanation)).to eq('expires_after_course')
+          expect(result.dig(:attributes, :candidate, :visa_explanation_details)).to be_nil
+        end
+      end
+    end
+
+    context 'candidate has declared their plan to review their visa as "other"' do
+      describe '#attributes' do
+        it 'returns the visa explanation details' do
+          application_form = create(:application_form, :submitted, visa_expired_at:)
+          application_choice = create(
+            :application_choice,
+            application_form:,
+            visa_explanation: 'other',
+            visa_explanation_details: 'Work in progress',
+          )
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :visa_expired_at)).to eq(visa_expired_at.iso8601)
+          expect(result.dig(:attributes, :candidate, :visa_explanation)).to eq('other')
+          expect(result.dig(:attributes, :candidate, :visa_explanation_details)).to eq('Work in progress')
+        end
+      end
+    end
+  end
+
+  describe 'length of country residency' do
+    context 'candidate does not declare their length of country residency' do
+      describe '#attributes' do
+        it 'does not return the country residency details' do
+          application_form = create(:application_form, :submitted)
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :country_residency_date_from)).to be_nil
+          expect(result.dig(:attributes, :candidate, :country_residency_since_birth)).to be_nil
+        end
+      end
+    end
+
+    context 'candidate has been a resident of their country since birth' do
+      let(:country_residency_date_from) { 24.years.ago.at_beginning_of_day }
+
+      describe '#attributes' do
+        it 'return the country residency details' do
+          application_form = create(
+            :application_form,
+            :submitted,
+            date_of_birth: country_residency_date_from,
+            country_residency_date_from:,
+            country_residency_since_birth: true,
+          )
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :country_residency_date_from)).to eq(country_residency_date_from.iso8601)
+          expect(result.dig(:attributes, :candidate, :country_residency_since_birth)).to be(true)
+        end
+      end
+    end
+
+    context 'candidate has not been a resident of their country since birth' do
+      let(:country_residency_date_from) { 2.years.ago.at_beginning_of_day }
+
+      describe '#attributes' do
+        it 'return the country residency details' do
+          application_form = create(
+            :application_form,
+            :submitted,
+            country_residency_date_from:,
+            country_residency_since_birth: false,
+          )
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :country_residency_date_from)).to eq(country_residency_date_from.iso8601)
+          expect(result.dig(:attributes, :candidate, :country_residency_since_birth)).to be(false)
+        end
       end
     end
   end

--- a/spec/requests/vendor_api/v1.8/post_create_interview_spec.rb
+++ b/spec/requests/vendor_api/v1.8/post_create_interview_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1.8/applications/:application_id/interviews/create' do
+  include VendorAPISpecHelpers
+
+  let(:application_choice) do
+    create_application_choice_for_currently_authenticated_provider(status: 'awaiting_provider_decision')
+  end
+
+  def post_interview!(params:)
+    request_body = { data: params }
+    expect(request_body[:data]).to be_valid_against_openapi_schema('CreateInterview', '1.8') if params.present?
+
+    post_api_request "/api/v1.8/applications/#{application_choice.id}/interviews/create", params: request_body
+  end
+
+  it_behaves_like 'an endpoint that requires metadata', '/interviews/create', '1.8'
+
+  describe 'create interview' do
+    context 'when passed interview params' do
+      let(:create_interview_params) do
+        {
+          provider_code: currently_authenticated_provider.code,
+          date_and_time: 1.day.from_now.iso8601,
+          location: 'Zoom call',
+          additional_details: 'Candidate requires assistance',
+        }
+      end
+
+      it 'succeeds and renders a SingleApplicationResponse' do
+        post_interview! params: create_interview_params
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['data']['attributes']['interviews'].count).to eq(1)
+        expect(parsed_response['data']['attributes']['status']).to eq('interviewing')
+        application_choice.reload
+        expect(application_choice.status).to eq('interviewing')
+      end
+    end
+
+    context 'when not passed interview params' do
+      it 'succeeds and renders a SingleApplicationResponse' do
+        post_interview! params: {}
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response['data']['attributes']['interviews'].count).to eq(0)
+        expect(parsed_response['data']['attributes']['status']).to eq('interviewing')
+        application_choice.reload
+        expect(application_choice.status).to eq('interviewing')
+      end
+    end
+  end
+end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe ApplicationStateChange do
   end
 
   describe '.states_visible_to_provider_without_deferred' do
-    it 'has corresponding entries in the OpenAPI spec - excluding the interview state' do
-      valid_states_in_openapi = VendorAPISpecification.new.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
+    it 'has corresponding entries in the OpenAPI spec - excluding the interview state before 1.8' do
+      valid_states_in_openapi = VendorAPISpecification.new(version: '1.7').as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
       expect(described_class.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn inactive])
         .to match_array(valid_states_in_openapi.map(&:to_sym) - %i[offer_deferred])


### PR DESCRIPTION
## Context

- Changes to the 1.8 API version to include visa expiry and country of residence details for a candidate
- Allow for providers to use the API endpoint to create an interview, without providing interview details (if they have declared they are handling interviews outside of the manage service)

## Changes proposed in this pull request

- Add visa expiry details to the 1.8 API version
- Add country of residence details to the 1.8 API version
- Allow for providers to use the API endpoint to create an interview, without providing interview details (if they have declared they are handling interviews outside of the manage service)
- Update release notes to reflect the changes

## Guidance to review
View the [release notes here](https://apply-review-11864.test.teacherservices.cloud/api-docs/v1.8/reference#important). 

_Candidate with visa_
`curl https://apply-review-11864.test.teacherservices.cloud//api/v1.8/applications/157 -H "Authorization: Bearer ZVqfLGfEEu5zHcgRrZKA"`

<img width="798" height="406" alt="Screenshot 2026-04-27 at 17 04 14" src="https://github.com/user-attachments/assets/3d16e03f-9c27-4ccb-9963-62aac90ea0fa" />

_Candidate without visa_
`curl https://apply-review-11864.test.teacherservices.cloud//api/v1.8/applications/19 -H "Authorization: Bearer ZVqfLGfEEu5zHcgRrZKA"`

<img width="796" height="401" alt="Screenshot 2026-04-27 at 17 07 35" src="https://github.com/user-attachments/assets/9240aa81-35b8-4bb9-af30-44915ae6563e" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
