### PR TITLE
Remove mid-cycle cap feature flag

### DIFF
--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -12,17 +12,10 @@ module ChoiceLimitsCalculator
   end
 
   def limits
-    @limits ||= if mid_cycle_cap_applies?
-                  Limits.new(
-                    unsuccessful_retry_limit: MID_CYCLE_UNSUCCESSFUL_RETRY_LIMIT,
-                    in_progress_limit: IN_PROGRESS_LIMIT,
-                  )
-                else
-                  Limits.new(
-                    unsuccessful_retry_limit: UNSUCCESSFUL_RETRY_LIMIT,
-                    in_progress_limit: IN_PROGRESS_LIMIT,
-                  )
-                end
+    @limits ||= Limits.new(
+      unsuccessful_retry_limit: UNSUCCESSFUL_RETRY_LIMIT,
+      in_progress_limit: IN_PROGRESS_LIMIT,
+    )
   end
 
   def unsuccessful_count
@@ -63,12 +56,6 @@ module ChoiceLimitsCalculator
 
   def in_progress_limit_reached?
     in_progress_count >= in_progress_limit
-  end
-
-  def mid_cycle_cap_applies?
-    FeatureFlag.active?(:mid_cycle_cap) &&
-      # The cap only applies to people who were unsubmitted at the time the cap was introduced
-      (submitted_at.nil? || submitted_at.after?(FeatureFlag.activated_at(:mid_cycle_cap)))
   end
 
   def can_add_more_choices?

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -67,35 +67,14 @@ class Pool::Candidates
                                                                 .where('pool_invite_decline_reasons.reason ILIKE ?', '%no_longer_interested%')
 
     # Subquery: To include only those forms who have not used all their application slows
-    if FeatureFlag.active?(:mid_cycle_cap)
-      active_date = FeatureFlag.activated_at(:mid_cycle_cap)
-      forms_with_available_slots_with_restriction = current_cycle_forms
-                                                      .where('submitted_at > ?', active_date)
-                                                      .joins(:application_choices)
-                                                      .group(:id)
-                                                      .having("COUNT(DISTINCT application_choices.id) < #{ApplicationForm::IN_PROGRESS_LIMIT}")
-                                                      .select(:id)
-
-      forms_with_available_slots_without_restriction = current_cycle_forms
-                                                         .where('submitted_at < ?', active_date)
-                                                         .joins(:application_choices)
-                                                         .where(application_choices: {
-                                                           status: ApplicationStateChange::UNSUCCESSFUL_STATES,
-                                                         })
-                                                         .group(:id)
-                                                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-                                                         .select(:id)
-      forms_with_available_slots = forms_with_available_slots_with_restriction + forms_with_available_slots_without_restriction
-    else
-      forms_with_available_slots = current_cycle_forms
-                           .joins(:application_choices)
-                           .where(application_choices: {
-                             status: ApplicationStateChange::UNSUCCESSFUL_STATES,
-                           })
-                           .group(:id)
-                           .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-                           .select(:id)
-    end
+    forms_with_available_slots = current_cycle_forms
+                         .joins(:application_choices)
+                         .where(application_choices: {
+                           status: ApplicationStateChange::UNSUCCESSFUL_STATES,
+                         })
+                         .group(:id)
+                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
+                         .select(:id)
 
     # Final query
     current_cycle_forms

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,7 +29,6 @@ class FeatureFlag
     [:api_token_management, 'Allow provider users to manage their own api tokens', 'Apply team'],
     [:ms_clarity, 'Record sessions with MS Clarity'],
     [:import_non_disclosure_trainee_withdrawals, 'Import Non-disclosure data from BigQuery to generate Possible Previous Teacher Training records', 'Apply team'],
-    [:mid_cycle_cap, 'For implementing a cap on applications', 'Apply team'],
     [:interview_handling, 'Allow provider users to state whether or not interview scheduling is handled outside of the Manage service.', 'Apply team'],
     ['2027_application_form_has_many_english_proficiencies', 'Change application form association from has one english proficiency to has many english proficiencies', 'Apply team'],
     ['2027_visa_expiry', 'Collect visa expiry dates for candidates', 'Apply team'],

--- a/spec/components/candidate_interface/applications_left_message_component_spec.rb
+++ b/spec/components/candidate_interface/applications_left_message_component_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent do
   let(:application_form) { create(:application_form) }
 
-  before { FeatureFlag.activate(:mid_cycle_cap) }
-
   subject(:message) do
     render_inline(described_class.new(application_form)).text
   end
@@ -26,17 +24,13 @@ RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent do
   context 'when submitted' do
     let(:application_form) { create(:application_form, :submitted) }
 
