### PR TITLE
Application state refactor

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -100,7 +100,6 @@ module CandidateInterface
         .includes(offer: :conditions)
         .order(id: :asc)
         .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
-      # .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
     end
 
     def all_application_choices
@@ -114,7 +113,6 @@ module CandidateInterface
     def application_choice_with_accepted_state_present?
       @application_form.application_choices
         .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
-      # .any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
     end
 
     def withdraw_row(application_choice)

--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -99,7 +99,8 @@ module CandidateInterface
         .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
         .includes(offer: :conditions)
         .order(id: :asc)
-        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
+        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+      # .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
     end
 
     def all_application_choices
@@ -111,7 +112,9 @@ module CandidateInterface
     end
 
     def application_choice_with_accepted_state_present?
-      @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+      @application_form.application_choices
+        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+      # .any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
     end
 
     def withdraw_row(application_choice)

--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -99,7 +99,7 @@ module CandidateInterface
         .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
         .includes(offer: :conditions)
         .order(id: :asc)
-        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status).offer_accepted? }
     end
 
     def all_application_choices
@@ -112,7 +112,7 @@ module CandidateInterface
 
     def application_choice_with_accepted_state_present?
       @application_form.application_choices
-        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status).offer_accepted? }
     end
 
     def withdraw_row(application_choice)

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -198,7 +198,9 @@ module CandidateInterface
     end
 
     def show_what_happens_next?
-      ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include?(@application_choice.status.to_sym)
+      ApplicationStateChange::ApplicationState.ids(:pending_provider_decision_or_inactive)
+        .include?(@application_choice.status.to_sym)
+      # ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include?(@application_choice.status.to_sym)
     end
 
     def holiday_response_time_warning_text

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -198,7 +198,7 @@ module CandidateInterface
     end
 
     def show_what_happens_next?
-      ApplicationStateChange::ApplicationState.ids(:pending_provider_decision_or_inactive)
+      ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive)
         .include?(@application_choice.status.to_sym)
       # ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include?(@application_choice.status.to_sym)
     end

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -200,7 +200,6 @@ module CandidateInterface
     def show_what_happens_next?
       ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive)
         .include?(@application_choice.status.to_sym)
-      # ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include?(@application_choice.status.to_sym)
     end
 
     def holiday_response_time_warning_text

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -259,7 +259,8 @@ module CandidateInterface
     def application_choices_with_accepted_states
       application_choices_with_includes.order(id: :asc)
         .order(id: :asc)
-        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
+        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+      # .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
     end
 
     def all_application_choices
@@ -267,7 +268,9 @@ module CandidateInterface
     end
 
     def application_choice_with_accepted_state_present?
-      @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+      @application_form.application_choices
+        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+      # .any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
     end
 
     def candidate_has_pending_or_missing_gcses?(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -259,7 +259,7 @@ module CandidateInterface
     def application_choices_with_accepted_states
       application_choices_with_includes.order(id: :asc)
         .order(id: :asc)
-        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+        .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status).offer_accepted? }
     end
 
     def all_application_choices
@@ -268,7 +268,7 @@ module CandidateInterface
 
     def application_choice_with_accepted_state_present?
       @application_form.application_choices
-        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
+        .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status).offer_accepted? }
     end
 
     def candidate_has_pending_or_missing_gcses?(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -260,7 +260,6 @@ module CandidateInterface
       application_choices_with_includes.order(id: :asc)
         .order(id: :asc)
         .select { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
-      # .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
     end
 
     def all_application_choices
@@ -270,7 +269,6 @@ module CandidateInterface
     def application_choice_with_accepted_state_present?
       @application_form.application_choices
         .any? { |ac| ApplicationStateChange::ApplicationState.find(ac.status.to_sym).offer_accepted? }
-      # .any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
     end
 
     def candidate_has_pending_or_missing_gcses?(application_choice)

--- a/app/components/candidate_interface/offer_other_applications_warning_component.rb
+++ b/app/components/candidate_interface/offer_other_applications_warning_component.rb
@@ -49,7 +49,7 @@ module CandidateInterface
     end
 
     def inflight_choices
-      @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::ApplicationState.ids(:interviewable))
+      @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::ApplicationState.state_ids(:interviewable))
       # @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::INTERVIEWABLE_STATES)
     end
 

--- a/app/components/candidate_interface/offer_other_applications_warning_component.rb
+++ b/app/components/candidate_interface/offer_other_applications_warning_component.rb
@@ -49,8 +49,10 @@ module CandidateInterface
     end
 
     def inflight_choices
-      @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::ApplicationState.state_ids(:interviewable))
-      # @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::INTERVIEWABLE_STATES)
+      @inflight_choices ||= sibling_choices
+                              .where(
+                                status: ApplicationStateChange::ApplicationState.state_ids(:interviewable),
+                              )
     end
 
     def sibling_choices

--- a/app/components/candidate_interface/offer_other_applications_warning_component.rb
+++ b/app/components/candidate_interface/offer_other_applications_warning_component.rb
@@ -49,7 +49,8 @@ module CandidateInterface
     end
 
     def inflight_choices
-      @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::INTERVIEWABLE_STATES)
+      @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::ApplicationState.ids(:interviewable))
+      # @inflight_choices ||= sibling_choices.where(status: ApplicationStateChange::INTERVIEWABLE_STATES)
     end
 
     def sibling_choices

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -118,7 +118,8 @@ module ProviderInterface
     end
 
     def offer_present?
-      ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offered?
+      # ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -118,7 +118,7 @@ module ProviderInterface
     end
 
     def offer_present?
-      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offered?
+      ApplicationStateChange::ApplicationState.find(application_choice.status).offered?
     end
   end
 end

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -119,7 +119,6 @@ module ProviderInterface
 
     def offer_present?
       ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offered?
-      # ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -50,9 +50,12 @@ module ProviderInterface
     end
 
     def application_in_correct_state?
-      @application_in_correct_state ||= ApplicationStateChange::POST_OFFERED_STATES.include?(
-        application_choice.status.to_sym,
-      )
+      @application_in_correct_state ||= ApplicationStateChange::ApplicationState
+        .find(application_choice.status.to_sym)
+        .post_offered?
+      # @application_in_correct_state ||= ApplicationStateChange::POST_OFFERED_STATES.include?(
+      #   application_choice.status.to_sym,
+      # )
     end
 
     def current_user_has_permission_to_view_diversity_information?

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -53,9 +53,6 @@ module ProviderInterface
       @application_in_correct_state ||= ApplicationStateChange::ApplicationState
         .find(application_choice.status.to_sym)
         .post_offered?
-      # @application_in_correct_state ||= ApplicationStateChange::POST_OFFERED_STATES.include?(
-      #   application_choice.status.to_sym,
-      # )
     end
 
     def current_user_has_permission_to_view_diversity_information?

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -51,7 +51,7 @@ module ProviderInterface
 
     def application_in_correct_state?
       @application_in_correct_state ||= ApplicationStateChange::ApplicationState
-        .find(application_choice.status.to_sym)
+        .find(application_choice.status)
         .post_offered?
     end
 

--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -8,7 +8,7 @@
       <dl class="govuk-list app-list--definition">
         <dt>Application status</dt>
         <dd><code><%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %></code></dd>
-        <% if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(state_name.to_sym) %>
+        <% if ApplicationStateChange::ApplicationState.find(state_name.to_sym).visible_to_provider? %>
           <dt>Appears to candidate as</dt>
           <% component = CandidateInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
           <dd><%= govuk_tag(text: t("candidate_application_states.#{state_name}"), colour: component.colour) %></dd>

--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -8,7 +8,7 @@
       <dl class="govuk-list app-list--definition">
         <dt>Application status</dt>
         <dd><code><%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %></code></dd>
-        <% if ApplicationStateChange::ApplicationState.find(state_name.to_sym).visible_to_provider? %>
+        <% if ApplicationStateChange::ApplicationState.find(state_name)&.visible_to_provider? %>
           <dt>Appears to candidate as</dt>
           <% component = CandidateInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
           <dd><%= govuk_tag(text: t("candidate_application_states.#{state_name}"), colour: component.colour) %></dd>

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -281,7 +281,7 @@ module SupportInterface
 
     def any_successful_application_choices?(application_choice)
       choice_statuses = application_choice.application_form.application_choices.map(&:status)
-      choice_statuses.any? { |choice_status| ApplicationStateChange::ApplicationState.find(choice_status.to_sym).offer_accepted? }
+      choice_statuses.any? { |choice_status| ApplicationStateChange::ApplicationState.find(choice_status).offer_accepted? }
     end
   end
 end

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -208,7 +208,7 @@ module SupportInterface
 
     def visible_over_vendor_api?
       ApplicationStateChange::ApplicationState
-        .find(application_choice.status.to_sym)
+        .find(application_choice.status)
         .visible_to_provider?
     end
 

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -210,7 +210,6 @@ module SupportInterface
       ApplicationStateChange::ApplicationState
         .find(application_choice.status.to_sym)
         .visible_to_provider?
-      # ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
     end
 
     def visible_over_register_api?
@@ -283,7 +282,6 @@ module SupportInterface
     def any_successful_application_choices?(application_choice)
       choice_statuses = application_choice.application_form.application_choices.map(&:status)
       choice_statuses.any? { |choice_status| ApplicationStateChange::ApplicationState.find(choice_status.to_sym).offer_accepted? }
-      # choice_statuses.any? { |choice_status| ApplicationStateChange::ACCEPTED_STATES.include? choice_status.to_sym }
     end
   end
 end

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -207,7 +207,10 @@ module SupportInterface
     end
 
     def visible_over_vendor_api?
-      ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
+      ApplicationStateChange::ApplicationState
+        .find(application_choice.status.to_sym)
+        .visible_to_provider?
+      # ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
     end
 
     def visible_over_register_api?
