### PR TITLE
Fix AmbiguousColumn start_date query for provider filters

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -176,7 +176,7 @@ module ProviderInterface
         provider_id: provider_ids,
         recruitment_cycle_year: applied_filters[:recruitment_cycle_year].presence || years_visible_to_provider,
       ).select(
-        Arel.sql("EXTRACT(month FROM start_date AT TIME ZONE 'UTC' AT TIME ZONE '#{Time.zone.tzinfo.name}') AS month"),
+        Arel.sql("EXTRACT(month FROM courses.start_date AT TIME ZONE 'UTC' AT TIME ZONE '#{Time.zone.tzinfo.name}') AS month"),
       ).distinct.to_sql
 
       september_ordered_months = Course.select('month')

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -46,14 +46,14 @@ class FilterApplicationChoicesForProviders
     def recruitment_cycle_year(application_choices, years)
       return application_choices if years.blank?
 
-      application_choices.where(course: { recruitment_cycle_year: years })
+      application_choices.where(courses: { recruitment_cycle_year: years })
     end
 
     def start_months(application_choices, months)
       return application_choices if months.blank?
 
       application_choices.joins(:course).where(
-        "EXTRACT(month from (start_date AT TIME ZONE 'UTC' AT TIME ZONE ?)) IN (?)",
+        "EXTRACT(month from (courses.start_date AT TIME ZONE 'UTC' AT TIME ZONE ?)) IN (?)",
         Time.zone.tzinfo.name,
         months,
       )


### PR DESCRIPTION
## Context

Sentry error

https://dfe-teacher-services.sentry.io/issues/7513904025/?project=1765973&query=release%3A%22cdc0d9467b7d68baadd4449c16963c6ca309f48e%22&referrer=release-drawer-issue-stream

The issue here is the inconsistency of how we reference the courses table in the provider filters on the application choice index page in manage.

## Changes proposed in this pull request

- I explicitly used `courses.start_date` to reference the table name
- The recruitment_cycle_year filter was changed to reference the same table name and not do it through active record. This way, both filters won't clash with each other.

## Guidance to review

Go on review app and use a combination of filters that contain the start date filter


https://github.com/user-attachments/assets/4d5b82a2-77e2-4461-a63a-f7c01806e6ba



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
