### PR TITLE
Reject and decline jan courses over current and previous cycle

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -93,11 +93,20 @@ class ApplicationChoice < ApplicationRecord
   scope :in_progress, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:in_progress)) }
   scope :active_previous, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:active_previous)) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
-  scope :course_starts_after_september, lambda { |recruitment_cycle_year|
-    start_date = Date.parse("30/09/#{recruitment_cycle_year}").at_end_of_day
-    joins(course_option: :course)
-      .where(current_recruitment_cycle_year: recruitment_cycle_year)
-      .where('courses.start_date > ?', start_date)
+  scope :course_starts_after_september, lambda { |course_start_date_year|
+    end_of_september = Date.parse("30/09/#{course_start_date_year}").at_end_of_day
+    end_of_next_august = Date.parse("31/08/#{course_start_date_year + 1}").at_end_of_day
+
+    course_joined_choices = joins(course_option: :course)
+    # Providers duplicate courses with January start dates into the next recruitment cycle.
+    # Therefore, application choices with January start dates are considered to be application choice:
+    # - with a course starting after September in the same year as the recruitment cycle
+    # - with a course starting before September in the next recruitment cycle
+    course_joined_choices.where(current_recruitment_cycle_year: course_start_date_year)
+                         .where('courses.start_date > ?', end_of_september).or(
+      course_joined_choices.where(current_recruitment_cycle_year: course_start_date_year + 1)
+                           .where('courses.start_date < ?', end_of_next_august)
+    )
   }
   scope :course_start_in_september, lambda { |recruitment_cycle_year|
     start_date = Date.parse("30/09/#{recruitment_cycle_year}").at_end_of_day
@@ -107,7 +116,11 @@ class ApplicationChoice < ApplicationRecord
   }
 
   def starts_after_september?
-    course.start_date > Date.parse("30/09/#{current_recruitment_cycle_year}").at_end_of_day
+    course.start_date > Date.parse("30/09/#{current_recruitment_cycle_year}").at_end_of_day ||
+      (
+        course.start_date < Date.parse("31/08/#{current_recruitment_cycle_year}").at_end_of_day &&
+          course.start_date > Date.parse("30/09/#{current_recruitment_cycle_year - 1}").at_end_of_day
+      )
   end
 
   def visa_expires_soon?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -104,9 +104,9 @@ class ApplicationChoice < ApplicationRecord
     # - with a course starting before September in the next recruitment cycle
     course_joined_choices.where(current_recruitment_cycle_year: course_start_date_year)
                          .where('courses.start_date > ?', end_of_september).or(
-      course_joined_choices.where(current_recruitment_cycle_year: course_start_date_year + 1)
-                           .where('courses.start_date < ?', end_of_next_august)
-    )
+                           course_joined_choices.where(current_recruitment_cycle_year: course_start_date_year + 1)
+                                                .where('courses.start_date < ?', end_of_next_august),
+                         )
   }
   scope :course_start_in_september, lambda { |recruitment_cycle_year|
     start_date = Date.parse("30/09/#{recruitment_cycle_year}").at_end_of_day

--- a/app/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker.rb
@@ -17,7 +17,6 @@ module EndOfCycle
               .where(rejected_by_default: true)
               .pluck(:application_form_id).uniq
       ApplicationForm
-        .previous_cycle
         .joins(:candidate).merge(Candidate.for_transaction_emails)
         .where(id: ids)
         .distinct

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe ApplicationChoice do
     let(:next_recruitment_cycle_course) { create(:course, start_date: Date.parse('01/09/2027')) }
     let(:october_course) { create(:course, start_date: Date.parse('01/10/2026')) }
     let(:january_course) { create(:course, start_date: Date.parse('01/01/2027')) }
+    let(:duplicated_january_course) { create(:course, recruitment_cycle_year: 2027, start_date: Date.parse('01/01/2027')) }
     let(:may_course) { create(:course, start_date: Date.parse('01/05/2027')) }
     let(:august_application_choice) do
       create(
@@ -185,11 +186,25 @@ RSpec.describe ApplicationChoice do
         course_option: create(:course_option, course: january_course),
       )
     end
+    let(:duplicated_january_choice) do
+      create(
+        :application_choice,
+        current_recruitment_cycle_year: current_recruitment_cycle_year + 1,
+        course_option: create(:course_option, course: duplicated_january_course),
+      )
+    end
     let(:may_choice) do
       create(
         :application_choice,
         current_recruitment_cycle_year:,
         course_option: create(:course_option, course: may_course),
+      )
+    end
+    let(:previous_recruitment_cycle_jan_choice) do
+      create(
+        :application_choice,
+        current_recruitment_cycle_year: current_recruitment_cycle_year + 1,
+        course_option: create(:course_option, course: january_course),
       )
     end
 
@@ -201,6 +216,7 @@ RSpec.describe ApplicationChoice do
       next_recruitment_cycle_choice
       october_choice
       january_choice
+      duplicated_january_choice
       may_choice
     end
 
@@ -211,6 +227,7 @@ RSpec.describe ApplicationChoice do
         october_choice,
         january_choice,
         may_choice,
+        duplicated_january_choice,
       )
     end
   end