@@ -279,8 +282,8 @@ module SupportInterface
 
     def any_successful_application_choices?(application_choice)
       choice_statuses = application_choice.application_form.application_choices.map(&:status)
-
-      choice_statuses.any? { |choice_status| ApplicationStateChange::ACCEPTED_STATES.include? choice_status.to_sym }
+      choice_statuses.any? { |choice_status| ApplicationStateChange::ApplicationState.find(choice_status.to_sym).offer_accepted? }
+      # choice_statuses.any? { |choice_status| ApplicationStateChange::ACCEPTED_STATES.include? choice_status.to_sym }
     end
   end
 end

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -12,9 +12,12 @@ module ProviderInterface
     before_action :move_to_interview_if_outside_service, only: %i[new]
 
     def index
-      application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
-        @application_choice.status.to_sym,
-      )
+      application_at_interviewable_stage = ApplicationStateChange::ApplicationState
+        .find(@application_choice.status.to_sym)
+        .interviewable?
+      # application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
+      #   @application_choice.status.to_sym,
+      # )
       @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_user_can_set_up_interviews
 
       redirect_to provider_interface_application_choice_path if @application_choice.interviews.none?

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -13,7 +13,7 @@ module ProviderInterface
 
     def index
       application_at_interviewable_stage = ApplicationStateChange::ApplicationState
-        .find(@application_choice.status.to_sym)
+        .find(@application_choice.status)
         .interviewable?
       @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_user_can_set_up_interviews
 

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -15,9 +15,6 @@ module ProviderInterface
       application_at_interviewable_stage = ApplicationStateChange::ApplicationState
         .find(@application_choice.status.to_sym)
         .interviewable?
-      # application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
-      #   @application_choice.status.to_sym,
-      # )
       @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_user_can_set_up_interviews
 
       redirect_to provider_interface_application_choice_path if @application_choice.interviews.none?

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -114,8 +114,6 @@ module ProviderInterface
     def confirm_application_is_in_offered_state
       return if ApplicationStateChange::ApplicationState.find(@application_choice.status.to_sym).offered?
 
-      # return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
-
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -112,7 +112,9 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_offered_state
-      return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+      return if ApplicationStateChange::ApplicationState.find(@application_choice.status.to_sym).offered?
+
+      # return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -112,7 +112,7 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_offered_state
-      return if ApplicationStateChange::ApplicationState.find(@application_choice.status.to_sym).offered?
+      return if ApplicationStateChange::ApplicationState.find(@application_choice.status).offered?
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -198,7 +198,10 @@ module ProviderInterface
         course_option: @application_choice.current_course_option,
       )
       @course_associated_with_user_providers = provider_authorisation.course_associated_with_user_providers?(course: @application_choice.current_course)
-      @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+      @offer_present = ApplicationStateChange::ApplicationState
+        .find(@application_choice.status.to_sym)
+        .offered?
+      # @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
     end
 
     def provider_authorisation

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -201,7 +201,6 @@ module ProviderInterface
       @offer_present = ApplicationStateChange::ApplicationState
         .find(@application_choice.status.to_sym)
         .offered?
-      # @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
     end
 
     def provider_authorisation

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -199,7 +199,7 @@ module ProviderInterface
       )
       @course_associated_with_user_providers = provider_authorisation.course_associated_with_user_providers?(course: @application_choice.current_course)
       @offer_present = ApplicationStateChange::ApplicationState
-        .find(@application_choice.status.to_sym)
+        .find(@application_choice.status)
         .offered?
     end
 

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -236,7 +236,7 @@ private
   def references_without_an_accepted_offer?
     @application_form.reload
     @application_form.application_choices.flat_map(&:status).none? do |status|
-      ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+      ApplicationStateChange::ApplicationState.find(status).offer_accepted?
     end
   end
 

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -235,7 +235,8 @@ private
 
   def references_without_an_accepted_offer?
     @application_form.reload
-    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
+    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).accepted? }
+    # @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
   end
 
   def set_reference_state

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -235,7 +235,7 @@ private
 
   def references_without_an_accepted_offer?
     @application_form.reload
-    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).accepted? }
+    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted? }
     # @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
   end
 

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -235,8 +235,9 @@ private
 
   def references_without_an_accepted_offer?
     @application_form.reload
-    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted? }
-    # @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
+    @application_form.application_choices.flat_map(&:status).none? do |status|
+      ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+    end
   end
 
   def set_reference_state

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -83,7 +83,8 @@ class ApplicationChoice < ApplicationRecord
   scope :visible_to_provider, -> { where(status: ApplicationStateChange.states_visible_to_provider) }
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
-  scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
+  # scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
+  scope :decision_pending, -> { where(status: ApplicationStateChange::ApplicationState.ids(:pending_provider_decision)) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -83,11 +83,8 @@ class ApplicationChoice < ApplicationRecord
   scope :visible_to_provider, -> { where(status: ApplicationStateChange.states_visible_to_provider) }
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
-  # scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
   scope :decision_pending, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision)) }
-  # scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive)) }
-  # scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:offer_accepted)) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
   scope :course_starts_after_september, lambda { |recruitment_cycle_year|
@@ -151,39 +148,32 @@ class ApplicationChoice < ApplicationRecord
 
   def decision_pending?
     ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive).include?(status.to_sym)
-    # ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include? status.to_sym
   end
 
   def pre_offer?
     !ApplicationStateChange::ApplicationState.find(status.to_sym).offered?
-    # ApplicationStateChange::OFFERED_STATES.exclude? status.to_sym
   end
 
   def application_in_progress?
     ApplicationStateChange::ApplicationState.find(status.to_sym).in_progress?
-    # ApplicationStateChange::IN_PROGRESS_STATES.include? status.to_sym
   end
 
   def self.in_progress
     where(status: ApplicationStateChange::ApplicationState.state_ids(:in_progress))
-    # where(status: ApplicationStateChange::IN_PROGRESS_STATES)
   end
 
   def application_unsuccessful?
     ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful?
-    # ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
   end
 
   def application_unsuccessful_without_inactive?
     return false if status.to_sym == :inactive
 
     application_unsuccessful?
-    # (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]).include? status.to_sym
   end
 
   def accepted_choice?
     ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
-    # ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
   end
 
   def different_offer?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -84,9 +84,11 @@ class ApplicationChoice < ApplicationRecord
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   # scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
-  scope :decision_pending, -> { where(status: ApplicationStateChange::ApplicationState.ids(:pending_provider_decision)) }
-  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
-  scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
+  scope :decision_pending, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision)) }
+  # scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
+  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive)) }
+  # scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
+  scope :accepted, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:offer_accepted)) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
   scope :course_starts_after_september, lambda { |recruitment_cycle_year|
     start_date = Date.parse("30/09/#{recruitment_cycle_year}").at_end_of_day
@@ -148,31 +150,40 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def decision_pending?
-    ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include? status.to_sym
+    ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive).include?(status.to_sym)
+    # ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include? status.to_sym
   end
 
   def pre_offer?
-    ApplicationStateChange::OFFERED_STATES.exclude? status.to_sym
+    !ApplicationStateChange::ApplicationState.find(status.to_sym).offered?
+    # ApplicationStateChange::OFFERED_STATES.exclude? status.to_sym
   end
 
   def application_in_progress?
-    ApplicationStateChange::IN_PROGRESS_STATES.include? status.to_sym
+    ApplicationStateChange::ApplicationState.find(status.to_sym).in_progress?
+    # ApplicationStateChange::IN_PROGRESS_STATES.include? status.to_sym
   end
 
   def self.in_progress
-    where(status: ApplicationStateChange::IN_PROGRESS_STATES)
+    where(status: ApplicationStateChange::ApplicationState.state_ids(:in_progress))
+    # where(status: ApplicationStateChange::IN_PROGRESS_STATES)
   end
 
   def application_unsuccessful?
-    ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
+    ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful?
+    # ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
   end
 
   def application_unsuccessful_without_inactive?
-    (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]).include? status.to_sym
+    return false if status.to_sym == :inactive
+
+    application_unsuccessful?
+    # (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]).include? status.to_sym
   end
 
   def accepted_choice?
-    ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
+    ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+    # ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
   end
 
   def different_offer?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -151,11 +151,11 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def pre_offer?
-    !ApplicationStateChange::ApplicationState.find(status.to_sym).offered?
+    !ApplicationStateChange::ApplicationState.find(status).offered?
   end
 
   def application_in_progress?
-    ApplicationStateChange::ApplicationState.find(status.to_sym).in_progress?
+    ApplicationStateChange::ApplicationState.find(status).in_progress?
   end
 
   def self.in_progress
@@ -163,7 +163,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def application_unsuccessful?
-    ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful?
+    ApplicationStateChange::ApplicationState.find(status).unsuccessful?
   end
 
   def application_unsuccessful_without_inactive?
@@ -173,7 +173,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def accepted_choice?
-    ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+    ApplicationStateChange::ApplicationState.find(status).offer_accepted?
   end
 
   def different_offer?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -385,7 +385,7 @@ class ApplicationForm < ApplicationRecord
     !submitted? ||
       application_choices.blank? ||
       application_choices.map(&:status).map(&:to_sym).all? do |status|
-        ApplicationStateChange::ApplicationState.find(status.to_sym).carry_over?
+        ApplicationStateChange::ApplicationState.find(status).carry_over?
       end
   end
 
@@ -405,7 +405,7 @@ class ApplicationForm < ApplicationRecord
     application_choices.present? &&
       application_choices
         .map(&:status)
-        .any? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).successful? }
+        .any? { |status| ApplicationStateChange::ApplicationState.find(status).successful? }
   end
 
   def any_offer_accepted?
@@ -413,7 +413,7 @@ class ApplicationForm < ApplicationRecord
       application_choices.map(&:status).any? do |status|
         next if status == 'conditions_not_met'
 
-        ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+        ApplicationStateChange::ApplicationState.find(status).offer_accepted?
       end
   end
 
