### PR TITLE
Increase spec retry attempts to five

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
     config.retry_reporter = reporter
 
     config.around do |ex|
-      ex.run_with_retry retry: 3
+      ex.run_with_retry retry: 5
     end
   end
 


### PR DESCRIPTION


## Context

We've had a lot more flaky specs, primary js ones, since changing ruby versions. It impacts how quickly we can deploy code. 

## Changes proposed in this pull request

This increases or flakey tolerance.

We'll still get a lot of the 'flakey test reports', but we shouldn't have so many failed deployments for a test failure. So we haven't deal with the underlying flakiness, but there is les snoise. 

## Guidance to review

Two successful builds indicates it's ok...?


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
