### PR TITLE
Add new mailers for jan start dates

### DIFF
--- a/app/lib/end_of_cycle/candidate_email_timetabler.rb
+++ b/app/lib/end_of_cycle/candidate_email_timetabler.rb
@@ -18,16 +18,24 @@ module EndOfCycle
         apply_deadline_second_reminder_date: get_weekday(apply_deadline_at - 1.month).to_date,
         application_deadline_has_passed_email_date: (apply_deadline_at + 1.day).to_date,
         reject_by_default_explainer_date: (reject_by_default_at + 1.day).to_date,
+        decline_by_default_explainer_date: (decline_by_default_at + 1.day).to_date,
         find_has_opened_announcement_date: find_opens_at.to_date,
         # We have delayed the "apply has opened" email in the past to deal with rate limiting from Notify on the first day of applications.
         apply_has_opened_announcement_date: (apply_opens_at + 2.days).to_date,
         winter_reject_by_default_explainer_date:,
+        winter_decline_by_default_explainer_date:,
       }
     end
 
     def winter_reject_by_default_explainer_date
       if timetable.try(:winter_reject_by_default_at).present?
         (timetable.try(:winter_reject_by_default_at) + 1.day).to_date
+      end
+    end
+
+    def winter_decline_by_default_explainer_date
+      if timetable.try(:winter_decline_by_default_at).present?
+        (timetable.try(:winter_decline_by_default_at) + 1.day).to_date
       end
     end
 
@@ -55,8 +63,16 @@ module EndOfCycle
       current_date == email_schedule.fetch(:reject_by_default_explainer_date)
     end
 
+    def send_decline_by_default_explainer?
+      current_date == email_schedule.fetch(:decline_by_default_explainer_date)
+    end
+
     def send_winter_reject_by_default_explainer?
       current_date == email_schedule.fetch(:winter_reject_by_default_explainer_date)
+    end
+
+    def send_winter_decline_by_default_explainer?
+      current_date == email_schedule.fetch(:winter_decline_by_default_explainer_date)
     end
 
   private

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -497,7 +497,7 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.decline_by_default_explainer.subject'),
-      )
+    )
   end
 
   def winter_reject_by_default_explainer(application_form)
@@ -520,7 +520,7 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.decline_by_default_explainer.subject'),
-      )
+    )
   end
 
   def find_has_opened(application_form)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -490,8 +490,8 @@ class CandidateMailer < ApplicationMailer
 
   def decline_by_default_explainer(application_form)
     timetable = application_form.recruitment_cycle_timetable
-    @this_academic_year = timetable.previously_closed_academic_year_range
-    @next_academic_year = timetable.next_available_academic_year_range
+    @next_academic_year_range = timetable.next_available_academic_year_range
+    @next_recruitment_cycle_year = timetable.relative_next_year
     @apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
 
     email_for_candidate(
@@ -502,7 +502,7 @@ class CandidateMailer < ApplicationMailer
 
   def winter_reject_by_default_explainer(application_form)
     timetable = application_form.recruitment_cycle_timetable
-    @this_academic_year = timetable.previously_closed_academic_year_range
+    @this_academic_year = timetable.academic_year_range_name
     @next_academic_year = timetable.next_available_academic_year_range
 
     email_for_candidate(
@@ -513,9 +513,9 @@ class CandidateMailer < ApplicationMailer
 
   def winter_decline_by_default_explainer(application_form)
     timetable = application_form.recruitment_cycle_timetable
-    @this_academic_year = timetable.previously_closed_academic_year_range
-    @next_academic_year = timetable.next_available_academic_year_range
-    @apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+    next_recruitment_cycle = timetable.relative_next_timetable
+    @next_academic_year = next_recruitment_cycle.academic_year_range_name
+    @apply_reopens_date = next_recruitment_cycle.apply_reopens_at.to_fs(:govuk_date_time_time_first)
 
     email_for_candidate(
       application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -462,8 +462,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def respond_to_offer_before_winter_deadline(_application_form)
-    raise 'Mailer still in development'
+  def respond_to_offer_before_winter_deadline(application_form)
+    timetable = application_form.recruitment_cycle_timetable
+    @winter_decline_by_default_deadline = timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first)
+    @next_recruitment_cycle_year = timetable.relative_next_year
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!(
+        'candidate_mailer.respond_to_offer_before_deadline.subject',
+        decline_by_default_date: @winter_decline_by_default_deadline,
+      ),
+    )
   end
 
   def reject_by_default_explainer(application_form)
@@ -478,8 +488,39 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def winter_reject_by_default_explainer(_application_form)
-    raise 'Mailer still in development'
+  def decline_by_default_explainer(application_form)
+    timetable = application_form.recruitment_cycle_timetable
+    @this_academic_year = timetable.previously_closed_academic_year_range
+    @next_academic_year = timetable.next_available_academic_year_range
+    @apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.decline_by_default_explainer.subject'),
+      )
+  end
+
+  def winter_reject_by_default_explainer(application_form)
+    timetable = application_form.recruitment_cycle_timetable
+    @this_academic_year = timetable.previously_closed_academic_year_range
+    @next_academic_year = timetable.next_available_academic_year_range
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.reject_by_default_explainer.subject'),
+    )
+  end
+
+  def winter_decline_by_default_explainer(application_form)
+    timetable = application_form.recruitment_cycle_timetable
+    @this_academic_year = timetable.previously_closed_academic_year_range
+    @next_academic_year = timetable.next_available_academic_year_range
+    @apply_reopens_date = timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.decline_by_default_explainer.subject'),
+      )
   end
 
   def find_has_opened(application_form)

