### PR TITLE
Add chase referee to matrix

### DIFF
--- a/spec/components/support_interface/application_state_matrix_component_spec.rb
+++ b/spec/components/support_interface/application_state_matrix_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SupportInterface::ApplicationStateMatrixComponent do
         'States',
         'Active previous',
         'Carry over',
+        'Chase referee',
         'In progress',
         'Interviewable',
         'Offer accepted',
@@ -27,6 +28,7 @@ RSpec.describe SupportInterface::ApplicationStateMatrixComponent do
       expect(described_class.new.scopes).to eq(%i[
         active_previous
         carry_over
+        chase_referee
         in_progress
         interviewable
         offer_accepted


### PR DESCRIPTION
## Context

- Fix bug caused by `chase_referee` attribute added to `ApplicationState` and not tested in Matrix tests.

## Changes proposed in this pull request

- Add `chase_referee` attribute to `ApplicationStateMatrixComponent` tests