### PR TITLE
Solid queue: reduce workers and polling frequency in non-prod envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.before_configuration do
       ENV["SOLID_QUEUE_CONFIG"] =
-        if %w[qa sandbox review].include?(ENV["HOSTING_ENVIRONMENT_NAME"])
+        if %w[qa sandbox staging review].include?(ENV["HOSTING_ENVIRONMENT_NAME"])
           "config/non_production_queue.yml"
         else
           "config/queue.yml"

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,15 @@ module ApplyForPostgraduateTeacherTraining
     # Handle exceptions not caught by controllers, e.g. db errors
     config.exceptions_app = ->(env) { RackExceptionsApp.call(env) }
 
+    config.before_configuration do
+      ENV["SOLID_QUEUE_CONFIG"] =
+        if %w[qa sandbox review].include?(ENV["HOSTING_ENVIRONMENT_NAME"])
+          "config/non_production_queue.yml"
+        else
+          "config/queue.yml"
+        end
+    end
+
     show_previews = HostingEnvironment.test_environment?
 
     config.action_mailer.preview_paths = [Rails.root.join("spec/mailers/previews")]

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.before_configuration do
       ENV["SOLID_QUEUE_CONFIG"] =
-        if %w[qa sandbox staging review].include?(ENV["HOSTING_ENVIRONMENT_NAME"]) || ENV["SANDBOX"] == "true"
+        if HostingEnvironment.test_environment? || HostingEnvironment.staging? || HostingEnvironment.sandbox_mode?
           "config/non_production_queue.yml"
         else
           "config/queue.yml"

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.before_configuration do
       ENV["SOLID_QUEUE_CONFIG"] =
-        if %w[qa sandbox staging review].include?(ENV["HOSTING_ENVIRONMENT_NAME"])
+        if %w[qa sandbox staging review].include?(ENV["HOSTING_ENVIRONMENT_NAME"]) || ENV["SANDBOX"] == "true"
           "config/non_production_queue.yml"
         else
           "config/queue.yml"

--- a/config/non_production_queue.yml
+++ b/config/non_production_queue.yml
@@ -1,0 +1,6 @@
+default:
+  workers:
+    - queues: [default, mailers, low_priority, big_query_sq]
+      threads: 1
+      processes: 1
+      polling_interval: 3

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -15,11 +15,24 @@ default: &default
       processes: <%= ENV.fetch("BIG_QUERY_QUEUE_PROCESSES", 1) %>
       polling_interval: 1
 
+non_production: &non_production
+  workers:
+    - queues: [default, mailers, low_priority, big_query_sq]
+      threads: 1
+      processes: 1
+      polling_interval: 3
+
+qa:
+  <<: *non_production
+
+sandbox:
+  <<: *non_production
+
 development:
-  <<: *default
+  <<: *non_production
 
 test:
-  <<: *default
+  <<: *non_production
 
 production:
   <<: *default

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -15,24 +15,11 @@ default: &default
       processes: <%= ENV.fetch("BIG_QUERY_QUEUE_PROCESSES", 1) %>
       polling_interval: 1
 
-non_production: &non_production
-  workers:
-    - queues: [default, mailers, low_priority, big_query_sq]
-      threads: 1
-      processes: 1
-      polling_interval: 3
-
-qa:
-  <<: *non_production
-
-sandbox:
-  <<: *non_production
-
 development:
-  <<: *non_production
+  <<: *default
 
 test:
-  <<: *non_production
+  <<: *default
 
 production:
   <<: *default


### PR DESCRIPTION
## Context

There is currently too much load on non-production environments using solid queue as they have 50% less memory allotted to them.

## Changes proposed in this pull request

- Compress queues into a single worker and reduce polling frequency.

## Guidance to review

- To monitor following merge.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