@@ -421,7 +421,7 @@ class ApplicationForm < ApplicationRecord
     application_choices.present? &&
       application_choices
       .map(&:status)
-      .all? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful? }
+      .all? { |status| ApplicationStateChange::ApplicationState.find(status).unsuccessful? }
   end
 
   def withdrawn_no_longer_training?
@@ -435,8 +435,8 @@ class ApplicationForm < ApplicationRecord
       application_choices
       .map(&:status)
       .all? do |status|
-        ApplicationStateChange::ApplicationState.find(status.to_sym).successful? ||
-          ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful?
+        ApplicationStateChange::ApplicationState.find(status).successful? ||
+          ApplicationStateChange::ApplicationState.find(status).unsuccessful?
       end
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -385,7 +385,8 @@ class ApplicationForm < ApplicationRecord
     !submitted? ||
       application_choices.blank? ||
       application_choices.map(&:status).map(&:to_sym).all? do |status|
-        ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES.include?(status)
+        ApplicationStateChange::ApplicationState.find(status.to_sym).carry_over?
+        # ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES.include?(status)
       end
   end
 
@@ -403,17 +404,28 @@ class ApplicationForm < ApplicationRecord
 
   def successful?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
+      application_choices
+        .map(&:status)
+        .any? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).successful? }
+    # application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
   end
 
   def any_offer_accepted?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met]).include?(status) }
+      application_choices.map(&:status).any? do |status|
+        next if status == 'conditions_not_met'
+
+        ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
+      end
+    # application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met]).include?(status) }
   end
 
   def ended_without_success?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
+      application_choices
+      .map(&:status)
+      .all? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful? }
+    # application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
   end
 
   def withdrawn_no_longer_training?
@@ -424,7 +436,10 @@ class ApplicationForm < ApplicationRecord
 
   def provider_decision_made?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }
+      application_choices
+      .map(&:status)
+      .all? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).successful? || ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful? }
+    # application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }
   end
 
   def incomplete_degree_information?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -386,7 +386,6 @@ class ApplicationForm < ApplicationRecord
       application_choices.blank? ||
       application_choices.map(&:status).map(&:to_sym).all? do |status|
         ApplicationStateChange::ApplicationState.find(status.to_sym).carry_over?
-        # ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES.include?(status)
       end
   end
 
@@ -407,7 +406,6 @@ class ApplicationForm < ApplicationRecord
       application_choices
         .map(&:status)
         .any? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).successful? }
-    # application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
   end
 
   def any_offer_accepted?
@@ -417,7 +415,6 @@ class ApplicationForm < ApplicationRecord
 
         ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted?
       end
-    # application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met]).include?(status) }
   end
 
   def ended_without_success?
@@ -425,7 +422,6 @@ class ApplicationForm < ApplicationRecord
       application_choices
       .map(&:status)
       .all? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful? }
-    # application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
   end
 
   def withdrawn_no_longer_training?
@@ -438,8 +434,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.present? &&
       application_choices
       .map(&:status)
-      .all? { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).successful? || ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful? }
-    # application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }
+      .all? do |status|
+        ApplicationStateChange::ApplicationState.find(status.to_sym).successful? ||
+          ApplicationStateChange::ApplicationState.find(status.to_sym).unsuccessful?
+      end
   end
 
   def incomplete_degree_information?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -384,7 +384,7 @@ class ApplicationForm < ApplicationRecord
 
     !submitted? ||
       application_choices.blank? ||
-      application_choices.map(&:status).map(&:to_sym).all? do |status|
+      application_choices.map(&:status).all? do |status|
         ApplicationStateChange::ApplicationState.find(status).carry_over?
       end
   end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -64,7 +64,8 @@ class ApplicationReference < ApplicationRecord
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
-    application_choices.where(status: ApplicationStateChange::ACCEPTED_STATES).touch_all
+    application_choices.where(status: ApplicationStateChange::ApplicationState.state_ids(:offer_accepted)).touch_all
+    # application_choices.where(status: ApplicationStateChange::ACCEPTED_STATES).touch_all
   end
 
   def self.requested_or_provided

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -64,8 +64,9 @@ class ApplicationReference < ApplicationRecord
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
-    application_choices.where(status: ApplicationStateChange::ApplicationState.state_ids(:offer_accepted)).touch_all
-    # application_choices.where(status: ApplicationStateChange::ACCEPTED_STATES).touch_all
+    application_choices.where(
+      status: ApplicationStateChange::ApplicationState.state_ids(:offer_accepted),
+    ).touch_all
   end
 
   def self.requested_or_provided

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -101,7 +101,6 @@ class Candidate < ApplicationRecord
       .where.not(id: current_application)
       .where(application_choices: { status: ApplicationStateChange::ApplicationState.state_ids(:active_previous) })
       .last
-    # .where(application_choices: { status: ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES }).last
   end
 
   def current_application_choices

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -99,8 +99,9 @@ class Candidate < ApplicationRecord
     ordered_application_forms
       .joins(:application_choices)
       .where.not(id: current_application)
-      .where(application_choices: { status: ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES })
+      .where(application_choices: { status: ApplicationStateChange::ApplicationState.state_ids(:active_previous) })
       .last
+    # .where(application_choices: { status: ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES }).last
   end
 
   def current_application_choices

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -71,9 +71,6 @@ class PerformanceStatistics
 
   def form_ended_without_success_sql
     sql = 'ARRAY_AGG(DISTINCT ch.status)'
-    # ApplicationStateChange::UNSUCCESSFUL_STATES.each do |state|
-    #   sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
-    # end
     ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider).each do |state|
       sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
     end
@@ -227,8 +224,6 @@ private
       .joins(application_form: :candidate)
       .where(status: ApplicationStateChange::ApplicationState.state_ids(:active_previous))
       .where('candidates.hide_in_reporting' => false)
-    # .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
-    # .where('candidates.hide_in_reporting' => false)
 
     if year
       choices.where(application_forms: { recruitment_cycle_year: year })

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -71,7 +71,10 @@ class PerformanceStatistics
 
   def form_ended_without_success_sql
     sql = 'ARRAY_AGG(DISTINCT ch.status)'
-    ApplicationStateChange::UNSUCCESSFUL_STATES.each do |state|
+    # ApplicationStateChange::UNSUCCESSFUL_STATES.each do |state|
+    #   sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
+    # end
+    ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider).each do |state|
       sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
     end
 
@@ -222,8 +225,10 @@ private
   def application_choices
     choices = ApplicationChoice
       .joins(application_form: :candidate)
-      .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+      .where(status: ApplicationStateChange::ApplicationState.state_ids(:active_previous))
       .where('candidates.hide_in_reporting' => false)
+    # .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    # .where('candidates.hide_in_reporting' => false)
 
     if year
       choices.where(application_forms: { recruitment_cycle_year: year })

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -70,11 +70,17 @@ class Pool::Candidates
     forms_with_available_slots = current_cycle_forms
                          .joins(:application_choices)
                          .where(application_choices: {
-                           status: ApplicationStateChange::UNSUCCESSFUL_STATES,
+                           status: ApplicationStateChange::ApplicationState.state_ids(:unsuccessful),
                          })
                          .group(:id)
                          .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-                         .select(:id)
+    #  .select(:id)
+    #  .where(application_choices: {
+    #    status: ApplicationStateChange::UNSUCCESSFUL_STATES,
+    #  })
+    #  .group(:id)
+    #  .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
+    #  .select(:id)
 
     # Final query
     current_cycle_forms

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -74,13 +74,7 @@ class Pool::Candidates
                          })
                          .group(:id)
                          .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-    #  .select(:id)
-    #  .where(application_choices: {
-    #    status: ApplicationStateChange::UNSUCCESSFUL_STATES,
-    #  })
-    #  .group(:id)
-    #  .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
-    #  .select(:id)
+                         .select(:id)
 
     # Final query
     current_cycle_forms

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -70,9 +70,12 @@ class Pool::Invite < ApplicationRecord
   end
 
   def self.matching_application_choices_exists_sql
-    visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+    visible_states = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
                        .map { |app_state| ActiveRecord::Base.connection.quote(app_state.to_s) }
                        .join(', ')
