### PR TITLE
Lb/1826 bug mailer previews

### DIFF
--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -8,9 +8,11 @@ Address or online meeting details:
 
 ^ <%= @interview.location %>
 
+<% if @interview.additional_details.present? %>
 Additional details:
 
 ^ <%= @interview.additional_details %>
+<% end %>
 
 Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.
 

--- a/app/views/candidate_mailer/offer_withdrawn.text.erb
+++ b/app/views/candidate_mailer/offer_withdrawn.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 <%= @provider_name %> has withdrawn their offer for you to study <%= @course_name_and_code %>. They’ve given feedback to explain this decision.
 
-^ # Why the offer was withdrawn
+# Why the offer was withdrawn
 ^ <%= @withdrawal_reason %>
 
 Contact <%= @provider_name %> directly if you have questions about this.

--- a/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
+++ b/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
@@ -8,6 +8,7 @@ module ProviderInterface
       render ProviderUserPermissionsFormComponent.new(
         form_model: form_model_for(provider),
         form_path: '',
+        form_method: :post,
         provider:,
         user_name:,
       )
@@ -18,6 +19,7 @@ module ProviderInterface
       render ProviderUserPermissionsFormComponent.new(
         form_model: form_model_for(provider),
         form_path: '',
+        form_method: :post,
         provider:,
         user_name:,
       )

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :provider do
-    sequence(:code, 'BAA')
+    code { SecureRandom.alphanumeric(3).upcase }
     sequence(:name) { |n| "#{Faker::University.name}-#{n}" }
     phone_number { Faker::PhoneNumber.phone_number }
     email_address { Faker::Internet.email }


### PR DESCRIPTION
## Context

On QA some of our mail previews were throwing 500 errors (sometimes) because the `provider.code` was not unique. 
Locally, I was able to re-recreate the problem by changing one of the provider codes to BAA. 
Many previews errored. 

We sequence the provider codes in our `FactoryBots`, eg `sequence(:code, 'BAA')`. So the first code is BAA, the second code is BAB, and so forth. This works fine in a test suite because we dump all the data between tests, but it doesn't work so well for previews because there are already providers with those codes in the database, potentially. 

## Changes proposed in this pull request

I've changed our method for generating codes to use random letters and numbers. There is still a chance that the code will be something that already exists, but relatively small, and if the page is refreshed, a different code will be generated, so the problem isn't going to be block the user. 

Also, in clicking on all the previews, I found some formatting issues, so there are a few little fixes here. 

## Guidance to review

In doing this, i found a bunch of our component previews don't work for unrelated issues. But they are used less than the mailer previews, so I don't want to delay getting this in. I'll create a second ticket for the components. 

Click on all the mailer previews -- mailers. They should all render successfully. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
