### PR TITLE
Change date we start looking for next year published courses

### DIFF
--- a/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
+++ b/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
@@ -3,7 +3,7 @@ module EndOfCycle
     include Sidekiq::Worker
 
     def first_full_sync_after
-      start_syncing_after = 8.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
+      start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
       start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?
       start_syncing_after
     end

--- a/spec/workers/end_of_cycle/next_year_full_sync_spec.rb
+++ b/spec/workers/end_of_cycle/next_year_full_sync_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
 
     context 'before full sync start start time' do
       it 'does not enqueue the job' do
-        start_syncing_after = 8.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
+        start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
         start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?
 
         travel_temporarily_to(1.minute.before(start_syncing_after)) do
@@ -34,7 +34,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
 
     context 'after the full sync start time' do
       it 'enqueues the job with the expected arguments' do
-        start_syncing_after = 8.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
+        start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
         start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?
 
         travel_temporarily_to(1.minute.after(start_syncing_after)) do

--- a/spec/workers/end_of_cycle/next_year_incremental_sync_spec.rb
+++ b/spec/workers/end_of_cycle/next_year_incremental_sync_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
 
     context 'before full sync start start time' do
       it 'does not enqueue the job' do
-        start_syncing_after = 8.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
+        start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
         start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?
 
         travel_temporarily_to(1.minute.before(start_syncing_after)) do
@@ -34,7 +34,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
 
     context 'after the full sync start time' do
       it 'enqueues the job with the expected arguments' do
-        start_syncing_after = 8.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
+        start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
         start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?
 
         travel_temporarily_to(1.minute.after(start_syncing_after)) do


### PR DESCRIPTION
## Context

I discussed rollover with Publish Tech lead, and rollover is not going to happen as early as july this year. So just changing the initial sync to a couple of weeks before the 2026 deadline instead of 2 months before. 

## Changes proposed in this pull request


## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
