### PR TITLE
Remove postgress service from backup workflow

### DIFF
--- a/.github/workflows/backup-db-via-ptr.yml
+++ b/.github/workflows/backup-db-via-ptr.yml
@@ -38,16 +38,6 @@ jobs:
   backup:
     name: Backup database
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     environment:
       name: ${{ inputs.environment || 'production' }}
     env:


### PR DESCRIPTION
## Context
Overnight backup for [apply-for-teacher-training](https://github.com/DFE-Digital/apply-for-teacher-training) is intermittently failing on PGDump, removing redundant Postgress service load which may help and step is redundant anyway.

https://trello.com/c/ycuALlRU/2775-change-apply-backup-to-use-ptr

## Changes proposed in this pull request
Remove Postgres service element

## Guidance to review
Review test runs against this action:
https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/25852892020

