### PR TITLE
Refactor matching logic in Possible Previous Teacher Training

### DIFF
--- a/app/services/generate_possible_previous_teacher_training.rb
+++ b/app/services/generate_possible_previous_teacher_training.rb
@@ -35,6 +35,8 @@ private
   end
 
   def previous_teacher_training_declared?(possible_previous_teacher_training_data)
+    return true if candidate.previous_teacher_trainings.exists?(['provider_name ILIKE ?', possible_previous_teacher_training_data.name])
+
     provider_record = accredited_provider(possible_previous_teacher_training_data.code)
     started_at = possible_previous_teacher_training_data.trainee_start_date.to_time.beginning_of_month
     ended_at = possible_previous_teacher_training_data.registered_date.to_time.end_of_month
@@ -45,10 +47,6 @@ private
 
     return false if previous_teacher_training_in_timeframe.blank?
 
-    ((provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)) ||
-      previous_teacher_training_in_timeframe.find_by(
-        'provider_name ILIKE ?',
-        possible_previous_teacher_training_data.name,
-      )).present?
+    (provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)).present?
   end
 end

--- a/app/services/generate_possible_previous_teacher_training.rb
+++ b/app/services/generate_possible_previous_teacher_training.rb
@@ -35,8 +35,6 @@ private
   end
 
   def previous_teacher_training_declared?(possible_previous_teacher_training_data)
-    return true if candidate.previous_teacher_trainings.exists?(['provider_name ILIKE ?', possible_previous_teacher_training_data.name])
-
     provider_record = accredited_provider(possible_previous_teacher_training_data.code)
     started_at = possible_previous_teacher_training_data.trainee_start_date.to_time.beginning_of_month
     ended_at = possible_previous_teacher_training_data.registered_date.to_time.end_of_month
@@ -47,6 +45,10 @@ private
 
     return false if previous_teacher_training_in_timeframe.blank?
 
-    (provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)).present?
+    ((provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)) ||
+      previous_teacher_training_in_timeframe.find_by(
+        'provider_name ILIKE ?',
+        possible_previous_teacher_training_data.name,
+      )).present?
   end
 end

--- a/app/services/generate_possible_previous_teacher_training.rb
+++ b/app/services/generate_possible_previous_teacher_training.rb
@@ -39,15 +39,16 @@ private
     started_at = possible_previous_teacher_training_data.trainee_start_date.to_time.beginning_of_month
     ended_at = possible_previous_teacher_training_data.registered_date.to_time.end_of_month
     previous_teacher_training_in_timeframe = candidate.previous_teacher_trainings.where(
-      started_at: started_at..,
-      ended_at: ..ended_at,
+      started_at: (started_at - 3.months)..,
+      ended_at: ..(ended_at + 3.months),
     )
 
     return false if previous_teacher_training_in_timeframe.blank?
 
     ((provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)) ||
       previous_teacher_training_in_timeframe.find_by(
-        provider_name: possible_previous_teacher_training_data.name,
+        'provider_name ILIKE ?',
+        possible_previous_teacher_training_data.name,
       )).present?
   end
 end

--- a/app/services/generate_possible_previous_teacher_training.rb
+++ b/app/services/generate_possible_previous_teacher_training.rb
@@ -47,8 +47,8 @@ private
 
     ((provider_record.present? && previous_teacher_training_in_timeframe.find_by(provider: provider_record)) ||
       previous_teacher_training_in_timeframe.find_by(
-        'provider_name ILIKE ?',
-        possible_previous_teacher_training_data.name,
+        'LOWER(provider_name) = ?',
+        possible_previous_teacher_training_data.name.downcase,
       )).present?
   end
 end

--- a/spec/services/generate_possible_previous_teacher_training_spec.rb
+++ b/spec/services/generate_possible_previous_teacher_training_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe GeneratePossiblePreviousTeacherTraining do
       end
     end
 
-    context 'when a PreviousTeacherTraining record for that data already exists within the timeframe' do
+    context 'when a PreviousTeacherTraining record for that data already exists' do
       let(:application_form) { create(:completed_application_form, candidate:) }
 
       context 'when the PreviousTeacherTraining record has no provider id' do
@@ -129,8 +129,8 @@ RSpec.describe GeneratePossiblePreviousTeacherTraining do
           :previous_teacher_training,
           application_form:,
           provider_name: 'The London Provider',
-          started_at: '10/10/2024',
-          ended_at: '02/03/2025',
+          started_at: '01/07/2024',
+          ended_at: '31/03/2025',
         )
       end
 
@@ -138,6 +138,25 @@ RSpec.describe GeneratePossiblePreviousTeacherTraining do
 
       it 'does not create a PossiblePreviousTeacherTraining' do
         expect { call }.not_to(change { PossiblePreviousTeacherTraining.count })
+      end
+    end
+
+    context 'when a PreviousTeacherTraining record for that data already exists outside of 3 months of the timeframe' do
+      let(:application_form) { create(:completed_application_form, candidate:) }
+      let(:previous_teacher_training) do
+        create(
+          :previous_teacher_training,
+          application_form:,
+          provider_name: 'The London Provider',
+          started_at: '01/05/2024',
+          ended_at: '31/05/2025',
+        )
+      end
+
+      before { previous_teacher_training }
+
+      it 'creates a PossiblePreviousTeacherTraining' do
+        expect { call }.to(change { PossiblePreviousTeacherTraining.count })
       end
     end
 

--- a/spec/services/generate_possible_previous_teacher_training_spec.rb
+++ b/spec/services/generate_possible_previous_teacher_training_spec.rb
@@ -121,5 +121,43 @@ RSpec.describe GeneratePossiblePreviousTeacherTraining do
         end
       end
     end
+
+    context 'when a PreviousTeacherTraining record for that data already exists within 3 months of the timeframe' do
+      let(:application_form) { create(:completed_application_form, candidate:) }
+      let(:previous_teacher_training) do
+        create(
+          :previous_teacher_training,
+          application_form:,
+          provider_name: 'The London Provider',
+          started_at: '10/10/2024',
+          ended_at: '02/03/2025',
+        )
+      end
+
+      before { previous_teacher_training }
+
+      it 'does not create a PossiblePreviousTeacherTraining' do
+        expect { call }.not_to(change { PossiblePreviousTeacherTraining.count })
+      end
+    end
+
+    context 'when a PreviousTeacherTraining record for that data already exists but the provider name does not match case-sensitively' do
+      let(:application_form) { create(:completed_application_form, candidate:) }
+      let(:previous_teacher_training) do
+        create(
+          :previous_teacher_training,
+          application_form:,
+          provider_name: 'THe LOnDon ProvIdeR',
+          started_at: '01/09/2024',
+          ended_at: '01/01/2025',
+        )
+      end
+
+      before { previous_teacher_training }
+
+      it 'does not create a PossiblePreviousTeacherTraining' do
+        expect { call }.not_to(change { PossiblePreviousTeacherTraining.count })
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

View this [blazer query](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1400-candidates-with-undeclared-declared-teacher-training), where candidates have declared ITT, but also been identified as not declaring.

## Changes proposed in this pull request

We want to make our matching criteria a bit looser so that we don’t flag so many possible trainings that are likely to be false positives. We have updated the matching logic so that we match if the following is true:

- the start or end date is within three months of the possible start or end date
- the provider name matches (not case sensitive)

## Guidance to review

- Check the spec file sufficiently tests the matching logic: `spec/services/generate_possible_previous_teacher_training_spec.rb`
- Once merged, we will rerun the query to check the returned rows are significantly reduced

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
