### PR TITLE
Add migrated SolidQueue table names/fields to the analytics blocklist

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -15,6 +15,89 @@
   - byte_size
   - duration
   - created_at
+  :solid_queue_semaphores:
+  - id
+  - key
+  - value
+  - expires_at
+  - created_at
+  - updated_at
+  :solid_queue_recurring_tasks:
+  - id
+  - key
+  - schedule
+  - command
+  - class_name
+  - arguments
+  - queue_name
+  - priority
+  - static
+  - description
+  - created_at
+  - updated_at
+  :solid_queue_processes:
+  - id
+  - kind
+  - last_heartbeat_at
+  - supervisor_id
+  - pid
+  - hostname
+  - metadata
+  - created_at
+  - name
+  :solid_queue_pauses:
+  - id
+  - queue_name
+  - created_at
+  :solid_queue_jobs:
+  - id
+  - queue_name
+  - class_name
+  - arguments
+  - priority
+  - active_job_id
+  - scheduled_at
+  - finished_at
+  - concurrency_key
+  - created_at
+  - updated_at
+  :solid_queue_scheduled_executions:
+  - id
+  - job_id
+  - queue_name
+  - priority
+  - scheduled_at
+  - created_at
+  :solid_queue_recurring_executions:
+  - id
+  - job_id
+  - task_key
+  - run_at
+  - created_at
+  :solid_queue_ready_executions:
+  - id
+  - job_id
+  - queue_name
+  - priority
+  - created_at
+  :solid_queue_failed_executions:
+  - id
+  - job_id
+  - error
+  - created_at
+  :solid_queue_claimed_executions:
+  - id
+  - job_id
+  - process_id
+  - created_at
+  :solid_queue_blocked_executions:
+  - id
+  - job_id
+  - queue_name
+  - priority
+  - concurrency_key
+  - expires_at
+  - created_at
   :regional_edi_reports:
   - id
   - statistics


### PR DESCRIPTION
## Context

This adds the table names and fields migrated in #11885 to the `analytics_blocklist.yml`.

## Changes proposed in this pull request

- Add table names to the blocklist.

## Guidance to review

- Check the yml file.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
