### PR TITLE
Data migration for normalizing unnormalized names on application forms

### DIFF
--- a/app/services/data_migrations/normalize_names_on_application_form.rb
+++ b/app/services/data_migrations/normalize_names_on_application_form.rb
@@ -1,0 +1,32 @@
+module DataMigrations
+  class NormalizeNamesOnApplicationForm
+    TIMESTAMP = 20260602110000
+    MANUAL_RUN = false
+
+    def change
+      forms_with_unnormalized_names do |application_form|
+        columns.each do |column|
+          next if application_form[column].nil?
+
+          application_form[column] = application_form[column].strip
+        end
+
+        application_form.save!
+      end
+    end
+
+  private
+
+    def forms_with_unnormalized_names
+      current_forms.where('first_name <> TRIM(first_name) OR last_name <> TRIM(last_name)')
+    end
+
+    def current_forms
+      @current_forms ||= ApplicationForm.where(recruitment_cycle_year: [2025, 2026])
+    end
+
+    def columns
+      %i[first_name last_name]
+    end
+  end
+end

--- a/app/services/data_migrations/normalize_names_on_application_form.rb
+++ b/app/services/data_migrations/normalize_names_on_application_form.rb
@@ -4,29 +4,14 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      forms_with_unnormalized_names do |application_form|
-        columns.each do |column|
-          next if application_form[column].nil?
-
-          application_form[column] = application_form[column].strip
-        end
-
-        application_form.save!
-      end
-    end
-
-  private
-
-    def forms_with_unnormalized_names
-      current_forms.where('first_name <> TRIM(first_name) OR last_name <> TRIM(last_name)')
-    end
-
-    def current_forms
-      @current_forms ||= ApplicationForm.where(recruitment_cycle_year: [2025, 2026])
-    end
-
-    def columns
-      %i[first_name last_name]
+      ActiveRecord::Base.connection.execute(<<~SQL)
+        UPDATE application_forms
+        SET first_name = TRIM(first_name),
+            last_name  = TRIM(last_name)
+        WHERE (first_name <> TRIM(first_name)
+            OR last_name  <> TRIM(last_name))
+          AND recruitment_cycle_year IN (2025, 2026);
+      SQL
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::NormalizeNamesOnApplicationForm',
   'DataMigrations::SetHideInReportingToFalse',
   'DataMigrations::RemoveProviderEdiReportFeatureFlag',
   'DataMigrations::PublishEnglishProficiencies',

--- a/spec/services/data_migrations/normalize_names_on_application_form_spec.rb
+++ b/spec/services/data_migrations/normalize_names_on_application_form_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::NormalizeNamesOnApplicationForm do
+  describe '#change' do
+    let!(:application_form) do
+      create(:application_form,
+             recruitment_cycle_year: 2026,
+             first_name: ' John ',
+             last_name: ' Doe ')
+    end
+
+    it 'strips leading and trailing whitespace from first_name and last_name' do
+      described_class.new.change
+
+      application_form.reload
+      expect(application_form.first_name).to eq('John')
+      expect(application_form.last_name).to eq('Doe')
+    end
+
+    context 'when the application is outside the recruitment_cycle_year scope' do
+      let!(:in_scope_form) do
+        create(:application_form,
+               recruitment_cycle_year: 2026,
+               first_name: ' John ',
+               last_name: ' Doe ')
+      end
+
+      let!(:out_of_scope_form) do
+        create(:application_form,
+               recruitment_cycle_year: 2024,
+               first_name: '  Alice  ',
+               last_name: '  Jones  ')
+      end
+
+      it 'does not modify applications from other recruitment cycles' do
+        original_attrs = out_of_scope_form.attributes.slice('first_name', 'last_name', 'updated_at')
+
+        described_class.new.change
+
+        out_of_scope_form.reload
+        expect(out_of_scope_form.attributes.slice('first_name', 'last_name', 'updated_at'))
+          .to eq(original_attrs)
+      end
+    end
+
+    context 'when names are already normalized' do
+      let!(:application_form) do
+        create(:application_form,
+               recruitment_cycle_year: 2026,
+               first_name: 'Jane',
+               last_name: 'Smith')
+      end
+
+      it 'does not modify applications' do
+        original_attrs = application_form.attributes.slice('first_name', 'last_name', 'updated_at')
+
+        described_class.new.change
+
+        application_form.reload
+        expect(application_form.attributes.slice('first_name', 'last_name', 'updated_at'))
+          .to eq(original_attrs)
+      end
+    end
+
+    context 'when some forms are normalized and some are not' do
+      let!(:normalized_form) do
+        create(:application_form,
+               recruitment_cycle_year: 2026,
+               first_name: 'Jane',
+               last_name: 'Smith')
+      end
+
+      let!(:unnormalized_form) do
+        create(:application_form,
+               recruitment_cycle_year: 2026,
+               first_name: ' John ',
+               last_name: ' Doe ')
+      end
+
+      it 'only updates forms with unnormalized names' do
+        original_attrs = normalized_form.attributes.slice('first_name', 'last_name', 'updated_at')
+
+        described_class.new.change
+
+        normalized_form.reload
+        unnormalized_form.reload
+
+        expect(normalized_form.attributes.slice('first_name', 'last_name', 'updated_at'))
+          .to eq(original_attrs)
+
+        expect(unnormalized_form.first_name).to eq('John')
+        expect(unnormalized_form.last_name).to eq('Doe')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

See #11977 for correcting an issue where candidates could enter their first and last names with extra whitespace. This had downstream effects for some providers when importing candidates.

## Changes proposed in this pull request

- Backfill live application form records to normalize first and last names (from 2025 and 2026 recruitment cycle years)
- The data migration should only touch applications within this year scope and where normalization is required

## Guidance to review

- Check the migration file and that the spec thoroughly tests the expected action.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [x] does the code safely backfill existing records for consistency
