### PR TITLE
Migrate two frequent jobs to sq

### DIFF
--- a/app/services/generate_candidate_pool_data.rb
+++ b/app/services/generate_candidate_pool_data.rb
@@ -43,6 +43,6 @@ class GenerateCandidatePoolData
     end
     CandidateLocationPreference.insert_all(location_preference_attrs)
 
-    FindACandidate::PopulatePoolWorker.perform_sync
+    FindACandidate::PopulatePoolWorker.perform_now
   end
 end

--- a/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
+++ b/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
@@ -1,6 +1,8 @@
 class Candidate::DeleteDraftCandidatePreferencesWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     CandidatePreference.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
+++ b/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
@@ -1,6 +1,8 @@
 class Candidate::DeleteDraftWithdrawalReasonRecordsWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     WithdrawalReason.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/app/workers/delete_all_drafts_worker.rb
+++ b/app/workers/delete_all_drafts_worker.rb
@@ -1,6 +1,8 @@
 class DeleteAllDraftsWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     Candidate::DeleteDraftWithdrawalReasonRecordsWorker.perform_later
     Provider::DeleteDraftPoolInvitesWorker.perform_later

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -1,7 +1,5 @@
-class FindACandidate::PopulatePoolWorker
-  include Sidekiq::Worker
-
-  sidekiq_options queue: :default
+class FindACandidate::PopulatePoolWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
   def perform
     if CandidatePoolApplication.closed?

--- a/app/workers/process_stale_applications_worker.rb
+++ b/app/workers/process_stale_applications_worker.rb
@@ -1,5 +1,5 @@
-class ProcessStaleApplicationsWorker
-  include Sidekiq::Worker
+class ProcessStaleApplicationsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
   def perform
     ProcessStaleApplications.new.call

--- a/app/workers/provider/delete_draft_pool_invites_worker.rb
+++ b/app/workers/provider/delete_draft_pool_invites_worker.rb
@@ -1,6 +1,8 @@
 class Provider::DeleteDraftPoolInvitesWorker < ApplicationJob
   self.queue_adapter = :solid_queue
 
+  queue_as :low_priority
+
   def perform
     Pool::Invite.draft.where('updated_at < ?', 3.days.ago).delete_all
   end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -15,7 +15,7 @@ class Clock
   end
 
   every(10.minutes, 'FindACandidate::PopulatePoolWorker', skip_first_run: true) do
-    FindACandidate::PopulatePoolWorker.perform_async
+    FindACandidate::PopulatePoolWorker.perform_later
   end
 
   # Hourly jobs
@@ -23,7 +23,7 @@ class Clock
   every(1.hour, 'FindACandidate::PoolInviteChaserWorker', at: '**:35', skip_first_run: true) { FindACandidate::PoolInviteChaserWorker.perform_async }
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async }
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
-    ProcessStaleApplicationsWorker.perform_async
+    ProcessStaleApplicationsWorker.perform_later
   end
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
   every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Candidate with submitted applications' do
 
   def when_one_of_my_applications_becomes_inactive
     travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_async
+      ProcessStaleApplicationsWorker.perform_now
     end
   end
 

--- a/spec/system/inactive_application_spec.rb
+++ b/spec/system/inactive_application_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Process Stale applications', :sidekiq do
 
   def when_we_process_stale_applications
     travel_temporarily_to(10.minutes.from_now) do
-      ProcessStaleApplicationsWorker.perform_async
+      ProcessStaleApplicationsWorker.perform_now
     end
   end
 


### PR DESCRIPTION
## Context

Previous PRs have set the configuration for SolidQueue (see #11971). This PR migrates two frequent sidekiq jobs to solid_queue for performance monitoring.

## Changes proposed in this pull request

- Migrate `PopulatePoolWorker`
- Migrate `ProcessStaleApplicationsWorker`

## Guidance to review

- Check https://apply-review-11974.test.teacherservices.cloud/support/jobs 
- As a provider user, check that the candidate pool has been populated
- Review code changes 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
