### PR TITLE
Add initial queues and prepare first frequent jobs for migration

### DIFF
--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -43,6 +43,6 @@ class GenerateCandidatePoolData
     end
     CandidateLocationPreference.insert_all(location_preference_attrs)
 
-    FindACandidate::PopulatePoolWorker.perform_later
+    FindACandidate::PopulatePoolWorker.perform_now
   end
 end

--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -43,6 +43,6 @@ class GenerateCandidatePoolData
     end
     CandidateLocationPreference.insert_all(location_preference_attrs)
 
-    FindACandidate::PopulatePoolWorker.perform_sync
+    FindACandidate::PopulatePoolWorker.perform_later
   end
 end

--- a/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
+++ b/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
@@ -1,6 +1,9 @@
 class Candidate::DeleteDraftCandidatePreferencesWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
+
   def perform
     CandidatePreference.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
+++ b/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
@@ -3,7 +3,6 @@ class Candidate::DeleteDraftCandidatePreferencesWorker < ApplicationJob
 
   queue_as :low_priority
 
-
   def perform
     CandidatePreference.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
+++ b/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
@@ -1,6 +1,8 @@
 class Candidate::DeleteDraftWithdrawalReasonRecordsWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     WithdrawalReason.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/app/workers/delete_all_drafts_worker.rb
+++ b/app/workers/delete_all_drafts_worker.rb
@@ -1,6 +1,8 @@
 class DeleteAllDraftsWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     Candidate::DeleteDraftWithdrawalReasonRecordsWorker.perform_later
     Provider::DeleteDraftPoolInvitesWorker.perform_later

--- a/app/workers/delete_finished_jobs_worker.rb
+++ b/app/workers/delete_finished_jobs_worker.rb
@@ -1,6 +1,8 @@
 class DeleteFinishedJobsWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)
   end

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -1,7 +1,7 @@
-class FindACandidate::PopulatePoolWorker
-  include Sidekiq::Worker
+class FindACandidate::PopulatePoolWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
-  sidekiq_options queue: :default
+  queue_as :default
 
   def perform
     if CandidatePoolApplication.closed?

--- a/app/workers/process_stale_applications_worker.rb
+++ b/app/workers/process_stale_applications_worker.rb
@@ -1,5 +1,7 @@
-class ProcessStaleApplicationsWorker
-  include Sidekiq::Worker
+class ProcessStaleApplicationsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
+  queue_as :default
 
   def perform
     ProcessStaleApplications.new.call

--- a/app/workers/provider/delete_draft_pool_invites_worker.rb
+++ b/app/workers/provider/delete_draft_pool_invites_worker.rb
@@ -1,6 +1,8 @@
 class Provider::DeleteDraftPoolInvitesWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     Pool::Invite.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -15,7 +15,7 @@ class Clock
   end
 
   every(10.minutes, 'FindACandidate::PopulatePoolWorker', skip_first_run: true) do
-    FindACandidate::PopulatePoolWorker.perform_async
+    FindACandidate::PopulatePoolWorker.perform_later
   end
 
   # Hourly jobs
@@ -23,7 +23,7 @@ class Clock
   every(1.hour, 'FindACandidate::PoolInviteChaserWorker', at: '**:35', skip_first_run: true) { FindACandidate::PoolInviteChaserWorker.perform_async }
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async }
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
-    ProcessStaleApplicationsWorker.perform_async
+    ProcessStaleApplicationsWorker.perform_later
   end
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
   every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -20,42 +20,11 @@ default: &default
       processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
       polling_interval: 2
 
-non_production: &non_production
-  workers:
-    - queues: [default]
-      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
-      polling_interval: 0.5
-
-    - queues: [big_query]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 1
-
-    - queues: [mailers]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 1
-
-    - queues: [low_priority]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 2
-
-review:
-  <<: *non_production
-
-staging:
-  <<: *non_production
-
-sandbox:
-  <<: *non_production
-
 development:
-  <<: *non_production
+  <<: *default
 
 test:
