### PR TITLE
Replace self_and_siblings with active_application_choices

### DIFF
--- a/app/components/candidate_interface/offer_other_applications_warning_component.rb
+++ b/app/components/candidate_interface/offer_other_applications_warning_component.rb
@@ -53,7 +53,7 @@ module CandidateInterface
     end
 
     def sibling_choices
-      @sibling_choices ||= @choice_with_offer.siblings
+      @sibling_choices ||= @choice_with_offer.candidate.active_application_choices.where.not(id: @choice_with_offer.id)
     end
   end
 end

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -21,7 +21,7 @@ module CandidateInterface
       @respond_to_offer = CandidateInterface::RespondToOfferForm.new(response:)
 
       if @respond_to_offer.invalid?
-        @offer_count = @application_choice.self_and_siblings.offer.count
+        @offer_count = active_application_choices.offer.count
         @decline_by_default_date = current_timetable.decline_by_default_at
         render :offer
       elsif @respond_to_offer.decline?

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -341,7 +341,6 @@ class CandidateMailer < ApplicationMailer
   def decline_last_application_choice(application_choice, course_recommendation_url = nil)
     @declined_course = application_choice
     @declined_course_name = "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}"
-    @rejected_course_choices_count = application_choice.self_and_siblings.select(&:rejected?).count
     @course_recommendation_url = course_recommendation_url
 
     email_for_candidate(

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -245,14 +245,6 @@ class ApplicationChoice < ApplicationRecord
     ].any?
   end
 
-  def self_and_siblings
-    application_form.application_choices
-  end
-
-  def siblings
-    self_and_siblings.where.not(id:)
-  end
-
   def no_feedback?
     rejection_reason.blank? && structured_rejection_reasons.blank?
   end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -97,12 +97,16 @@ private
   end
 
   def can_not_receive_other_offers?
-    (application_choice.self_and_siblings - [application_choice])
+    (active_application_choices - [application_choice])
       .map(&:status).map(&:to_sym)
       .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])
   end
 
   def candidate_in_apply_2?
     application_choice.candidate.in_apply_2?
+  end
+
+  def active_application_choices
+    application_choice.candidate.active_application_choices
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -97,7 +97,7 @@ private
   end
 
   def can_not_receive_other_offers?
-    (active_application_choices - [application_choice])
+    active_application_choices.where.not(id: application_choice.id)
       .map(&:status).map(&:to_sym)
       .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -1123,27 +1123,6 @@ RSpec.describe ApplicationChoice do
     end
   end
 
-  describe '#self_and_siblings' do
-    it 'returns the applications choice and the other choices for the application form' do
-      application_form = create(:application_form)
-      choices = create_list(:application_choice, 3, application_form:)
-      choice = choices.first
-
-      expect(choice.self_and_siblings).to match_array(choices)
-    end
-  end
-
-  describe '#siblings' do
-    it 'returns the other choices associated with the application form' do
-      application_form = create(:application_form)
-      choices = create_list(:application_choice, 3, application_form:)
-      choice = choices.first
-
-      expect(choice.siblings.count).to eq 2
-      expect(choice.siblings).not_to include choice
-    end
-  end
-
   describe '#find_provider_url' do
     let(:application_choice) { create(:application_choice) }
 


### PR DESCRIPTION
## Context

- Replace `self_and_siblings` with `active_application_choices`

## Changes proposed in this pull request

- Replace `self_and_siblings` with `active_application_choices`

## Guidance to review

- Review the code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/7Jff1XE5/1825-replace-selfandsiblings-with-activeapplicationschoices