+    # visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+    #                    .map { |app_state| ActiveRecord::Base.connection.quote(app_state.to_s) }
+    #                    .join(', ')
 
     <<~SQL.squish
       EXISTS (

--- a/app/models/pool/invite.rb
+++ b/app/models/pool/invite.rb
@@ -73,9 +73,6 @@ class Pool::Invite < ApplicationRecord
     visible_states = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
                        .map { |app_state| ActiveRecord::Base.connection.quote(app_state.to_s) }
                        .join(', ')
-    # visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
-    #                    .map { |app_state| ActiveRecord::Base.connection.quote(app_state.to_s) }
-    #                    .join(', ')
 
     <<~SQL.squish
       EXISTS (

--- a/app/models/provider_interface/candidate_invites_filter.rb
+++ b/app/models/provider_interface/candidate_invites_filter.rb
@@ -130,9 +130,6 @@ module ProviderInterface
       visible_states = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
                            .map { |s| ActiveRecord::Base.connection.quote(s.to_s) }
                            .join(', ')
-      # visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
-      #                      .map { |s| ActiveRecord::Base.connection.quote(s.to_s) }
-      #                      .join(', ')
 
       <<~SQL.squish
         pool_invites.*,

--- a/app/models/provider_interface/candidate_invites_filter.rb
+++ b/app/models/provider_interface/candidate_invites_filter.rb
@@ -127,9 +127,12 @@ module ProviderInterface
     end
 
     def matching_choice_sql
-      visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+      visible_states = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
                            .map { |s| ActiveRecord::Base.connection.quote(s.to_s) }
                            .join(', ')
+      # visible_states = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+      #                      .map { |s| ActiveRecord::Base.connection.quote(s.to_s) }
+      #                      .join(', ')
 
       <<~SQL.squish
         pool_invites.*,

--- a/app/presenters/concerns/hesa_itt_data_api_data.rb
+++ b/app/presenters/concerns/hesa_itt_data_api_data.rb
@@ -5,8 +5,6 @@ module HesaIttDataAPIData
   def hesa_itt_data
     return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
 
-    # return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
-
     unless (data = application_form&.equality_and_diversity).nil?
       hesa_codes(data).merge(additional_hesa_itt_data(data))
     end

--- a/app/presenters/concerns/hesa_itt_data_api_data.rb
+++ b/app/presenters/concerns/hesa_itt_data_api_data.rb
@@ -3,7 +3,9 @@ module HesaIttDataAPIData
   HESA_DISABILITY_OTHER = '96'.freeze
 
   def hesa_itt_data
-    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
+
+    # return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
 
     unless (data = application_form&.equality_and_diversity).nil?
       hesa_codes(data).merge(additional_hesa_itt_data(data))

--- a/app/presenters/concerns/hesa_itt_data_api_data.rb
+++ b/app/presenters/concerns/hesa_itt_data_api_data.rb
@@ -3,7 +3,7 @@ module HesaIttDataAPIData
   HESA_DISABILITY_OTHER = '96'.freeze
 
   def hesa_itt_data
-    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
+    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status).offer_accepted?
 
     unless (data = application_form&.equality_and_diversity).nil?
       hesa_codes(data).merge(additional_hesa_itt_data(data))

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -139,11 +139,13 @@ module VendorAPI
     end
 
     def application_accepted?
-      ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
+      # ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
     end
 
     def application_unsuccessful?
-      ApplicationStateChange::UNSUCCESSFUL_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).unsuccessful?
+      # ApplicationStateChange::UNSUCCESSFUL_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -140,12 +140,10 @@ module VendorAPI
 
     def application_accepted?
       ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
-      # ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
     end
 
     def application_unsuccessful?
       ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).unsuccessful?
-      # ApplicationStateChange::UNSUCCESSFUL_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -139,11 +139,11 @@ module VendorAPI
     end
 
     def application_accepted?
-      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted?
+      ApplicationStateChange::ApplicationState.find(application_choice.status).offer_accepted?
     end
 
     def application_unsuccessful?
-      ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).unsuccessful?
+      ApplicationStateChange::ApplicationState.find(application_choice.status).unsuccessful?
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -8,7 +8,7 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
   end
 
   def equality_and_diversity
-    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted? &&
+    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status).offer_accepted? &&
                       application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
 
     equality_and_diversity_data = application_form&.equality_and_diversity

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -11,8 +11,6 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
     return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted? &&
                       application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
 
-    # return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
-
     equality_and_diversity_data = application_form&.equality_and_diversity
 
     if equality_and_diversity_data

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -8,7 +8,10 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
   end
 
   def equality_and_diversity
-    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
+    return nil unless ApplicationStateChange::ApplicationState.find(application_choice.status.to_sym).offer_accepted? &&
+                      application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
+
+    # return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
 
     equality_and_diversity_data = application_form&.equality_and_diversity
 

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -89,7 +89,6 @@ class GetActivityLogEvents
     end.join(' OR ')
 
     filtered_statuses = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - IGNORE_STATUS
-    # filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
     status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
 
     application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -88,7 +88,8 @@ class GetActivityLogEvents
       "jsonb_exists(audited_changes, '#{change}')"
     end.join(' OR ')
 
-    filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
+    filtered_statuses = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - IGNORE_STATUS
+    # filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
     status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
 
     application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -11,8 +11,10 @@ class GetUnsuccessfulAndUnsubmittedCandidates
         previous_recruitment_year:,
         successful: ApplicationChoice
             .select(1)
-            .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
+            .where(status: ApplicationStateChange::ApplicationState.state_ids(:successful))
             .where('application_choices.application_form_id = application_forms.id'),
+        # .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
+        # .where('application_choices.application_form_id = application_forms.id'),
       )
       .or(
         # Candidates who have started working on applications this year, but not submitted.

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -13,8 +13,6 @@ class GetUnsuccessfulAndUnsubmittedCandidates
             .select(1)
             .where(status: ApplicationStateChange::ApplicationState.state_ids(:successful))
             .where('application_choices.application_form_id = application_forms.id'),
-        # .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
-        # .where('application_choices.application_form_id = application_forms.id'),
       )
       .or(
         # Candidates who have started working on applications this year, but not submitted.

--- a/app/services/application_form_state_inferrer.rb
+++ b/app/services/application_form_state_inferrer.rb
@@ -28,7 +28,7 @@ class ApplicationFormStateInferrer
       :pending_conditions
     elsif any_state_is?('offer_deferred')
       :offer_deferred
-    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_STATES).empty?
+    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::ApplicationState.state_ids(:unsuccessful)).empty?
       :ended_without_success
     elsif any_state_is?('unsubmitted')
       :unsubmitted_in_progress

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -1,5 +1,6 @@
 class ApplicationStateChange
   include Workflow
+  include DefineApplicationState
 
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
   STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -140,16 +140,17 @@ private
 
   def funding_type
     # Does the Candidate have any submitted Applications?
+    status = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
     return unless candidate.application_choices
                            .joins(:application_form)
                            .where(application_form: { recruitment_cycle_year: current_year })
-                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+                           .exists?(status:)
 
     # What Course funding types has the Candidate applied for?
     candidate.application_choices
                       .joins(:application_form)
                       .where(application_form: { recruitment_cycle_year: current_year })
-                             .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+                             .where(status:)
                              .joins(course_option: :course)
                              .pluck('courses.funding_type')
                              .compact_blank
@@ -159,16 +160,17 @@ private
 
   def study_type
     # Does the Candidate have any submitted Applications?
+    status = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
     return unless candidate.application_choices
                            .joins(:application_form)
                            .where(application_form: { recruitment_cycle_year: current_year })
-                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+                           .exists?(status:)
 
     # What Course study types has the Candidate applied for?
     candidate.application_choices
                            .joins(:application_form)
                            .where(application_form: { recruitment_cycle_year: current_year })
-                           .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+                           .where(status:)
                            .joins(course_option: :course)
                            .pluck('course_options.study_mode')
                            .compact_blank
@@ -177,18 +179,19 @@ private
   end
 
   def subjects
+    status = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
     # Does the Candidate have any submitted Applications?
     return unless candidate.application_choices
                            .joins(:application_form)
                            .where(application_form: { recruitment_cycle_year: current_year })
-                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+                           .exists?(status:)
 
     # What Course subjects has the Candidate applied for?
     # subject codes
     candidate.application_choices
       .joins(:application_form)
       .where(application_form: { recruitment_cycle_year: current_year })
-      .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+      .where(status:)
       .joins(course_option: { course: :subjects })
       .pluck('subjects.code')
       .compact_blank

--- a/app/services/concerns/define_application_state.rb
+++ b/app/services/concerns/define_application_state.rb
@@ -105,6 +105,7 @@ module DefineApplicationState
     end
 
     def self.find(state_id)
+      state_id = state_id.to_sym
       all.find { |state| state.id == state_id }
     end
 
@@ -160,6 +161,10 @@ module DefineApplicationState
 
     def self.pending_provider_decision_or_inactive
       pending_provider_decision | where(id: :inactive)
+    end
+
+    def self.redactable
+      pending_provider_decision_or_inactive
     end
 
     def self.reapply