-  <<: *non_production
+  <<: *default
 
 production:
   <<: *default

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,17 +3,7 @@ default: &default
     - queues: [default]
       threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 1) %>
       processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
-      polling_interval: 0.5
-
-    - queues: [big_query]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 1
-
-    - queues: [mailers]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 1
+      polling_interval: 2
 
     - queues: [low_priority]
       threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -7,24 +7,24 @@ default: &default
     - queues: [default]
       threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
       processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 2) %>
-      polling_interval: 0.1
+      polling_interval: 0.5
 
     - queues: [low_priority]
       threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
       processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 2) %>
-      polling_interval: 0.1
+      polling_interval: 0.5
 
 non_production: &non_production
   workers:
     - queues: [default]
       threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
       processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
 
     - queues: [low_priority]
       threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
       processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
 
 review:
   <<: *non_production

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,30 +1,46 @@
 default: &default
-  dispatchers:
-    - polling_interval: 1
-      batch_size: 500
-
   workers:
     - queues: [default]
-      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
-      processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 2) %>
+      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
       polling_interval: 0.5
 
+    - queues: [big_query]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
+      polling_interval: 1
+
+    - queues: [mailers]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
+      polling_interval: 1
+
     - queues: [low_priority]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
-      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 2) %>
-      polling_interval: 0.5
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
+      polling_interval: 2
 
 non_production: &non_production
   workers:
     - queues: [default]
-      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
+      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 1) %>
       processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
+      polling_interval: 0.5
+
+    - queues: [big_query]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
+      polling_interval: 1
+
+    - queues: [mailers]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
       polling_interval: 1
 
     - queues: [low_priority]
-      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 1) %>
       processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
-      polling_interval: 1
+      polling_interval: 2
 
 review:
   <<: *non_production

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -2,17 +2,44 @@ default: &default
   dispatchers:
     - polling_interval: 1
       batch_size: 500
+
   workers:
-    - queues: "*"
-      threads: <%= ENV.fetch("SOLIDQUEUE_THREADS", 3) %>
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 2) %>
+    - queues: [default]
+      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
+      processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 2) %>
       polling_interval: 0.1
 
+    - queues: [low_priority]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 2) %>
+      polling_interval: 0.1
+
+non_production: &non_production
+  workers:
+    - queues: [default]
+      threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 3) %>
+      processes: <%= ENV.fetch("DEFAULT_QUEUE_PROCESSES", 1) %>
+      polling_interval: 0.1
+
+    - queues: [low_priority]
+      threads: <%= ENV.fetch("LOW_PRIORITY_QUEUE_THREADS", 2) %>
+      processes: <%= ENV.fetch("LOW_PRIORITY_QUEUE_PROCESSES", 1) %>
+      polling_interval: 0.1
+
+review:
+  <<: *non_production
+
+staging:
+  <<: *non_production
+
+sandbox:
+  <<: *non_production
+
 development:
-  <<: *default
+  <<: *non_production
 
 test:
-  <<: *default
+  <<: *non_production
 
 production:
   <<: *default

--- a/spec/models/provider_interface/candidate_invites_filter_spec.rb
+++ b/spec/models/provider_interface/candidate_invites_filter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ProviderInterface::CandidateInvitesFilter do
     second_invite_with_candidate_in_pool
     declined_invite
 
-    FindACandidate::PopulatePoolWorker.new.perform
+    FindACandidate::PopulatePoolWorker.new.perform_now
   end
 
   context 'user does not have saved filters and no filter_params provided' do

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Candidate with submitted applications' do
 
   def when_one_of_my_applications_becomes_inactive
     travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_async
+      ProcessStaleApplicationsWorker.perform_later
     end
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -20,16 +20,19 @@ RSpec.describe 'Candidate with submitted applications' do
   end
 
   def and_i_have_submitted_applications
