### PR TITLE
reschedule original db backup for 8pm UTC

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -23,6 +23,9 @@ on:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
+  schedule:
+    - cron: "0 20 * * *" # 20:00 UTC
+
 env:
   SERVICE_NAME: apply
   SERVICE_SHORT: att


### PR DESCRIPTION
## Context

PTR backup at 05.50 UTC still mostly fails. 
This indicates it's not a db server issue, as this backs up a PTR copy and not the live server.

## Changes proposed in this pull request

Manually running the normal db backup late evening has worked several times without failure.
So will add this workflow back, scheduled for 8pm UTC, leaving the PTR backup in place at 05.50.

## Guidance to review

See 3 successful runs at https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/backup-db.yml and no failures.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
