### PR TITLE
Configure mission control for SolidQueue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,3 +201,4 @@ gem 'jsbundling-rails', '~> 1.3'
 gem 'propshaft', '~> 1.3'
 
 gem 'solid_queue', '~> 1.4'
+gem 'mission_control-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,6 +397,10 @@ GEM
     humanize (3.1.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    importmap-rails (2.2.3)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.8.2)
     io-like (0.4.0)
     irb (1.18.0)
@@ -459,10 +463,19 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     multi_json (1.20.1)
     multi_xml (0.6.0)
     multipart-post (2.4.1)
@@ -780,6 +793,8 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
     stoplight (3.0.2)
       redlock (~> 1.0)
     stringio (3.2.0)
@@ -804,6 +819,9 @@ GEM
     timeout (0.6.1)
     trailblazer-option (0.1.2)
     tsort (0.2.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2026.2)
@@ -929,6 +947,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.11)
   mail-notify
+  mission_control-jobs
   notifications-ruby-client
   oj
   okcomputer
@@ -1123,6 +1142,7 @@ CHECKSUMS
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   humanize (3.1.0) sha256=cbcc371a885bd661239d1e7a0cd192bc6e5f090b43973bae38ed5bfe57913bbe
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  importmap-rails (2.2.3)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-like (0.4.0) sha256=808994312907b3d59c548e75215183ccd950e63101ad08800c4df4188a2a0211
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
@@ -1146,8 +1166,8 @@ CHECKSUMS
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  mission_control-jobs (1.1.0)
   multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
   multi_xml (0.6.0) sha256=d24393cf958adb226db884b976b007914a89c53ad88718e25679d7008823ad52
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
@@ -1270,6 +1290,7 @@ CHECKSUMS
   smart_properties (1.17.0) sha256=f9323f8122e932341756ddec8e0ac9ec6e238408a7661508be99439ca6d6384b
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
   solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a
+  stimulus-rails (1.3.4)
   stoplight (3.0.2) sha256=9bc2697a9c380aa6d8380d820c2663bda50cee3a9680a256ea035f8cf0e918ee
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   strip_attributes (2.0.1) sha256=604cb833fc69aedefffc60a79bd91a7faf3753caf34db3889beaf2d88afa7e8b
@@ -1283,6 +1304,7 @@ CHECKSUMS
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  turbo-rails (2.0.23)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   tzinfo-data (1.2026.2) sha256=7db0d3d3d53b8d7601fc183fccc8c6d056a3004e14eb59ea995bf6aec4ae10bc
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,6 +76,9 @@ module ApplyForPostgraduateTeacherTraining
 
     config.active_job.queue_adapter = :sidekiq
 
+    config.mission_control.jobs.adapters = [ :solid_queue ]
+    config.mission_control.jobs.http_basic_auth_enabled = false
+
     config.action_controller.perform_caching = true
     config.cache_store = :memory_store
 

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -323,6 +323,7 @@ namespace :support_interface, path: '/support' do
   mount SupportInterface::RackApp.new(Sidekiq::Web) => '/sidekiq', as: :sidekiq
   mount SupportInterface::RackApp.new(Blazer::Engine) => '/blazer', as: :blazer
   mount SupportInterface::RackApp.new(FieldTest::Engine) => '/field-test', as: :field_test
+  mount SupportInterface::RackApp.new(MissionControl::Jobs::Engine) => '/jobs', as: :jobs
 
   get '*path', to: 'errors#not_found'
 end

--- a/spec/config/routes_spec.rb
+++ b/spec/config/routes_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe 'routes.rb' do
 
     paths.each do |path|
       next if path.starts_with?('/rails')
+      next if path == '/recede_historical_location(.:format)'
+      next if path == '/resume_historical_location(.:format)'
+      next if path == '/refresh_historical_location(.:format)'
       next if path == '/_system_test_entrypoint(.:format)'
 
       has_underscores = path.split('/').any? { |component| !component.start_with?(':') && component.match('_') }


### PR DESCRIPTION
## Context

We introduced SolidQueue in #11893. Mission control is a dashboard to monitor worker/job performance as we gradually move them to SolidQueue.

## Changes proposed in this pull request

- Add the mission control gem
- Add a route to view the dashboard to the Support interface (therefore no specific mission control auth needed)

## Guidance to review

- Visit `/support/jobs` to view the dashboards
- Give view regarding whether setting `config.mission_control.jobs.http_basic_auth_enabled` to `false` is sufficient given its place in the Support interface

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
