### PR TITLE
Replace current application choices with active application choices

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -105,12 +105,7 @@ module CandidateInterface
     def redirect_to_candidate_root
       return if current_application.any_offer_accepted? || active_previous_application&.any_offer_accepted?
 
-      can_carry_over = if active_previous_application.present?
-                         current_application.carry_over? && active_previous_application.carry_over?
-                       else
-                         current_application.carry_over?
-                       end
-      if can_carry_over
+      if current_application.carry_over?
         redirect_to candidate_interface_carry_over_path
       elsif candidate_made_choices_and_completed_details
         redirect_to candidate_interface_application_choices_path
@@ -128,16 +123,7 @@ module CandidateInterface
       completed_application_form = CandidateInterface::CompletedApplicationForm.new(
         application_form: current_application,
       )
-      previous_completed_application_form = if active_previous_application.present?
-                                              CandidateInterface::CompletedApplicationForm.new(
-                                                application_form: active_previous_application,
-                                              )
-                                            end
-      if previous_completed_application_form.present?
-        completed_application_form.valid? && previous_completed_application_form.valid?
-      else
-        completed_application_form.valid?
-      end
+      completed_application_form.valid?
     end
 
     def redirect_to_application_if_signed_in

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -103,9 +103,14 @@ module CandidateInterface
     end
 
     def redirect_to_candidate_root
-      return if current_application.any_offer_accepted?
+      return if current_application.any_offer_accepted? || active_previous_application&.any_offer_accepted?
 
-      if current_application.carry_over?
+      can_carry_over = if active_previous_application.present?
+                         current_application.carry_over? && active_previous_application.carry_over?
+                       else
+                         current_application.carry_over?
+                       end
+      if can_carry_over
         redirect_to candidate_interface_carry_over_path
       elsif candidate_made_choices_and_completed_details
         redirect_to candidate_interface_application_choices_path
@@ -115,12 +120,24 @@ module CandidateInterface
     end
 
     def candidate_made_choices_and_completed_details
+      candidate_made_choices = active_application_choices.any?
+      candidate_made_choices && candidate_details_complete
+    end
+
+    def candidate_details_complete
       completed_application_form = CandidateInterface::CompletedApplicationForm.new(
         application_form: current_application,
       )
-      candidate_details_complete = completed_application_form.valid?
-      candidate_made_choices = current_application.application_choices.any?
-      candidate_made_choices && candidate_details_complete
+      previous_completed_application_form = if active_previous_application.present?
+                                              CandidateInterface::CompletedApplicationForm.new(
+                                                application_form: active_previous_application,
+                                              )
+                                            end
+      if previous_completed_application_form.present?
+        completed_application_form.valid? && previous_completed_application_form.valid?
+      else
+        completed_application_form.valid?
+      end
     end
 
     def redirect_to_application_if_signed_in
@@ -175,11 +192,11 @@ module CandidateInterface
     end
 
     def any_accepted_offer?
-      current_application.application_choices.map(&:status).include?('pending_conditions')
+      active_application_choices.pluck(:status).include?('pending_conditions')
     end
 
     def any_deferred_offer?
-      current_application.application_choices.map(&:status).include?('offer_deferred')
+      active_application_choices.pluck(:status).include?('offer_deferred')
     end
 
     def no_offers_accepted_or_deferred_and_not_recruited?

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -95,7 +95,7 @@ module CandidateInterface
       end
 
       def application_choice
-        @application_choice ||= current_application.application_choices.find(params[:application_choice_id])
+        @application_choice ||= active_application_choices.find(params[:application_choice_id])
       end
 
     private

--- a/app/controllers/candidate_interface/course_choices/review_and_submit_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_and_submit_controller.rb
@@ -6,8 +6,8 @@ module CandidateInterface
       before_action :redirect_to_course_choice_review_unless_ready_to_submit
 
       def show
-        @application_choice = current_application.application_choices.find(params[:application_choice_id])
-        @application_form = current_application
+        @application_choice = active_application_choices.find(params[:application_choice_id])
+        @application_form = @application_choice.application_form
       end
 
     private

--- a/app/controllers/candidate_interface/course_choices/review_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
       skip_before_action :redirect_to_your_applications_if_cycle_is_over
 
       def show
-        @application_choice = current_application.application_choices.find(params[:application_choice_id])
+        @application_choice = active_application_choices.find(params[:application_choice_id])
 
         if params['return_to'] == 'invite'
           invite = application_choice.published_invites.last

--- a/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
@@ -4,8 +4,8 @@ module CandidateInterface
       before_action :redirect_to_your_applications_if_submitted
 
       def show
-        @application_choice = current_application.application_choices.find(params[:application_choice_id])
-        @word_count = current_application.becoming_a_teacher.scan(/\S+/).size
+        @application_choice = active_application_choices.find(params[:application_choice_id])
+        @word_count = @application_choice.application_form.becoming_a_teacher.scan(/\S+/).size
         @continue_path = ReviewInterruptionPathDecider.decide_path(@application_choice, current_step: :short_personal_statement)
       end
     end

--- a/app/controllers/candidate_interface/course_choices/review_references_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_references_interruption_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       before_action :redirect_to_your_applications_if_submitted
 
       def show
