### PR TITLE
Solid cache redirection from slow timeseries view

### DIFF
--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -325,6 +325,7 @@ namespace :support_interface, path: '/support' do
   mount SupportInterface::RackApp.new(Blazer::Engine) => '/blazer', as: :blazer
   mount SupportInterface::RackApp.new(FieldTest::Engine) => '/field-test', as: :field_test
   mount SupportInterface::RackApp.new(MissionControl::Jobs::Engine) => '/jobs', as: :jobs
+  get '/solid-cache' => redirect('/support/solid-cache/stats'), as: nil
   mount SupportInterface::RackApp.new(SolidCacheDashboard::Engine) => '/solid-cache', as: :solid_cache
 
   get '*path', to: 'errors#not_found'

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -22,6 +22,7 @@
 20. [Change application choices to main site](#changing-application-choices-to-main-site)
 21. [Previous teacher training](#previous-teacher-training)
 22. [Create DuplicateMatch](#create-duplicatematch)
+23. [Cache dashboard](#cache-dashboard)
 
 ## Support Trello board
 
@@ -989,3 +990,7 @@ DuplicateMatch.create!(
   candidates:,
 )
 ```
+
+## Cache Dashboard
+
+Go to https://www.apply-for-teacher-training.service.gov.uk/support/solid-cache to view the solid cache dashboard. Where you can see the overall stats and also check what keys are written, deleted or what they contain


### PR DESCRIPTION
## Context

There is no quick fix(it's quite slow if you have a lot of records) for the timeseries dashboard of solid cache. The dashboard where it shows the cache hits over time. The rest of it works fine so this just redirect to the /stats endpoint.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and hit the /support/solid-cache url

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
