### PR TITLE
Cache splitter, Redis and Solid cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -202,3 +202,5 @@ gem 'propshaft', '~> 1.3'
 
 gem 'solid_queue', '~> 1.4'
 gem 'mission_control-jobs'
+gem 'solid_cache', '~> 1.0'
+gem 'solid_cache_dashboard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,8 @@ GEM
     govuk_markdown (2.0.4)
       activesupport
       redcarpet
+    groupdate (6.8.0)
+      activesupport (>= 7.2)
     grover (1.2.10)
       nokogiri (~> 1)
     guard (2.18.1)
@@ -795,6 +797,15 @@ GEM
       thor (>= 1.3.1)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    solid_cache_dashboard (0.2.0)
+      chartkick (>= 5.0)
+      groupdate (>= 6.5)
+      pagy (>= 6.0)
+      solid_cache (>= 0.2.0)
     stoplight (3.0.2)
       redlock (~> 1.0)
     stringio (3.2.0)
@@ -997,6 +1008,8 @@ DEPENDENCIES
   simplecov-cobertura
   skylight
   solid_queue (~> 1.4)
+  solid_cache (~> 1.0)
+  solid_cache_dashboard
   strip_attributes
   strong_migrations
   super_diff
@@ -1129,6 +1142,7 @@ CHECKSUMS
   govuk-components (6.2.0) sha256=85ec75f93b425e62cbedf83e04a749d7cdd35eeed6208071974dd24775013207
   govuk_design_system_formbuilder (6.1.0) sha256=b0fdb3714e59665f1a522291840bcc89801cb4325f243e8717e0f9be87d1192c
   govuk_markdown (2.0.4) sha256=c744f0a041607d60942c24dcf3d8fd24eaf73c4eb8299ea025455691a211242e
+  groupdate (6.8.0) sha256=16f90ea18ca981c38e41e592416480b28353aa5e5cc3e7cb13a68b8fb5d40510
   grover (1.2.10) sha256=989b21d1a0048e3793b9939b392152fb309c7a107911ad04c10e422de4e1479b
   guard (2.18.1) sha256=a3893d3b23d538a9b2d6f05a27713e0ed53ea881df0f0550b21a3393c6d87c09
   guard-compat (1.2.1) sha256=3ad21ab0070107f92edfd82610b5cdc2fb8e368851e72362ada9703443d646fe
@@ -1290,7 +1304,9 @@ CHECKSUMS
   smart_properties (1.17.0) sha256=f9323f8122e932341756ddec8e0ac9ec6e238408a7661508be99439ca6d6384b
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
   solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a
-  stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
+  stimulus-rails (1.3.4)
+  solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
+  solid_cache_dashboard (0.2.0) sha256=b59d4145d80c0989c4958125052a3edec709d066b1f4297a5b7d85ddce4bd994
   stoplight (3.0.2) sha256=9bc2697a9c380aa6d8380d820c2663bda50cee3a9680a256ea035f8cf0e918ee
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   strip_attributes (2.0.1) sha256=604cb833fc69aedefffc60a79bd91a7faf3753caf34db3889beaf2d88afa7e8b

--- a/config/application.rb
+++ b/config/application.rb
@@ -80,7 +80,14 @@ module ApplyForPostgraduateTeacherTraining
     config.mission_control.jobs.http_basic_auth_enabled = false
 
     config.action_controller.perform_caching = true
-    config.cache_store = :memory_store
+
+    config.cache_store = [
+      :splitter_cache_store,
+      caches: {
+        redis: :redis_cache_store,
+        solid_cache: :solid_cache_store
+      },
+    ]
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
 

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,16 @@
+default: &default
+  store_options:
+    max_age: <%= 7.days.to_i %>
+    max_size: <%= 2.5.gigabytes %>
+    namespace: <%= Rails.env %>
+    expiry_method: :job
+    expiry_queue: low_priority
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,7 +1,7 @@
 default: &default
   store_options:
     max_age: <%= 7.days.to_i %>
-    max_size: <%= 2.5.gigabytes %>
+    max_size: <%= 1.gigabytes %>
     namespace: <%= Rails.env %>
     expiry_method: :job
     expiry_queue: low_priority

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,13 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = [
+      :splitter_cache_store,
+      caches: {
+        redis: :redis_cache_store,
+        solid_cache: :solid_cache_store
+      },
+    ]
     config.public_file_server.headers = { "cache-control" => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,13 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }
+  config.cache_store = [
+    :splitter_cache_store,
+    caches: {
+      redis: [:redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }],
+      solid_cache: :solid_cache_store
+    },
+  ]
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -324,6 +324,7 @@ namespace :support_interface, path: '/support' do
   mount SupportInterface::RackApp.new(Blazer::Engine) => '/blazer', as: :blazer
   mount SupportInterface::RackApp.new(FieldTest::Engine) => '/field-test', as: :field_test
   mount SupportInterface::RackApp.new(MissionControl::Jobs::Engine) => '/jobs', as: :jobs