--- a/app/views/candidate_mailer/decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/decline_by_default_explainer.text.erb
@@ -1,0 +1,15 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+Your offer of a place on a teacher training course has been declined automatically.
+
+This is because you did not respond before the deadline.
+
+# What happens next?
+
+You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year. You will be able to apply to these courses from <%= @apply_reopens_date %>.
+
+[Sign in to your account to update your details](<%= sign_in_link %>)
+
+<%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/decline_by_default_explainer.text.erb
@@ -8,8 +8,10 @@ This is because you did not respond before the deadline.
 
 # What happens next?
 
-You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year. You will be able to apply to these courses from <%= @apply_reopens_date %>.
+You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year_range}" %> academic year. You will be able to apply to these courses from <%= "#{@apply_reopens_date}" %>.
 
 [Sign in to your account to update your details](<%= sign_in_link %>)
+
+There may be a small number of courses starting in January still available. If you apply, providers have until January <%= "#{@next_recruitment_cycle_year}" %> to respond.
 
 <%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/decline_by_default_explainer.text.erb
@@ -12,6 +12,4 @@ You can update your details to get ready to apply for courses starting in the <%
 
 [Sign in to your account to update your details](<%= sign_in_link %>)
 
-There may be a small number of courses starting in January still available. If you apply, providers have until January <%= "#{@next_recruitment_cycle_year}" %> to respond.
-
 <%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/end_of_cycle/_contact_us.text.erb
+++ b/app/views/candidate_mailer/end_of_cycle/_contact_us.text.erb
@@ -1,0 +1,3 @@
+# Contact us
+
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))

--- a/app/views/candidate_mailer/end_of_cycle/_contact_us.text.erb
+++ b/app/views/candidate_mailer/end_of_cycle/_contact_us.text.erb
@@ -1,3 +1,3 @@
 # Contact us
 
-Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays)).

--- a/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
@@ -16,9 +16,9 @@ This is because the provider did not respond before their deadline. If you have 
 
 # What happens next?
 
-If you want to accept your offer of a place on a teacher training course, you must do so by <%= @winter_decline_by_default_deadline %>.
+If you want to accept your offer of a place on a teacher training course, you must do so by <%= "#{@winter_decline_by_default_deadline}" %>.
 
-If you do not want to accept this offer, you can still apply to courses starting in September <%= @next_recruitment_cycle_year %>.
+If you do not want to accept this offer, you can still apply to courses starting later in <%= "#{@next_recruitment_cycle_year}" %> and in <%= "#{@next_recruitment_cycle_year + 1}" %>.
 
 [Sign in to your account to apply for courses](<%= application_choices_link %>)
 

--- a/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
@@ -1,0 +1,25 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+You have been offered a place on a teacher training course.
+
+If you want to accept this place, you must do so by <%=  @winter_decline_by_default_deadline %>.
+
+[Sign in to your account to update your details](<%= application_choices_link %>)
+
+# Your other applications
+
+Your other applications for teacher training starting in January <%= "#{@next_recruitment_cycle_year}" %> have been automatically rejected.
+
+This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+
+# What happens next
+
+If you want to accept your offer of a place on a teacher training course, you must do so by <%= @winter_decline_by_default_deadline %>.
+
+If you do not want to accept this offer, you can still apply to courses starting in September <%= @next_recruitment_cycle_year %>.
+
+[Sign in to your account to apply for courses](<%= application_choices_link %>).
+
+<%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
@@ -14,12 +14,12 @@ Your other applications for teacher training starting in January <%= "#{@next_re
 
 This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
 
-# What happens next
+# What happens next?
 
 If you want to accept your offer of a place on a teacher training course, you must do so by <%= @winter_decline_by_default_deadline %>.
 
 If you do not want to accept this offer, you can still apply to courses starting in September <%= @next_recruitment_cycle_year %>.
 
-[Sign in to your account to apply for courses](<%= application_choices_link %>).
+[Sign in to your account to apply for courses](<%= application_choices_link %>)
 
 <%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -14,6 +14,6 @@ Training provider make offers throughout the year. Providers may close applicati
 
 Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.
 
-[Sign in to your account to update your details](<%= sign_in_link %>)
+[Sign in to your account to apply for courses](<%= sign_in_link %>)
 
 <%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -8,7 +8,7 @@ This is because you did not respond before the deadline.
 
 # What happens next?
 