--- a/app/services/concerns/define_application_state.rb
+++ b/app/services/concerns/define_application_state.rb
@@ -1,0 +1,171 @@
+module DefineApplicationState
+  ApplicationState = Data.define(:id,
+                                 :visible_to_provider,
+                                 :interviewable,
+                                 :offered,
+                                 :post_offered,
+                                 :offer_accepted,
+                                 :unsuccessful,
+                                 :carry_over,
+                                 :successful,
+                                 :pending_provider_decision,
+                                 :reapply,
+                                 :terminal,
+                                 :in_progress,
+                                 :active_previous) do
+    alias_method :visible_to_provider?, :visible_to_provider
+    alias_method :interviewable?, :interviewable
+    alias_method :offered?, :offered
+    alias_method :post_offered?, :post_offered
+    alias_method :offer_accepted?, :offer_accepted
+    alias_method :unsuccessful?, :unsuccessful
+    alias_method :carry_over?, :carry_over
+    alias_method :successful?, :successful
+    alias_method :pending_provider_decision?, :pending_provider_decision
+    alias_method :reapply?, :reapply
+    alias_method :terminal?, :terminal
+    alias_method :in_progress?, :in_progress
+    alias_method :active_previous?, :active_previous
+
+    delegate :to_s, to: :id
+
+    def self.all
+      [
+        ApplicationState.new(id: :unsubmitted, visible_to_provider: false, interviewable: false, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false,
+                             successful: false, pending_provider_decision: false, reapply: false, terminal: false,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :cancelled, visible_to_provider: false, interviewable: false, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: true, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :awaiting_provider_decision, visible_to_provider: true, interviewable: true,
+                             offered: false, post_offered: false, offer_accepted: false, unsuccessful: false,
+                             carry_over: false, successful: false, pending_provider_decision: true, reapply: false,
+                             terminal: false, in_progress: true, active_previous: true),
+        ApplicationState.new(id: :inactive, visible_to_provider: true, interviewable: true, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: false,
+                             successful: false, pending_provider_decision: false, reapply: false, terminal: true,
+                             in_progress: false, active_previous: true),
+        ApplicationState.new(id: :interviewing, visible_to_provider: true, interviewable: true, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false,
+                             successful: false, pending_provider_decision: true, reapply: false, terminal: false,
+                             in_progress: true, active_previous: true),
+        ApplicationState.new(id: :offer, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false,
+                             successful: true, pending_provider_decision: false, reapply: false, terminal: false,
+                             in_progress: true, active_previous: true),
+        ApplicationState.new(id: :pending_conditions, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false,
+                             successful: true, pending_provider_decision: false, reapply: false, terminal: false,
+                             in_progress: true, active_previous: true),
+        ApplicationState.new(id: :recruited, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false,
+                             successful: true, pending_provider_decision: false, reapply: false, terminal: true,
+                             in_progress: true, active_previous: true),
+        ApplicationState.new(id: :rejected, visible_to_provider: true, interviewable: false, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: true, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :application_not_sent, visible_to_provider: false, interviewable: false, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: false, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :offer_withdrawn, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: true, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :declined, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: true, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :withdrawn, visible_to_provider: true, interviewable: false, offered: false,
+                             post_offered: false, offer_accepted: false, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: true, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :conditions_not_met, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: true, unsuccessful: true, carry_over: true,
+                             successful: false, pending_provider_decision: false, reapply: false, terminal: true,
+                             in_progress: false, active_previous: false),
+        ApplicationState.new(id: :offer_deferred, visible_to_provider: true, interviewable: false, offered: true,
+                             post_offered: true, offer_accepted: true, unsuccessful: false, carry_over: false,
+                             successful: true, pending_provider_decision: false, reapply: false, terminal: false,
+                             in_progress: true, active_previous: false),
+      ]
+    end
+
+    def self.where(**args)
+      all.select do |state|
+        args.all? do |attr, values|
+          Array.wrap(values).any? do |value|
+            state.public_send(attr) == value
+          end
+        end
+      end
+    end
+
+    def self.find(state_id)
+      all.find { |state| state.id == state_id }
+    end
+
+    def self.not_visible_to_provider
+      where(visible_to_provider: false)
+    end
+
+    def self.visible_to_provider
+      where(visible_to_provider: true)
+    end
+
+    def self.interviewable
+      where(interviewable: true)
+    end
+
+    def self.offered
+      where(offered: true)
+    end
+
+    def self.post_offered
+      where(post_offered: true)
+    end
+
+    def self.offer_accepted
+      where(offer_accepted: true)
+    end
+
+    def self.unsuccessful
+      where(unsuccessful: true)
+    end
+
+    def self.carry_over
+      where(carry_over: true)
+    end
+
+    def self.successful
+      where(successful: true)
+    end
+
+    def self.pending_provider_decision
+      where(pending_provider_decision: true)
+    end
+
+    def self.pending_provider_decision_or_inactive
+      pending_provider_decision | where(id: :inactive)
+    end
+
+    def self.reapply
+      where(reapply: true)
+    end
+
+    def self.terminal
+      where(terminal: true)
+    end
+
+    def self.in_progress
+      where(in_progress: true)
+    end
+
+    def self.active_previous
+      where(active_previous: true)
+    end
+  end
+end

--- a/app/services/concerns/define_application_state.rb
+++ b/app/services/concerns/define_application_state.rb
@@ -108,7 +108,7 @@ module DefineApplicationState
       all.find { |state| state.id == state_id }
     end
 
-    def self.ids(attribute_or_method = nil)
+    def self.state_ids(attribute_or_method = nil)
       if attribute_or_method.nil?
         all
       else

--- a/app/services/concerns/define_application_state.rb
+++ b/app/services/concerns/define_application_state.rb
@@ -108,6 +108,16 @@ module DefineApplicationState
       all.find { |state| state.id == state_id }
     end
 
+    def self.ids(attribute_or_method = nil)
+      if attribute_or_method.nil?
+        all
+      else
+        try(attribute_or_method)
+      end.map(&:id)
+    rescue StandardError
+      raise 'Application state does not exist'
+    end
+
     def self.not_visible_to_provider
       where(visible_to_provider: false)
     end

--- a/app/services/end_of_cycle/reject_by_default_service.rb
+++ b/app/services/end_of_cycle/reject_by_default_service.rb
@@ -1,6 +1,6 @@
 module EndOfCycle
   class RejectByDefaultService
-    REJECTABLE_STATUSES = ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive).freeze
+    REJECTABLE_STATUSES = ApplicationStateChange::ApplicationState.state_ids(:redactable).freeze
 
     def initialize(application_form)
       @application_form = application_form

--- a/app/services/end_of_cycle/reject_by_default_service.rb
+++ b/app/services/end_of_cycle/reject_by_default_service.rb
@@ -1,6 +1,6 @@
 module EndOfCycle
   class RejectByDefaultService
-    REJECTABLE_STATUSES = ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.freeze
+    REJECTABLE_STATUSES = ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive).freeze
 
     def initialize(application_form)
       @application_form = application_form

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -1,6 +1,6 @@
 class GetRefereesToChase
   attr_accessor :chase_referee_by, :rejected_chased_ids
-  APPLICATION_STATUSES = ApplicationStateChange::SUCCESSFUL_STATES - [:offer]
+  APPLICATION_STATUSES = ApplicationStateChange::ApplicationState.state_ids(:successful) - [:offer]
 
   def initialize(chase_referee_by:, rejected_chased_ids:)
     @chase_referee_by = chase_referee_by

--- a/app/services/interview_validations.rb
+++ b/app/services/interview_validations.rb
@@ -1,7 +1,7 @@
 class InterviewValidations
   include ActiveModel::Model
 
-  APPLICATION_STATES_ALLOWING_CHANGES = ApplicationStateChange::INTERVIEWABLE_STATES.map(&:to_s).freeze
+  APPLICATION_STATES_ALLOWING_CHANGES = ApplicationStateChange::ApplicationState.state_ids(:interviewable).map(&:to_s).freeze
 
   attr_reader :interview, :today
 

--- a/app/services/interview_workflow_constraints.rb
+++ b/app/services/interview_workflow_constraints.rb
@@ -1,5 +1,5 @@
 class InterviewWorkflowConstraints
-  STATES_ALLOWING_INTERVIEW_CHANGES = ApplicationStateChange::INTERVIEWABLE_STATES.map(&:to_s).freeze
+  STATES_ALLOWING_INTERVIEW_CHANGES = ApplicationStateChange::ApplicationState.state_ids(:interviewable).freeze
 
   attr_reader :interview, :today
   delegate :application_choice, to: :interview
@@ -40,7 +40,7 @@ class InterviewWorkflowConstraints
   end
 
   def application_not_in_interviewing_states?
-    unless STATES_ALLOWING_INTERVIEW_CHANGES.include?(application_choice.status)
+    unless STATES_ALLOWING_INTERVIEW_CHANGES.include?(application_choice.status.to_sym)
       raise WorkflowError, error_message(:changing_interviews_for_application_not_in_interviewing_states)
     end
   end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -99,7 +99,7 @@ private
   def can_not_receive_other_offers?
     (application_choice.self_and_siblings - [application_choice])
       .map(&:status).map(&:to_sym)
-      .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])
+      .intersect?(ApplicationStateChange::ApplicationState.state_ids(:offer_accepted) - [:conditions_not_met])
   end
 
   def candidate_in_apply_2?

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -46,7 +46,7 @@ module ProviderInterface
 
     def export_data
       GetApplicationChoicesForProviders.call(providers: actor.providers, recruitment_cycle_year:)
-        .where('candidates.hide_in_reporting' => false, 'status' => ApplicationStateChange::ACCEPTED_STATES)
+        .where('candidates.hide_in_reporting' => false, 'status' => ApplicationStateChange::ApplicationState.state_ids(:offer_accepted))
         .joins(application_form: :candidate)
     end
 

--- a/app/services/redact_application.rb
+++ b/app/services/redact_application.rb
@@ -27,6 +27,6 @@ private
       .application_choices
       .joins(:current_course)
       .where('current_course.recruitment_cycle_year' => RecruitmentCycleTimetable.current_year)
-      .exists?(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES + ApplicationStateChange::ACCEPTED_STATES)
+      .exists?(status: ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision_or_inactive) + ApplicationStateChange::ApplicationState.state_ids(:offer_accepted))
   end
 end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -44,7 +44,7 @@ private
   end
 
   def accepted_application
-    @application_choices ||= reference.application_form.application_choices.where(status: ApplicationStateChange::SUCCESSFUL_STATES).first
+    @application_choices ||= reference.application_form.application_choices.where(status: ApplicationStateChange::ApplicationState.state_ids(:successful)).first
   end
 
   # Only progress the applications if the reference that is being submitted is

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -41,7 +41,7 @@ module SupportInterface
       ApplicationForm
         .includes(%i[candidate application_choices])
         .joins(application_choices: [:course_option])
-        .where.not(application_choices: { status: ApplicationStateChange::TERMINAL_STATES })
+        .where.not(application_choices: { status: ApplicationStateChange::ApplicationState.state_ids(:terminal) })
         .order('application_forms.id desc')
         .distinct
     end

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -115,7 +115,7 @@ module SupportInterface
     def ended_without_success
       earliest_update_audit_for(
         @application_choice,
-        status: ApplicationStateChange::UNSUCCESSFUL_STATES.map(&:to_s),
+        status: ApplicationStateChange::ApplicationState.state_ids(:unsuccessful).map(&:to_s),
       )
     end
 

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ApplicationStateError < StandardError; end
 
   class ChangeApplicationChoiceCourseOption
-    VALID_STATES = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+    VALID_STATES = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider)
 
     attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment, :recruitment_cycle_year
     attr_accessor :confirm_course_change

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -39,11 +39,13 @@ module SupportInterface
     end
 
     def count_offers(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::OFFERED_STATES.include?(status.to_sym) }
+      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offered? }
+      # choice_statuses.count { |status| ApplicationStateChange::OFFERED_STATES.include?(status.to_sym) }
     end
 
     def count_acceptances(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
+      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted? }
+      # choice_statuses.count { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
     end
   end
 end

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -40,12 +40,10 @@ module SupportInterface
 
     def count_offers(choice_statuses)
       choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offered? }
