### PR TITLE
Fix checkbox error losing state

### DIFF
--- a/app/forms/support_interface/editable_until_form.rb
+++ b/app/forms/support_interface/editable_until_form.rb
@@ -6,6 +6,7 @@ module SupportInterface
     attr_writer :sections, :editable_until
 
     validates :audit_comment, :policy_confirmation, presence: true
+    validates :policy_confirmation, inclusion: { in: %w[true] }
     validates_with ZendeskUrlValidator
 
     def non_editable_sections

--- a/app/views/support_interface/application_forms/editable_extension/edit.html.erb
+++ b/app/views/support_interface/application_forms/editable_extension/edit.html.erb
@@ -15,9 +15,11 @@
       <%= f.govuk_text_field :audit_comment_description, label: { text: 'Why are you making this application editable? (optional)', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change.' } %>
 
       <%= f.govuk_check_boxes_fieldset :policy_confirmation, legend: nil do %>
-        <%= f.govuk_check_box :policy_confirmation, 'true', multiple: false,
-          label: { text: 'I have spoken to and received confirmation from the Policy team to action this request.' },
-          link_errors: true %>
+        <%= f.govuk_check_box :policy_confirmation,
+                              'true',
+                              multiple: false,
+                              label: { text: 'I have spoken to and received confirmation from the Policy team to action this request.' },
+                              link_errors: true %>
       <% end %>
 
       <%= f.govuk_submit 'Update' %>

--- a/app/views/support_interface/application_forms/editable_extension/edit.html.erb
+++ b/app/views/support_interface/application_forms/editable_extension/edit.html.erb
@@ -15,7 +15,9 @@
       <%= f.govuk_text_field :audit_comment_description, label: { text: 'Why are you making this application editable? (optional)', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change.' } %>
 
       <%= f.govuk_check_boxes_fieldset :policy_confirmation, legend: nil do %>
-        <%= f.govuk_check_box :policy_confirmation, true, multiple: false, label: { text: 'I have spoken to and received confirmation from the Policy team to action this request.' }, link_errors: true %>
+        <%= f.govuk_check_box :policy_confirmation, 'true', multiple: false,
+          label: { text: 'I have spoken to and received confirmation from the Policy team to action this request.' },
+          link_errors: true %>
       <% end %>
 
       <%= f.govuk_submit 'Update' %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -410,3 +410,4 @@ en:
               invalid: Enter a valid Zendesk ticket URL
             policy_confirmation:
               blank: Select if you have received Policy confirmation
+              inclusion: Select if you have received Policy confirmation

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
     when_i_check_degrees
     and_i_check_english_gcse
     and_i_add_an_audit_comment
+    and_i_check_to_say_i_have_spoken_to_the_policy_team
     and_click_update
     then_i_see_the_application_page
     and_the_application_is_now_updated_with_the_temporarily_editable_sections
@@ -77,7 +78,10 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
   end
 
   def then_i_see_a_validation_message
-    expect(page).to have_content('Add a link to the Zendesk ticket')
+    within('.govuk-error-summary__list') do
+      expect(page).to have_content('Add a link to the Zendesk ticket')
+      expect(page).to have_content('Select if you have received Policy confirmation')
+    end
   end
 
   def when_i_check_degrees
@@ -90,6 +94,10 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
 
   def and_i_add_an_audit_comment
     fill_in 'Zendesk ticket', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def and_i_check_to_say_i_have_spoken_to_the_policy_team
+    check 'I have spoken to and received confirmation from the Policy team to action this request.'
   end
 
   def and_click_update


### PR DESCRIPTION
## Context

- Fix bug with checkbox not holding selection when erroring
- Fix error message not appearing above checkbox when not selected

## Changes proposed in this pull request

- Fix bug with checkbox not holding selection when erroring
- Fix error message not appearing above checkbox when not selected

## Guidance to review

- Visit https://apply-review-11875.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-11875.test.teacherservices.cloud/support/applications/74/editable-extension
- Click "Update"
- Check that the validation errors appear
- Check the "I have spoken to and received confirmation from the Policy team to action this request." checkbox
- Click "Update"
- Check that the checked status of the "I have spoken to and received confirmation from the Policy team to action this request." checkbox persists

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/d5X9Udee/1366-minor-bug-checkbox-loses-state-when-error-shown

## Screen recording

https://github.com/user-attachments/assets/2cc635fd-fa13-4050-bf99-4594ab1b6413