-You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year.
+You can now apply to courses starting in the <%= "#{@next_academic_year}" %> academic year.
 
 Training provider make offers throughout the year. Providers may close applications early if a course fills up.
 

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -1,0 +1,15 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+Your offer of a place on a teacher training course has been declined automatically.
+
+This is because you did not respond before the deadline.
+
+# What happens next?
+
+You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year. You will be able to apply to these courses from <%= @apply_reopens_date %>.
+
+[Sign in to your account to update your details](<%= sign_in_link %>)
+
+<%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -8,7 +8,11 @@ This is because you did not respond before the deadline.
 
 # What happens next?
 
-You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year. You will be able to apply to these courses from <%= @apply_reopens_date %>.
+You can update your details to get ready to apply for courses starting in the <%= "#{@next_academic_year}" %> academic year.
+
+Training provider make offers throughout the year. Providers may close applications early if a course fills up.
+
+Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.
 
 [Sign in to your account to update your details](<%= sign_in_link %>)
 

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -10,7 +10,7 @@ This is because you did not respond before the deadline.
 
 You can now apply to courses starting in the <%= "#{@next_academic_year}" %> academic year.
 
-Training provider make offers throughout the year. Providers may close applications early if a course fills up.
+Training providers make offers throughout the year. Providers may close applications early if a course fills up.
 
 Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.
 

--- a/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
@@ -1,0 +1,15 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+Your application for teacher training starting in the  <%= @this_academic_year %> academic year has been rejected automatically.
+
+This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+
+# What happens next
+
+Courses are open for applications for courses starting in the <%= @next_academic_year %> academic year.
+
+[Sign in to your account to apply for courses](<%= sign_in_link %>).
+
+<%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
@@ -8,7 +8,7 @@ This is because the provider did not respond before their deadline. If you have 
 
 # What happens next?
 
-Courses are open for applications for courses starting in the <%= @next_academic_year %> academic year.
+You can now apply to courses starting in the <%= @next_academic_year %> academic year.
 
 [Sign in to your account to apply for courses](<%= sign_in_link %>).
 

--- a/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
@@ -6,7 +6,7 @@ Your application for teacher training starting in the  <%= @this_academic_year %
 
 This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
 
-# What happens next
+# What happens next?
 
 Courses are open for applications for courses starting in the <%= @next_academic_year %> academic year.
 

--- a/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -1,0 +1,33 @@
+module EndOfCycle
+  class SendDeclineByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
+    BATCH_SIZE = 120
+
+    def perform
+      return unless CandidateEmailTimetabler.new.send_decline_by_default_explainer?
+
+      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
+        SendRejectByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+      end
+    end
+
+    def relation
+      ApplicationForm
+        .current_cycle
+        .joins(:candidate).merge(Candidate.for_transaction_emails)
+        .joins(:application_choices).where('application_choices.declined_by_default': true)
+        .distinct
+    end
+  end
+
+  class SendRejectByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
+    def perform(application_form_ids)
+      ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
+        CandidateMailer.decline_by_default_explainer(application_form).deliver_later
+      end
+    end
+  end
+end

--- a/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -8,7 +8,7 @@ module EndOfCycle
       return unless CandidateEmailTimetabler.new.send_decline_by_default_explainer?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendRejectByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+        SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -21,7 +21,7 @@ module EndOfCycle
     end
   end
 
-  class SendRejectByDefaultExplainerEmailToCandidatesBatchWorker
+  class SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker
     include Sidekiq::Worker
 
     def perform(application_form_ids)

--- a/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -1,0 +1,46 @@
+module EndOfCycle
+  class SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
+    BATCH_SIZE = 120
+
+    def perform
+      return unless send_emails?
+
+      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
+        SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+      end
+    end
+
+    def relation
+      ids = ApplicationChoice.course_starts_after_september(timetable.recruitment_cycle_year)
+                             .where(declined_by_default: true)
+                             .pluck(:application_form_id).uniq
+      ApplicationForm
+        .previous_cycle
+        .joins(:candidate).merge(Candidate.for_transaction_emails)
+        .where(id: ids)
+        .distinct
+    end
+
+    private
+
+    def send_emails?
+      CandidateEmailTimetabler.new(timetable:).send_winter_decline_by_default_explainer?
+    end
+
+    def timetable
+      @timetable ||= RecruitmentCycleTimetable.previous_timetable
+    end
+  end
+
+  class SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
+    def perform(application_form_ids)
+      ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
+        CandidateMailer.winter_decline_by_default_explainer(application_form).deliver_later
+      end
+    end
+  end
+end

--- a/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -23,7 +23,7 @@ module EndOfCycle
         .distinct
     end
 