-      # choice_statuses.count { |status| ApplicationStateChange::OFFERED_STATES.include?(status.to_sym) }
     end
 
     def count_acceptances(choice_statuses)
       choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted? }
-      # choice_statuses.count { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
     end
   end
 end

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -39,11 +39,11 @@ module SupportInterface
     end
 
     def count_offers(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offered? }
+      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status).offered? }
     end
 
     def count_acceptances(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status.to_sym).offer_accepted? }
+      choice_statuses.count { |status| ApplicationStateChange::ApplicationState.find(status).offer_accepted? }
     end
   end
 end

--- a/app/validators/reapply_validator.rb
+++ b/app/validators/reapply_validator.rb
@@ -29,7 +29,8 @@ class ReapplyValidator < ActiveModel::Validator
   end
 
   def record_has_reapply_status?(record)
-    ApplicationStateChange::REAPPLY_STATUSES.include?(record.status.to_s.to_sym)
+    ApplicationStateChange::ApplicationState.find(record.status.to_s.to_sym)&.reapply? || false
+    # ApplicationStateChange::REAPPLY_STATUSES.include?(record.status.to_s.to_sym)
   end
 
   def blank_attributes?(record)

--- a/app/validators/reapply_validator.rb
+++ b/app/validators/reapply_validator.rb
@@ -30,7 +30,6 @@ class ReapplyValidator < ActiveModel::Validator
 
   def record_has_reapply_status?(record)
     ApplicationStateChange::ApplicationState.find(record.status.to_s.to_sym)&.reapply? || false
-    # ApplicationStateChange::REAPPLY_STATUSES.include?(record.status.to_s.to_sym)
   end
 
   def blank_attributes?(record)

--- a/app/validators/reapply_validator.rb
+++ b/app/validators/reapply_validator.rb
@@ -29,7 +29,7 @@ class ReapplyValidator < ActiveModel::Validator
   end
 
   def record_has_reapply_status?(record)
-    ApplicationStateChange::ApplicationState.find(record.status.to_s.to_sym)&.reapply? || false
+    ApplicationStateChange::ApplicationState.find(record.status.to_s)&.reapply? || false
   end
 
   def blank_attributes?(record)

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
@@ -47,7 +47,7 @@
 
 <p class="govuk-body">Applications in the following states will transition to the <code>withdrawn</code> state:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state| %>
+  <% (ApplicationStateChange::ApplicationState.state_ids(:successful) + ApplicationStateChange::ApplicationState.state_ids(:pending_provider_decision)).each do |state| %>
     <li><code><%= state %></code></li>
   <% end %>
 </ul>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -69,7 +69,7 @@
   </div>
 <% end %>
 
-<% if @provider_user_can_make_decisions && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym) %>
+<% if @provider_user_can_make_decisions && ApplicationStateChange::ApplicationState.find(@application_choice.status.to_sym).pending_provider_decision %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
     course_option: @application_choice.course_option,

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -69,7 +69,7 @@
   </div>
 <% end %>
 
-<% if @provider_user_can_make_decisions && ApplicationStateChange::ApplicationState.find(@application_choice.status.to_sym).pending_provider_decision %>
+<% if @provider_user_can_make_decisions && ApplicationStateChange::ApplicationState.find(@application_choice.status)&.pending_provider_decision %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
     course_option: @application_choice.course_option,

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -41,7 +41,6 @@ private
 
   def states_for_this_cycle
     ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - [:inactivate]
-    # ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - [:inactive]
   end
 
   def states_for_next_cycle

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -40,7 +40,8 @@ private
   end
 
   def states_for_this_cycle
-    ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - [:inactive]
+    ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - [:inactivate]
+    # ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - [:inactive]
   end
 
   def states_for_next_cycle

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -35,7 +35,7 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
         previous_recruitment_year:,
         successful: ApplicationChoice
                       .select(1)
-                      .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
+                      .where(status: ApplicationStateChange::ApplicationState.state_ids(:successful))
                       .where('application_choices.application_form_id = application_forms.id'),
       )
       .distinct

