### PR TITLE
Remove NEW_GOVUK_NOTIFY_CALLBACK_API_KEY, no longer needed

### DIFF
--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -20,8 +20,7 @@ module Integrations
 
     def authorized?
       authenticate_with_http_token do |token|
-        token == ENV.fetch('GOVUK_NOTIFY_CALLBACK_API_KEY') ||
-          token == ENV.fetch('NEW_GOVUK_NOTIFY_CALLBACK_API_KEY')
+        token == ENV.fetch('GOVUK_NOTIFY_CALLBACK_API_KEY')
       end
     end
 

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', :sidekiq 
   let(:reference) do
     create(:reference, feedback_status: 'feedback_requested', application_form:)
   end
-  let(:notify_callback_token) { ENV.fetch('NEW_GOVUK_NOTIFY_CALLBACK_API_KEY') }
+  let(:notify_callback_token) { ENV.fetch('GOVUK_NOTIFY_CALLBACK_API_KEY') }
   let(:headers) do
     { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{notify_callback_token}" }
   end
@@ -16,32 +16,15 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', :sidekiq 
     end
   end
 
-  context 'with old callback key' do
-    let(:notify_callback_token) { ENV.fetch('GOVUK_NOTIFY_CALLBACK_API_KEY') }
+  it 'returns success if token matches environment variable' do
+    request_body = {
+      reference: "test-reference_request-#{reference.id}",
+      status: 'permanent-failure',
+    }.to_json
 
-    it 'returns success if token matches environment variable' do
-      request_body = {
-        reference: "test-reference_request-#{reference.id}",
-        status: 'permanent-failure',
-      }.to_json
+    post '/integrations/notify/callback', headers: headers, params: request_body
 
-      post '/integrations/notify/callback', headers: headers, params: request_body
-
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  context 'with new callback key' do
-    it 'returns success if token matches environment variable' do
-      request_body = {
-        reference: "test-reference_request-#{reference.id}",
-        status: 'permanent-failure',
-      }.to_json
-
-      post '/integrations/notify/callback', headers: headers, params: request_body
-
-      expect(response).to have_http_status(:success)
-    end
+    expect(response).to have_http_status(:success)
   end
 
   it 'returns unauthorized if token is not provided' do


### PR DESCRIPTION
## Context

We can go back to use GOVUK_NOTIFY_CALLBACK_API_KEY the `NEW` one was needed just so we can transition to the new notify integration

I did change `GOVUK_NOTIFY_CALLBACK_API_KEY` to have the new key in production.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Can't really test this. The only thing we can do is check that the new integration callback api is in the `GOVUK_NOTIFY_CALLBACK_API_KEY` env variable in production azure.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
