### PR TITLE
Add PTR restore and backup

### DIFF
--- a/.github/workflows/backup-db-via-ptr.yml
+++ b/.github/workflows/backup-db-via-ptr.yml
@@ -1,4 +1,4 @@
-name: Backup database to Azure storage
+name: Backup database via PTR to Azure storage
 
 on:
   workflow_dispatch:
@@ -22,6 +22,9 @@ on:
       db-server:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
+
+  schedule:
+    - cron: "50 5 * * *" # 05:50 UTC
 
 env:
   SERVICE_NAME: apply
@@ -78,8 +81,31 @@ jobs:
           BACKUP_FILE=${BACKUP_FILE}
         fi
         echo "BACKUP_FILE=${BACKUP_FILE}" >> $GITHUB_ENV
+        if [[ -n "${{ inputs.db-server }}" ]]; then
+          DB_SERVER="${{ inputs.db-server }}"
+        else
+          DB_SERVER="${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG}-psql"
+        fi
+        echo "DB_SERVER=${DB_SERVER}" >> $GITHUB_ENV
+
+        echo "NEW_DB_SERVER=${DB_SERVER}-temp-backup-ptr" >> $GITHUB_ENV
+        echo "RESTORE_TIME=$(date '+%FT%H:%M:%S')" >> $GITHUB_ENV
+
+    - name: Restore ${{ inputs.environment }} postgres
+      id: create_ptr
+      uses: DFE-Digital/github-actions/ptr-postgres@master
+      with:
+        resource-group: ${{ env.RESOURCE_GROUP_NAME }}
+        source-server: ${{ env.DB_SERVER }}
+        new-server: ${{ env.NEW_DB_SERVER }}
+        restore-time: ${{ env.RESTORE_TIME }}
+        cluster: ${{ env.CLUSTER }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Backup ${{ env.DEPLOY_ENV }} postgres
+      if: ${{ steps.create_ptr.outcome == 'success' }}
       uses: DFE-Digital/github-actions/backup-postgres@master
       with:
         storage-account: ${{ env.STORAGE_ACCOUNT_NAME }}
@@ -91,6 +117,11 @@ jobs:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         backup-file: ${{ env.BACKUP_FILE }}.sql
-        db-server-name: ${{ inputs.db-server }}
+        db-server-name: ${{ env.NEW_DB_SERVER }}
         teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
         service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+
+    - name: Delete Backup PTR
+      if: ${{ always() && steps.create_ptr.outcome == 'success' }}
+      run: |
+        az postgres flexible-server delete --resource-group ${{ env.RESOURCE_GROUP_NAME }} --name ${{ env.NEW_DB_SERVER }} --yes

--- a/.github/workflows/postgres-ptr.yml
+++ b/.github/workflows/postgres-ptr.yml
@@ -54,7 +54,7 @@ jobs:
         echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
         echo "RESOURCE_GROUP_NAME=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
 
-        DB_SERVER="${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-psql"
+        DB_SERVER="${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG}-psql"
         if [[ -n "${{ inputs.new-db-server }}" ]]; then
           NEW_DB_SERVER="${{ inputs.new-db-server }}"
         else


### PR DESCRIPTION
## Context

https://trello.com/c/ycuALlRU/2775-change-apply-backup-to-use-ptr

Overnight backup keeps failing, altering to create a PTR and backup that up instead before deleting it on assumption failure is related to size and load on the DB which should be relieved using a PTR.

## Changes proposed in this pull request

Add new Github workflow [Backup database via PTR to Azure storage](https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/backup-db-via-ptr.yml) to create PTR, then backup, then delete..

Update Github workflow [Backup database to Azure storage](https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/backup-db.yml), remove scheduled runs (now via PTR)

Update Github workflow [Restore database from point in time to new database server](https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/postgres-ptr.yml)[Restore database from point in time to new database server](https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/postgres-ptr.yml) to use full config name when building DB name.

## Guidance to review
See completed workflows for various scenarios:

#### Normal behaviour: PTR Created, backup completed, PTR deleted
https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/25549160774

#### Exception, we've create a PTR but something has failed in the backup but we still want to delete the PTR we created.
PTR Created, error backing up (due to existing backup file)
The created PTR is removed: https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/25553307897/job/75006160236

#### Exception, creating the PTR has failed, eg PTR already exists, no attempt should be made to delete PTR's we didnt create.
Simulated PTR failure, no attempt to remove any PTR as we did not create it: https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/25554707200

