### PR TITLE
Cancelling interview after handling interviews outside service

### DIFF
--- a/app/controllers/provider_interface/interviews/cancel_controller.rb
+++ b/app/controllers/provider_interface/interviews/cancel_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   module Interviews
     class CancelController < InterviewsController
       skip_before_action :redirect_to_index_if_store_cleared
+      skip_before_action :move_to_interview_if_outside_service
       before_action :confirm_interview_is_not_in_the_past, only: %i[new create]
 
       def show


### PR DESCRIPTION
## Context

When this was implemented https://github.com/DFE-Digital/apply-for-teacher-training/pull/11809 I think the goal was to automatically move any application choice to `interview` when the `Move to interview` button was pressed.

The issue with this is that the `before` action that does this is also called when we try to cancel an interview. So the user is not allowed to cancel an interview that is in our service.

This PR should fix this, we just skip this check for the cancel controller. Allowing the provider user to cancel interviews that are scheduled in our application.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and try to cancel some interviews

Impersonate this provider https://apply-review-11984.test.teacherservices.cloud/support/users/provider/5

And try to cancel some interviews. You should be able to do that now.


https://github.com/user-attachments/assets/b2e2f24a-7008-4fb6-a5ec-7c14bddae434



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
