### PR TITLE
Start date filter on manage

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -180,7 +180,7 @@ module ProviderInterface
       ).distinct.to_sql
 
       september_ordered_months = Course.select('month')
-        .from("(#{distinct_course_months})")
+        .from("(#{distinct_course_months}) as course_months")
         .order(Arel.sql('(month + 3) % 12'))
 
       {

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -176,7 +176,7 @@ module ProviderInterface
         provider_id: provider_ids,
         recruitment_cycle_year: applied_filters[:recruitment_cycle_year].presence || years_visible_to_provider,
       ).select(
-        "EXTRACT(month FROM start_date AT TIME ZONE 'UTC' AT TIME ZONE '#{Time.zone.tzinfo.name}') AS month",
+        Arel.sql("EXTRACT(month FROM start_date AT TIME ZONE 'UTC' AT TIME ZONE '#{Time.zone.tzinfo.name}') AS month"),
       ).distinct.to_sql
 
       september_ordered_months = Course.select('month')

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -32,7 +32,7 @@ module ProviderInterface
         study_modes_filter <<
         course_type_filter <<
         invited_candidates_filter <<
-        start_date_filter
+        start_month_filter
       ).concat(provider_locations_filters).compact
     end
 
@@ -59,7 +59,22 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: [], course_type: [], invited_only: []).to_h)
+      compact_params(
+        params.permit(
+          :remove,
+          :candidate_name,
+          recruitment_cycle_year: [],
+          provider: [],
+          status: [],
+          accredited_provider: [],
+          provider_location: [],
+          subject: [],
+          study_mode: [],
+          course_type: [],
+          invited_only: [],
+          start_months: [],
+        ).to_h,
+      )
     end
 
     def save_filter_state!
@@ -155,7 +170,7 @@ module ProviderInterface
       }
     end
 
-    def start_date_filter
+    def start_month_filter
       provider_ids = applied_filters[:provider].presence || ProviderOptionsService.new(provider_user).providers.pluck(:id)
       distinct_course_months = Course.where(
         provider_id: provider_ids,
@@ -168,13 +183,13 @@ module ProviderInterface
 
       {
         type: :checkboxes,
-        heading: I18n.t('provider_interface.filters.start_date.heading'),
-        name: 'start_date',
+        heading: I18n.t('provider_interface.filters.start_month.heading'),
+        name: 'start_months',
         options: september_ordered_months.map do |course|
           {
             value: course.month,
             label: Date::MONTHNAMES[course.month],
-            checked: applied_filters[:start_date]&.include?(course.month),
+            checked: applied_filters[:start_months]&.include?(course.month),
           }
         end,
       }

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -23,7 +23,17 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter << course_type_filter << invited_candidates_filter).concat(provider_locations_filters).compact
+      ([] << search_filter <<
+        recruitment_cycle_filter <<
+        status_filter <<
+        provider_filter <<
+        accredited_provider_filter <<
+        subject_filter <<
+        study_modes_filter <<
+        course_type_filter <<
+        invited_candidates_filter <<
+        start_date_filter
+      ).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -142,6 +152,31 @@ module ProviderInterface
             checked: applied_filters[:invited_only]&.include?('invited_only'),
           },
         ],
+      }
+    end
+
+    def start_date_filter
+      provider_ids = applied_filters[:provider].presence || ProviderOptionsService.new(provider_user).providers.pluck(:id)
+      distinct_course_months = Course.where(
+        provider_id: provider_ids,
+        recruitment_cycle_year: applied_filters[:recruitment_cycle_year] || years_visible_to_provider,
+      ).select('EXTRACT(month FROM start_date) AS month').distinct.to_sql
+
+      september_ordered_months = Course.select('month')
+        .from("(#{distinct_course_months})")
+        .order(Arel.sql('(month + 3) % 12'))
+
+      {
+        type: :checkboxes,
+        heading: I18n.t('provider_interface.filters.start_date.heading'),
+        name: 'start_date',
+        options: september_ordered_months.map do |course|
+          {
+            value: course.month,
+            label: Date::MONTHNAMES[course.month],
+            checked: applied_filters[:start_date]&.include?(course.month),
+          }
+        end,
       }
     end
 

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -174,8 +174,10 @@ module ProviderInterface
       provider_ids = applied_filters[:provider].presence || ProviderOptionsService.new(provider_user).providers.pluck(:id)
       distinct_course_months = Course.where(
         provider_id: provider_ids,
-        recruitment_cycle_year: applied_filters[:recruitment_cycle_year] || years_visible_to_provider,
-      ).select('EXTRACT(month FROM start_date) AS month').distinct.to_sql
+        recruitment_cycle_year: applied_filters[:recruitment_cycle_year].presence || years_visible_to_provider,
+      ).select(
+        "EXTRACT(month FROM start_date AT TIME ZONE 'UTC' AT TIME ZONE '#{Time.zone.tzinfo.name}') AS month",
+      ).distinct.to_sql
 
       september_ordered_months = Course.select('month')
         .from("(#{distinct_course_months})")
@@ -189,7 +191,7 @@ module ProviderInterface
           {
             value: course.month,
             label: Date::MONTHNAMES[course.month],
-            checked: applied_filters[:start_months]&.include?(course.month),
+            checked: applied_filters[:start_months]&.include?(course.month.to_s),
           }
         end,
       }

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -52,7 +52,11 @@ class FilterApplicationChoicesForProviders
     def start_months(application_choices, months)
       return application_choices if months.blank?
 
-      application_choices.joins(:course).where("EXTRACT(month from start_date) IN (#{months.join(',')})")
+      application_choices.joins(:course).where(
+        "EXTRACT(month from (start_date AT TIME ZONE 'UTC' AT TIME ZONE ?)) IN (?)",
+        Time.zone.tzinfo.name,
+        months,
+      )
     end
 
     def status(application_choices, statuses)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -49,6 +49,12 @@ class FilterApplicationChoicesForProviders
       application_choices.where(course: { recruitment_cycle_year: years })
     end
 
