### PR TITLE
2683 - New GitHub action validate infra workflow

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,41 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: terraform/application
+          - display: Domains infrastructure
+            validation_plan: domains-infra
+            terraform_base: terraform/domains/infrastructure
+          - display: Domains environment
+            validation_plan: domains-env
+            terraform_base: terraform/domains/environment_domains
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ deploy-init: vendor-modules set-azure-account
 	$(eval export TF_VAR_service_name=${SERVICE_NAME})
 
 deploy-plan: deploy-init
-	terraform -chdir=terraform/$(PLATFORM) plan -var-file=./workspace_variables/$(APP_ENV).tfvars.json ${TF_VARS}
+	terraform -chdir=terraform/$(PLATFORM) plan ${DETAILED_EXITCODE} -var-file=./workspace_variables/$(APP_ENV).tfvars.json ${TF_VARS}
 
 deploy: deploy-init
 	terraform -chdir=terraform/$(PLATFORM) apply -var-file=./workspace_variables/$(APP_ENV).tfvars.json ${TF_VARS} $(AUTO_APPROVE)
@@ -238,7 +238,7 @@ domains-infra-init: domains vendor-domain-infra-modules set-azure-account
 		-backend-config=workspace_variables/${DNS_ZONE}_backend.tfvars
 
 domains-infra-plan: domains-infra-init # make domains-infra-plan
-	terraform -chdir=terraform/custom_domains/infrastructure plan -var-file workspace_variables/${DNS_ZONE}.tfvars.json
+	terraform -chdir=terraform/custom_domains/infrastructure plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DNS_ZONE}.tfvars.json
 
 domains-infra-apply: domains-infra-init # make domains-infra-apply
 	terraform -chdir=terraform/custom_domains/infrastructure apply -var-file workspace_variables/${DNS_ZONE}.tfvars.json ${AUTO_APPROVE}
@@ -253,7 +253,7 @@ domains-init: domains vendor-domain-modules set-azure-account
 	terraform -chdir=terraform/custom_domains/environment_domains init -upgrade -reconfigure -backend-config=workspace_variables/${DNS_ZONE}_${DNS_ENV}_backend.tfvars
 
 domains-plan: domains-init  # make qa domains-plan
-	terraform -chdir=terraform/custom_domains/environment_domains plan -var-file workspace_variables/${DNS_ZONE}_${DNS_ENV}.tfvars.json
+	terraform -chdir=terraform/custom_domains/environment_domains plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DNS_ZONE}_${DNS_ENV}.tfvars.json
 
 domains-apply: domains-init # make qa domains-apply
 	terraform -chdir=terraform/custom_domains/environment_domains apply -var-file workspace_variables/${DNS_ZONE}_${DNS_ENV}.tfvars.json ${AUTO_APPROVE}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Regenerate this diagram with `bundle exec rake erd`.
 
 This app provides several APIs for programmatic access to the Apply service. [Read about them here](/docs/development/apply-apis.md).
 
+## Infrastructure validation workflow
+
+The scheduled workflow defined in `.github/workflows/validate-infra.yml` runs Terraform plan validations for the AKS cluster plus domains infrastructure/environment each day at **07:00 UTC** against **production** only. Failures and drift notifications are sent to the SD Infra alerts Teams channel via the `TEAMS_WEBHOOK_URL_INFRA` secret.
+
 ## License
 
 [MIT Licence](LICENCE)


### PR DESCRIPTION
## Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform

## Changes proposed in this pull request

Add a new GitHub action workflow validate-infrastructure.yml.
${DETAILED_EXITCODE} added to Terraform plan in Makefile.
README.md updated.
TEAMS_WEBHOOK_URL_TESTING added as an Action repository secret.

## Guidance to review

Manually test changes by altering terraform/domains/environment_domains/config/production.tfvars.json **rate_limit_max** and running locally the following command.
`make production domains-plan CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/domains/environment_domains/config/production.tfvars.json **rate_limit_max**.
Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
