### PR TITLE
Remove support user email address from logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,6 +13,7 @@ SANITIZED_REQUEST_PARAMS = %i[
   date_of_birth
   email
   email_address
+  dfe_sign_in_uid
   support_user_email
   first_name
   full_name

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,6 +13,7 @@ SANITIZED_REQUEST_PARAMS = %i[
   date_of_birth
   email
   email_address
+  support_user_email
   first_name
   full_name
   last_name


### PR DESCRIPTION
## Context

Investigating logs related to container restarts and I noticed that the support user email address shows up in some of the requests.

## Changes proposed in this pull request

add support user_email address to `SANITIZED_REQUST_PARAMS` constant so that it is removed from the payload:
| where it is removed | field in Logit |
| ----- | ----- |
| <img width="966" height="161" alt="image" src="https://github.com/user-attachments/assets/113ddb8b-b5d8-4432-9e0e-c0a719971383" /> | <img width="314" height="34" alt="image" src="https://github.com/user-attachments/assets/2fb7774b-5187-4bae-b27b-d6b55b0d434e" /> |



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
