### PR TITLE
Only run remove inactive provider user worker on live environments

### DIFF
--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -6,7 +6,7 @@ class RemoveInactiveProviderUsersWorker
   INACTIVE_MONTHS_AGO = 12
 
   def perform
-    return unless HostingEnvironment.production?? || HostingEnvironment.staging? || HostingEnvironment.sandbox?
+    return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?
 
     ProviderUser.where('last_signed_in_at < ?', INACTIVE_MONTHS_AGO.months.ago)
       .or(ProviderUser.where(

--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -6,6 +6,8 @@ class RemoveInactiveProviderUsersWorker
   INACTIVE_MONTHS_AGO = 12
 
   def perform
+    return unless HostingEnvironment.production?? || HostingEnvironment.staging? || HostingEnvironment.sandbox?
+
     ProviderUser.where('last_signed_in_at < ?', INACTIVE_MONTHS_AGO.months.ago)
       .or(ProviderUser.where(
             'last_signed_in_at IS NULL AND created_at < ?', INACTIVE_MONTHS_AGO.months.ago


### PR DESCRIPTION
## Context

- Add a line of code to only run the `RemoveInactiveProviderUsersWorker` on `production`, `staging` and `sandbox`

## Changes proposed in this pull request

- Add a line of code to only run the `RemoveInactiveProviderUsersWorker` on `production`, `staging` and `sandbox`

## Guidance to review

- Make sure the line of code makes sense.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
