### PR TITLE
Use DfE autocomplete on collection select component if more than 20 options

### DIFF
--- a/app/components/utility/collection_select_component.html.erb
+++ b/app/components/utility/collection_select_component.html.erb
@@ -3,15 +3,30 @@
     <%= form_with model: form_object, url: form_path, method: form_method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_radio_buttons attribute,
-                                           collection,
-                                           value_method,
-                                           text_method,
-                                           hint_method,
-                                           hint:,
-                                           bold_labels: bold_labels,
-                                           legend: { text: page_title, size: 'l' },
-                                           caption: { text: caption, size: 'l' } %>
+      <% if collection_count < 20 %>
+        <%= f.govuk_collection_radio_buttons attribute,
+                                             collection,
+                                             value_method,
+                                             text_method,
+                                             hint_method,
+                                             hint:,
+                                             bold_labels: bold_labels,
+                                             legend: { text: page_title, size: 'l' },
+                                             caption: { text: caption, size: 'l' } %>
+      <% else %>
+        <%= render DfE::Autocomplete::View.new(
+          f,
+          attribute_name: attribute,
+          form_field: f.govuk_select(
+            attribute,
+            options_for_select(collection_options_for_select, form_object.try(attribute)),
+            data: { controller: 'autocomplete' },
+            label: { text: page_title, size: 'l' },
+            caption: { text: caption, size: 'l' },
+            hint: { text: hint },
+          ),
+        ) %>
+      <% end %>
       <%= f.govuk_submit t('continue') %>
     <% end %>
     <%= content %>

--- a/app/components/utility/collection_select_component.rb
+++ b/app/components/utility/collection_select_component.rb
@@ -20,4 +20,18 @@ class CollectionSelectComponent < ApplicationComponent
     @page_title = page_title
     @caption = caption
   end
+
+  def collection_options_for_select
+    collection.map do |option|
+      [
+        (hint_method.present? ? "#{option.try(text_method)} - #{option.try(hint_method)}" : option.try(text_method)),
+        option.try(value_method),
+      ]
+    end.unshift([nil, nil])
+  end
+
+  def collection_count
+    count_of_items = collection.count
+    count_of_items.is_a?(Hash) ? count_of_items.keys.count : count_of_items
+  end
 end

--- a/spec/components/previews/collection_select_component_preview.rb
+++ b/spec/components/previews/collection_select_component_preview.rb
@@ -35,4 +35,19 @@ class CollectionSelectComponentPreview < ViewComponent::Preview
                                          page_title: 'Select course',
                                          caption: 'Jane Doe')
   end
+
+  def course_select_example_with_over_20_courses
+    courses = FactoryBot.build_stubbed_list(:course, 25)
+    form_object = FormObject.new(course_id: courses.last.id)
+    render CollectionSelectComponent.new(attribute: :course_id,
+                                         collection: courses,
+                                         value_method: :id,
+                                         text_method: :name_and_code,
+                                         hint_method: :description_and_accredited_provider,
+                                         bold_labels: false,
+                                         form_object:,
+                                         form_path: '',
+                                         page_title: 'Select course',
+                                         caption: 'Jane Doe')
+  end
 end

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -76,6 +76,60 @@ RSpec.describe 'Provider changes an existing offer' do
     then_i_see_that_the_offer_was_successfully_updated
   end
 
