### PR TITLE
2683 - terraform-plan is required by validate-infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ deploy-init: vendor-modules set-azure-account
 deploy-plan: deploy-init
 	terraform -chdir=terraform/$(PLATFORM) plan ${DETAILED_EXITCODE} -var-file=./workspace_variables/$(APP_ENV).tfvars.json ${TF_VARS}
 
+terraform-plan: deploy-plan
+
 deploy: deploy-init
 	terraform -chdir=terraform/$(PLATFORM) apply -var-file=./workspace_variables/$(APP_ENV).tfvars.json ${TF_VARS} $(AUTO_APPROVE)
 


### PR DESCRIPTION
## Context

The validate-infra workflow requires the Makefile contains a terraform-plan section. 

## Changes proposed in this pull request

A section terraform-plan has been added that calls the existing deploy-plan.

## Guidance to review

Manually test changes by altering terraform/aks/workspace_variables/production.tfvars.json **webapp_replicas**.

To obtain the current docker image, run  command
`kubectl get deployment apply-production -o jsonpath='{.spec.template.spec.containers[0].image}' | cut -d ':' -f2`

`make production terraform-plan CONFIRM_PRODUCTION=yes IMAGE_TAG=<docker image>`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/aks/workspace_variables/production.tfvars.json **webapp_replicas**.
Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**. It may also produce a drift of Kubernetes images.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