--- a/spec/services/concerns/define_application_state_spec.rb
+++ b/spec/services/concerns/define_application_state_spec.rb
@@ -1,0 +1,669 @@
+require 'rails_helper'
+
+RSpec.describe DefineApplicationState do
+  describe ApplicationStateChange::ApplicationState do
+    describe 'attributes' do
+      it 'has attributes for each of the ApplicationStateChange constants' do
+        attributes = { id: :blah, visible_to_provider: false, interviewable: false, offered: false,
+                       post_offered: false, offer_accepted: false, unsuccessful: false, carry_over: false,
+                       successful: false, pending_provider_decision: false, reapply: false, terminal: false,
+                       in_progress: false, active_previous: false }
+        expect(described_class.new(**attributes)).to have_attributes(**attributes)
+      end
+    end
+
+    describe '.all' do
+      it 'returns all application states with their attributes' do
+        states = described_class.all
+
+        expect(states.size).to eq(15)
+
+        expect(states.map(&:id)).to contain_exactly(
+          :withdrawn, :unsubmitted, :awaiting_provider_decision, :inactive,
+          :interviewing, :rejected, :application_not_sent, :offer,
+          :offer_withdrawn, :declined, :pending_conditions,
+          :conditions_not_met, :recruited, :cancelled, :offer_deferred,
+        )
+
+        expect(states).to all(be_a(described_class))
+      end
+    end
+
+    describe '.find' do
+      it 'returns the correct application state by id' do
+        state = described_class.find(:withdrawn)
+
+        expect(state.id).to eq(:withdrawn)
+        expect(state).to be_a(described_class)
+      end
+
+      it 'returns nil form unknown ids' do
+        state = described_class.find(:unknown)
+
+        expect(state).to be_nil
+      end
+    end
+
+    describe '.where' do
+      it 'returns the correct application states by ids' do
+        states = described_class.where(id: %i[withdrawn unsubmitted])
+
+        expect(states.size).to eq(2)
+        expect(states.map(&:id)).to contain_exactly(:withdrawn, :unsubmitted)
+        expect(states).to all(be_a(described_class))
+      end
+
+      it 'returns an empty array for unknown ids' do
+        states = described_class.where(id: [:unknown])
+
+        expect(states).to be_empty
+      end
+
+      it 'returns the correct application states using attributes' do
+        states = described_class.where(
+          offered: true,
+          post_offered: true,
+          terminal: true,
+        )
+
+        expect(states.size).to eq(4)
+        expect(states.map(&:id)).to contain_exactly(
+          :offer_withdrawn, :declined, :conditions_not_met, :recruited
+        )
+      end
+    end
+
+    describe 'scopes' do
+      describe '.not_visible_to_provider' do
+        subject(:not_visible_to_provider) { described_class.not_visible_to_provider }
+
+        it 'returns only states that are not visible to provider' do
+          expect(not_visible_to_provider.map(&:id)).to contain_exactly(
+            :unsubmitted,
+            :application_not_sent,
+            :cancelled,
+          )
+        end
+
+        it 'matches STATES_NOT_VISIBLE_TO_PROVIDER' do
+          expect(not_visible_to_provider.map(&:id)).to match_array(
+            ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER,
+          )
+        end
+      end
+
+      describe '.visible_to_provider' do
+        subject(:scope_method) { described_class.visible_to_provider }
+
+        it 'returns only states that are visible to provider' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision,
+                                              :withdrawn,
+                                              :rejected,
+                                              :inactive,
+                                              :interviewing,
+                                              :offer,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :pending_conditions,
+                                              :conditions_not_met,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches STATES_VISIBLE_TO_PROVIDER' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER,
+                                              )
+        end
+      end
+
+      describe '.interviewable' do
+        subject(:scope_method) { described_class.interviewable }
+
+        it 'returns only states that are interviewable' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision,
+                                              :inactive,
+                                              :interviewing,
+                                              )
+        end
+
+        it 'matches INTERVIEWABLE_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::INTERVIEWABLE_STATES,
+                                              )
+        end
+      end
+
+      describe '.offer_accepted' do
+        subject(:scope_method) { described_class.offer_accepted }
+
+        it 'returns only states that have accepted offers' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :pending_conditions,
+                                              :conditions_not_met,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches ACCEPTED_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::ACCEPTED_STATES,
+                                              )
+        end
+      end
+
+      describe '.offered' do
+        subject(:scope_method) { described_class.offered }
+
+        it 'returns only states that have offers' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :offer,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :pending_conditions,
+                                              :conditions_not_met,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches OFFERED_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::OFFERED_STATES,
+                                              )
+        end
+      end
+
+      describe '.post_offered' do
+        subject(:scope_method) { described_class.post_offered }
+
+        it 'returns only states that are post-offered' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :pending_conditions,
+                                              :conditions_not_met,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches POST_OFFERED_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::POST_OFFERED_STATES,
+                                              )
+        end
+      end
+
+      describe '.unsuccessful' do
+        subject(:scope_method) { described_class.unsuccessful }
+
+        it 'returns only states that are unsuccessful' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :application_not_sent,
+                                              :cancelled,
+                                              :withdrawn,
+                                              :rejected,
+                                              :inactive,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :conditions_not_met,
+                                              )
+        end
+
+        it 'matches UNSUCCESSFUL_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::UNSUCCESSFUL_STATES,
+                                              )
+        end
+      end
+
+      describe '.carry_over' do
+        subject(:scope_method) { described_class.carry_over }
+
+        it 'returns only states that are eligible for carry over' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :application_not_sent,
+                                              :cancelled,
+                                              :withdrawn,
+                                              :rejected,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :conditions_not_met,
+                                              )
+        end
+
+        it 'matches CARRY_OVER_ELIGIBLE_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES,
+                                              )
+        end
+      end
+
+      describe '.successful' do
+        subject(:scope_method) { described_class.successful }
+
+        it 'returns only states that are successful' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :offer,
+                                              :pending_conditions,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches SUCCESSFUL_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::SUCCESSFUL_STATES,
+                                              )
+        end
+      end
+
+      describe '.pending_provider_decision' do
+        subject(:scope_method) { described_class.pending_provider_decision }
+
+        it 'returns only states that are pending provider decisions' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision,
+                                              :interviewing,
+                                              )
+        end
+
+        it 'matches DECISION_PENDING_STATUSES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::DECISION_PENDING_STATUSES,
+                                              )
+        end
+      end
+
+      describe '.pending_provider_decision_or_inactive' do
+        subject(:scope_method) { described_class.pending_provider_decision_or_inactive }
+
+        it 'returns only states that are pending provider decisions or are inactive' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision,
+                                              :interviewing,
+                                              :inactive,
+                                              )
+        end
+
+        it 'matches DECISION_PENDING_AND_INACTIVE_STATUSES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES,
+                                              )
+        end
+      end
+
+      describe '.reapply' do
+        subject(:scope_method) { described_class.reapply }
+
+        it 'returns only states that allow reapplying' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :cancelled,
+                                              :withdrawn,
+                                              :rejected,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              )
+        end
+
+        it 'matches REAPPLY_STATUSES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::REAPPLY_STATUSES,
+                                              )
+        end
+      end
+
+      describe '.terminal' do
+        subject(:scope_method) { described_class.terminal }
+
+        it 'returns only states that are terminal' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :application_not_sent,
+                                              :cancelled,
+                                              :withdrawn,
+                                              :rejected,
+                                              :inactive,
+                                              :offer_withdrawn,
+                                              :declined,
+                                              :conditions_not_met,
+                                              :recruited,
+                                              )
+        end
+
+        it 'matches TERMINAL_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::TERMINAL_STATES,
+                                              )
+        end
+      end
+
+      describe '.in_progress' do
+        subject(:scope_method) { described_class.in_progress }
+
+        it 'returns only states that are in progress' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision,
+                                              :interviewing,
+                                              :offer,
+                                              :pending_conditions,
+                                              :recruited,
+                                              :offer_deferred,
+                                              )
+        end
+
+        it 'matches IN_PROGRESS_STATES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::IN_PROGRESS_STATES,
+                                              )
+        end
+      end
+
+      describe '.active_previous' do
+        subject(:scope_method) { described_class.active_previous }
+
+        it 'returns only states that are in progress' do
+          expect(scope_method.map(&:id)).to contain_exactly(
+                                              :awaiting_provider_decision, :interviewing, :pending_conditions, :recruited, :offer, :inactive
+                                              )
+        end
+
+        it 'matches ACTIVE_PREVIOUS_STATUSES' do
+          expect(scope_method.map(&:id)).to match_array(
+                                              ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES,
+                                              )
+        end
+      end
+    end
+
+    describe 'states make sense' do
+      it 'ensures that no state is both successful and unsuccessful' do
+        successful_states = described_class.successful.map(&:id)
+        unsuccessful_states = described_class.unsuccessful.map(&:id)
+
+        expect(successful_states & unsuccessful_states).to be_empty
+      end
+
+      it 'ensures that no state is both pending provider decision and not visible to provider' do
+        pending_provider_decision_states = described_class.pending_provider_decision.map(&:id)
+        not_visible_to_provider_states = described_class.not_visible_to_provider.map(&:id)
+
+        expect(pending_provider_decision_states & not_visible_to_provider_states).to be_empty
+      end
+    end
+
+    describe 'awaiting_provider_decision state' do
+      subject { described_class.find(:awaiting_provider_decision) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.to be_pending_provider_decision }
+      it { is_expected.to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'unsubmitted state' do
+      subject { described_class.find(:unsubmitted) }
+
+      it { is_expected.not_to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'application_not_sent state' do
+      subject { described_class.find(:application_not_sent) }
+
+      it { is_expected.not_to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'cancelled state' do
+      subject { described_class.find(:cancelled) }
+
+      it { is_expected.not_to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'withdrawn state' do
+      subject { described_class.find(:withdrawn) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'rejected state' do
+      subject { described_class.find(:rejected) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'inactive state' do
+      subject { described_class.find(:inactive) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'interviewing state' do
+      subject { described_class.find(:interviewing) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.to be_pending_provider_decision }
+      it { is_expected.to be_interviewable }
+      it { is_expected.not_to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'offer state' do
+      subject { described_class.find(:offer) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.not_to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'offer_withdrawn state' do
+      subject { described_class.find(:offer_withdrawn) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'declined state' do
+      subject { described_class.find(:declined) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.not_to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'pending_conditions state' do
+      subject { described_class.find(:pending_conditions) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'conditions_not_met state' do
+      subject { described_class.find(:conditions_not_met) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.to be_offer_accepted }
+      it { is_expected.to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.to be_unsuccessful }
+      it { is_expected.not_to be_successful }
+      it { is_expected.not_to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+
+    describe 'recruited state' do
+      subject { described_class.find(:recruited) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.to be_terminal }
+      it { is_expected.to be_active_previous }
+    end
+
+    describe 'offer_deferred state' do
+      subject { described_class.find(:offer_deferred) }
+
+      it { is_expected.to be_visible_to_provider }
+      it { is_expected.not_to be_pending_provider_decision }
+      it { is_expected.not_to be_interviewable }
+      it { is_expected.to be_offered }
+      it { is_expected.to be_post_offered }
+      it { is_expected.to be_offer_accepted }
+      it { is_expected.not_to be_carry_over }
+      it { is_expected.not_to be_reapply }
+      it { is_expected.not_to be_unsuccessful }
+      it { is_expected.to be_successful }
+      it { is_expected.to be_in_progress }
+      it { is_expected.not_to be_terminal }
+      it { is_expected.not_to be_active_previous }
+    end
+  end
+end

--- a/spec/services/concerns/define_application_state_spec.rb
+++ b/spec/services/concerns/define_application_state_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DefineApplicationState do
           :withdrawn, :unsubmitted, :awaiting_provider_decision, :inactive,
           :interviewing, :rejected, :application_not_sent, :offer,
           :offer_withdrawn, :declined, :pending_conditions,
-          :conditions_not_met, :recruited, :cancelled, :offer_deferred,
+          :conditions_not_met, :recruited, :cancelled, :offer_deferred
         )
 
         expect(states).to all(be_a(described_class))
@@ -97,25 +97,25 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are visible to provider' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision,
-                                              :withdrawn,
-                                              :rejected,
-                                              :inactive,
-                                              :interviewing,
-                                              :offer,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :pending_conditions,
-                                              :conditions_not_met,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :awaiting_provider_decision,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :interviewing,
+            :offer,
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches STATES_VISIBLE_TO_PROVIDER' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER,
-                                              )
+            ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER,
+          )
         end
       end
 
@@ -124,16 +124,16 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are interviewable' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision,
-                                              :inactive,
-                                              :interviewing,
-                                              )
+            :awaiting_provider_decision,
+            :inactive,
+            :interviewing,
+          )
         end
 
         it 'matches INTERVIEWABLE_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::INTERVIEWABLE_STATES,
-                                              )
+            ApplicationStateChange::INTERVIEWABLE_STATES,
+          )
         end
       end
 
@@ -142,17 +142,17 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that have accepted offers' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :pending_conditions,
-                                              :conditions_not_met,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches ACCEPTED_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::ACCEPTED_STATES,
-                                              )
+            ApplicationStateChange::ACCEPTED_STATES,
+          )
         end
       end
 
@@ -161,20 +161,20 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that have offers' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :offer,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :pending_conditions,
-                                              :conditions_not_met,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :offer,
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches OFFERED_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::OFFERED_STATES,
-                                              )
+            ApplicationStateChange::OFFERED_STATES,
+          )
         end
       end
 
@@ -183,19 +183,19 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are post-offered' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :pending_conditions,
-                                              :conditions_not_met,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches POST_OFFERED_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::POST_OFFERED_STATES,
-                                              )
+            ApplicationStateChange::POST_OFFERED_STATES,
+          )
         end
       end
 
@@ -204,21 +204,21 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are unsuccessful' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :application_not_sent,
-                                              :cancelled,
-                                              :withdrawn,
-                                              :rejected,
-                                              :inactive,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :conditions_not_met,
-                                              )
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+          )
         end
 
         it 'matches UNSUCCESSFUL_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::UNSUCCESSFUL_STATES,
-                                              )
+            ApplicationStateChange::UNSUCCESSFUL_STATES,
+          )
         end
       end
 
@@ -227,20 +227,20 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are eligible for carry over' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :application_not_sent,
-                                              :cancelled,
-                                              :withdrawn,
-                                              :rejected,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :conditions_not_met,
-                                              )
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+          )
         end
 
         it 'matches CARRY_OVER_ELIGIBLE_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES,
-                                              )
+            ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES,
+          )
         end
       end
 
@@ -249,17 +249,17 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are successful' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :offer,
-                                              :pending_conditions,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :offer,
+            :pending_conditions,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches SUCCESSFUL_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::SUCCESSFUL_STATES,
-                                              )
+            ApplicationStateChange::SUCCESSFUL_STATES,
+          )
         end
       end
 
@@ -268,15 +268,15 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are pending provider decisions' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision,
-                                              :interviewing,
-                                              )
+            :awaiting_provider_decision,
+            :interviewing,
+          )
         end
 
         it 'matches DECISION_PENDING_STATUSES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::DECISION_PENDING_STATUSES,
-                                              )
+            ApplicationStateChange::DECISION_PENDING_STATUSES,
+          )
         end
       end
 
@@ -285,16 +285,16 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are pending provider decisions or are inactive' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision,
-                                              :interviewing,
-                                              :inactive,
-                                              )
+            :awaiting_provider_decision,
+            :interviewing,
+            :inactive,
+          )
         end
 
         it 'matches DECISION_PENDING_AND_INACTIVE_STATUSES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES,