@@ -1142,10 +1159,11 @@ RSpec.describe ApplicationChoice do
   end
 
   describe '#starts_after_september?' do
+    let(:current_recruitment_cycle_year) { 2026 }
     let(:application_choice) do
       create(
         :application_choice,
-        current_recruitment_cycle_year: 2026,
+        current_recruitment_cycle_year:,
         course_option: create(:course_option, course:),
       )
     end
@@ -1155,6 +1173,15 @@ RSpec.describe ApplicationChoice do
 
       it 'returns true' do
         expect(application_choice.starts_after_september?).to be(true)
+      end
+
+      context 'when the application choice and course occur in the next recruitment cycle' do
+        let(:current_recruitment_cycle_year) { 2027 }
+        let(:course) { create(:course, start_date: Date.parse('01/10/2026'), recruitment_cycle_year: current_recruitment_cycle_year) }
+
+        it 'returns true' do
+          expect(application_choice.starts_after_september?).to be(true)
+        end
       end
     end
 

--- a/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -25,18 +25,27 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWo
       end
 
       it 'enqueues batch worker' do
+        september_course = create(:course, recruitment_cycle_year: previous_year, start_date: Date.parse("01/09/#{previous_year}"))
+        january_course = create(:course, recruitment_cycle_year: previous_year, start_date: Date.parse("01/01/#{previous_year + 1}"))
+        another_january_course = create(:course, recruitment_cycle_year: previous_year, start_date: Date.parse("01/01/#{previous_year + 1}"))
+        duplication_january_course = create(
+          :course,
+          start_date: Date.parse("01/01/#{previous_year + 1}"),
+        )
         rejected_with_offer = create(:application_form, recruitment_cycle_year: previous_year)
         create(
           :application_choice,
           :rejected_by_default,
           application_form: rejected_with_offer,
           current_recruitment_cycle_year: previous_year,
+          course_option: create(:course_option, course: january_course),
         )
         create(
           :application_choice,
           :offered,
           application_form: rejected_with_offer,
           current_recruitment_cycle_year: previous_year,
+          course_option: create(:course_option, course: another_january_course),
         )
 
         rejected_without_offer = create(:application_form, recruitment_cycle_year: previous_year)
@@ -45,6 +54,23 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWo
           :rejected_by_default,
           application_form: rejected_without_offer,
           current_recruitment_cycle_year: previous_year,
+          course_option: create(:course_option, course: january_course),
+        )
+
+        last_september_form = create(:application_form, recruitment_cycle_year: previous_year)
+        create(
+          :application_choice,
+          :rejected_by_default,
+          application_form: last_september_form,
+          current_recruitment_cycle_year: previous_year,
+          course_option: create(:course_option, course: september_course),
+        )
+        duplication_january_course_form = create(:application_form)
+        create(
+          :application_choice,
+          :rejected_by_default,
+          application_form: duplication_january_course_form,
+          course_option: create(:course_option, course: duplication_january_course),
         )
 
         # These applications should not be included