+    def start_months(application_choices, months)
+      return application_choices if months.blank?
+
+      application_choices.joins(:course).where("EXTRACT(month from start_date) IN (#{months.join(',')})")
+    end
+
     def status(application_choices, statuses)
       return application_choices if statuses.blank?
 
@@ -121,6 +127,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = invited_candidates(filtered_application_choices, filters[:invited_only], filters[:recruitment_cycle_year])
       filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
+      filtered_application_choices = start_months(filtered_application_choices, filters[:start_months])
       filtered_application_choices = provider(filtered_application_choices, filters[:provider])
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -9,3 +9,5 @@ en:
       invited_candidates:
         heading: Invited candidates
         invited_only: Only show candidates who have been invited to apply
+      start_date:
+        heading: Start date

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -9,5 +9,5 @@ en:
       invited_candidates:
         heading: Invited candidates
         invited_only: Only show candidates who have been invited to apply
-      start_date:
+      start_month:
         heading: Start date

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
   let(:provider_3_subjects) { create_list(:subject, 1) }
   let(:accredited_provider_subjects) { create_list(:subject, 1) }
 
-  let(:course1) { create(:course, subjects: provider_1_subjects, study_mode: 'part_time') }
-  let(:course2) { create(:course, subjects: provider_2_subjects) }
+  let(:course1) { create(:course, subjects: provider_1_subjects, study_mode: 'part_time', start_date: '2026-05-10') }
+  let(:course2) { create(:course, subjects: provider_2_subjects, start_date: '2026-04-10') }
   let(:course3) { create(:course, subjects: provider_3_subjects) }
   let(:accredited_course) { create(:course, subjects: accredited_provider_subjects, accredited_provider:) }
 
@@ -46,7 +46,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Locations filter' do
-          expected_number_of_filters = 8
+          expected_number_of_filters = 9
           recruitment_cycle_index = 1
           providers_array_index = 3
           number_of_courses = 2
@@ -67,7 +67,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Providers filter' do
-          expected_number_of_filters = 8
+          expected_number_of_filters = 9
 
           expect(filter.filters.size).to eq(expected_number_of_filters)
           expect(headings).not_to include('Provider')
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       end
 
       it 'does include the course type filter' do
-        expect(filter.filters.size).to be(8)
+        expect(filter.filters.size).to be(9)
         expect(headings).to include('Course type')
       end
     end
@@ -93,11 +93,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           relevant_provider_labels = [provider1.sites.first.name_and_code, provider1.sites.last.name_and_code]
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][0][:value])
-          expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][1][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][0][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][1][:value])
 
-          expect(relevant_provider_labels).to include(filter.filters[7][:options][0][:label])
-          expect(relevant_provider_labels).to include(filter.filters[7][:options][1][:label])
+          expect(relevant_provider_labels).to include(filter.filters[8][:options][0][:label])
+          expect(relevant_provider_labels).to include(filter.filters[8][:options][1][:label])
         end
       end
 
@@ -115,8 +115,8 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           old_site_label = old_site.name_and_code
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(old_site_name_and_code).not_to include(filter.filters[7][:options][0][:value])
-          expect(old_site_label).not_to include(filter.filters[7][:options][0][:label])
+          expect(old_site_name_and_code).not_to include(filter.filters[8][:options][0][:value])
+          expect(old_site_label).not_to include(filter.filters[8][:options][0][:label])
         end
       end
     end
@@ -135,11 +135,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include("Locations for #{provider1.name}")
 
-        expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][0][:value])
-        expect(relevant_provider_name_and_code).to include(filter.filters[8][:options][1][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[9][:options][0][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[9][:options][1][:value])
 
-        expect(relevant_provider_labels).to include(filter.filters[8][:options][0][:label])
-        expect(relevant_provider_labels).to include(filter.filters[8][:options][1][:label])
+        expect(relevant_provider_labels).to include(filter.filters[9][:options][0][:label])
+        expect(relevant_provider_labels).to include(filter.filters[9][:options][1][:label])
       end
     end
 
@@ -174,6 +174,23 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include('Full time or part time')
         expect(filter_study_modes).to match_array(study_modes)
+      end
+    end
+
+    context 'when a start date is selected' do
+      let(:params) { ActionController::Parameters.new }
+      let(:filter) do
+        described_class.new(params:,
+                            provider_user:,
+                            state_store:)
+      end
+
+      it 'can return a filter config for a list start months' do
+        expected_months = %w[April May]
+        months = filter.filters[8][:options].map { |h| h[:label] }
+
+        expect(headings).to include('Start date')
+        expect(months).to match_array(expected_months)
       end
     end
   end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe FilterApplicationChoicesForProviders do
       expect(result).to eq([application_choices.last])
     end
 
+    it 'filters by start_months' do
+      application_choices.last.course.update(start_date: '2026-05-10')
+
+      result = described_class.call(application_choices:, filters: { start_months: ['5.0'] })
+
+      expect(result).to eq([application_choices.last])
+    end
+
     context 'when filtering by status' do
       it 'filters by selected status' do
         application_choices.first.update(status: 'rejected', rejected_at: Time.zone.now)


### PR DESCRIPTION
## Context

This adds a start date filter to the manage interface.

It will filter by specific months. The months shown are the ones from the provider's own course start dates and are ordered by September first.

We don't really care about years here. The year bit will be filtered by recruitment cycle year.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review and use the new filter


https://github.com/user-attachments/assets/eb33dd6f-9058-4f2f-a1a9-05d311347131



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
