### PR TITLE
[1797] PII in Logs

### DIFF
--- a/app/lib/custom_log_formatter.rb
+++ b/app/lib/custom_log_formatter.rb
@@ -9,6 +9,7 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     add_custom_fields
     sanitize_payload_fields
     remove_post_params
+    redact_mailer_arguments
 
     hash.to_json
   end
@@ -56,6 +57,13 @@ private
     return unless method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
 
     hash[:payload][:params].clear
+  end
+
+  def redact_mailer_arguments
+    return if hash.dig(:payload, :job_class).blank? || hash.dig(:payload, :arguments).blank?
+    return unless hash.dig(:payload, :job_class).include? 'ActionMailer::MailDeliveryJob'
+
+    hash[:payload][:arguments] = REDACTED
   end
 
   def method_is_post_or_put_or_patch?

--- a/spec/lib/custom_log_formatter_spec.rb
+++ b/spec/lib/custom_log_formatter_spec.rb
@@ -82,4 +82,30 @@ RSpec.describe CustomLogFormatter do
     expect(log_hash[:payload][:subject]).to eq('[REDACTED]')
     expect(log_hash[:payload][:to]).to eq('[REDACTED]')
   end
+
+  it 'filters out arguments when the job class is "ActionMailer::MailDeliveryJob"' do
+    log.message = 'Enqueued Message'
+    log.payload = {
+      job_class: 'ActionMailer::MailDeliveryJob',
+      arguments: {
+        token: 'ABC123',
+        email_address: 'email@email.example.com',
+      },
+      event_name: 'deliver.action_mailer',
+      mailer: 'CandidateMailer',
+      action: nil,
+      message_id: '1234@apply-review-1234-worker-1234-1234.mail',
+      perform_deliveries: true,
+      subject: '[REVIEW] You have submitted your teacher training application',
+      to: ['some.email+testlog@education.gov.uk'],
+      from: nil,
+      bcc: nil,
+      cc: nil,
+      date: '2024-07-19 14:12:25 UTC',
+      duration: 101.07,
+      args: nil,
+    }
+
+    expect(log_hash[:payload][:arguments]).to eq('[REDACTED]')
+  end
 end


### PR DESCRIPTION
## Context

It's been brought to our attention by another team that we have some PII leaking into our logs.

We have a few filters in place to redact it PII, but we found an edge case for the job updates related to mail delivery. Namely, where such data is sent as personalisation arguments to Notify. 

I"ve looked through other job related logs, eg mailers, api requests, etc, and the filters are working as expected. 

## Changes proposed in this pull request
This PR just redacts all extra arguments from the call back jobs


## Guidance to review
We will be able to see the change after it is merged by going to Logit and filtering by job_queue name == ActionMailer::MailDeliveryJob and domain == our web address. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
