### PR TITLE
Add worker to update english proficiencies with 2027 attributes

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -82,7 +82,7 @@ class DuplicateApplication
           efl_qualification:,
           application_form: new_application_form,
         )
-        # Todo: Remove after 1 Nov
+        # TODO: Remove after 1 Nov
         if dup_english_proficiency.qualification_statuses.blank?
           if dup_english_proficiency.qualification_status == 'has_qualification'
             dup_english_proficiency.update!(has_qualification: true)

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -77,11 +77,21 @@ class DuplicateApplication
                                 **original_application_form.english_proficiency.efl_qualification.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
                               )
                             end
-        EnglishProficiency.create!(
+        dup_english_proficiency = EnglishProficiency.create!(
           **original_application_form.english_proficiency.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
           efl_qualification:,
           application_form: new_application_form,
         )
+        # Todo: Remove after 1 Nov
+        if dup_english_proficiency.qualification_statuses.blank?
+          if dup_english_proficiency.qualification_status == 'has_qualification'
+            dup_english_proficiency.update!(has_qualification: true)
+          elsif dup_english_proficiency.qualification_status == 'no_qualification'
+            dup_english_proficiency.update!(no_qualification: true)
+          elsif dup_english_proficiency.qualification_status == 'qualification_not_needed'
+            dup_english_proficiency.update!(qualification_not_needed: true)
+          end
+        end
       end
 
       original_application_form.application_work_history_breaks.each do |w|

--- a/app/workers/candidate/english_proficiency_data_conversion_worker.rb
+++ b/app/workers/candidate/english_proficiency_data_conversion_worker.rb
@@ -1,0 +1,11 @@
+class Candidate::EnglishProficiencyDataConversionWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
+  queue_as :low_priority
+
+  def perform
+    EnglishProficiency.has_qualification.where(has_qualification: false).update_all(has_qualification: true)
+    EnglishProficiency.no_qualification.where(no_qualification: false).update_all(no_qualification: true)
+    EnglishProficiency.qualification_not_needed.where(qualification_not_needed: false).update_all(qualification_not_needed: true)
+  end
+end

--- a/app/workers/candidate/english_proficiency_data_conversion_worker.rb
+++ b/app/workers/candidate/english_proficiency_data_conversion_worker.rb
@@ -4,8 +4,8 @@ class Candidate::EnglishProficiencyDataConversionWorker < ApplicationJob
   queue_as :low_priority
 
   def perform
-    EnglishProficiency.has_qualification.where(has_qualification: false).update_all(has_qualification: true)
-    EnglishProficiency.no_qualification.where(no_qualification: false).update_all(no_qualification: true)
-    EnglishProficiency.qualification_not_needed.where(qualification_not_needed: false).update_all(qualification_not_needed: true)
+    EnglishProficiency.has_qualification.where.not(has_qualification: true).update_all(has_qualification: true)
+    EnglishProficiency.no_qualification.where.not(no_qualification: true).update_all(no_qualification: true)
+    EnglishProficiency.qualification_not_needed.where.not(qualification_not_needed: true).update_all(qualification_not_needed: true)
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -82,6 +82,7 @@ class Clock
   every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision
   every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
+  every(1.day, 'Candidate::EnglishProficiencyDataConversionWorker', at: '23:00') { Candidate::EnglishProficiencyDataConversionWorker.perform_async }
 
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -82,7 +82,7 @@ class Clock
   every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision
   every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
-  every(1.day, 'Candidate::EnglishProficiencyDataConversionWorker', at: '23:00') { Candidate::EnglishProficiencyDataConversionWorker.perform_async }
+  every(1.day, 'Candidate::EnglishProficiencyDataConversionWorker', at: '23:00') { Candidate::EnglishProficiencyDataConversionWorker.perform_later }
 
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do

--- a/spec/workers/candidate/english_proficiency_data_conversion_worker_spec.rb
+++ b/spec/workers/candidate/english_proficiency_data_conversion_worker_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Candidate::EnglishProficiencyDataConversionWorker do
+  describe '#perform' do
+    let!(:updated_has_qualification) { create(:english_proficiency, qualification_status: 'has_qualification', has_qualification: true) }
+    let!(:has_qualification_1) { create(:english_proficiency, qualification_status: 'has_qualification') }
+    let!(:has_qualification_2) { create(:english_proficiency, qualification_status: 'has_qualification') }
+    let!(:qualification_not_needed_1) { create(:english_proficiency, qualification_status: 'qualification_not_needed') }
+    let!(:qualification_not_needed_2) { create(:english_proficiency, qualification_status: 'qualification_not_needed') }
+    let!(:qualification_not_needed_3) { create(:english_proficiency, qualification_status: 'qualification_not_needed') }
+    let!(:no_qualification_1) { create(:english_proficiency, qualification_status: 'no_qualification') }
+    let!(:no_qualification_2) { create(:english_proficiency, qualification_status: 'no_qualification') }
+    let!(:no_qualification_3) { create(:english_proficiency, qualification_status: 'no_qualification') }
+    let!(:no_qualification_4) { create(:english_proficiency, qualification_status: 'no_qualification') }
+
+    it 'toggles the boolean attribute associated with the qualification_status of each EnglishProficiency record' do
+      expect { described_class.new.perform_now }.to change { EnglishProficiency.where(has_qualification: true).count }.from(1).to(3).and(
+        change { EnglishProficiency.where(qualification_not_needed: true).count }.to(3).and(
+          change { EnglishProficiency.where(no_qualification: true).count }.to(4)
+        )
+      )
+
+      expect(has_qualification_1.reload.has_qualification).to be(true)
+      expect(has_qualification_1.reload.qualification_not_needed).to be(false)
+      expect(has_qualification_1.reload.no_qualification).to be(false)
+
+      expect(has_qualification_2.reload.has_qualification).to be(true)
+      expect(has_qualification_2.reload.qualification_not_needed).to be(false)
+      expect(has_qualification_2.reload.no_qualification).to be(false)
+
+      expect(qualification_not_needed_1.reload.qualification_not_needed).to be(true)
+      expect(qualification_not_needed_1.reload.has_qualification).to be(false)
+      expect(qualification_not_needed_1.reload.no_qualification).to be(false)
+
+      expect(qualification_not_needed_2.reload.qualification_not_needed).to be(true)
+      expect(qualification_not_needed_2.reload.has_qualification).to be(false)
+      expect(qualification_not_needed_2.reload.no_qualification).to be(false)
+
+      expect(qualification_not_needed_3.reload.qualification_not_needed).to be(true)
+      expect(qualification_not_needed_3.reload.has_qualification).to be(false)
+      expect(qualification_not_needed_3.reload.no_qualification).to be(false)
+
+      expect(no_qualification_1.reload.no_qualification).to be(true)
+      expect(no_qualification_1.reload.qualification_not_needed).to be(false)
+      expect(no_qualification_1.reload.has_qualification).to be(false)
+
+      expect(no_qualification_2.reload.no_qualification).to be(true)
+      expect(no_qualification_2.reload.qualification_not_needed).to be(false)
+      expect(no_qualification_2.reload.has_qualification).to be(false)
+
+      expect(no_qualification_3.reload.no_qualification).to be(true)
+      expect(no_qualification_3.reload.qualification_not_needed).to be(false)
+      expect(no_qualification_3.reload.has_qualification).to be(false)
+
+      expect(no_qualification_4.reload.no_qualification).to be(true)
+      expect(no_qualification_4.reload.qualification_not_needed).to be(false)
+      expect(no_qualification_4.reload.has_qualification).to be(false)
+    end
+  end
+end

--- a/spec/workers/candidate/english_proficiency_data_conversion_worker_spec.rb
+++ b/spec/workers/candidate/english_proficiency_data_conversion_worker_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Candidate::EnglishProficiencyDataConversionWorker do
     it 'toggles the boolean attribute associated with the qualification_status of each EnglishProficiency record' do
       expect { described_class.new.perform_now }.to change { EnglishProficiency.where(has_qualification: true).count }.from(1).to(3).and(
         change { EnglishProficiency.where(qualification_not_needed: true).count }.to(3).and(
-          change { EnglishProficiency.where(no_qualification: true).count }.to(4)
-        )
+          change { EnglishProficiency.where(no_qualification: true).count }.to(4),
+        ),
       )
 
       expect(has_qualification_1.reload.has_qualification).to be(true)


### PR DESCRIPTION
## Context

- Add a background job to update English proficiency records, toggling their associated attributes to `true`.

## Changes proposed in this pull request

- Add a background job to update English proficiency records, toggling their associated attributes to `true`.

## Guidance to review

- Review the code. The job should update only records which have not already been updated.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello
https://trello.com/c/KDI07XKG/1886-english-language-flow-make-2026-data-compatible-with-2027
