### PR TITLE
Add 'Moved to interview' event to the ApplicationChoice Timeline

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -54,8 +54,10 @@ module ProviderInterface
       map_activity_log_events_for('status') do |event|
         new_status = event.application_status_at_event
 
-        next if new_status == 'interviewing' && interview_exists_for_event?(event)
+        # filter out status changes to interviewing audits that are represented by interview_events
+        next if new_status == 'interviewing' && interview_exists_for_new_status?(event)
 
+        # identify status changes to interviewing audits without interview_events
         moved_to_interview = new_status == 'interviewing'
 
         link_name, link_path =
@@ -151,10 +153,11 @@ module ProviderInterface
       end
     end
 
-    def interview_exists_for_event?(status_event)
+    def interview_exists_for_new_status?(new_status_event)
+      # check if the status change was accompanied by an interview event
       @activity_log_events.any? do |event|
         event.audit.auditable.is_a?(Interview) &&
-          event.created_at.to_i == status_event.created_at.to_i
+          event.created_at.to_i == new_status_event.created_at.to_i
       end
     end
 

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -15,7 +15,7 @@ module ProviderInterface
 
     TITLES = {
       'awaiting_provider_decision' => 'Application received',
-      'interviewing' => 'Interviewing',
+      'interviewing' => 'Moved to interview',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
       'offer_withdrawn' => 'Offer withdrawn',
@@ -57,22 +57,11 @@ module ProviderInterface
         # filter out status changes to interviewing audits that are represented by interview_events
         next if new_status == 'interviewing' && interview_exists_for_new_status?(event)
 
-        # identify status changes to interviewing audits without interview_events
-        moved_to_interview = new_status == 'interviewing'
-
-        link_name, link_path =
-          if moved_to_interview
-            [nil, nil]
-          else
-            link_params_for_status(new_status)
-          end
-
         Event.new(
-          moved_to_interview ? 'Moved to interview' : title_for(new_status),
+          title_for(new_status),
           actor_for(event),
           event.created_at,
-          link_name,
-          link_path,
+          *link_params_for_status(event.application_status_at_event),
         )
       end
     end
@@ -248,6 +237,8 @@ module ProviderInterface
     end
 
     def link_params_for_status(status)
+      return if status == 'interviewing'
+
       title_for(status).match(/^Application/) ? application_link_params : offer_link_params
     end
 

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -56,7 +56,7 @@ module ProviderInterface
 
         next if new_status == 'interviewing' && interview_exists_for_event?(event)
 
-        moved_to_interview = new_status == 'interviewing' && !interview_exists_for_event?(event)
+        moved_to_interview = new_status == 'interviewing'
 
         link_name, link_path =
           if moved_to_interview

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -31,9 +31,9 @@ module ProviderInterface
 
     def map_activity_log_events_for(attr)
       @activity_log_events
-        .reject { |event| event.application_status_at_event == 'interviewing' }
         .select { |event| event.changes.key?(attr) && event.changes['status']&.at(1) != 'inactive' }
         .map { |event| yield(event) }
+        .compact
     end
 
     def timeline_events
@@ -52,11 +52,25 @@ module ProviderInterface
 
     def status_change_events
       map_activity_log_events_for('status') do |event|
+        new_status = event.application_status_at_event
+
+        next if new_status == 'interviewing' && interview_exists_for_event?(event)
+
+        moved_to_interview = new_status == 'interviewing' && !interview_exists_for_event?(event)
+
+        link_name, link_path =
+          if moved_to_interview
+            [nil, nil]
+          else
+            link_params_for_status(new_status)
+          end
+
         Event.new(
-          title_for(event.application_status_at_event),
+          moved_to_interview ? 'Moved to interview' : title_for(new_status),
           actor_for(event),
           event.created_at,
-          *link_params_for_status(event.application_status_at_event),
+          link_name,
+          link_path,
         )
       end
     end
@@ -134,6 +148,13 @@ module ProviderInterface
           'View Application',
           provider_interface_application_choice_path(application_choice, anchor: 'interview-preferences-section'),
         )