+  mount SupportInterface::RackApp.new(SolidCacheDashboard::Engine) => '/solid-cache', as: :solid_cache
 
   get '*path', to: 'errors#not_found'
 end

--- a/lib/active_support/cache/splitter_cache_store.rb
+++ b/lib/active_support/cache/splitter_cache_store.rb
@@ -1,0 +1,58 @@
+module ActiveSupport
+  module Cache
+    class SplitterCacheStore < Store
+      attr_reader :caches
+
+      def self.supports_cache_versioning?
+        true
+      end
+
+      def initialize(options)
+        @caches = options.delete(:caches).to_h do |name, cache_args|
+          [name, ActiveSupport::Cache.lookup_store(cache_args)]
+        end
+        super
+      end
+
+      def fetch(name, options = nil, &)
+        choose_cache(name).fetch(name, options, &)
+      end
+
+      def read(name, options = nil)
+        choose_cache(name).read(name, options)
+      end
+
+      def write(name, value, options = nil)
+        choose_cache(name).write(name, value, options)
+      end
+
+      def delete(name, options = nil)
+        choose_cache(name).delete(name, options)
+      end
+
+      def increment(name, amount = 1, options = nil)
+        choose_cache(name).increment(name, amount, **options)
+      end
+
+      def exist?(name, options = nil)
+        choose_cache(name).exist?(name, options)
+      end
+
+      def clear(options = nil)
+        caches[:redis].clear(options)
+      end
+
+    private
+
+      def choose_cache(key)
+        normalized_key = normalize_key(key)
+
+        if normalized_key.include?('vendor_api')
+          caches[:solid_cache]
+        else
+          caches[:redis]
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/active_support/cache/splitter_cache_store_spec.rb
+++ b/spec/lib/active_support/cache/splitter_cache_store_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveSupport::Cache::SplitterCacheStore do
   let(:options) do
     {
       caches: {
-        redis: [:redis_cache_store, { url: 'redis://localhost:6379/0' }],
+        redis: [:redis_cache_store, { url: ENV.fetch('REDIS_URL', 'redis://redis:6379/0') }],
         solid_cache: :solid_cache_store,
       },
     }

--- a/spec/lib/active_support/cache/splitter_cache_store_spec.rb
+++ b/spec/lib/active_support/cache/splitter_cache_store_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ActiveSupport::Cache::SplitterCacheStore do
+  describe '.supports_cache_versioning?' do
+    it 'returns true' do
+      expect(described_class.supports_cache_versioning?).to be(true)
+    end
+  end
+
+  describe '#new' do
+    it 'initialises the caches' do
+      options = {
+        caches: {
+          redis: [:redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }],
+          solid_cache: :solid_cache_store,
+        },
+      }
+      store = described_class.new(options)
+
+      expect(store.caches[:redis].class).to eq(
+        ActiveSupport::Cache::RedisCacheStore,
+      )
+      expect(store.caches[:solid_cache].class).to eq(
+        ActiveSupport::Cache::SolidCacheStore,
+      )
+    end
+  end
+
+  describe '#fetch' do
+    it 'fetches the value' do
+      options = {
+        caches: {
+          redis: [:redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }],
+          solid_cache: :solid_cache_store,
+        },
+      }
+      store = described_class.new(options)
+      store.caches[:redis].write('test', 'value')
+      expect(store.caches[:redis].fetch('test')).to eq('value')
+
+      ## Set things in before
+      ## Test both caches
+    end
+  end
+end

--- a/spec/lib/active_support/cache/splitter_cache_store_spec.rb
+++ b/spec/lib/active_support/cache/splitter_cache_store_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ActiveSupport::Cache::SplitterCacheStore do
+  subject(:store) { described_class.new(options) }
+
+  let(:options) do
+    {
+      caches: {
+        redis: [:redis_cache_store, { url: 'redis://localhost:6379/0' }],
+        solid_cache: :solid_cache_store,
+      },
+    }
+  end
+
   describe '.supports_cache_versioning?' do
     it 'returns true' do
       expect(described_class.supports_cache_versioning?).to be(true)
@@ -9,14 +20,6 @@ RSpec.describe ActiveSupport::Cache::SplitterCacheStore do
 
   describe '#new' do
     it 'initialises the caches' do
-      options = {
-        caches: {
-          redis: [:redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }],
-          solid_cache: :solid_cache_store,
-        },
-      }
-      store = described_class.new(options)
-
       expect(store.caches[:redis].class).to eq(
         ActiveSupport::Cache::RedisCacheStore,
       )
@@ -26,20 +29,101 @@ RSpec.describe ActiveSupport::Cache::SplitterCacheStore do
     end
   end
 
