### PR TITLE
Content change to deadline banner component

### DIFF
--- a/app/components/candidate_interface/deadline_banner_component.html.erb
+++ b/app/components/candidate_interface/deadline_banner_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
   <% notification_banner.with_heading do %>
-    <%= t('candidate_interface.deadline_banner_component.heading', academic_year:, deadline_time: deadline[:time], deadline_date: deadline[:date]) %>
+    <%= t('candidate_interface.deadline_banner_component.heading', recruitment_cycle_year:, deadline_time: deadline[:time], deadline_date: deadline[:date]) %>
   <% end %>
   <p class="govuk-body"><%= t('candidate_interface.deadline_banner_component.text') %></p>
 <% end %>

--- a/app/components/candidate_interface/deadline_banner_component.html.erb
+++ b/app/components/candidate_interface/deadline_banner_component.html.erb
@@ -1,4 +1,6 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
-  <% notification_banner.with_heading(text: t('candidate_interface.deadline_banner_component.heading', academic_year:, deadline_time: deadline[:time], deadline_date: deadline[:date])) %>
+  <% notification_banner.with_heading do %>
+    <%= t('candidate_interface.deadline_banner_component.heading', academic_year:, deadline_time: deadline[:time], deadline_date: deadline[:date]) %>
+  <% end %>
   <p class="govuk-body"><%= t('candidate_interface.deadline_banner_component.text') %></p>
 <% end %>

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -13,12 +13,12 @@ class CandidateInterface::DeadlineBannerComponent < ApplicationComponent
 
   def deadline
     {
-      date: @timetable.apply_deadline_at.strftime('%d %B'),
+      date: @timetable.apply_deadline_at.to_fs(:day_and_month),
       time: @timetable.apply_deadline_at.to_fs(:govuk_time),
     }
   end
 
-  def academic_year
+  def recruitment_cycle_year
     @timetable.recruitment_cycle_year
   end
 

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -13,13 +13,13 @@ class CandidateInterface::DeadlineBannerComponent < ApplicationComponent
 
   def deadline
     {
-      date: @timetable.apply_deadline_at.to_fs(:govuk_date),
+      date: @timetable.apply_deadline_at.strftime('%d %B'),
       time: @timetable.apply_deadline_at.to_fs(:govuk_time),
     }
   end
 
   def academic_year
-    @timetable.academic_year_range_name
+    @timetable.recruitment_cycle_year
   end
 
   def show_appy_deadline_banner?

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -18,9 +18,7 @@ class CandidateInterface::DeadlineBannerComponent < ApplicationComponent
     }
   end
 
-  def recruitment_cycle_year
-    @timetable.recruitment_cycle_year
-  end
+  delegate :recruitment_cycle_year, to: :@timetable
 
   def show_appy_deadline_banner?
     !@application_form.successful? &&

--- a/config/locales/candidate_interface/deadline_banner_component.yml
+++ b/config/locales/candidate_interface/deadline_banner_component.yml
@@ -1,5 +1,5 @@
 en:
   candidate_interface:
     deadline_banner_component:
-      heading: The deadline for applying to courses starting in %{academic_year} is %{deadline_time} on %{deadline_date}
-      text: Courses may fill up before then. Check course availability with the provider.
+      heading: The deadline for applying to courses starting by the end of September %{academic_year} is %{deadline_time} on %{deadline_date}
+      text: Providers may close applications early if a course becomes full. You can check the number of available places with the provider.

--- a/config/locales/candidate_interface/deadline_banner_component.yml
+++ b/config/locales/candidate_interface/deadline_banner_component.yml
@@ -1,5 +1,5 @@
 en:
   candidate_interface:
     deadline_banner_component:
-      heading: The deadline for applying to courses starting by the end of September %{academic_year} is %{deadline_time} on %{deadline_date}
+      heading: The deadline for applying to courses starting by the end of September %{recruitment_cycle_year} is %{deadline_time} on %{deadline_date}
       text: Providers may close applications early if a course becomes full. You can check the number of available places with the provider.

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
       travel_temporarily_to(current_timetable.apply_deadline_at - 1.minute) do
         result = render_inline(described_class.new(application_form:, flash_empty: true))
         deadline_time = current_timetable.apply_deadline_at.to_fs(:govuk_time)
-        deadline_date = current_timetable.apply_deadline_at.strftime('%d %B')
+        deadline_date = current_timetable.apply_deadline_at.to_fs(:day_and_month)
         academic_year = current_timetable.recruitment_cycle_year
 
         expect(result.text).to include(

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -27,11 +27,14 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
       travel_temporarily_to(current_timetable.apply_deadline_at - 1.minute) do
         result = render_inline(described_class.new(application_form:, flash_empty: true))
         deadline_time = current_timetable.apply_deadline_at.to_fs(:govuk_time)
-        deadline_date = current_timetable.apply_deadline_at.to_fs(:govuk_date)
-        academic_year = current_timetable.academic_year_range_name
+        deadline_date = current_timetable.apply_deadline_at.strftime('%d %B')
+        academic_year = current_timetable.recruitment_cycle_year
 
         expect(result.text).to include(
-          "The deadline for applying to courses starting in #{academic_year} is #{deadline_time} on #{deadline_date}",
+          "The deadline for applying to courses starting by the end of September #{academic_year} is #{deadline_time} on #{deadline_date}",
+        )
+        expect(result.text).to include(
+          "Providers may close applications early if a course becomes full. You can check the number of available places with the provider.",
         )
       end
     end

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
           "The deadline for applying to courses starting by the end of September #{academic_year} is #{deadline_time} on #{deadline_date}",
         )
         expect(result.text).to include(
-          "Providers may close applications early if a course becomes full. You can check the number of available places with the provider.",
+          'Providers may close applications early if a course becomes full. You can check the number of available places with the provider.',
         )
       end
     end


### PR DESCRIPTION
## Context

- Content changes to the deadline banner, related to applications with a September start date.

## Changes proposed in this pull request

- Content changes to the deadline banner, related to applications with a September start date.

## Guidance to review

- Visit https://apply-review-11978.test.teacherservices.cloud/support
- Sign in as a Support User
- Visit https://apply-review-11978.test.teacherservices.cloud/rails/view_components/candidate_interface/summer_recruitment_banner_component/deadline_approaching_banner
- Check the content shows as is expected in [Figma](https://www.figma.com/design/ydNylUjTKF18Ta80v34bmB/Jan-starts?node-id=115-2574&p=f)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/9orWnpJm/1858-jan-start-dates-important-banners

## Screenshot

<img width="977" height="222" alt="Screenshot 2026-06-01 at 16 07 42" src="https://github.com/user-attachments/assets/dade09a9-9c93-4437-b5c7-7873e60c003a" />