-    context 'when some applications are submitted and some unsuccessfull' do
+    context 'when some applications are submitted and some unsuccessful' do
       it 'returns message of how many more can be added' do
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :rejected, application_form:)
         create(:application_choice, :inactive, application_form:)
-        if application_form.mid_cycle_cap_applies?
-          expect(message).to include('You cannot add any more applications')
-        else
-          expect(message).to include('You can submit 2 more applications.')
-        end
+        expect(message).to include('You can submit 2 more applications.')
       end
     end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_withdrawn_spec.rb
@@ -48,8 +48,19 @@ RSpec.describe CandidateMailer do
     context 'mid cycle', time: mid_cycle do
       let(:recruitment_cycle_year) { current_year }
 
-      context 'without mid cycle cap' do
-        before { FeatureFlag.deactivate(:mid_cycle_cap) }
+      it_behaves_like(
+        'a mail with subject and content',
+        'Offer withdrawn by Arithmetic College',
+        'greeting' => 'Dear Fred',
+        'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
+        'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
+        'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+      )
+
+      context 'with a course recommendation url' do
+        let(:email) { described_class.offer_withdrawn(application_form.application_choices.first, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
 
         it_behaves_like(
           'a mail with subject and content',
@@ -60,60 +71,9 @@ RSpec.describe CandidateMailer do
           'withdrawal reason' => 'You lied to us about secretly being Spiderman',
           'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+          'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
+          'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
         )
-      end
-
-      context 'with the mid cycle cap' do
-        before { FeatureFlag.activate(:mid_cycle_cap) }
-
-        it_behaves_like(
-          'a mail with subject and content',
-          'Offer withdrawn by Arithmetic College',
-          'greeting' => 'Dear Fred',
-          'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
-          'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
-          'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-          'realistic job preview' => 'Try the realistic job preview tool',
-          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-        )
-      end
-
-      context 'with a course recommendation url' do
-        let(:email) { described_class.offer_withdrawn(application_form.application_choices.first, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
-
-        context 'without mid-cycle cap' do # rubocop:disable RSpec/NestedGroups
-          before { FeatureFlag.deactivate(:mid_cycle_cap) }
-
-          it_behaves_like(
-            'a mail with subject and content',
-            'Offer withdrawn by Arithmetic College',
-            'greeting' => 'Dear Fred',
-            'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
-            'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
-            'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-            'realistic job preview' => 'Try the realistic job preview tool',
-            'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-            'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
-            'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
-          )
-        end
-
-        context 'with mid-cycle cap' do # rubocop:disable RSpec/NestedGroups
-          before { FeatureFlag.activate(:mid_cycle_cap) }
-
-          it_behaves_like(
-            'a mail with subject and content',
-            'Offer withdrawn by Arithmetic College',
-            'greeting' => 'Dear Fred',
-            'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
-            'offer details' => 'Arithmetic College has withdrawn their offer for you to study Mathematics (M101)',
-            'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-            'realistic job preview' => 'Try the realistic job preview tool',
-            'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-            'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
-            'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
-          )
-        end
       end
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_withdraw_last_application_choice_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
-  describe '.withdraw_last_application_choice with mid_cycle_cap feature flag inactive' do
-    before { FeatureFlag.deactivate(:mid_cycle_cap) }
-
+  describe '.withdraw_last_application_choice' do
     let(:recruitment_cycle_year) { current_year }
     let(:application_form_with_references) do
       create(:application_form, first_name: 'Fred',
@@ -48,81 +46,6 @@ RSpec.describe CandidateMailer do
           'You have withdrawn your application',
           'heading' => 'Hello Fred',
           'still interested' => 'If now’s the right time for you, you can still apply for up to 4 more courses this year.',
-          'application_withdrawn' => 'You have withdrawn your application',
-          'realistic job preview' => 'Try the realistic job preview tool',
-          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-          'course recommendation' => 'Based on the details in your previous application, you could be suitable for other teacher training courses.',
-          'course recommendation link' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
-        )
-      end
-    end
-
-    context 'between cycles, before find opens', time: after_apply_deadline(2024) do
-      it_behaves_like(
-        'a mail with subject and content',
-        'You have withdrawn your application',
-        'heading' => 'Hello Fred',
-        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
-        'when to apply again' => 'submit from 9am UK time on 8 October 2024',
-      )
-    end
-
-    context 'between cycles, before apply reopens', time: after_find_opens(2025) do
-      it_behaves_like(
-        'a mail with subject and content',
-        'You have withdrawn your application',
-        'heading' => 'Hello Fred',
-        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
-        'when to apply again' => 'submit from 9am UK time on 8 October 2024',
-      )
-    end
-  end
-
-  describe '.withdraw_last_application_choice mid_cycle_cap feature flag active' do
-    before { FeatureFlag.activate(:mid_cycle_cap) }
-
-    let(:recruitment_cycle_year) { current_year }
-    let(:application_form_with_references) do
-      create(:application_form, first_name: 'Fred',
-                                recruitment_cycle_year: recruitment_cycle_year,
-                                application_choices: application_choices,
-                                application_references: [referee1, referee2])
-    end
-    let(:referee1) { create(:reference, name: 'Jenny', feedback_status: :feedback_requested) }
-    let(:referee2) { create(:reference, name: 'Luke',  feedback_status: :feedback_requested) }
-    let(:email) { described_class.withdraw_last_application_choice(application_form_with_references) }
-
-    let(:application_choices) { [create(:application_choice, status: 'withdrawn')] }
-
-    context 'mid cycle', time: mid_cycle do
-      it_behaves_like(
-        'a mail with subject and content',
-        'You have withdrawn your application',
-        'heading' => 'Hello Fred',
-        'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
-        'application_withdrawn' => 'You have withdrawn your application',
-        'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-      )
-
-      context 'when a candidate has 2 or 3 offers that were withdrawn' do
-        let(:application_choices) { [create(:application_choice, :withdrawn), create(:application_choice, :withdrawn)] }
-
-        it_behaves_like(
-          'a mail with subject and content',
-          'You have withdrawn your applications',
-          'application_withdrawn' => 'You have withdrawn your application',
-        )
-      end
-
-      context 'with a course recommendation url' do
-        let(:email) { described_class.withdraw_last_application_choice(application_form_with_references, 'https://www.find-postgraduate-teacher-training.service.gov.uk/results') }
-
-        it_behaves_like(
-          'a mail with subject and content',
-          'You have withdrawn your application',
-          'heading' => 'Hello Fred',
-          'still interested' => 'If now’s the right time for you, you can still apply for up to 3 more courses this year.',
           'application_withdrawn' => 'You have withdrawn your application',
           'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -1,193 +1,87 @@
 require 'rails_helper'
 
 RSpec.describe ChoiceLimitsCalculator do
-  context 'midcycle feature flag on' do
-    before { FeatureFlag.activate(:mid_cycle_cap) }
+  describe '#limits' do
+    it 'the cap is applied to all applications' do
+      previously_submitted_limits = create(:application_form, submitted_at: 1.day.ago).limits
+      future_submitted_new_limits = create(:application_form, submitted_at: 1.day.from_now).limits
+      unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
 
-    describe '#limits' do
-      it 'the cap is applied to new applications' do
-        previously_submitted_limits = create(:application_form, submitted_at: 1.day.ago).limits
-        future_submitted_new_limits = create(:application_form, submitted_at: 1.day.from_now).limits
-        unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
-
-        expect(previously_submitted_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
-        expect(previously_submitted_limits.total_application_limit).to eq 19
-
-        expect(unsubmitted_new_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 0, in_progress_limit: 4 })
-        expect(unsubmitted_new_limits.total_application_limit).to eq 4
-
-        expect(future_submitted_new_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 0, in_progress_limit: 4 })
-        expect(future_submitted_new_limits.total_application_limit).to eq 4
-      end
-    end
-
-    describe '#maximum_number_of_choices_reached?' do
-      it 'only allows 4 unsuccessful applications' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :withdrawn, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
-
-        create(:application_choice, :withdrawn, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
-
-      it 'only allows 4 in progress applications' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
-
-        create(:application_choice, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
-
-      it 'only allows 4 total submitted applications, regardless of state' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
-
-        create(:application_choice, :rejected, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
-    end
-
-    describe '#number_of_slots_left' do
-      it 'only allows 4 draft slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
-
-        create(:application_choice, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
-
-      it 'only allows 4 in progress slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
-
-        create(:application_choice, :interviewing, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
-
-      it 'only allows 4 unsuccessful slots total' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :withdrawn, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
-
-        create(:application_choice, :rejected, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
-
-      it 'only allows 4 submitted slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 2, :withdrawn, application_form:)
-        create(:application_choice, :interviewing, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
-
-        create(:application_choice, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
-
-      it 'only allows more choices if the total of 4 slots in progress and draft' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 2, :awaiting_provider_decision, application_form:)
-        create(:application_choice, :interviewing, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
-
-        create(:application_choice, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
+      expect(previously_submitted_limits.to_h)
+        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+      expect(unsubmitted_new_limits.to_h)
+        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+      expect(future_submitted_new_limits.to_h)
+        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
     end
   end
 
-  context 'midcycle feature flag off' do
-    before { FeatureFlag.deactivate(:mid_cycle_cap) }
+  describe '#maximum_number_of_choices_reached?' do
+    it 'only allows 15 unsuccessful applications' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 14, :withdrawn, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be false
 
-    describe '#limits' do
-      it 'the cap is applied to all applications' do
-        previously_submitted_limits = create(:application_form, submitted_at: 1.day.ago).limits
-        future_submitted_new_limits = create(:application_form, submitted_at: 1.day.from_now).limits
-        unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
-
-        expect(previously_submitted_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
-        expect(unsubmitted_new_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
-        expect(future_submitted_new_limits.to_h)
-          .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
-      end
+      create(:application_choice, :withdrawn, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be true
     end
 
-    describe '#maximum_number_of_choices_reached?' do
-      it 'only allows 15 unsuccessful applications' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 14, :withdrawn, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
+    it 'only allows 4 in progress applications' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be false
 
-        create(:application_choice, :withdrawn, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
-
-      it 'only allows 4 in progress applications' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
-
-        create(:application_choice, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
-
-      it 'only allows 19 total submitted applications, regardless of state' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        create_list(:application_choice, 14, :rejected, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be false
-
-        create_list(:application_choice, 2, :rejected, application_form:)
-        expect(application_form.reload.cannot_submit_more_choices?).to be true
-      end
+      create(:application_choice, :awaiting_provider_decision, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be true
     end
 
-    describe '#number_of_slots_left' do
-      it 'only allows 4 draft slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
+    it 'only allows 19 total submitted applications, regardless of state' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+      create_list(:application_choice, 14, :rejected, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be false
 
-        create(:application_choice, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
+      create_list(:application_choice, 2, :rejected, application_form:)
+      expect(application_form.reload.cannot_submit_more_choices?).to be true
+    end
+  end
 
-      it 'only allows 4 in progress slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
+  describe '#number_of_slots_left' do
+    it 'only allows 4 draft slots' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 3, :unsubmitted, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 1
 
-        create(:application_choice, :interviewing, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
+      create(:application_choice, :unsubmitted, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 0
+    end
 
-      it 'allows 15 unsuccessful before reducing slots' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 15, :withdrawn, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 4
+    it 'only allows 4 in progress slots' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 1
 
-        create(:application_choice, :rejected, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 3
-      end
+      create(:application_choice, :interviewing, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 0
+    end
 
-      it 'only allows more choices if the total of 4 slots in progress and draft' do
-        application_form = create(:application_form)
-        create_list(:application_choice, 2, :awaiting_provider_decision, application_form:)
-        create(:application_choice, :interviewing, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 1
+    it 'allows 15 unsuccessful before reducing slots' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 15, :withdrawn, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 4
 
-        create(:application_choice, :unsubmitted, application_form:)
-        expect(application_form.reload.number_of_slots_left).to eq 0
-      end
+      create(:application_choice, :rejected, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 3
+    end
+
+    it 'only allows more choices if the total of 4 slots in progress and draft' do
+      application_form = create(:application_form)
+      create_list(:application_choice, 2, :awaiting_provider_decision, application_form:)
+      create(:application_choice, :interviewing, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 1
+
+      create(:application_choice, :unsubmitted, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 0
     end
   end
 end

--- a/spec/models/pool/candidates_spec.rb
+++ b/spec/models/pool/candidates_spec.rb
@@ -172,23 +172,4 @@ RSpec.describe Pool::Candidates do
       expect(application_forms).to be_empty
     end
   end
-
-  describe '#application_forms_in_the_pool, when mid_cycle_cap has applied' do
-    it 'applies different application choices limits based on submission date' do
-      FeatureFlag.deactivate(:mid_cycle_cap)
-      no_mid_cycle_cap = create(:application_form, :submitted, submitted_at: 2.minutes.ago)
-      create(:candidate_preference, application_form: no_mid_cycle_cap)
-      create_list(:application_choice, 4, :rejected, application_form: no_mid_cycle_cap)
-
-      FeatureFlag.activate(:mid_cycle_cap)
-      yes_mid_cycle_cap = create(:application_form, :submitted, submitted_at: 1.minute.from_now)
-      create(:candidate_preference, application_form: yes_mid_cycle_cap)
-      create_list(:application_choice, 4, :rejected, application_form: yes_mid_cycle_cap)
-
-      application_forms = described_class.new.application_forms_in_the_pool
-
-      expect(application_forms).to include(no_mid_cycle_cap)
-      expect(application_forms).not_to include(yes_mid_cycle_cap)
-    end
-  end
 end


### PR DESCRIPTION
## Context

We no longer need the mid-cycle cap feature flag, it is been decided not to implement this .

## Changes proposed in this pull request

Removal of feature flag and conditional code related to the mid-cycle cap

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
