### PR TITLE
OpenSSL::SSL::SSLError eof possible fix

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -32,7 +32,7 @@ class Redis
       rescue Errno::EAGAIN
         raise TimeoutError
       rescue OpenSSL::SSL::SSLError => e
-        if e.message.match?(/SSL_read: unexpected eof while reading/i) || e.message.match?(/tls_retry_write_records/i)
+        if e.message.match?(/SSL_read: unexpected eof while reading/i) || e.message.match?(/tls_retry_write_records failure/i)
           raise EOFError, e.message
         else
           raise

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,6 @@ Sidekiq.configure_server do |config|
   config.redis = {
     url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/0' },
     timeout: 10,
-    ssl_params: { options: OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF },
   }
 
   config.server_middleware do |chain|
@@ -20,3 +19,25 @@ Sidekiq.configure_server do |config|
 end
 
 require 'sidekiq/web'
+
+require 'redis/connection/ruby'
+
+class Redis
+  module Connection
+    class Ruby
+      def read
+        line = @sock.gets
+        reply_type = line.slice!(0, 1)
+        format_reply(reply_type, line)
+      rescue Errno::EAGAIN
+        raise TimeoutError
+      rescue OpenSSL::SSL::SSLError => e
+        if e.message.match?(/SSL_read: unexpected eof while reading/i) || e.message.match?(/tls_retry_write_records/i)
+          raise EOFError, e.message
+        else
+          raise
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,7 @@ Sidekiq.configure_server do |config|
   config.redis = {
     url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/0' },
     timeout: 10,
+    ssl_params: { options: OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF },
   }
 
   config.server_middleware do |chain|

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -18,15 +18,13 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     )
   end
 
-  if Candidate.find_by(token: 'dev-candidate').blank?
-    candidate = Candidate.find_or_create_by!(
-      email_address: 'dev-candidate@example.com',
-    )
-    candidate.create_one_login_auth!(
-      token: 'dev-candidate',
-      email_address: candidate.email_address,
-    )
-  end
+  candidate = Candidate.find_or_create_by!(
+    email_address: 'dev-candidate@example.com',
+  )
+  candidate.create_one_login_auth!(
+    token: 'dev-candidate',
+    email_address: candidate.email_address,
+  )
 
   puts 'Creating all RecruitmentCycleTimetables'
   ProductionRecruitmentCycleTimetablesAPI::SyncTimetablesWithProduction.new.call


### PR DESCRIPTION
## Context

This is an insane one.

Our ruby 4.0.4 upgrade upgraded the openssl version to [4.x](https://github.com/ruby/ruby/blob/master/ext/openssl/lib/openssl/version.rb#L5). Previously it was [3.3.0](https://github.com/ruby/ruby/blob/v3_4_4/ext/openssl/lib/openssl/version.rb#L4C3-L4C20)

It seems like the openssl 3.x used to return an error named `SSL_read: unexpected eof while reading` but the upgrade changed that error message to `SSL_read: (null) (tls_retry_write_records failure)` This is the error we see in [sentry](https://dfe-teacher-services.sentry.io/issues/7501381626/events/?environment=production&project=1765973&query=&referrer=issue-stream)

This error raised by both gems is an error that tries to say that the redis connection has been closed without a `notification`. Usually because it's an idle connection.

The redis-gem 4.8.1 that we use was handing this by re raising a different error, which has handled gracefully. But the error message has changed with our ruby upgrade.

So this PR just adds a new message alongside the old one. It monkey patches [this](https://github.com/redis/redis-rb/blob/v4.8.1/lib/redis/connection/ruby.rb#L381-L393).

This is inspired by a different error another user had [here](https://github.com/redis/redis-rb/issues/1174#issuecomment-1412993295) where he monkey paches a different issue 😆 

The proper fix would be to upgrade our redis gem. This is the proper fix in the [redis gem](https://github.com/redis/redis/pull/10931). This is in version 7.x. But we can't upgrade redis because we would need to upgrade sidekiq

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
