### PR TITLE
Fix NonDisclose BigQuery date column to registered_date

### DIFF
--- a/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
+++ b/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
@@ -6,7 +6,7 @@ module DfE
       SELECT_COLUMNS = %w[trainee_start_date
                           accredited_provider.name
                           accredited_provider.code
-                          withdraw.date].freeze
+                          withdraw.registered_date].freeze
 
       attr_reader :candidate
 

--- a/app/services/generate_possible_previous_teacher_training.rb
+++ b/app/services/generate_possible_previous_teacher_training.rb
@@ -18,7 +18,7 @@ class GeneratePossiblePreviousTeacherTraining
           provider_name: possible_previous_teacher_training_data.name,
           provider: accredited_provider(possible_previous_teacher_training_data.code),
           started_on: possible_previous_teacher_training_data.trainee_start_date,
-          ended_on: possible_previous_teacher_training_data.date,
+          ended_on: possible_previous_teacher_training_data.registered_date,
         )
       end
     end
@@ -37,7 +37,7 @@ private
   def previous_teacher_training_declared?(possible_previous_teacher_training_data)
     provider_record = accredited_provider(possible_previous_teacher_training_data.code)
     started_at = possible_previous_teacher_training_data.trainee_start_date.to_time.beginning_of_month
-    ended_at = possible_previous_teacher_training_data.date.to_time.end_of_month
+    ended_at = possible_previous_teacher_training_data.registered_date.to_time.end_of_month
     previous_teacher_training_in_timeframe = candidate.previous_teacher_trainings.where(
       started_at: started_at..,
       ended_at: ..ended_at,

--- a/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
+++ b/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
       { name: 'trainee_start_date', type: 'DATE', value: '01/09/2024' },
       { name: 'name', type: 'STRING', value: 'The London Provider' },
       { name: 'code', type: 'STRING', value: '1AB' },
-      { name: 'date', type: 'DATE', value: '01/01/2025' },
+      { name: 'registered_date', type: 'DATE', value: '01/01/2025' },
     ]]
   end
 
@@ -26,7 +26,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
           trainee_start_date: '2024-09-01',
           name: 'The London Provider',
           code: '1AB',
-          date: '2025-01-01',
+          registered_date: '2025-01-01',
         },
       ]
     end
@@ -49,7 +49,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
       allow(Google::Apis::BigqueryV2::QueryRequest).to receive(:new).and_call_original
       trainee_data
       expect(Google::Apis::BigqueryV2::QueryRequest).to have_received(:new).with(query: <<~SQL, timeout_ms: 10_000, use_legacy_sql: false)
-        SELECT trainee_start_date, accredited_provider.name, accredited_provider.code, withdraw.date
+        SELECT trainee_start_date, accredited_provider.name, accredited_provider.code, withdraw.registered_date
         FROM `1_key_tables.non_disclosure_trainee_withdrawals`
         WHERE email = 'john_doe%40example.com' OR (first_name IN #{first_names_sql} AND last_name IN ('doe') AND date_of_birth = '1990-01-01')
       SQL
@@ -61,7 +61,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
       expect(response.trainee_start_date).to eq(Date.parse('2024-09-01'))
       expect(response.name).to eq('The London Provider')
       expect(response.code).to eq('1AB')
-      expect(response.date).to eq(Date.parse('2025-01-01'))
+      expect(response.registered_date).to eq(Date.parse('2025-01-01'))
     end
 
     context 'when the api returns no data for the candidate' do

--- a/spec/services/generate_possible_previous_teacher_training_spec.rb
+++ b/spec/services/generate_possible_previous_teacher_training_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe GeneratePossiblePreviousTeacherTraining do
             { name: 'trainee_start_date', type: 'DATE', value: '01/09/2024' },
             { name: 'name', type: 'STRING', value: 'The London Provider' },
             { name: 'code', type: 'STRING', value: '1AB' },
-            { name: 'date', type: 'DATE', value: '01/01/2025' },
+            { name: 'registered_date', type: 'DATE', value: '01/01/2025' },
           ],
           [
             { name: 'trainee_start_date', type: 'DATE', value: '01/09/2023' },
             { name: 'name', type: 'STRING', value: 'The Brixton Provider' },
             { name: 'code', type: 'STRING', value: '2ZZ' },
-            { name: 'date', type: 'DATE', value: '01/02/2024' },
+            { name: 'registered_date', type: 'DATE', value: '01/02/2024' },
           ],
         ]
       end

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -252,7 +252,7 @@ module DfE
           { name: 'trainee_start_date', type: 'DATE', value: '01/09/2024' },
           { name: 'name', type: 'STRING', value: 'The London Provider' },
           { name: 'code', type: 'STRING', value: '1AB' },
-          { name: 'date', type: 'DATE', value: '01/01/2025' },
+          { name: 'registered_date', type: 'DATE', value: '01/01/2025' },
         ]], job_complete:, page_token:, result:)
       end
     end


### PR DESCRIPTION
## Context

- Fix issue with NonDisclosureTraineeWithdrawals request to BigQuery, due to column name change.

## Changes proposed in this pull request

- Replace selected column requested to BigQuery from `date` to `registered_date`

## Guidance to review

- Difficult to prove it works until it is live.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
