### PR TITLE
Bug fix: refactor query in application data export form

### DIFF
--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -17,25 +17,33 @@ module ProviderInterface
 
     def years_to_export
       user_provider_ids = providers_that_actor_belongs_to.pluck(:id)
+      visible_states = ApplicationStateChange.states_visible_to_provider
+
+      connection = ApplicationRecord.connection
+
+      provider_ids_sql = "ARRAY[#{user_provider_ids.join(',')}]::bigint[]"
+
+      states_sql = visible_states.map { |state| connection.quote(state) }.join(', ')
 
       sql = <<~SQL
-        SELECT distinct on (current_recruitment_cycle_year) current_recruitment_cycle_year
+        SELECT DISTINCT ON (current_recruitment_cycle_year)
+              current_recruitment_cycle_year
         FROM application_choices
-        WHERE application_choices.provider_ids && ARRAY[#{user_provider_ids.join(', ')}]::bigint[]
-        AND application_choices.status IN (#{ApplicationStateChange.states_visible_to_provider.map { |s| "'#{s}'" }.join(', ')})
+        WHERE application_choices.provider_ids && #{provider_ids_sql}
+          AND application_choices.status IN (#{states_sql})
       SQL
 
-      years = ActiveRecord::Base.connection
-        .execute(sql)
-        .map { |row| row['current_recruitment_cycle_year'].to_i }
+      years = connection
+        .exec_query(sql)
+        .rows
+        .flatten
+        .map(&:to_i)
 
       RecruitmentCycleYearsPresenter.call(
         start_year: years.min,
         end_year: years.max,
         with_current_indicator: true,
-      ).filter do |year, _label|
-        year.to_i.in? years
-      end
+      ).select { |year, _| year.to_i.in?(years) }
     end
 
     def providers_that_actor_belongs_to

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -19,25 +19,26 @@ module ProviderInterface
       user_provider_ids = providers_that_actor_belongs_to.pluck(:id)
       visible_states = ApplicationStateChange.states_visible_to_provider
 
-      connection = ApplicationRecord.connection
+      sql = ApplicationRecord.send(
+        :sanitize_sql_array,
+        [
+          <<~SQL,
+            SELECT DISTINCT ON (current_recruitment_cycle_year)
+                  current_recruitment_cycle_year
+            FROM application_choices
+            WHERE application_choices.provider_ids && ARRAY[:provider_ids]::bigint[]
+              AND application_choices.status IN (:states)
+          SQL
+          {
+            provider_ids: user_provider_ids,
+            states: visible_states,
+          },
+        ],
+      )
 
-      provider_ids_sql = "ARRAY[#{user_provider_ids.join(',')}]::bigint[]"
-
-      states_sql = visible_states.map { |state| connection.quote(state) }.join(', ')
-
-      sql = <<~SQL
-        SELECT DISTINCT ON (current_recruitment_cycle_year)
-              current_recruitment_cycle_year
-        FROM application_choices
-        WHERE application_choices.provider_ids && #{provider_ids_sql}
-          AND application_choices.status IN (#{states_sql})
-      SQL
-
-      years = connection
-        .exec_query(sql)
-        .rows
-        .flatten
-        .map(&:to_i)
+      years = ActiveRecord::Base.connection
+            .execute(sql)
+            .map { |row| row['current_recruitment_cycle_year'].to_i }
 
       RecruitmentCycleYearsPresenter.call(
         start_year: years.min,

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -44,7 +44,9 @@ module ProviderInterface
         start_year: years.min,
         end_year: years.max,
         with_current_indicator: true,
-      ).select { |year, _| year.to_i.in?(years) }
+      ).filter do |year, _label|
+        year.to_i.in? years
+      end
     end
 
     def providers_that_actor_belongs_to

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -16,11 +16,19 @@ module ProviderInterface
     end
 
     def years_to_export
-      choices = GetApplicationChoicesForProviders.call(
-        providers: providers_that_actor_belongs_to,
-        recruitment_cycle_year: RecruitmentCycleTimetable.pluck(:recruitment_cycle_year),
-      )
-      years = choices.map(&:current_recruitment_cycle_year).uniq
+      user_provider_ids = providers_that_actor_belongs_to.pluck(:id)
+
+      sql = <<~SQL
+        SELECT distinct on (current_recruitment_cycle_year) current_recruitment_cycle_year
+        FROM application_choices
+        WHERE application_choices.provider_ids && ARRAY[#{user_provider_ids.join(', ')}]::bigint[]
+        AND application_choices.status IN (#{ApplicationStateChange.states_visible_to_provider.map { |s| "'#{s}'" }.join(', ')})
+      SQL
+
+      years = ActiveRecord::Base.connection
+        .execute(sql)
+        .map { |row| row['current_recruitment_cycle_year'].to_i }
+
       RecruitmentCycleYearsPresenter.call(
         start_year: years.min,
         end_year: years.max,

--- a/spec/forms/provider_interface/application_data_export_form_spec.rb
+++ b/spec/forms/provider_interface/application_data_export_form_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationDataExportForm do
   context 'when there are application choices' do
     let(:provider) { create(:provider) }
-    let(:provider_user) { create(:provider_user, providers: [provider]) }
+    let(:provider_2) { create(:provider) }
+    let(:provider_3) { create(:provider) }
+    let(:provider_user) { create(:provider_user, providers: [provider, provider_2]) }
 
     let(:application_form) { create(:completed_application_form, :with_degree) }
     let!(:application_choice) do
@@ -12,6 +14,24 @@ RSpec.describe ProviderInterface::ApplicationDataExportForm do
         :offered,
         application_form: application_form,
         provider_ids: [provider.id],
+      )
+    end
+    let!(:application_choice_2) do
+      create(
+        :application_choice,
+        :withdrawn,
+        current_recruitment_cycle_year: 2025,
+        application_form: application_form,
+        provider_ids: [provider_2.id],
+      )
+    end
+    let!(:application_choice_3) do
+      create(
+        :application_choice,
+        :declined,
+        current_recruitment_cycle_year: 2024,
+        application_form: application_form,
+        provider_ids: [provider_3.id],
       )
     end
 
@@ -28,7 +48,8 @@ RSpec.describe ProviderInterface::ApplicationDataExportForm do
 
       years = form.years_to_export
 
-      expect(years.keys.map(&:to_i)).to include(application_choice.current_recruitment_cycle_year)
+      expect(years.keys.map(&:to_i)).to eq([application_choice.current_recruitment_cycle_year, application_choice_2.current_recruitment_cycle_year])
+      expect(years.keys.map(&:to_i)).not_to include(application_choice_3.current_recruitment_cycle_year)
     end
   end
 end

--- a/spec/forms/provider_interface/application_data_export_form_spec.rb
+++ b/spec/forms/provider_interface/application_data_export_form_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe ProviderInterface::ApplicationDataExportForm do
       years = form.years_to_export
 
       expect(years.keys.map(&:to_i)).to eq([application_choice.current_recruitment_cycle_year, application_choice_2.current_recruitment_cycle_year])
+    end
+
+    it 'returns only the years for the relevant providers' do
+      form = described_class.new(current_provider_user: provider_user)
+
+      years = form.years_to_export
+
       expect(years.keys.map(&:to_i)).not_to include(application_choice_3.current_recruitment_cycle_year)
     end
   end

--- a/spec/forms/provider_interface/application_data_export_form_spec.rb
+++ b/spec/forms/provider_interface/application_data_export_form_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationDataExportForm do
+  context 'when there are application choices' do
+    let(:provider) { create(:provider) }
+    let(:provider_user) { create(:provider_user, providers: [provider]) }
+
+    let(:application_form) { create(:completed_application_form, :with_degree) }
+    let!(:application_choice) do
+      create(
+        :application_choice,
+        :offered,
+        application_form: application_form,
+        provider_ids: [provider.id],
+      )
+    end
+
+    let!(:maths_gcse) do
+      create(:gcse_qualification, application_form:, subject: 'maths', grade: 'B', award_year: 2019)
+    end
+
+    let!(:english_gcse) do
+      create(:gcse_qualification, application_form:, subject: 'english', grade: 'A', award_year: 2019)
+    end
+
+    it 'returns only the years where there are application choices' do
+      form = described_class.new(current_provider_user: provider_user)
+
+      years = form.years_to_export
+
+      expect(years.keys.map(&:to_i)).to include(application_choice.current_recruitment_cycle_year)
+    end
+  end
+end


### PR DESCRIPTION
## Context

A large provider user got an Azure Front Door error when trying to export application data due to a query that mapped over all application choices to retrieve live application recruitment cycle years.

## Changes proposed in this pull request

- Replace the service with an SQL query 
- Add a spec

## Guidance to review

- Review the SQL query
- Log in as a provider user
- Visit the "Export application data" form 
- Make sure the years displayed match what you expected

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
