### PR TITLE
Increase SQ memory in production from 1Gi to 2Gi

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -10,6 +10,7 @@
   "webapp_memory_max": "3Gi",
   "worker_memory_max": "2Gi",
   "secondary_worker_memory_max": "2Gi",
+  "solid_queue_worker_memory_max": "2Gi",
   "clock_worker_memory_max": "1Gi",
   "webapp_replicas": 4,
   "worker_replicas": 2,


### PR DESCRIPTION
## Context

We are seeing spikes in Grafana for the single SolidQueue worker that is currently in production. It uses 3 threads (+ 2) and 2 processes. We want to see if increasing memory resolves the issue in production. 

Next, we will reduce the number of processes running in non-prod environments, such as QA, sandbox, and staging.

As we scale up the queues and jobs we are assigning to SolidQueue, we should carefully consider the resourcing for each pod. 

## Changes proposed in this pull request

- Override the default `secondary_worker_memory_max` value set in `variables.tf` (1Gi) to 2Gi for production.

## Guidance to review

- Compare the change with the default variable set in `variables.tf` and check that the change is as expected
- Check that merging this change will not impact on other processes

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
