### PR TITLE
Release v1.8 to production

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -9,9 +9,9 @@ module VendorAPI
   VERSION_1_5 = '1.5'.freeze
   VERSION_1_6 = '1.6'.freeze
   VERSION_1_7 = '1.7'.freeze
-  VERSION_1_8 = '1.8pre'.freeze # the pre suffix should make v1.8 available to dev envs and sandbox only
+  VERSION_1_8 = '1.8'.freeze # the pre suffix should make v1.8 available to dev envs and sandbox only
 
-  VERSION = '1.8'.freeze
+  VERSION = VERSION_1_8
 
   VERSIONS = {
     '1.0' => [
@@ -76,7 +76,7 @@ module VendorAPI
     '1.7' => [
       Changes::V17::AddPossibleUndeclaredPreviousTeacherTrainingUrl,
     ],
-    '1.8pre' => [
+    '1.8' => [
       Changes::V18::EnglishAsAForeignLanguageCandidateResponse,
       Changes::V18::VisaExpiry,
       Changes::V18::LengthOfResidency,

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -9,7 +9,7 @@ module VendorAPI
   VERSION_1_5 = '1.5'.freeze
   VERSION_1_6 = '1.6'.freeze
   VERSION_1_7 = '1.7'.freeze
-  VERSION_1_8 = '1.8'.freeze # the pre suffix should make v1.8 available to dev envs and sandbox only
+  VERSION_1_8 = '1.8'.freeze
 
   VERSION = VERSION_1_8
 

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_8_changes.html.erb
@@ -2,6 +2,10 @@
   <h2 class="govuk-heading-l" id="changes">Version 1.8 changes</h2>
 </span>
 
+<p class="govuk-body">
+  Released Tuesday 26 May 2026
+</p>
+
 <h3 class="govuk-heading-m">
   Candidate object new attributes
 </h3>

--- a/spec/lib/concerns/versioning_helpers_spec.rb
+++ b/spec/lib/concerns/versioning_helpers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VersioningHelpers do
       before { allow(HostingEnvironment).to receive(:production?).and_return true }
 
       it 'returns the production version' do
-        expect(released_version).to eq '1.7'
+        expect(released_version).to eq '1.8'
       end
     end
 

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -39,6 +39,6 @@ RSpec.describe 'API docs' do
   end
 
   def then_i_get_redirected_to_the_latest_production_version
-    expect(page).to have_current_path api_docs_versioned_reference_path(api_version: 'v1.7'), ignore_query: true
+    expect(page).to have_current_path api_docs_versioned_reference_path(api_version: 'v1.8'), ignore_query: true
   end
 end


### PR DESCRIPTION
## Context

We have had 1.8 in sandbox for testing for 2 weeks. 

## Changes proposed in this pull request

This PR makes 1.8 the default version in production

## Guidance to review
Have a look at this [1.8 release PR for reference](https://github.com/DFE-Digital/apply-for-teacher-training/pull/11717/changes) 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