+  context 'when there are more than 20 courses' do
+    scenario 'Changing an offer which has already been made' do
+      given_i_am_a_provider_user
+      and_i_am_permitted_to_make_decisions_for_my_provider
+      and_i_sign_in_to_the_provider_interface
+
+      given_the_provider_user_can_offer_more_than_20_provider_courses
+
+      when_i_visit_the_provider_interface
+      and_i_click_an_application_choice_with_an_offer
+      and_i_click_on_the_offer_tab
+      then_i_see_the_offer_details
+
+      when_i_choose_to_change_the_provider
+      then_i_am_taken_to_the_change_provider_page
+
+      when_i_select_a_different_provider
+      and_i_click_continue
+
+      when_i_select_a_different_course_from_the_dropdown
+      and_i_click_continue
+      then_no_study_mode_is_pre_selected
+
+      when_i_select_a_study_mode
+      and_i_click_continue
+
+      when_i_select_a_new_location_from_the_dropdown
+      and_i_click_continue
+
+      then_the_conditions_page_is_loaded
+      and_the_conditions_of_the_original_offer_are_filled_in
+
+      when_i_add_a_further_condition
+      and_i_add_another_and_then_remove_a_further_condition
+      then_the_correct_conditions_are_displayed
+
+      and_i_click_continue
+
+      then_the_review_page_is_loaded
+      and_i_can_confirm_the_changed_offer_details
+
+      when_i_send_the_offer
+      then_i_see_that_the_offer_was_successfully_updated
+
+      when_i_choose_to_change_the_conditions
+      and_i_click_continue
+
+      then_the_review_page_is_loaded
+      when_i_send_the_offer
+
+      then_i_see_that_the_offer_was_successfully_updated
+    end
+  end
+
   def given_i_am_a_provider_user
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
   end
@@ -98,6 +152,32 @@ RSpec.describe 'Provider changes an existing offer' do
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
                       create(:course_option, :part_time, course: @selected_course)]
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @selected_provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    @selected_course_option = course_options.sample
+  end
+
+  def given_the_provider_user_can_offer_more_than_20_provider_courses
+    @selected_provider = create(:provider)
+    create(:provider_permissions, provider: @selected_provider, provider_user:, make_decisions: true)
+    courses = create_list(:course, 25, :with_course_options, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    @selected_course = courses.sample
+
+    course_options = create_list(:course_option, 25, :part_time, course: @selected_course)
+    create(:course_option, :full_time, course: @selected_course)
 
     create(
       :provider_relationship_permissions,
@@ -155,6 +235,10 @@ RSpec.describe 'Provider changes an existing offer' do
     choose @selected_course.name_and_code
   end
 
+  def when_i_select_a_different_course_from_the_dropdown
+    select @selected_course.name_and_code, from: 'Course'
+  end
+
   def then_no_study_mode_is_pre_selected
     expect(find_field('Full time')).not_to be_checked
     expect(find_field('Part time')).not_to be_checked
@@ -166,6 +250,10 @@ RSpec.describe 'Provider changes an existing offer' do
 
   def when_i_select_a_new_location
     choose @selected_course_option.site_name
+  end
+
+  def when_i_select_a_new_location_from_the_dropdown
+    select @selected_course_option.site_name, from: 'Location'
   end
 
   def then_the_conditions_page_is_loaded


### PR DESCRIPTION
## Context

- If more than 20 elements are in a collection passed to the `CollectionSelectComponent`, render a DfE AutoComplete instead of radio buttons.

## Changes proposed in this pull request

- If more than 20 elements are in a collection passed to the `CollectionSelectComponent`, render a DfE AutoComplete instead of radio buttons.

## Guidance to review

- Visit https://apply-review-11880.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-11880.test.teacherservices.cloud/support/users/provider/2
- Click "Sign in as this provider user"
- Visit https://apply-review-11880.test.teacherservices.cloud/provider/applications/156/offers
- Click "Change" to change the course
- The radio buttons appear because there are 19 courses
- Click "Back"
- Click "Change" to change location
- The radio buttons are replaced by DfE autocomplete select, because there are more than 20 locations. (Both the course selection and location selection pages use the same component)
- Enter a new location (e.g., "Manor Hill")
- Click "Continue"
- Continue with the edit journey
- Check that the summary shows the changed location.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/l0baMt6Z/1741-tech-debt-use-dfe-autocomplete-for-selecting-schools-when-changing-an-offer

## Screen recording

https://github.com/user-attachments/assets/6038c378-b486-4d04-8aa4-8e6987044793

