### PR TITLE
Add bin/jobs to Procfile

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,7 @@
 web: SERVICE_TYPE=web bundle exec puma -C config/puma.rb
 worker: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-main.yml
 worker_secondary: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-secondary.yml
+solid_queue: bin/jobs
 clock: SERVICE_TYPE=clock bundle exec clockwork config/clock.rb
 caddy: caddy run -c Caddyfile.dev -a caddyfile
 css: yarn build:css --watch


### PR DESCRIPTION
## Context

Now that Ruby has been upgraded, we can add solid_queue to the Procfile to run locally without the crash issues some of us experienced before.

## Changes proposed in this pull request

- Add solid_queue to the Procfile so it can be run as part of `bin/dev`.

## Guidance to review

To prove that solid_queue is both enqueuing and executing jobs locally:

- Pull the branch
- Open a console and type the following `WithdrawalReason.last.update(status: 'draft', updated_at: Date.new(2026-05-01))`.
- Check the value of `WithdrawalReason.draft.count`
- Run `Candidate::DeleteDraftWithdrawalReasonRecordsWorker.perform_later` 
- Visit http://localhost:3000/support/jobs/ and check that the job appears in the Finished jobs tab.
- Finally, run `WithdrawalReason.draft.count` again and check that the value of draft withdrawal reasons has gone down by at least 1. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
