### PR TITLE
Remove old references flow constant and tests

### DIFF
--- a/.github/scripts/comment_on_flakey_specs.js
+++ b/.github/scripts/comment_on_flakey_specs.js
@@ -7,18 +7,38 @@ module.exports = ({github, context}) => {
   }
 
   const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
-  if (FLAKEY_TEST_DATA.length) {
+  if (FLAKEY_TEST_DATA && FLAKEY_TEST_DATA.length) {
+    const matches = FLAKEY_TEST_DATA.match(/\[.*?\]/gs);
+    if (!matches) {
+      return;
+    }
+
+    const flakeyErrors = [];
+
+    matches.forEach((chunk) => {
+      const parsed = JSON.parse(chunk);
+      if (Array.isArray(parsed)) {
+        flakeyErrors.push(...parsed);
+      }
+    });
+
+    if (!flakeyErrors.length) {
+      return;
+    }
+
     const { issue: { number: issue_number }, repo: { owner, repo } } = context;
     const heading = 'You have one or more flakey tests on this branch!';
     let commentBody = `<h2>${heading} :snowflake: :snowflake: :snowflake:</h2>`;
     let branchName = GITHUB_HEAD_REF.split('/').pop();
     let createComment = false;
-    JSON.parse(FLAKEY_TEST_DATA).forEach(function(error) {
+
+    flakeyErrors.forEach(function(error) {
       let errorPath = `/${owner}/${repo}/blob/${branchName}/${error['location'].replace(':', '#L')}`;
       let errorLink = `<a href="${errorPath}">${error['location']}</a>`;
       commentBody += `Failed ${error['attempts']} out of ${error['retry_count']} times at ${errorLink}: :warning: ${error['messages'].toString()}<br>`;
       createComment = true;
     })
+
     if (createComment) {
       github.rest.issues.createComment({ issue_number, owner, repo, body: commentBody });
       throw new FlakeySpecError(heading);

--- a/.github/scripts/comment_on_flakey_specs.js
+++ b/.github/scripts/comment_on_flakey_specs.js
@@ -7,38 +7,18 @@ module.exports = ({github, context}) => {
   }
 
   const { FLAKEY_TEST_DATA, GITHUB_HEAD_REF } = process.env;
-  if (FLAKEY_TEST_DATA && FLAKEY_TEST_DATA.length) {
-    const matches = FLAKEY_TEST_DATA.match(/\[.*?\]/gs);
-    if (!matches) {
-      return;
-    }
-
-    const flakeyErrors = [];
-
-    matches.forEach((chunk) => {
-      const parsed = JSON.parse(chunk);
-      if (Array.isArray(parsed)) {
-        flakeyErrors.push(...parsed);
-      }
-    });
-
-    if (!flakeyErrors.length) {
-      return;
-    }
-
+  if (FLAKEY_TEST_DATA.length) {
     const { issue: { number: issue_number }, repo: { owner, repo } } = context;
     const heading = 'You have one or more flakey tests on this branch!';
     let commentBody = `<h2>${heading} :snowflake: :snowflake: :snowflake:</h2>`;
     let branchName = GITHUB_HEAD_REF.split('/').pop();
     let createComment = false;
-
-    flakeyErrors.forEach(function(error) {
+    JSON.parse(FLAKEY_TEST_DATA).forEach(function(error) {
       let errorPath = `/${owner}/${repo}/blob/${branchName}/${error['location'].replace(':', '#L')}`;
       let errorLink = `<a href="${errorPath}">${error['location']}</a>`;
       commentBody += `Failed ${error['attempts']} out of ${error['retry_count']} times at ${errorLink}: :warning: ${error['messages'].toString()}<br>`;
       createComment = true;
     })
-
     if (createComment) {
       github.rest.issues.createComment({ issue_number, owner, repo, body: commentBody });
       throw new FlakeySpecError(heading);

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -14,7 +14,6 @@ module ProviderInterface
 
     def set_references
       @references = @application_choice.application_form.application_references.for_provider
-      @references = @references.selected
     end
   end
 end

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -14,11 +14,7 @@ module ProviderInterface
 
     def set_references
       @references = @application_choice.application_form.application_references.for_provider
-      @references = @references.selected unless new_references_flow?
-    end
-
-    def new_references_flow?
-      @application_choice.application_form.recruitment_cycle_year > ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR
+      @references = @references.selected
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -101,7 +101,6 @@ class ApplicationForm < ApplicationRecord
 
   REQUIRED_REFERENCE_SELECTIONS = 2
   REQUIRED_REFERENCES = 2
-  OLD_REFERENCE_FLOW_CYCLE_YEAR = 2022
 
   MAXIMUM_REFERENCES = 10
   EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze

--- a/spec/mailers/previews/referee/references_mailer_preview.rb
+++ b/spec/mailers/previews/referee/references_mailer_preview.rb
@@ -39,7 +39,6 @@ private
     FactoryBot.build_stubbed(:application_form,
                              first_name: 'Rachael',
                              last_name: 'Harvey',
-                             recruitment_cycle_year: ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1,
                              application_choices: [application_choice])
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RefereeMailer do
                               application_form:)
   end
   let(:application_form) { build_stubbed(:application_form, first_name: 'Elliot', last_name: 'Alderson', application_choices:, recruitment_cycle_year: recruitment_cycle_year) }
-  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
+  let(:recruitment_cycle_year) { current_recruitment_cycle_year }
 
   before do
     allow(reference).to receive(:refresh_feedback_token!).and_return('raw_token')

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RefereeMailer do
                               application_form:)
   end
   let(:application_form) { build_stubbed(:application_form, first_name: 'Elliot', last_name: 'Alderson', application_choices:, recruitment_cycle_year: recruitment_cycle_year) }
-  let(:recruitment_cycle_year) { current_recruitment_cycle_year }
+  let(:recruitment_cycle_year) { current_year }
 
   before do
     allow(reference).to receive(:refresh_feedback_token!).and_return('raw_token')

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -3,11 +3,6 @@ require 'rails_helper'
 RSpec.describe AcceptOffer do
   include CourseOptionHelpers
 
-  before do
-    timetable = get_timetable(ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
-    TestSuiteTimeMachine.travel_permanently_to(timetable.apply_opens_at)
-  end
-
   describe '#valid?' do
     context 'when valid references' do
       it 'returns true' do

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe 'Provider views an application in new cycle' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  before do
-    TestSuiteTimeMachine.travel_permanently_to(mid_cycle(2023))
-  end
-
   scenario 'Provider views the new references tab' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
@@ -46,7 +42,6 @@ RSpec.describe 'Provider views an application in new cycle' do
                                  status: 'awaiting_provider_decision',
                                  course_option:)
 
-    @my_provider_choice.application_form.update(recruitment_cycle_year: 2023)
     @my_provider_choice.application_form.application_references.update(feedback_status: 'feedback_requested')
   end
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -3,13 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Referee can submit reference', :with_audited do
   include CandidateHelper
 
-  around do |example|
-    old_references = RecruitmentCycleTimetable
-                       .find_by(recruitment_cycle_year: ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)
-                       &.apply_opens_at
-    travel_temporarily_to(old_references) { example.run }
-  end
-
   it 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
     given_i_am_a_referee_of_an_application
     and_i_received_the_initial_reference_request_email


### PR DESCRIPTION
## Context

While working on something else, I came across this old reference flow constant is not relevant any more (pre 2022). Only provider views were dependant on it, and they can only view applications from the past 2 year (2026, 2025), so this flow is irrelevant. 

## Changes proposed in this pull request

Remove references to old references flow

## Guidance to review

Read the code and let me know if I'm being wreckless. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