-    private
+  private
 
     def send_emails?
       CandidateEmailTimetabler.new(timetable:).send_winter_decline_by_default_explainer?

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -59,6 +59,7 @@ class Clock
   every(1.day, 'EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker', at: '09:00') { EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker.new.perform }
   every(1.day, 'EndOfCycle:SendRejectByDefaultExplainerToCandidatesWorker', at: '09:01') { EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
   every(1.day, 'Candidate::PoolEligibleApplicationFormWorker', at: '09:02') { Candidate::PoolEligibleApplicationFormWorker.new.perform }
+  every(1.day, 'EndOfCycle:SendDeclineByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker.new.perform }
 
   # End of cycle january start dates/winter end dates jobs
   # every(1.day, 'EndOfCycle:SendWinterRejectByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
@@ -66,6 +67,7 @@ class Clock
   # every(1.day, 'EndOfCycle:WinterDeclineByDefaultWorker', at: '09:05') { EndOfCycle::WinterDeclineByDefaultWorker.new.perform }
   # every(1.day, 'EndOfCycle::WinterRejectByDefaultWorker', at: '09:06') { EndOfCycle::WinterRejectByDefaultWorker.new.perform }\
   # every(1.day, 'EndOfCycle::CancelReferenceRequestsWorker', at: '09:07') { EndOfCycle::CancelReferenceRequestsWorker.new.perform }
+  # every(1.day, 'EndOfCycle:SendWinterDeclineByDefaultExplainerToCandidatesWorker', at: '09:08') { EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker.new.perform }
 
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -93,6 +93,8 @@ en:
       subject: Accept your place on a teacher training course by %{decline_by_default_date}
     reject_by_default_explainer:
       subject: Your application has been rejected automatically
+    decline_by_default_explainer:
+      subject: Your application has been declined automatically
     new_cycle_has_started:
       subject: Apply for teacher training starting in the %{academic_year} academic year
     find_has_opened:

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -127,6 +127,10 @@ en:
             new_cycle_has_started: Candidates can now submit applications for teacher training in the latest recruitment cycle.
             reject_by_default_explainer: Applications that have not received a response by the end of the cycle are rejected by default.
             respond_to_offer_before_deadline: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before the end of the cycle. Sent 2 weeks before the reject by default date before the end of the cycle.
+            respond_to_offer_before_winter_deadline: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before winter reject by default date. Sent 2 weeks before the winter reject by default date.
+            decline_by_default_explainer: A candidate is notified that there application has been declined. Sent after the decline by default date.
+            winter_reject_by_default_explainer: A candidate is notified that there application has been rejected by default. Sent after the winter reject by default date.
+            winter_decline_by_default_explainer: A candidate is notified that there application has been declined by default. Sent after the winter decline by default date.
           candidate_interview:
             interview_cancelled: A scheduled interview has been cancelled.
             interview_updated: Details about a scheduled interview have been changed.

--- a/spec/lib/end_of_cycle/candidate_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/candidate_email_timetabler_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
   describe '.email_schedule' do
     subject(:email_schedule) { instance.email_schedule }
 
+    describe 'decline_by_default_explainer_date' do
+      it 'returns the decline_by_default_at plus one day' do
+        expect(
+          email_schedule[:decline_by_default_explainer_date],
+        ).to eq timetable.decline_by_default_at.to_date + 1.day
+      end
+    end
+
     describe 'winter_reject_by_default_explainer_date' do
       context 'when the timetable winter_reject_by_default_at attribute is nil' do
         before do
@@ -23,6 +31,26 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
           expect(
             email_schedule[:winter_reject_by_default_explainer_date],
           ).to eq timetable.winter_reject_by_default_at.to_date + 1.day
+        end
+      end
+    end
+
+    describe 'winter_decline_by_default_explainer_date' do
+      context 'when the timetable winter_decline_by_default_at attribute is nil' do
+        before do
+          allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new)
+        end
+
+        it 'returns nil' do
+          expect(instance.winter_decline_by_default_explainer_date).to be_nil
+        end
+      end
+
+      context 'when the timetable winter_decline_by_default_at attribute is not nil' do
+        it 'returns the winter_decline_by_default_at plus one day' do
+          expect(
+            email_schedule[:winter_decline_by_default_explainer_date],
+          ).to eq timetable.winter_decline_by_default_at.to_date + 1.day
         end
       end
     end
@@ -53,6 +81,58 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
       it 'returns true' do
         travel_temporarily_to(current_timetable.winter_reject_by_default_at + 1.day) do
           expect(send_winter_reject_by_default_explainer?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe 'send_winter_decline_by_default_explainer?' do
+    subject(:send_winter_decline_by_default_explainer?) { instance.send_winter_decline_by_default_explainer? }
+
+    context 'when winter_decline_by_default_explainer_date is nil' do
+      before do
+        allow(instance).to receive(:winter_decline_by_default_explainer_date).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(send_winter_decline_by_default_explainer?).to be(false)
+      end
+    end
+
+    context 'when the current date does not match the winter decline by default explainer date' do
+      it 'returns false' do
+        travel_temporarily_to(current_timetable.winter_decline_by_default_at + 1.month, freeze: true) do
+          expect(send_winter_decline_by_default_explainer?).to be(false)
+        end
+      end
+    end
+
+    context 'when the current date matches the winter decline by default explainer date' do
+      it 'returns true' do
+        travel_temporarily_to(current_timetable.winter_decline_by_default_at + 1.day) do
+          expect(send_winter_decline_by_default_explainer?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe 'send_decline_by_default_explainer?' do
+    subject(:send_decline_by_default_explainer?) { instance.send_decline_by_default_explainer? }
+
+    let(:timetable) { current_timetable }
+
+    context 'when the current date does not match the decline by default explainer date' do
+      it 'returns false' do
+        travel_temporarily_to(current_timetable.decline_by_default_at + 1.month, freeze: true) do
+          expect(send_decline_by_default_explainer?).to be(false)
+        end
+      end
+    end
+
+    context 'when the current date matches the decline by default explainer date' do
+      it 'returns true' do
+        travel_temporarily_to(current_timetable.decline_by_default_at + 1.day) do
+          expect(send_decline_by_default_explainer?).to be(true)
         end
       end
     end

--- a/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
@@ -33,11 +33,5 @@ RSpec.describe CandidateMailer do
         "You will be able to apply to these courses from #{apply_reopens_date}.",
       )
     end
-
-    it 'renders content for applying for January courses' do
-      expect(email.body).to include(
-        "There may be a small number of courses starting in January still available. If you apply, providers have until January #{next_recruitment_cycle_year} to respond.",
-      )
-    end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe CandidateMailer do
   describe '.decline_by_default_explainer' do
     let(:email) { described_class.decline_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
-    let(:next_academic_year) { timetable.next_available_academic_year_range }
+    let(:next_academic_year_range) { timetable.next_available_academic_year_range }
+    let(:next_recruitment_cycle_year) { timetable.relative_next_year }
     let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
 
     it_behaves_like(
@@ -23,13 +24,19 @@ RSpec.describe CandidateMailer do
 
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(
-        "You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.",
+        "You can update your details to get ready to apply for courses starting in the #{next_academic_year_range} academic year.",
       )
     end
 
     it 'renders content for applying for courses' do
       expect(email.body).to include(
         "You will be able to apply to these courses from #{apply_reopens_date}.",
+      )
+    end
+
+    it 'renders content for applying for January courses' do
+      expect(email.body).to include(
+        "There may be a small number of courses starting in January still available. If you apply, providers have until January #{next_recruitment_cycle_year} to respond.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer do
+  include TestHelpers::MailerSetupHelper
+
+  describe '.decline_by_default_explainer' do
+    let(:email) { described_class.decline_by_default_explainer(application_form) }
+    let(:timetable) { application_form.recruitment_cycle_timetable }
+    let(:next_academic_year) { timetable.next_available_academic_year_range }
+    let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Your application has been declined automatically',
+      'greeting' => 'Dear Fred',
+      'details' => 'Your offer of a place on a teacher training course has been declined automatically.',
+      'cause' => 'This is because you did not respond before the deadline.',
+      'what happens next' => 'What happens next?',
+      'sign in' => 'Sign in to your account to update your details',
+      'contact us' => 'Contact us',
+      'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+    )
+
+    it 'renders content for updating the recipients details' do
+      expect(email.body).to include(
+        "You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.",
+      )
+    end
+
+    it 'renders content for applying for courses' do
+      expect(email.body).to include(
+        "You will be able to apply to these courses from #{apply_reopens_date}.",
+      )
+    end
+  end
+end

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
@@ -3,12 +3,38 @@ require 'rails_helper'
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
+  let(:email) { described_class.respond_to_offer_before_winter_deadline(application_form) }
+  let(:timetable) { application_form.recruitment_cycle_timetable }
+  let(:winter_deadline) { timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first) }
+  let(:next_recruitment_cycle_year) { timetable.relative_next_year }
+
   describe '.respond_to_offer_before_winter_deadline' do
-    it 'raises an error' do
-      application_form = build(:completed_application_form)
-      expect {
-        described_class.respond_to_offer_before_winter_deadline(application_form).deliver_now
-      }.to raise_error('Mailer still in development')
+    it 'renders the content' do
+      expect(email.subject).to eq(
+        "Accept your place on a teacher training course by #{winter_deadline}",
+      )
+      expect(email.body).to include("Dear #{application_form.first_name}")
+      expect(email.body).to include('You have been offered a place on a teacher training course.')
+      expect(email.body).to include("If you want to accept this place, you must do so by #{winter_deadline}.")
+      expect(email.body).to include('Sign in to your account to update your details')
+      expect(email.body).to include('Your other applications')
+      expect(email.body).to include(
+        "Your other applications for teacher training starting in January #{next_recruitment_cycle_year} have been automatically rejected.",
+      )
+      expect(email.body).to include(
+        'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
+      )
+      expect(email.body).to include('What happens next')
+      expect(email.body).to include(
+        "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
+      )
+      expect(email.body).to include(
+        "If you do not want to accept this offer, you can still apply to courses starting in September #{next_recruitment_cycle_year}.",
+      )
+      expect(email.body).to include('Sign in to your account to apply for courses')
+      expect(email.body).to include(
+        'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+      )
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CandidateMailer do
       expect(email.body).to include(
         'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
       )
-      expect(email.body).to include('What happens next')
+      expect(email.body).to include('What happens next?')
       expect(email.body).to include(
         "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
       )

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateMailer do
         "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
       )
       expect(email.body).to include(
-        "If you do not want to accept this offer, you can still apply to courses starting in September #{next_recruitment_cycle_year}.",
+        "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
       )
       expect(email.body).to include('Sign in to your account to apply for courses')
       expect(email.body).to include(

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe CandidateMailer do
   describe '.winter_decline_by_default_explainer' do
     let(:email) { described_class.winter_decline_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
-    let(:next_academic_year) { timetable.next_available_academic_year_range }
-    let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
+    let(:next_timetable) { timetable.relative_next_timetable }
+    let(:next_academic_year) { next_timetable.academic_year_range_name
+    let(:apply_reopens_date) { next_timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
 
     it_behaves_like(
       'a mail with subject and content',

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateMailer do
     let(:email) { described_class.winter_decline_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:next_timetable) { timetable.relative_next_timetable }
-    let(:next_academic_year) { next_timetable.academic_year_range_name
+    let(:next_academic_year) { next_timetable.academic_year_range_name }
     let(:apply_reopens_date) { next_timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
 
     it_behaves_like(

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CandidateMailer do
       'details' => 'Your offer of a place on a teacher training course has been declined automatically.',
       'cause' => 'This is because you did not respond before the deadline.',
       'what happens next' => 'What happens next?',
-      'providers make offers' => 'Training provider make offers throughout the year. Providers may close applications early if a course fills up.',
+      'providers make offers' => 'Training providers make offers throughout the year. Providers may close applications early if a course fills up.',
       'courses can close' => 'Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.',
       'sign in' => 'Sign in to your account to apply for courses',
       'contact us' => 'Contact us',

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateMailer do
       'what happens next' => 'What happens next?',
       'providers make offers' => 'Training provider make offers throughout the year. Providers may close applications early if a course fills up.',
       'courses can close' => 'Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.',
-      'sign in' => 'Sign in to your account to update your details',
+      'sign in' => 'Sign in to your account to apply for courses',
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
     )

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CandidateMailer do
 
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(
-        "You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.",
+        "You can now apply to courses starting in the #{next_academic_year} academic year.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer do
+  include TestHelpers::MailerSetupHelper
+
+  describe '.winter_decline_by_default_explainer' do
+    let(:email) { described_class.winter_decline_by_default_explainer(application_form) }
+    let(:timetable) { application_form.recruitment_cycle_timetable }
+    let(:next_academic_year) { timetable.next_available_academic_year_range }
+    let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Your application has been declined automatically',
+      'greeting' => 'Dear Fred',
+      'details' => 'Your offer of a place on a teacher training course has been declined automatically.',
+      'cause' => 'This is because you did not respond before the deadline.',
+      'what happens next' => 'What happens next?',
+      'sign in' => 'Sign in to your account to update your details',
+      'contact us' => 'Contact us',
+      'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+    )
+
+    it 'renders content for updating the recipients details' do
+      expect(email.body).to include(
+        "You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.",
+      )
+    end
+
+    it 'renders content for applying for courses' do
+      expect(email.body).to include(
+        "You will be able to apply to these courses from #{apply_reopens_date}.",
+      )
+    end
+  end
+end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe CandidateMailer do
       'details' => 'Your offer of a place on a teacher training course has been declined automatically.',
       'cause' => 'This is because you did not respond before the deadline.',
       'what happens next' => 'What happens next?',
+      'providers make offers' => 'Training provider make offers throughout the year. Providers may close applications early if a course fills up.',
+      'courses can close' => 'Courses can fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until the next year to apply.',
       'sign in' => 'Sign in to your account to update your details',
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
@@ -25,12 +27,6 @@ RSpec.describe CandidateMailer do
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(
         "You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.",
-      )
-    end
-
-    it 'renders content for applying for courses' do
-      expect(email.body).to include(
-        "You will be able to apply to these courses from #{apply_reopens_date}.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateMailer do
 
     it 'renders content for open courses' do
       expect(email.body).to include(
-        "You can now apply  courses starting in the #{next_academic_year} academic year.",
+        "You can now apply courses starting in the #{next_academic_year} academic year.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateMailer do
 
     it 'renders content for open courses' do
       expect(email.body).to include(
-        "Courses are open for applications for courses starting in the #{next_academic_year} academic year.",
+        "You can now apply  courses starting in the #{next_academic_year} academic year.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateMailer do
   describe '.winter_reject_by_default_explainer' do
     let(:email) { described_class.winter_reject_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
-    let(:this_academic_year) { timetable.previously_closed_academic_year_range }
+    let(:this_academic_year) { timetable.academic_year_range_name }
     let(:next_academic_year) { timetable.next_available_academic_year_range }
 
     it_behaves_like(

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateMailer do
 
     it 'renders content for open courses' do
       expect(email.body).to include(
-        "You can now apply courses starting in the #{next_academic_year} academic year.",
+        "You can now apply to courses starting in the #{next_academic_year} academic year.",
       )
     end
   end

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -4,11 +4,32 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.winter_reject_by_default_explainer' do
-    it 'raises an error' do
-      application_form = build(:completed_application_form)
-      expect {
-        described_class.winter_reject_by_default_explainer(application_form).deliver_now
-      }.to raise_error('Mailer still in development')
+    let(:email) { described_class.winter_reject_by_default_explainer(application_form) }
+    let(:timetable) { application_form.recruitment_cycle_timetable }
+    let(:this_academic_year) { timetable.previously_closed_academic_year_range }
+    let(:next_academic_year) { timetable.next_available_academic_year_range }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Your application has been rejected automatically',
+      'greeting' => 'Dear Fred',
+      'cause' => 'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
+      'what happens next' => 'What happens next?',
+      'sign in' => 'Sign in to your account to apply for courses',
+      'contact us' => 'Contact us',
+      'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+    )
+
+    it 'renders content for application rejected automatically' do
+      expect(email.body).to include(
+        "Your application for teacher training starting in the  #{this_academic_year} academic year has been rejected automatically.",
+      )
+    end
+
+    it 'renders content for open courses' do
+      expect(email.body).to include(
+        "Courses are open for applications for courses starting in the #{next_academic_year} academic year.",
+      )
     end
   end
 end

--- a/spec/mailers/previews/candidate/end_of_cycle_preview.rb
+++ b/spec/mailers/previews/candidate/end_of_cycle_preview.rb
@@ -109,4 +109,28 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
 
     CandidateMailer.visa_sponsorship_deadline_change(application_form, course)
   end
+
+  def winter_reject_by_default_explainer
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+
+    CandidateMailer.winter_reject_by_default_explainer(application_form)
+  end
+
+  def respond_to_offer_before_winter_deadline
+    application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+
+    CandidateMailer.respond_to_offer_before_winter_deadline(application_form)
+  end
+
+  def decline_by_default_explainer
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+
+    CandidateMailer.decline_by_default_explainer(application_form)
+  end
+
+  def winter_decline_by_default_explainer
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+
+    CandidateMailer.winter_decline_by_default_explainer(application_form)
+  end
 end

--- a/spec/support/cycle_timetable_helper.rb
+++ b/spec/support/cycle_timetable_helper.rb
@@ -131,6 +131,11 @@ module_function
     timetable.reject_by_default_at + 1.day
   end
 
+  def decline_by_default_explainer_date(year = nil)
+    timetable = get_timetable(year)
+    timetable.decline_by_default_at + 1.day
+  end
+
   def get_timetable(year = nil)
     seed_timetables if RecruitmentCycleTimetable.all.empty?
 

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe 'Docs' do
       candidate_mailer-respond_to_offer_before_winter_deadline
       candidate_mailer-winter_reject_by_default_explainer
       provider_mailer-respond_to_applications_before_winter_reject_by_default_date
+      candidate_mailer-decline_by_default_explainer
+      candidate_mailer-winter_decline_by_default_explainer
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker do
+  describe '#perform' do
+    it 'enqueues email telling candidate why their application was declined' do
+      application_form = create(:application_form)
+      create(:application_choice, :declined_by_default, application_form:)
+
+      expect { described_class.new.perform([application_form.id]) }
+        .to have_enqueued_mail(CandidateMailer, :decline_by_default_explainer)
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker do
+  describe '#perform' do
+    context 'before the date for sending the explainer email', time: decline_by_default_explainer_date - 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_choice, :declined_by_default)
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'after the date for sending the explainer email', time: decline_by_default_explainer_date + 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_choice, :declined_by_default)
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'the date for sending the explainer email', time: decline_by_default_explainer_date do
+      it 'enqueues batch worker' do
+        rejected_with_offer = create(:application_form)
+        create(:application_choice, :declined_by_default, application_form: rejected_with_offer)
+        create(:application_choice, :offered, application_form: rejected_with_offer)
+
+        rejected_without_offer = create(:application_choice, :declined_by_default).application_form
+
+        # These applications should not be included
+        create(:application_choice, :inactive)
+        create(:application_choice, :interviewing)
+        create(:application_choice, :awaiting_provider_decision)
+
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id])
+      end
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker do
+  describe '#perform' do
+    it 'enqueues email telling candidate why their application was declined' do
+      application_form = create(:application_form)
+      create(:application_choice, :declined_by_default, application_form:)
+
+      expect { described_class.new.perform([application_form.id]) }
+        .to have_enqueued_mail(CandidateMailer, :winter_decline_by_default_explainer)
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker do
+  let(:instance) { described_class.new }
+  let(:previous_year) { RecruitmentCycleTimetable.previous_year }
+
+  describe '#perform' do
+    context 'before or after the date for sending the winter explainer email' do
+      before do
+        allow(instance).to receive(:send_emails?).and_return(false)
+      end
+
+      it 'does not enqueue the batch worker' do
+        create(
+          :application_choice,
+          :declined_by_default,
+          current_recruitment_cycle_year: previous_year,
+          application_form: create(:application_form, recruitment_cycle_year: previous_year),
+        )
+        allow(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'the date for sending the explainer email' do
+      before do
+        allow(instance).to receive(:send_emails?).and_return(true)
+      end
+
+      it 'enqueues batch worker' do
+        declined_by_default_application = create(:application_form, recruitment_cycle_year: previous_year)
+        create(
+          :application_choice,
+          :declined_by_default,
+          application_form: declined_by_default_application,
+          current_recruitment_cycle_year: previous_year,
+        )
+
+        # These applications should not be included
+        create(:application_choice, :inactive, application_form: build(:application_form, recruitment_cycle_year: previous_year))
+        create(:application_choice, :interviewing, application_form: build(:application_form, recruitment_cycle_year: previous_year))
+        create(:application_choice, :awaiting_provider_decision, application_form: build(:application_form, recruitment_cycle_year: previous_year))
+        create(:application_choice, :declined_by_default)
+
+        allow(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        instance.perform
+
+        expect(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [declined_by_default_application.id])
+      end
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker do
+  describe '#perform' do
+    context 'candidate has offers' do
+      it 'enqueues email asking candidate to respond to offers' do
+        application_form = create(:application_form)
+        create(:application_choice, :offered, application_form:)
+        create(:application_choice, :rejected_by_default, application_form:)
+
+        expect { described_class.new.perform([application_form.id]) }
+          .to have_enqueued_mail(CandidateMailer, :respond_to_offer_before_winter_deadline)
+      end
+    end
+
+    context 'candidate does not have offers' do
+      it 'enqueues email telling candidate why their application was rejected' do
+        application_form = create(:application_form)
+        create(:application_choice, :rejected_by_default, application_form:)
+
+        expect { described_class.new.perform([application_form.id]) }
+          .to have_enqueued_mail(CandidateMailer, :winter_reject_by_default_explainer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Add new mailers for rejecting and declining applications with January start dates.

## Changes proposed in this pull request

- Add the following Mailers:
  - decline_by_default_explainer
  - respond_to_applications_before_winter_reject_by_default_date
  - winter_reject_by_default_explainer
  - winter_decline_by_default_explainer

## Guidance to review

- Visit https://apply-review-11987.test.teacherservices.cloud/support
- Sign in as a Support User
- Visit https://apply-review-11987.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/decline_by_default_explainer
- Check the email content against [Figma](https://www.figma.com/design/ydNylUjTKF18Ta80v34bmB/Jan-starts?node-id=115-2574&p=f) for (`decline_by_default_explainer` AKA "After decline by default 1")
- Visit https://apply-review-11987.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/respond_to_offer_before_winter_deadline
- Check the email content against [Figma](https://www.figma.com/design/ydNylUjTKF18Ta80v34bmB/Jan-starts?node-id=115-2574&p=f) for (`respond_to_offer_before_winter_deadline` AKA "New mailer before DBD2")
- Visit https://apply-review-11987.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_reject_by_default_explainer
- Check the email content against [Figma](https://www.figma.com/design/ydNylUjTKF18Ta80v34bmB/Jan-starts?node-id=115-2574&p=f) for (`winter_reject_by_default_explainer` AKA "New mailer after RBD2")
- Visit https://apply-review-11987.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_decline_by_default_explainer
- Check the email content against [Figma](https://www.figma.com/design/ydNylUjTKF18Ta80v34bmB/Jan-starts?node-id=115-2574&p=f) for (`winter_decline_by_default_explainer` AKA "New mailer to say you've been declined by default")


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/2FSoreaJ/1857-jan-start-dates-new-mailers

## Screenshot
_decline_by_default_explainer_
<img width="583" height="577" alt="Screenshot 2026-06-05 at 14 47 37" src="https://github.com/user-attachments/assets/add4d0c0-a828-4665-9a82-e538bd8f93c2" />

_respond_to_offer_before_winter_deadline_
<img width="463" height="694" alt="Screenshot 2026-06-05 at 14 48 26" src="https://github.com/user-attachments/assets/a991005e-0d5d-46fc-af51-b578e199759f" />

_winter_reject_by_default_explainer_
<img width="574" height="579" alt="Screenshot 2026-06-05 at 14 48 59" src="https://github.com/user-attachments/assets/00272545-0fd3-4af4-a391-d25e9a03edaa" />

_winter_decline_by_default_explainer_
<img width="579" height="702" alt="Screenshot 2026-06-05 at 14 49 43" src="https://github.com/user-attachments/assets/0e8992a8-c44f-4c9b-b85b-ac2be3dd3288" />

