### PR TITLE
Scale database in preparation for migrating away from Redis

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -15,7 +15,7 @@
   "worker_replicas": 2,
   "secondary_worker_replicas": 2,
   "clock_worker_replicas": 1,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,
   "redis_queue_sku_name": "Premium",


### PR DESCRIPTION
## Context

Before we deploy code that will start to move jobs / cache to redis, we want to scale the database and be able to monitor the impact.

On advice from Rick, we will

- Scale from `GP_Standard_D2ds_v4` to `GP_Standard_D4ds_v5` This takes us from `2vcpu` → `4vcpu` (plus 15% cpu performance improvement) AND 8g → 16g.
- After each incremental change to caching / queuing, monitor increases
- If, when we get the whole thing in, the changes haven’t made a massive impact on our db, we can scale back down (but scale up, as usual during peak times)

## Changes proposed in this pull request

This should not be merged until the maintenance page has been deployed at 7am on Thursday morning as it will cause some down time.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
