### PR TITLE
Add normalize to ApplicationForm and add to spec

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -99,6 +99,8 @@ class ApplicationForm < ApplicationRecord
       .or(ApplicationForm.where(right_to_work_or_study: 'yes', immigration_status: VISAS_REQUIRING_SPONSORSHIP))
   }
 
+  normalizes :first_name, :last_name, with: ->(value) { value.strip }
+
   REQUIRED_REFERENCE_SELECTIONS = 2
   REQUIRED_REFERENCES = 2
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe ApplicationForm do
     it { is_expected.to delegate_method(:opt_in?).to(:published_preference).with_prefix.allow_nil }
   end
 
+  describe 'normalizes name' do
+    it 'removes white space from names' do
+      application_form = create(:application_form, first_name: '  Thomas', last_name: 'Moore ')
+      expect(application_form.first_name).to eq 'Thomas'
+      expect(application_form.last_name).to eq 'Moore'
+    end
+  end
+
   describe 'callbacks' do
     before do
       allow(FeatureFlag).to receive(:active?)


### PR DESCRIPTION
## Context

A provider had issues importing candidates who submitted applications with whitespace in the `first_name` or `last_name`.

## Changes proposed in this pull request

- Normalize first and last names on the ApplicationForm

## Guidance to review

- Review the small code change and check the spec adequately tests the change.
- Visit the review app console and update the first name on `ApplicationForm.last` to add whitespace.
- Check `ApplicationForm.last` again and verify that the saved version does not include the whitespace.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
