### PR TITLE
ensure all tests are run with ff on and off

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -144,12 +144,13 @@ jobs:
             integration_shared,
             integration_provider,
             integration_candidate,
+            integration_candidate_entering_details,
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
         offset-date: [real_world]
         # Use these offsets through mid-cycle
-        # offset-date: [real_world]
+        # offset-date: [real_world, after_apply_deadline, before_apply_reopens, after_apply_reopens]
 
         include:
           - tests: unit_shared

--- a/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
 
     context 'when the current date does not match the winter reject by default explainer date' do
       before do
+        TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.next_weekday.to_date)
         allow(instance).to receive(:timetable).and_return(Struct.new(:winter_reject_by_default_at).new(winter_reject_by_default_at))
       end
 
@@ -26,6 +27,7 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
 
     context 'when the current date matches the winter reject by default explainer date' do
       before do
+        TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.next_weekday.to_date)
         allow(instance).to receive(:timetable).and_return(Struct.new(:winter_reject_by_default_at).new(winter_reject_by_default_at))
       end
 

--- a/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/add_other_qualification_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Add Other qualification' do
   include CandidateHelper
   include EFLHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'Candidate completes EFL section with details of a qualification type we do not provide an option for' do
     given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality

--- a/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'Candidate updates their contact information from an international address to a UK' do
   include CandidateHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_contact_details_residency_questions')
+  end
+
   scenario 'Candidate submits their contact information' do
     given_i_am_signed_in_with_one_login
     and_i_have_already_filled_in_an_international_address

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Choosing visa or immigration status' do
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_visa_expiry')
+  end
+
   scenario 'non eu candidate who has the right to work' do
     given_i_am_logged_in_as_a_non_eu_candidate_who_has_the_right_to_work_or_study
     and_i_visit_the_immigration_status_edit_page

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Entering their contact information' do
   include CandidateHelper
 
+  before do
+    FeatureFlag.deactivate('2027_application_form_contact_details_residency_questions')
+  end
+
   scenario 'Candidate submits their contact information' do
     given_i_am_signed_in_with_one_login
     and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -3,13 +3,19 @@ require 'rails_helper'
 RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle do
   include CandidateHelper
 
-  it 'I can specify that I need to apply for right to work or study in the UK' do
-    and_i_am_signed_in
-    and_i_can_complete_personal_information_stating_that_i_need_a_visa_sponsorship
-    and_i_can_change_state_that_i_have_permanent_residence
-    and_i_can_change_nationality_to_an_eu_country_with_settled_status
-    and_i_can_change_immigration_status
-    and_i_can_mark_the_section_complete
+  context 'visa expiry flag is off' do
+    before do
+      FeatureFlag.deactivate('2027_visa_expiry')
+    end
+
+    it 'I can specify that I need to apply for right to work or study in the UK' do
+      and_i_am_signed_in
+      and_i_can_complete_personal_information_stating_that_i_need_a_visa_sponsorship
+      and_i_can_change_state_that_i_have_permanent_residence
+      and_i_can_change_nationality_to_an_eu_country_with_settled_status
+      and_i_can_change_immigration_status
+      and_i_can_mark_the_section_complete
+    end
   end
 
   context 'visa expiry flag is on' do

--- a/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'Candidate updating english proficiency' do
   include CandidateHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'When application form does not have an english proficiency associations' do
     given_i_am_signed_in_with_one_login
     and_i_do_not_have_an_english_proficiency_attached_to_my_application_form

--- a/spec/system/candidate_interface/entering_details/change_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/change_qualification_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Change qualification' do
   include CandidateHelper
   include EFLHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'Candidate changes their IELTS to a TOEFL' do
     given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality

--- a/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_no_qualification_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Declare no EFL qualification' do
   include CandidateHelper
   include EFLHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'Candidate declares they have no qualification and provides more detail' do
     given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality

--- a/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
+++ b/spec/system/candidate_interface/entering_details/declare_qualification_not_needed_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Declare EFL qualification not required' do
   include CandidateHelper
   include EFLHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'Candidate declares that English is not a foreign language to them' do
     given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality

--- a/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'View EFL form' do
   end
 
   def then_i_see_the_efl_form
-    expect(page).to have_text 'Have you done an English as a foreign language assessment?'
+    if FeatureFlag.active? '2027_application_form_has_many_english_proficiencies'
+      'Proving your level of English'
+    else
+      expect(page).to have_text 'Have you done an English as a foreign language assessment?'
+    end
   end
 end

--- a/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Your IELTS result' do
   include CandidateHelper
   include EFLHelper
 
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
+
   scenario 'Candidate completes EFL section with details of their IELTS' do
     given_i_am_signed_in_with_one_login
     and_i_declare_a_non_english_speaking_nationality

--- a/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_toefl_result_spec.rb
@@ -1,8 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe 'Your TOEFL result' do
+RSpec.describe 'Your TOEFL result, pre 2027' do
   include CandidateHelper
   include EFLHelper
+
+  before do
+    # This whole spec can be deleted after this feature flag is removed, it is testing an old flow
+    FeatureFlag.deactivate('2027_application_form_has_many_english_proficiencies')
+  end
 
   scenario 'Candidate completes EFL section with details of their TOEFL' do
     given_i_am_signed_in_with_one_login


### PR DESCRIPTION
## Context

A set of tests were only running with Feature Flags off. I've added them to the config so that they are run with both feature flags on and off. 

## Changes proposed in this pull request

- Add missing tests to the config to run with feature flags on and off
- Fixes specs

## Guidance to review

All of the failures were to do with recently implemented feature flags, testing old flows for english language qualifications, residency requirements, and visa expiry. 

I _think_ that the notes I've made with each one are true, that once the feature flag is removed, the entire test file can be removed. If you are closer to those features, have a look and confirm that I'm talking sense and that the new flows are thoroughly tested elsewhere.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