@@ -57,7 +83,7 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWo
         instance.perform
 
         expect(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker)
-          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id])
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id, duplication_january_course_form.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
     end
 
     context 'when winter reject by default is set, and it is on the reminder date' do
-      it 'calls batch worker with application choices with september start dates' do
+      it 'calls batch worker with application choices with start dates after september' do
         travel_temporarily_to(email_send_date) do
           allow(instance).to receive(:send_email?).and_return(true)
 
-          september_course = create(:course, start_date: Date.parse("01/09/#{previous_year}"))
+          september_course = create(:course, recruitment_cycle_year: previous_year, start_date: Date.parse("01/09/#{previous_year}"))
           _inactive_application = create(:application_choice,
                                          :inactive,
                                          current_recruitment_cycle_year: previous_year,
@@ -36,15 +36,17 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
           _interview_application = create(
             :application_choice,
             :interviewing,
+            current_recruitment_cycle_year: previous_year,
             course_option: create(:course_option, course: september_course),
           )
           _awaiting_application = create(
             :application_choice,
             :awaiting_provider_decision,
+            current_recruitment_cycle_year: previous_year,
             course_option: create(:course_option, course: september_course),
           )
 
-          january_course = create(:course, start_date: Date.parse("01/01/#{previous_year + 1}"))
+          january_course = create(:course, recruitment_cycle_year: previous_year, start_date: Date.parse("01/01/#{previous_year + 1}"))
           _jan_inactive_application = create(
             :application_choice,
             :inactive,
@@ -63,6 +65,15 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
             current_recruitment_cycle_year: previous_year,
             course_option: create(:course_option, course: january_course),
           )
+          duplication_january_course = create(
+            :course,
+            start_date: Date.parse("01/01/#{previous_year + 1}"),
+          )
+          _jan_inactive_application_this_cycle = create(
+            :application_choice,
+            :inactive,
+            course_option: create(:course_option, course: duplication_january_course),
+          )
 
           # These two application choices should not be included
           create(:application_choice, :rejected, current_recruitment_cycle_year: previous_year)
@@ -73,7 +84,7 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
 
           expect(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker)
             .to have_received(:perform_at).with(kind_of(Time), [
-              january_course.provider.id,
+              january_course.provider.id, duplication_january_course.provider.id
             ])
         end
       end

--- a/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
@@ -3,18 +3,40 @@ require 'rails_helper'
 RSpec.describe EndOfCycle::WinterDeclineByDefaultWorker do
   let(:year) { RecruitmentCycleTimetable.current_year }
   let(:instance) { described_class.new }
+  let(:last_september_course) { create(:course, recruitment_cycle_year: year - 1, start_date: Date.parse("01/09/#{year - 1}")) }
   let(:september_course) { create(:course, start_date: Date.parse("01/09/#{year}")) }
-  let(:january_course) { create(:course, start_date: Date.parse("01/01/#{year}")) }
-  let!(:undeclineable) do
-    create(:application_choice, :offer, course_option: create(:course_option, course: september_course))
+  let(:january_course) { create(:course, recruitment_cycle_year: year - 1, start_date: Date.parse("01/01/#{year}")) }
+  let(:duplicate_january_course) { create(:course, start_date: Date.parse("01/01/#{year}")) }
+  let!(:undeclineable_this_cycle) do
+    create(
+      :application_choice,
+      :offer,
+      course_option: create(:course_option, course: september_course),
+    )
   end
-  let!(:declineable) do
+  let!(:undeclineable_last_cycle) do
+    create(
+      :application_choice,
+      :offer,
+      current_recruitment_cycle_year: year - 1,
+      course_option: create(:course_option, course: last_september_course),
+    )
+  end
+  let!(:declineable_last_cycle) do
     create(
       :application_choice,
       :offer,
       current_recruitment_cycle_year: year - 1,
       course_option: create(:course_option, course: january_course),
     )
+  end
+  let!(:declineable_this_cycle) do
+    create(
+      :application_choice,
+      :offer,
+      current_recruitment_cycle_year: year,
+      course_option: create(:course_option, course: duplicate_january_course),
+      )
   end
 
   describe '#perform' do
@@ -23,7 +45,7 @@ RSpec.describe EndOfCycle::WinterDeclineByDefaultWorker do
         allow(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).to receive(:perform_at)
         instance.perform(true)
         expect(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
-          .to have_received(:perform_at).with(kind_of(Time), [declineable.application_form.id])
+          .to have_received(:perform_at).with(kind_of(Time), [declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id])
       end
     end
 
@@ -33,7 +55,7 @@ RSpec.describe EndOfCycle::WinterDeclineByDefaultWorker do
         allow(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).to receive(:perform_at)
         instance.perform
         expect(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
-          .to have_received(:perform_at).with(kind_of(Time), [declineable.application_form.id])
+          .to have_received(:perform_at).with(kind_of(Time), [declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id])
       end
     end
 

--- a/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe EndOfCycle::WinterDeclineByDefaultWorker do
       :offer,
       current_recruitment_cycle_year: year,
       course_option: create(:course_option, course: duplicate_january_course),
-      )
+    )
   end
 
   describe '#perform' do

--- a/spec/workers/end_of_cycle/winter_reject_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/winter_reject_by_default_worker_spec.rb
@@ -3,14 +3,32 @@ require 'rails_helper'
 RSpec.describe EndOfCycle::WinterRejectByDefaultWorker do
   let(:year) { RecruitmentCycleTimetable.current_year }
   let(:instance) { described_class.new }
+  let(:last_september_course) { create(:course, recruitment_cycle_year: year - 1, start_date: Date.parse("01/09/#{year - 1}")) }
   let(:september_course) { create(:course, start_date: Date.parse("01/09/#{year}")) }
-  let(:january_course) { create(:course, start_date: Date.parse("01/01/#{year}")) }
+  let(:january_course) { create(:course, recruitment_cycle_year: year - 1, start_date: Date.parse("01/01/#{year}")) }
+  let(:duplicate_january_course) { create(:course, start_date: Date.parse("01/01/#{year}")) }
+  let!(:last_september_choice) do
+    create(
+      :application_choice,
+      :inactive,
+      current_recruitment_cycle_year: year - 1,
+      course_option: create(:course_option, course: last_september_course),
+    )
+  end
   let!(:inactive_choice) do
     create(
       :application_choice,
       :inactive,
       current_recruitment_cycle_year: year - 1,
       course_option: create(:course_option, course: january_course),
+    )
+  end
+  let!(:inactive_choice_this_cycle) do
+    create(
+      :application_choice,
+      :inactive,
+      current_recruitment_cycle_year: year,
+      course_option: create(:course_option, course: duplicate_january_course),
     )
   end
   let!(:interviewing_choice) do
@@ -55,6 +73,7 @@ RSpec.describe EndOfCycle::WinterRejectByDefaultWorker do
                     inactive_choice.application_form.id,
                     interviewing_choice.application_form.id,
                     awaiting_decision_choice.application_form.id,
+                    inactive_choice_this_cycle.application_form.id,
                   ),
                 )
       end
@@ -73,6 +92,7 @@ RSpec.describe EndOfCycle::WinterRejectByDefaultWorker do
                     inactive_choice.application_form.id,
                     interviewing_choice.application_form.id,
                     awaiting_decision_choice.application_form.id,
+                    inactive_choice_this_cycle.application_form.id,
                   ),
                 )
       end


### PR DESCRIPTION
## Context

- Change code so that `ApplicationChoices` where their`course_starts_after_september`, consider application choices from the current and previous recruitment cycle.

## Changes proposed in this pull request

- Update `course_starts_after_september` scope to return application choices which either:
  - have a course starting after September in the given recruitment cycle
  - have a course starting before September of the next recruitment cycle

## Guidance to review

- Review the code.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/F9y0LrY1/1880-apply-winter-reject-dates-to-jan-courses-regardless-of-cycle