+      end
+    end
+
+    def interview_exists_for_event?(status_event)
+      @activity_log_events.any? do |event|
+        event.audit.auditable.is_a?(Interview) &&
+          event.created_at.to_i == status_event.created_at.to_i
       end
     end
 

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -30,8 +30,6 @@ class GetActivityLogEvents
     offer_changed_at
   ].freeze
 
-  IGNORE_STATUS = %i[interviewing].freeze
-
   def self.call(application_choices:, since: nil)
     since ||= application_choices.includes(:application_form).minimum('application_forms.created_at')
 
@@ -88,15 +86,16 @@ class GetActivityLogEvents
       "jsonb_exists(audited_changes, '#{change}')"
     end.join(' OR ')
 
-    filtered_statuses = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - IGNORE_STATUS
-
-    status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
+    status_transitions_to_include = ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider).map { |status| "'#{status}'" }.join(', ')
 
     application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
     application_choice_audits_filter + ignore_interview_cancelled_application_choice_status_change_sql
   end
 
   def self.ignore_interview_cancelled_application_choice_status_change_sql
-    %( AND NOT audited_changes @> '{"status" : ["interviewing", "awaiting_provider_decision"]}')
+    %( AND NOT (
+      audited_changes::json#>>'{status,0}' = 'interviewing'
+      AND audited_changes::json#>>'{status,1}' = 'awaiting_provider_decision'
+    ))
   end
 end

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
   end
 
-  context 'for a status change from awaiting provider decision to interviewing without an interview event' do
+  context 'for a status change to interviewing without an interview event' do
     it 'renders the "moved to interview" event' do
       audit = build_stubbed(
         :application_choice_audit,

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -239,6 +239,30 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
   end
 
+  context 'for a status change from awaiting provider decision to interviewing without an interview event' do
+    it 'renders the "moved to interview" event' do
+      audit = build_stubbed(
+        :application_choice_audit,
+        audited_changes: { 'status' => %w[awaiting_provider_decision interviewing] },
+        user: provider_user,
+        created_at: 2.days.ago,
+      )
+
+      activity_log_event = ActivityLogEvent.new(audit:)
+      allow(ActivityLogEvent).to receive(:new).with(audit:).and_return(activity_log_event)
+      allow(activity_log_event).to receive(:application_status_at_event).and_return('interviewing')
+
+      application_choice = application_choice_with_audits([audit])
+
+      rendered = render_inline(described_class.new(application_choice:))
+
+      expect(rendered.text).to include 'Moved to interview'
+      expect(rendered.text).to include 'Bob Roberts'
+
+      expect(rendered.css('a').text).not_to include 'View interview'
+    end
+  end
+
   describe 'user who made the changes' do
     let(:user) { build_stubbed(:support_user) }
     let(:username) { nil }


### PR DESCRIPTION
## Context

Providers can update their interview settings to arrange interviews off service. When they do so, they click the ‘Move to interview’ button when reviewing the application which updates the status to 'interviewing'.

If the provider creates an interview on service, it is reflected in the timeline. We need a timeline entry for when they manage it off service.

## Changes proposed in this pull request

In the `ApplicationTimelineComponent`:
- No longer block entries for status changes to interviewing
- Intervene in the `status_change_events` method to identify status changes to `interviewing` without accompanying interview events
- Use the title 'Moved to interview' in these cases

## Guidance to review

Flow review:
- Run `FeatureFlag.activate('interview_handling')` in the review app
- Sign in as a Provider user
- Go to "Organisation settings" and click "Interview options" under one of your providers
- Set it to "Arrange interviews outside this service"
- Review an application in a "Received" state
- Check the current timeline entries
- Click "Move to interview" and observe the new timeline entry
- Compare this with the flow when "Interview options" is set to "Record interview details in manage"

Code review:
- Review the logic changes and spec 


_Comparison of both flows:_

https://github.com/user-attachments/assets/6a0b7bd1-46fa-43b4-b489-94047c4d4361

_New event:_

<img width="453" height="295" alt="Screenshot 2026-06-05 at 16 29 25" src="https://github.com/user-attachments/assets/72651119-fabf-4ad4-9793-6ba4e94f0009" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