-                                              )
+            ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES,
+          )
         end
       end
 
@@ -303,18 +303,18 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that allow reapplying' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :cancelled,
-                                              :withdrawn,
-                                              :rejected,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              )
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :offer_withdrawn,
+            :declined,
+          )
         end
 
         it 'matches REAPPLY_STATUSES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::REAPPLY_STATUSES,
-                                              )
+            ApplicationStateChange::REAPPLY_STATUSES,
+          )
         end
       end
 
@@ -323,22 +323,22 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are terminal' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :application_not_sent,
-                                              :cancelled,
-                                              :withdrawn,
-                                              :rejected,
-                                              :inactive,
-                                              :offer_withdrawn,
-                                              :declined,
-                                              :conditions_not_met,
-                                              :recruited,
-                                              )
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+            :recruited,
+          )
         end
 
         it 'matches TERMINAL_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::TERMINAL_STATES,
-                                              )
+            ApplicationStateChange::TERMINAL_STATES,
+          )
         end
       end
 
@@ -347,19 +347,19 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are in progress' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision,
-                                              :interviewing,
-                                              :offer,
-                                              :pending_conditions,
-                                              :recruited,
-                                              :offer_deferred,
-                                              )
+            :awaiting_provider_decision,
+            :interviewing,
+            :offer,
+            :pending_conditions,
+            :recruited,
+            :offer_deferred,
+          )
         end
 
         it 'matches IN_PROGRESS_STATES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::IN_PROGRESS_STATES,
-                                              )
+            ApplicationStateChange::IN_PROGRESS_STATES,
+          )
         end
       end
 
@@ -368,14 +368,14 @@ RSpec.describe DefineApplicationState do
 
         it 'returns only states that are in progress' do
           expect(scope_method.map(&:id)).to contain_exactly(
-                                              :awaiting_provider_decision, :interviewing, :pending_conditions, :recruited, :offer, :inactive
-                                              )
+            :awaiting_provider_decision, :interviewing, :pending_conditions, :recruited, :offer, :inactive
+          )
         end
 
         it 'matches ACTIVE_PREVIOUS_STATUSES' do
           expect(scope_method.map(&:id)).to match_array(
-                                              ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES,
-                                              )
+            ApplicationStateChange::ACTIVE_PREVIOUS_STATUSES,
+          )
         end
       end
     end

--- a/spec/services/concerns/define_application_state_spec.rb
+++ b/spec/services/concerns/define_application_state_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe DefineApplicationState do
       describe '.active_previous' do
         subject(:scope_method) { described_class.active_previous }
 
-        it 'returns only states that are in progress' do
+        it 'returns only states that are active_previous' do
           expect(scope_method.map(&:id)).to contain_exactly(
             :awaiting_provider_decision, :interviewing, :pending_conditions, :recruited, :offer, :inactive
           )
@@ -664,6 +664,201 @@ RSpec.describe DefineApplicationState do
       it { is_expected.to be_in_progress }
       it { is_expected.not_to be_terminal }
       it { is_expected.not_to be_active_previous }
+    end
+
+    describe '.state_ids' do
+      subject(:state_ids) { described_class.state_ids(args) }
+
+      context 'when given method not_visible_to_provider' do
+        let(:args) { :not_visible_to_provider }
+
+        it 'returns the ids of Application States where visible_to_provider is false' do
+          expect(state_ids).to contain_exactly(:unsubmitted, :application_not_sent, :cancelled)
+        end
+      end
+
+      context 'when given method visible_to_provider' do
+        let(:args) { :visible_to_provider }
+
+        it 'returns the ids of Application States where visible_to_provider is true' do
+          expect(state_ids).to contain_exactly(
+            :awaiting_provider_decision,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :interviewing,
+            :offer,
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
+        end
+      end
+
+      context 'when given method interviewable' do
+        let(:args) { :interviewable }
+
+        it 'returns the ids of Application States where interviewable is true' do
+          expect(state_ids).to contain_exactly(:awaiting_provider_decision, :inactive, :interviewing)
+        end
+      end
+
+      context 'when given method offered' do
+        let(:args) { :offered }
+
+        it 'returns the ids of Application States where offered is true' do
+          expect(state_ids).to contain_exactly(
+            :offer,
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
+        end
+      end
+
+      context 'when given method post_offered' do
+        let(:args) { :post_offered }
+
+        it 'returns the ids of Application States where post_offered is true' do
+          expect(state_ids).to contain_exactly(
+            :offer_withdrawn,
+            :declined,
+            :pending_conditions,
+            :conditions_not_met,
+            :recruited,
+            :offer_deferred,
+          )
+        end
+      end
+
+      context 'when given method unsuccessful' do
+        let(:args) { :unsuccessful }
+
+        it 'returns the ids of Application States where unsuccessful is true' do
+          expect(state_ids).to contain_exactly(
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+          )
+        end
+      end
+
+      context 'when given method carry_over' do
+        let(:args) { :carry_over }
+
+        it 'returns the ids of Application States where carry_over is true' do
+          expect(state_ids).to contain_exactly(
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+          )
+        end
+      end
+
+      context 'when given method successful' do
+        let(:args) { :successful }
+
+        it 'returns the ids of Application States where successful is true' do
+          expect(state_ids).to contain_exactly(
+            :offer,
+            :pending_conditions,
+            :recruited,
+            :offer_deferred,
+          )
+        end
+      end
+
+      context 'when given method pending_provider_decision' do
+        let(:args) { :pending_provider_decision }
+
+        it 'returns the ids of Application States where pending_provider_decision is true' do
+          expect(state_ids).to contain_exactly(:awaiting_provider_decision, :interviewing)
+        end
+      end
+
+      context 'when given method pending_provider_decision_or_inactive' do
+        let(:args) { :pending_provider_decision_or_inactive }
+
+        it 'returns the ids of Application States where pending_provider_decision_or_inactive is true' do
+          expect(state_ids).to contain_exactly(
+            :awaiting_provider_decision,
+            :interviewing,
+            :inactive,
+          )
+        end
+      end
+
+      context 'when given method reapply' do
+        let(:args) { :reapply }
+
+        it 'returns the ids of Application States where reapply is true' do
+          expect(state_ids).to contain_exactly(
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :offer_withdrawn,
+            :declined,
+          )
+        end
+      end
+
+      context 'when given method terminal' do
+        let(:args) { :terminal }
+
+        it 'returns the ids of Application States where terminal is true' do
+          expect(state_ids).to contain_exactly(
+            :application_not_sent,
+            :cancelled,
+            :withdrawn,
+            :rejected,
+            :inactive,
+            :offer_withdrawn,
+            :declined,
+            :conditions_not_met,
+            :recruited,
+          )
+        end
+      end
+
+      context 'when given method in_progress' do
+        let(:args) { :in_progress }
+
+        it 'returns the ids of Application States where in_progress is true' do
+          expect(state_ids).to contain_exactly(
+            :awaiting_provider_decision,
+            :interviewing,
+            :offer,
+            :pending_conditions,
+            :recruited,
+            :offer_deferred,
+          )
+        end
+      end
+
+      context 'when given method active_previous' do
+        let(:args) { :active_previous }
+
+        it 'returns the ids of Application States where active_previous is true' do
+          expect(state_ids).to contain_exactly(
+            :awaiting_provider_decision, :interviewing, :pending_conditions, :recruited, :offer, :inactive
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

- Based on [Making Application States easier to understand
](https://github.com/DFE-Digital/apply-for-teacher-training/pull/11109), update the Application State models and replace the use of ApplicationStateChange constants within the code.

## Changes proposed in this pull request

- Update the Application State models
- Replace the use of ApplicationStateChange constants within the code.

(Tests and CONSTANTS left in code and will be removed in a separate PR, once the changes have been proven to work.)

## Guidance to review

Updated state table

| State                      | visible_to_provider | pending_provider_decision | interviewable | offered | post_offered | offer_accepted | carry_over | reapply | unsuccessful | successful | in_progress | terminal | active_previous |
|----------------------------|---------------------|---------------------------|---------------|---------|--------------|----------------|------------|---------|--------------|------------|-------------|----------|----------|
| unsubmitted                | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ❌           | ❌        | ❌        |
| application_not_sent       | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ❌       | ✅            | ❌          | ❌           | ✅        | ❌        |
| awaiting_provider_decision | ✅                   | ✅                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ✅           | ❌        | ✅           | 
| cancelled                  | ❌                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        |❌           |
| withdrawn                  | ✅                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        | ❌           |
| rejected                   | ✅                   | ❌                         | ❌             | ❌       | ❌            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        | ❌           |
| inactive                   | ✅                   | ❌                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ✅            | ❌          | ❌           | ✅        |  ✅                   |
| interviewing               | ✅                   | ✅                         | ✅             | ❌       | ❌            | ❌              | ❌          | ❌       | ❌            | ❌          | ✅           | ❌        |  ✅                   |
| offer                      | ✅                   | ❌                         | ❌             | ✅       | ❌            | ❌              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        |  ✅                   |
| offer_withdrawn            | ✅                   | ❌                         | ❌             | ✅       | ✅            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        | ❌           | 
| declined                   | ✅                   | ❌                         | ❌             | ✅       | ✅            | ❌              | ✅          | ✅       | ✅            | ❌          | ❌           | ✅        | ❌           | 
| pending_conditions         | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        | ✅                   | 
| conditions_not_met         | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ✅          | ❌       | ✅            | ❌          | ❌           | ✅        | ❌           | 
| recruited                  | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ✅        |  ✅           | 
| offer_deferred             | ✅                   | ❌                         | ❌             | ✅       | ✅            | ✅              | ❌          | ❌       | ❌            | ✅          | ✅           | ❌        | ❌        |


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/ImL62Hrn/1822-application-state-refactor