### PR TITLE
Reduce batch size on application scope

### DIFF
--- a/app/presenters/vendor_api/multiple_applications_presenter.rb
+++ b/app/presenters/vendor_api/multiple_applications_presenter.rb
@@ -24,7 +24,7 @@ module VendorAPI
 
     def applications_scope
       applications
-        .find_each(batch_size: 500)
+        .find_each(batch_size: 250)
         .sort_by(&:updated_at)
         .reverse
     end

--- a/spec/presenters/vendor_api/v1.1/multiple_applications_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.1/multiple_applications_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'MultipleApplicationsPresenter' do
     it 'performs a batch find' do
       allow(applications).to receive(:find_each).and_call_original
       multiple_applications_presenter.new('1.0', applications).applications_scope
-      expect(applications).to have_received(:find_each).with(batch_size: 500)
+      expect(applications).to have_received(:find_each).with(batch_size: 250)
     end
   end
 end


### PR DESCRIPTION
## Context

Every morning at 6am, one of our pods crashes because of an out-of- memory (OOM) error. This began a few weeks ago.

We are also getting occasional OOM errors during the day, for instance yesterday.

The 6am event can be linked directly to an API requests for all applications without pagination (ie, no meaningful since or page params). For yesterday, that included about 6750 applications.

Other failures, for instances yesterday around 10:30am were a combination of the provider activity page and an expensive API request.

## Changes proposed in this pull request

Long term, I want to require pagination for the applications index view, but that's a breaking change so will have to be done with lots of advance notice. 

In the meanwhile, a few little things we can do to free up a bit of memory while building the response. I want to make this change and see if we see a change tomorrow morning. Next step is to use the garbage collector to do a bit of manual memory allocation.

If neither this or the memory allocation makes a difference, we'll increase the pod memory at least until the start of the cycle. 

## Guidance to review
Not much to test at this stage, it won't break anything, so we can merge and see the impact tomorrow at 6am. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
