### PR TITLE
Fix visa-expiry-carry-over issues

### DIFF
--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -35,24 +35,7 @@ module CandidateInterface
     private
 
       def all_sections_valid?
-        @personal_details_form.valid? &&
-          @nationalities_form.valid? &&
-          right_to_work_valid? &&
-          visa_expiry_valid?
-      end
-
-      def right_to_work_valid?
-        return true if current_application.british_or_irish?
-
-        @immigration_right_to_work_form.valid?
-      end
-
-      def visa_expiry_valid?
-        if current_application.temporary_immigration_status?
-          VisaExpiryForm.new(current_application).valid?
-        else
-          true
-        end
+        current_application.personal_information_section_valid?
       end
 
       def save_section_complete_form

--- a/app/forms/candidate_interface/immigration_right_to_work_form.rb
+++ b/app/forms/candidate_interface/immigration_right_to_work_form.rb
@@ -16,17 +16,23 @@ module CandidateInterface
       return false unless valid?
 
       if right_to_work_or_study?
-        application_form.update(
+        application_form.update!(
           right_to_work_or_study:,
         )
       else
-        application_form.update(
+        application_form.update!(
           right_to_work_or_study:,
           right_to_work_or_study_details: nil,
           immigration_status: nil,
           visa_expired_at: nil,
         )
       end
+
+      if application_form.personal_details_completed && !application_form.personal_information_section_valid?
+        application_form.update!(personal_details_completed: false)
+      end
+
+      true
     end
 
     def right_to_work_or_study?

--- a/app/forms/candidate_interface/immigration_status_form.rb
+++ b/app/forms/candidate_interface/immigration_status_form.rb
@@ -21,13 +21,19 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.update(
+      application_form.update!(
         immigration_status:,
         right_to_work_or_study_details: other_immigration_status? ? right_to_work_or_study_details : nil,
         visa_expired_at: if application_form.temporary_immigration_status?(immigration_status)
                            application_form.visa_expired_at
                          end,
       )
+
+      if application_form.personal_details_completed && !application_form.personal_information_section_valid?
+        application_form.update!(personal_details_completed: false)
+      end
+
+      true
     end
 
     def eu_nationality?

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -43,6 +43,12 @@ module CandidateInterface
           fifth_nationality: nationalities[4],
         )
       end
+
+      if application_form.personal_details_completed && !application_form.personal_information_section_valid?
+        application_form.update!(personal_details_completed: false)
+      end
+
+      true
     end
 
     def candidates_nationalities

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -143,9 +143,15 @@ class ApplicationForm < ApplicationRecord
   def personal_information_section_valid?
     CandidateInterface::PersonalDetailsForm.build_from_application(self).valid? &&
       CandidateInterface::NationalitiesForm.build_from_application(self).valid? &&
-      CandidateInterface::ImmigrationStatusForm.build_from_application(self).valid? &&
+      immigration_status_valid? &&
       right_to_work_valid? &&
       visa_expiry_valid?
+  end
+
+  def immigration_status_valid?
+    return true if british_or_irish?
+
+    CandidateInterface::ImmigrationStatusForm.build_from_application(self).valid?
   end
 
   def right_to_work_valid?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -140,6 +140,28 @@ class ApplicationForm < ApplicationRecord
 
   VISAS_REQUIRING_SPONSORSHIP = %w[student_visa skilled_worker_visa].freeze
 
+  def personal_information_section_valid?
+    CandidateInterface::PersonalDetailsForm.build_from_application(self).valid? &&
+      CandidateInterface::NationalitiesForm.build_from_application(self).valid? &&
+      CandidateInterface::ImmigrationStatusForm.build_from_application(self).valid? &&
+      right_to_work_valid? &&
+      visa_expiry_valid?
+  end
+
+  def right_to_work_valid?
+    return true if british_or_irish?
+
+    CandidateInterface::ImmigrationRightToWorkForm.build_from_application(self).valid?
+  end
+
+  def visa_expiry_valid?
+    if temporary_immigration_status?
+      CandidateInterface::VisaExpiryForm.new(self).valid?
+    else
+      true
+    end
+  end
+
   def international_qualification?
     application_qualifications.any?(&:international)
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -143,21 +143,21 @@ class ApplicationForm < ApplicationRecord
   def personal_information_section_valid?
     CandidateInterface::PersonalDetailsForm.build_from_application(self).valid? &&
       CandidateInterface::NationalitiesForm.build_from_application(self).valid? &&
-      immigration_status_valid? &&
       right_to_work_valid? &&
+      immigration_status_valid? &&
       visa_expiry_valid?
-  end
-
-  def immigration_status_valid?
-    return true if british_or_irish?
-
-    CandidateInterface::ImmigrationStatusForm.build_from_application(self).valid?
   end
 
   def right_to_work_valid?
     return true if british_or_irish?
 
     CandidateInterface::ImmigrationRightToWorkForm.build_from_application(self).valid?
+  end
+
+  def immigration_status_valid?
+    return true if british_or_irish? || right_to_work_or_study_no?
+
+    CandidateInterface::ImmigrationStatusForm.build_from_application(self).valid?
   end
 
   def visa_expiry_valid?

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -25,9 +25,7 @@ class DuplicateApplication
         )
       end
 
-      if !original_application_form.restructured_immigration_status? &&
-         new_application_form.restructured_immigration_status? &&
-         !new_application_form.british_or_irish?
+      if !new_application_form.british_or_irish?
         new_application_form.update(
           personal_details_completed: false,
         )

--- a/spec/forms/candidate_interface/immigration_right_to_work_form_spec.rb
+++ b/spec/forms/candidate_interface/immigration_right_to_work_form_spec.rb
@@ -67,5 +67,20 @@ RSpec.describe CandidateInterface::ImmigrationRightToWorkForm, type: :model do
       expect(application_form.right_to_work_or_study_details).not_to be_nil
       expect(application_form.visa_expired_at).not_to be_nil
     end
+
+    it 'resets the section completed if section is invalid' do
+      application_data = {
+        right_to_work_or_study: 'no',
+        immigration_status: 'other',
+        right_to_work_or_study_details: 'I have permanent residence',
+        visa_expired_at: Time.zone.today,
+        personal_details_completed: true,
+      }
+      application_form = build(:application_form, application_data)
+      form = described_class.new(right_to_work_or_study: 'yes')
+
+      expect(form.save(application_form)).to be(true)
+      expect(application_form.personal_details_completed).to be(false)
+    end
   end
 end

--- a/spec/forms/candidate_interface/immigration_status_form_spec.rb
+++ b/spec/forms/candidate_interface/immigration_status_form_spec.rb
@@ -119,5 +119,20 @@ RSpec.describe CandidateInterface::ImmigrationStatusForm, type: :model do
       expect(application_form.immigration_status).to eq('eu_settled')
       expect(application_form.visa_expired_at).to be_nil
     end
+
+    it 'resets the section completed if section is invalid' do
+      application_data = {
+        right_to_work_or_study: 'yes',
+        immigration_status: 'other',
+        right_to_work_or_study_details: 'I have permanent residence',
+        visa_expired_at: Time.zone.now,
+        personal_details_completed: true,
+      }
+      application_form = build(:application_form, application_data)
+      form = described_class.new(form_data)
+
+      expect(form.save(application_form)).to be(true)
+      expect(application_form.personal_details_completed).to be(false)
+    end
   end
 end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -136,6 +136,19 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
         expect(application_form.right_to_work_or_study).to eq 'yes'
         expect(application_form.right_to_work_or_study_details).to eq 'I have a visa.'
       end
+
+      it 'resets the section completed if section is invalid' do
+        application_form = build(
+          :application_form,
+          right_to_work_or_study: 'yes',
+          right_to_work_or_study_details: 'I have a visa.',
+          personal_details_completed: true,
+        )
+        nationalities = described_class.new(form_data)
+
+        expect(nationalities.save(application_form)).to be(true)
+        expect(application_form.personal_details_completed).to be(false)
+      end
     end
   end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -2107,6 +2107,13 @@ RSpec.describe ApplicationForm do
       end
     end
 
+    context 'when candidate is has no right to work' do
+      it 'returns true, they do not need immigration_status' do
+        application_form = build(:application_form, right_to_work_or_study: 'no')
+        expect(application_form.right_to_work_valid?).to be(true)
+      end
+    end
+
     context 'when candidate is not British or Irish' do
       context 'and immigration_status is set' do
         it 'returns true' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -2063,4 +2063,112 @@ RSpec.describe ApplicationForm do
       expect(described_class.previous_cycle).to contain_exactly(previous_application_form)
     end
   end
+
+  describe '#personal_information_section_valid?' do
+    context 'when all personal information sections are valid' do
+      it 'returns true' do
+        application_form = build(:application_form,
+                                 first_name: 'John',
+                                 last_name: 'Doe',
+                                 date_of_birth: Date.new(1990, 1, 1),
+                                 first_nationality: 'British',
+                                 immigration_status: 'eu_settled',
+                                 right_to_work_or_study: 'yes')
+        expect(application_form.personal_information_section_valid?).to be(true)
+      end
+    end
+
+    context 'when personal details are invalid' do
+      it 'returns false' do
+        application_form = build(:application_form, first_name: nil, date_of_birth: nil)
+        expect(application_form.personal_information_section_valid?).to be(false)
+      end
+    end
+
+    context 'when nationalities are missing' do
+      it 'returns false' do
+        application_form = build(:application_form,
+                                 first_name: 'John',
+                                 last_name: 'Doe',
+                                 date_of_birth: Date.new(1990, 1, 1),
+                                 first_nationality: nil,
+                                 immigration_status: 'eu_settled',
+                                 right_to_work_or_study: 'yes')
+        expect(application_form.personal_information_section_valid?).to be(false)
+      end
+    end
+  end
+
+  describe '#right_to_work_valid?' do
+    context 'when candidate is British or Irish' do
+      it 'returns true' do
+        application_form = build(:application_form, first_nationality: 'British')
+        expect(application_form.right_to_work_valid?).to be(true)
+      end
+    end
+
+    context 'when candidate is not British or Irish' do
+      context 'and right_to_work_or_study is set' do
+        it 'returns true' do
+          application_form = build(:application_form, first_nationality: 'French', right_to_work_or_study: 'yes')
+          expect(application_form.right_to_work_valid?).to be(true)
+        end
+      end
+
+      context 'and right_to_work_or_study is not set' do
+        it 'returns false' do
+          application_form = build(:application_form, first_nationality: 'French', right_to_work_or_study: nil)
+          expect(application_form.right_to_work_valid?).to be(false)
+        end
+      end
+    end
+  end
+
+  describe '#visa_expiry_valid?' do
+    context 'when candidate is British or Irish' do
+      it 'returns true' do
+        application_form = build(:application_form, first_nationality: 'British')
+        expect(application_form.visa_expiry_valid?).to be(true)
+      end
+    end
+
+    context 'when immigration_status is not temporary' do
+      it 'returns true' do
+        application_form = build(:application_form,
+                                 first_nationality: 'French',
+                                 immigration_status: 'eu_settled')
+        expect(application_form.visa_expiry_valid?).to be(true)
+      end
+    end
+
+    context 'when immigration_status is temporary' do
+      before do
+        FeatureFlag.activate('2027_visa_expiry')
+      end
+
+      after do
+        FeatureFlag.deactivate('2027_visa_expiry')
+      end
+
+      context 'and visa_expired_at is a future date' do
+        it 'returns true' do
+          application_form = build(:application_form,
+                                   first_nationality: 'French',
+                                   immigration_status: 'student_visa',
+                                   visa_expired_at: 1.year.from_now)
+          expect(application_form.visa_expiry_valid?).to be(true)
+        end
+      end
+
+      context 'and visa_expired_at is nil' do
+        it 'returns false' do
+          application_form = build(:application_form,
+                                   first_nationality: 'French',
+                                   immigration_status: 'student_visa',
+                                   visa_expired_at: nil)
+          expect(application_form.visa_expiry_valid?).to be(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -2099,6 +2099,31 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#immigration_status_valid?' do
+    context 'when candidate is British or Irish' do
+      it 'returns true' do
+        application_form = build(:application_form, first_nationality: 'British')
+        expect(application_form.right_to_work_valid?).to be(true)
+      end
+    end
+
+    context 'when candidate is not British or Irish' do
+      context 'and immigration_status is set' do
+        it 'returns true' do
+          application_form = build(:application_form, first_nationality: 'French', immigration_status: 'student_visa')
+          expect(application_form.immigration_status_valid?).to be(true)
+        end
+      end
+
+      context 'and immigration_status is not set' do
+        it 'returns false' do
+          application_form = build(:application_form, first_nationality: 'French', immigration_status: nil)
+          expect(application_form.immigration_status_valid?).to be(false)
+        end
+      end
+    end
+  end
+
   describe '#right_to_work_valid?' do
     context 'when candidate is British or Irish' do
       it 'returns true' do


### PR DESCRIPTION
## Context

There are 2 parts to this PR.
- Update the carry over script to set the personal_details section to incomplete to everyone that is not British or Irish
- Fix a bug where the candidate can have their personal details section completed even though they do require to input right to work, visa status or visa expiry date.

## Changes proposed in this pull request

- Moved logic that checks if the personal_details section is completed from the controller to the application form model.
- Added logic to personal details forms where we check if the form has become incomplete and mark the section incomplete. This fixes the bug where a candidate can have their personal details section completed without filling all the fields we ask them to.

## Guidance to review

Go on review app and try to change someone's personal details, you should see that the personal details section will change to incomplete. They need to have this section completed in the first place.


https://github.com/user-attachments/assets/c16e1147-62f3-4816-b159-4c5882bc8792



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
