### PR TITLE
Add grace period for inactive user to accept new invitation

### DIFF
--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -12,6 +12,9 @@ class RemoveInactiveProviderUsersWorker
       .or(ProviderUser.where(
             'last_signed_in_at IS NULL AND created_at < ?', INACTIVE_MONTHS_AGO.months.ago
           )).each do |provider_user|
+      # Skip if they were re-added recently (permissions created within the last week)
+      next if provider_user.provider_permissions.exists?(['created_at > ?', 1.week.ago])
+
       provider_user.provider_permissions.each do |permissions_to_remove|
         SupportInterface::RemoveUserFromProvider.new(permissions_to_remove:).call!
       end

--- a/spec/workers/remove_inactive_provider_users_worker_spec.rb
+++ b/spec/workers/remove_inactive_provider_users_worker_spec.rb
@@ -2,17 +2,28 @@ require 'rails_helper'
 
 RSpec.describe RemoveInactiveProviderUsersWorker do
   describe '#perform' do
-    it 'revoke inactive provider users permissions' do
+    it 'revokes inactive provider users permissions except those re-added within the last week' do
       should_revoke = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 1.day)
+      should_revoke.provider_permissions.update_all(created_at: 12.weeks.ago)
+
       account_never_used = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 1.day)
+      account_never_used.provider_permissions.update_all(created_at: 2.weeks.ago)
+
       should_not_revoke = create(:provider_user, :with_provider, last_signed_in_at: 8.months.ago)
+      should_not_revoke.provider_permissions.update_all(created_at: 2.weeks.ago)
+
       account_created_now = create(:provider_user, :with_provider, last_signed_in_at: nil)
+      account_created_now.provider_permissions.update_all(created_at: 2.weeks.ago)
+
+      recently_readded = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 1.day)
+      recently_readded.provider_permissions.update_all(created_at: 2.days.ago)
 
       expect { described_class.new.perform }.to change { ProviderPermissions.count }.by(-2)
       expect(should_revoke.provider_permissions).to eq([])
       expect(account_never_used.provider_permissions).to eq([])
       expect(should_not_revoke.provider_permissions.exists?).to be(true)
       expect(account_created_now.provider_permissions.exists?).to be(true)
+      expect(recently_readded.provider_permissions.exists?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Context

This originated with a support ticket. A user with organisational permissions invited an inactive user but they could not accept the invitation in time.

## Changes proposed in this pull request

- Do not remove the provider user if any of their permissions were created in the last 7 days

## Guidance to review

- Review small code change and spec

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