-  describe '#fetch' do
-    it 'fetches the value' do
-      options = {
-        caches: {
-          redis: [:redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }],
-          solid_cache: :solid_cache_store,
-        },
-      }
-      store = described_class.new(options)
-      store.caches[:redis].write('test', 'value')
-      expect(store.caches[:redis].fetch('test')).to eq('value')
+  context 'use solid_cache' do
+    describe '#fetch' do
+      it 'writes and fetches the value' do
+        store.write('vendor_api', 'value')
+        expect(store.caches[:solid_cache].fetch('vendor_api')).to eq('value')
+        expect(store.fetch('vendor_api')).to eq('value')
+      end
+    end
 
-      ## Set things in before
-      ## Test both caches
+    describe '#read' do
+      it 'writes and reads the value' do
+        store.write('vendor_api', 'value')
+        expect(store.caches[:solid_cache].read('vendor_api')).to eq('value')
+        expect(store.read('vendor_api')).to eq('value')
+      end
+    end
+
+    describe '#delete' do
+      it 'writes and delets the value' do
+        store.write('vendor_api', 'value')
+        store.delete('vendor_api')
+        expect(store.caches[:solid_cache].read('vendor_api')).to be_nil
+      end
+    end
+
+    describe '#increment' do
+      it 'writes and increments' do
+        store.write('vendor_api', 1, raw: true)
+        expect(store.increment('vendor_api')).to eq(2)
+      end
+    end
+
+    describe '#exist?' do
+      it 'writes and check exist?' do
+        store.write('vendor_api', 'value')
+        expect(store.caches[:solid_cache].exist?('vendor_api')).to be(true)
+        expect(store.exist?('vendor_api')).to be(true)
+      end
+    end
+
+    describe '#clear?' do
+      it 'clears redis not solid_cache' do
+        store.write('vendor_api', 'value')
+        store.clear
+        expect(store.caches[:solid_cache].read('vendor_api')).to eq('value')
+      end
+    end
+  end
+
+  context 'use redis' do
+    describe '#fetch' do
+      it 'writes and fetches the value' do
+        store.write('test', 'value')
+        expect(store.caches[:redis].fetch('test')).to eq('value')
+        expect(store.fetch('test')).to eq('value')
+      end
+    end
+
+    describe '#read' do
+      it 'writes and reads the value' do
+        store.write('test', 'value')
+        expect(store.caches[:redis].read('test')).to eq('value')
+        expect(store.read('test')).to eq('value')
+      end
+    end
+
+    describe '#delete' do
+      it 'writes and delets the value' do
+        store.write('test', 'value')
+        store.delete('test')
+        expect(store.caches[:redis].read('test')).to be_nil
+      end
+    end
+
+    describe '#increment' do
+      it 'writes and increments' do
+        store.write('test', 1, raw: true)
+        expect(store.increment('test')).to eq(2)
+      end
+    end
+
+    describe '#exist?' do
+      it 'writes and check exist?' do
+        store.write('test', 'value')
+        expect(store.exist?('test')).to be(true)
+        expect(store.caches[:redis].exist?('test')).to be(true)
+      end
+    end
+
+    describe '#clear?' do
+      it 'writes and clears redis' do
+        store.write('test', 'value')
+        store.clear
+        expect(store.caches[:redis].read('test')).to be_nil
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -225,4 +225,14 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.before(:each, :with_cache) do
+    allow(Rails).to receive(:cache) do
+      ActiveSupport::Cache.lookup_store(:solid_cache_store)
+    end
+    Rails.cache.clear
+  end
+  config.after(:each, :with_cache) do
+    allow(Rails).to receive(:cache).and_return(nil)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -225,14 +225,4 @@ RSpec.configure do |config|
       example.run
     end
   end
-
-  config.before(:each, :with_cache) do
-    allow(Rails).to receive(:cache) do
-      ActiveSupport::Cache.lookup_store(:solid_cache_store)
-    end
-    Rails.cache.clear
-  end
-  config.after(:each, :with_cache) do
-    allow(Rails).to receive(:cache).and_return(nil)
-  end
 end


### PR DESCRIPTION
## Context

This implements a cache splitter. Requests that contain the 'vendor_api' string will be cached in solid cache and the rest in redis.

This adds a custom cache class that will just pass the relevant methods we use to cache our results to the relevent cache store, redis or solid cache.

It also adds a gem so that we can have a dashboard to monitor our cache.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and click around. Nothing should break. And the caching of the app will be done using redis.

If you want to test this you'll need to go into the rails console of this review app and run

```
make review console PR_NUMBER=11884

redis = Redis.new
redis.keys # All the keys in the cache
redis.get(key) # Get your value from the cache
redis.flushdb # clear the cache, it might be easier if you do this first so you can see the new keys you're writting
```

To save data in solid cache send some api requests.
Then go to dashboard and view the data you cached.
https://apply-review-11884.test.teacherservices.cloud/support/solid-cache/

Curl with UCL token
```
curl https://apply-review-11884.test.teacherservices.cloud/api/v1.8/applications?since="2026-03-20" -H "Authorization: Bearer VfLdsCxM77AF43afv3yb" | jq
```

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