-    current_candidate.application_forms << build(:application_form, :completed)
-    current_candidate.current_application.application_choices << build_list(:application_choice, 4, :awaiting_provider_decision, sent_to_provider_at: 1.day.ago)
+    current_candidate.application_forms << create(:application_form, :completed)
+
+    current_candidate.current_application.application_choices <<
+      create_list(:application_choice, 4,
+                  :awaiting_provider_decision,
+                  sent_to_provider_at: 1.day.ago)
+
     @application_choice = current_candidate.current_application.application_choices.last
-    @application_choice.update(reject_by_default_at: Time.zone.now)
+    @application_choice.update!(reject_by_default_at: 1.minute.ago)
   end
 
   def when_one_of_my_applications_becomes_inactive
-    travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_later
-    end
+    ProcessStaleApplicationsWorker.perform_now
   end
 
   def then_i_can_see_the_change_in_content

--- a/spec/system/inactive_application_spec.rb
+++ b/spec/system/inactive_application_spec.rb
@@ -37,9 +37,7 @@ RSpec.describe 'Process Stale applications', :sidekiq do
   end
 
   def when_we_process_stale_applications
-    travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_later
-    end
+    ProcessStaleApplicationsWorker.perform_now
   end
 
   def then_the_application_is_inactive

--- a/spec/system/inactive_application_spec.rb
+++ b/spec/system/inactive_application_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Process Stale applications', :sidekiq do
 
   def when_we_process_stale_applications
     travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_async
+      ProcessStaleApplicationsWorker.perform_later
     end
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_views_invited_candidates_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_views_invited_candidates_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Invited candidate list' do
     invite_with_candidate_in_pool
     second_invite_with_candidate_in_pool
 
-    FindACandidate::PopulatePoolWorker.new.perform
+    FindACandidate::PopulatePoolWorker.new.perform_now
   end
 
   scenario 'I can navigate to a candidate that is currently in the pool' do


### PR DESCRIPTION
## Context

Previous PRs have installed and configured SolidQueue and migrated five jobs to its workers. This PR introduces a new queue design to expand the `queue.yml` configuration and migrates two frequent jobs for performance monitoring.

⚠️ Relevant existing azure envs will need to be updated to align with this PR

## Changes proposed in this pull request

- Add `low_priority` queue
- Move `DeleteAllDrafts` and `DeleteFinishedJobs` to `low_priority`
- Migrate `FindACandidate::PopulatePoolWorker` and `ProcessStaleApplicationsWorker` from sidekiq to solid queue's `default` queue
- Add blueprint for the `mailers` and `big_query` queues
- Add some additional config for non-production environments

## Reference to documentation for config roles

<img width="825" height="577" alt="Screenshot 2026-05-19 at 10 33 47" src="https://github.com/user-attachments/assets/a201f561-b681-4be8-a074-6fbab9286895" />

## Guidance to review

**Queue configuration**
- Review the configuration of the `queue.yml` with reference to[ this Teams post ](https://teams.microsoft.com/l/message/19:685ab91a98ca4490aa82bb3d62eed412@thread.tacv2/1779207621325?tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9&groupId=5e035efe-5b2b-491b-9e3e-d832445e4ad1&parentMessageId=1779207621325&teamName=Schools%20Digital&channelName=REC%20Apply%20and%20Manage%20Tech&createdTime=1779207621325)
- With 1Gi of memory and two processes with three threads each polling at 0.1s intervals, the worker was overwhelmed in production. We now have 2Gi of memory, 4 processes with a thread each, and less intense intervals. The aim is to monitor the impact on the worker, check that you agree with this rationale.

**Migrated jobs**
- Visit https://apply-review-11931.test.teacherservices.cloud/support/jobs to check that jobs are running without failures
- Check that jobs are performing the expected tasks (e.g. if the FAC pool is populated by `PopulatePoolWorker`)
- Check that the Sidekiq methods replaced by SolidQueue methods in spec files still sufficiently test what the spec is designed to test, e.g. `perform_async` has been replaced with `perform_now` to mimic the `:inline` behaviour of the test environment with Sidekiq, but which is overridden by setting SolidQueue as the queue adapter for a specific job.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