-        @application_choice = current_application.application_choices.find(params.require(:application_choice_id))
+        @application_choice = active_application_choices.find(params.require(:application_choice_id))
         @continue_without_editing_path = ReviewInterruptionPathDecider.decide_path(
           @application_choice,
           current_step: :references_with_personal_email_addresses,

--- a/app/controllers/candidate_interface/course_choices/review_undergraduate_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_undergraduate_interruption_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       before_action :redirect_to_your_applications_if_submitted
 
       def show
-        @application_choice = current_application.application_choices.find(params[:application_choice_id])
+        @application_choice = active_application_choices.find(params[:application_choice_id])
         @continue_without_editing_path = ReviewInterruptionPathDecider.decide_path(
           @application_choice,
           current_step: :undergraduate_course_with_degree,

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -59,11 +59,11 @@ module CandidateInterface
   private
 
     def set_application_choice
-      @application_choice = @current_application.application_choices.find(params[:id])
+      @application_choice = active_application_choices.find(params[:id])
     end
 
     def single_application_choice?
-      @current_application.application_choices.size == 1
+      active_application_choices.size == 1
     end
     helper_method :single_application_choice?
 

--- a/app/controllers/candidate_interface/offer_dashboard_controller.rb
+++ b/app/controllers/candidate_interface/offer_dashboard_controller.rb
@@ -7,8 +7,7 @@ module CandidateInterface
 
     def show
       authorize %i[candidate_interface offer_dashboard], :show?
-      @application_form = current_application
-      choices = current_application.application_choices.includes(:offer, course_option: [course: :provider])
+      choices = active_application_choices.includes(:offer, course_option: [course: :provider])
       @application_choice = choices.pending_conditions.first || choices.recruited.first || choices.offer_deferred.first
       @provider = @application_choice.current_provider
       @course_name_and_code = @application_choice.current_course.name_and_code

--- a/app/controllers/candidate_interface/withdrawal_reasons/withdrawals_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/withdrawals_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
     private
 
       def set_application_choice
-        @application_choice = @current_application.application_choices.find(params[:id])
+        @application_choice = active_application_choices.find(params[:id])
       end
 
       def check_that_candidate_can_withdraw

--- a/app/controllers/concerns/accept_offer_confirm_references.rb
+++ b/app/controllers/concerns/accept_offer_confirm_references.rb
@@ -18,6 +18,6 @@ module AcceptOfferConfirmReferences
   end
 
   def application_choice
-    @application_choice ||= @current_application.application_choices.find(params[:application_id])
+    @application_choice ||= active_application_choices.find(params[:application_id])
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -37,9 +37,25 @@ class ApplicationPolicy
 private
 
   def current_application
-    if user.is_a?(Candidate)
+    if user_is_a_candidate?
       @current_application ||= user.current_application
     end
+  end
+
+  def active_previous_application
+    if user_is_a_candidate?
+      @active_previous_application ||= user.active_previous_application
+    end
+  end
+
+  def active_application_choices
+    if user_is_a_candidate?
+      @active_application_choices ||= user.active_application_choices
+    end
+  end
+
+  def user_is_a_candidate?
+    @user_is_a_candidate ||= user.is_a?(Candidate)
   end
 
   class Scope

--- a/app/policies/candidate_interface/offer_dashboard_policy.rb
+++ b/app/policies/candidate_interface/offer_dashboard_policy.rb
@@ -7,11 +7,11 @@ module CandidateInterface
   private
 
     def any_offer_pending_conditions?
-      current_application.application_choices.map(&:status).include?('pending_conditions')
+      active_application_choices.pluck(:status).include?('pending_conditions')
     end
 
     def any_deferred_offer?
-      current_application.application_choices.map(&:status).include?('offer_deferred')
+      active_application_choices.pluck(:status).include?('offer_deferred')
     end
 
     class Scope < ApplicationPolicy::Scope

--- a/app/views/candidate_interface/details/index.html.erb
+++ b/app/views/candidate_interface/details/index.html.erb
@@ -115,7 +115,7 @@
     <% elsif @application_form_presenter.can_submit_more_applications? %>
       <div class="app-grid-column--grey">
         <h2 class="govuk-heading-m">You have completed your details</h2>
-        <% if current_application.application_choices.any? %>
+        <% if active_application_choices.any? %>
           <p class="govuk-body">You can apply to courses now.</p>
         <% else %>
           <p class="govuk-body">You can start applying to courses.</p>


### PR DESCRIPTION
## Context

- Replace `current_application.application_choices` with `active_application_choices`

- Remaining instances of `current_application.application_choices`:
  - `app/controllers/candidate_interface/degrees/base_controller.rb` (Should be related only to the current application)
  - `app/controllers/candidate_interface/degrees/degree_grade_interruption_controller.rb` (Should be related only to the current application)
  - `app/models/candidate.rb` (Only the `current_application_choices` method)
  - `app/services/candidate_courses_recommender.rb` (Should be related only to the current application)
  - `app/services/candidate_interface/section_policy.rb` (Only used in controllers which should related to the current application)
  - `app/services/candidate_interface/course_choices/course_selection_store.rb` (I think this should only look at current_application?)
  - `app/validators/course_selection_validator.rb` (I think this should only look at current_application?)

## Changes proposed in this pull request

- Replace `current_application.application_choices` with `active_application_choices`

## Guidance to review

- Review the code.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
