### PR TITLE
Add additional frequent workers in Solid Queue

### DIFF
--- a/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
+++ b/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
@@ -1,6 +1,8 @@
 module CandidateMailers
-  class SendVisaSponsorshipDeadlineReminderWorker < ApplicationJob
-    self.queue_adapter = :solid_queue
+  class SendVisaSponsorshipDeadlineReminderWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :mailers
 
     def perform(application_choice_ids)
       ApplicationChoice.where(id: application_choice_ids).each do |choice|

--- a/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
+++ b/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
@@ -1,8 +1,6 @@
 module CandidateMailers
-  class SendVisaSponsorshipDeadlineReminderWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :mailers
+  class SendVisaSponsorshipDeadlineReminderWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
 
     def perform(application_choice_ids)
       ApplicationChoice.where(id: application_choice_ids).each do |choice|

--- a/app/workers/chase_references.rb
+++ b/app/workers/chase_references.rb
@@ -1,5 +1,5 @@
-class ChaseReferences
-  include Sidekiq::Worker
+class ChaseReferences < ApplicationJob
+  self.queue_adapter = :solid_queue
 
   REFEREE_CHASERS = [
     {

--- a/app/workers/chasers/candidate/offer_worker.rb
+++ b/app/workers/chasers/candidate/offer_worker.rb
@@ -1,7 +1,7 @@
 module Chasers
   module Candidate
-    class OfferWorker
-      include Sidekiq::Worker
+    class OfferWorker < ApplicationJob
+      self.queue_adapter = :solid_queue
 
       def perform
         Chasers::Candidate.chaser_to_date_range.each do |chaser_type, date_range|

--- a/app/workers/delete_expired_sessions_worker.rb
+++ b/app/workers/delete_expired_sessions_worker.rb
@@ -1,7 +1,7 @@
-class DeleteExpiredSessionsWorker
-  include Sidekiq::Worker
+class DeleteExpiredSessionsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
-  sidekiq_options queue: :low_priority
+  queue_as :low_priority
 
   def perform
     Session.where('updated_at < ?', 7.days.ago).delete_all

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -1,6 +1,6 @@
 # Detect state that *should* be impossible in the system and report them to Sentry
-class DetectInvariantsDailyCheck
-  include Sidekiq::Worker
+class DetectInvariantsDailyCheck < ApplicationJob
+  self.queue_adapter = :solid_queue
 
   def perform
     detect_if_the_monthly_statistics_has_not_run

--- a/app/workers/end_of_cycle/next_year_full_sync.rb
+++ b/app/workers/end_of_cycle/next_year_full_sync.rb
@@ -3,7 +3,7 @@ module EndOfCycle
     def perform
       return unless sync_next_year?
 
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_later(
         false, # incremental_sync
         next_year, # year
       )

--- a/app/workers/end_of_cycle/next_year_incremental_sync.rb
+++ b/app/workers/end_of_cycle/next_year_incremental_sync.rb
@@ -1,9 +1,11 @@
 module EndOfCycle
   class NextYearIncrementalSync < SyncNextYearsCoursesAndProviders
+    self.queue_adapter = :solid_queue
+
     def perform
       return unless sync_next_year?
 
-      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(
+      TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_later(
         true, # incremental_sync
         next_year, # year
       )

--- a/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
+++ b/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
@@ -1,6 +1,6 @@
 module EndOfCycle
-  class SyncNextYearsCoursesAndProviders
-    include Sidekiq::Worker
+  class SyncNextYearsCoursesAndProviders < ApplicationJob
+    self.queue_adapter = :solid_queue
 
     def first_full_sync_after
       start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)

--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -1,7 +1,7 @@
-class RemoveInactiveProviderUsersWorker
-  include Sidekiq::Worker
+class RemoveInactiveProviderUsersWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
-  sidekiq_options queue: :low_priority
+  queue_as :low_priority
 
   INACTIVE_MONTHS_AGO = 12
 

--- a/app/workers/remove_inactive_support_users_worker.rb
+++ b/app/workers/remove_inactive_support_users_worker.rb
@@ -1,7 +1,7 @@
-class RemoveInactiveSupportUsersWorker
-  include Sidekiq::Worker
+class RemoveInactiveSupportUsersWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
 
-  sidekiq_options queue: :low_priority
+  queue_as :low_priority
 
   def perform
     SupportUser.where('last_signed_in_at < ?', 9.months.ago)

--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -1,8 +1,10 @@
 module TeacherTrainingPublicAPI
-  class SyncAllProvidersAndCoursesWorker
-    include Sidekiq::Worker
+  class SyncAllProvidersAndCoursesWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
 
-    sidekiq_options retry: 3, queue: :low_priority
+    queue_as :low_priority
+
+    retry_on StandardError, attempts: 3
 
     def perform(incremental = true, year = nil)
       return if HostingEnvironment.review?

--- a/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
+++ b/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
@@ -1,5 +1,5 @@
-class UpdateOutOfDateProviderIdsOnApplicationChoices
-  include Sidekiq::Worker
+class UpdateOutOfDateProviderIdsOnApplicationChoices < ApplicationJob
+  self.queue_adapter = :solid_queue
 
   def perform
     return unless out_of_date_application_choices.any?

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -11,7 +11,7 @@ class Clock
   # More-than-hourly jobs
 
   every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) do
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true)
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_later(true)
   end
 
   every(10.minutes, 'FindACandidate::PopulatePoolWorker', skip_first_run: true) do
@@ -25,24 +25,24 @@ class Clock
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
     ProcessStaleApplicationsWorker.perform_later
   end
-  every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
-  every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
+  every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_later }
+  every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_later }
   every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_later }
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_later }
   every(1.hour, 'Adviser::FetchTeachingSubjectsWorker', at: '**:15') { Adviser::FetchTeachingSubjectsWorker.perform_later }
   every(1.hour, 'EndOfCycle::NextYearIncrementalSync', at: '**:14', skip_first_run: true) do
-    EndOfCycle::NextYearIncrementalSync.perform_async
+    EndOfCycle::NextYearIncrementalSync.perform_later
   end
 
   # Daily jobs
-  every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_async }
-  every(1.day, 'RemoveInactiveSupportUsersWorker', at: '5:02') { RemoveInactiveSupportUsersWorker.perform_async }
-  every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_async }
+  every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_later }
+  every(1.day, 'RemoveInactiveSupportUsersWorker', at: '5:02') { RemoveInactiveSupportUsersWorker.perform_later }
+  every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_later }
   every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_later }
   every(1.day, 'DeleteFinishedJobs', at: '19:00') { DeleteFinishedJobsWorker.perform_later }
-  every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
+  every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_later }
 
-  every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }
+  every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_later }
 
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
 
@@ -85,7 +85,7 @@ class Clock
 
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_later(false)
   end
 
   every(7.days, 'EndOfCycle::NextYearFullSync', at: 'Friday 00:05') { EndOfCycle::NextYearFullSync.perform_async }

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Clockwork, :clockwork do
       end
 
       it 'queues a worker task' do
-        allow(worker[:worker]).to receive(:perform_async)
+        allow(worker[:worker]).to receive(:perform_later)
         Clockwork::Test.run(max_ticks: 60, tick_speed: 1.minute, file: './config/clock.rb')
         Clockwork::Test.block_for(worker[:task]).call
-        expect(worker[:worker]).to have_received(:perform_async)
+        expect(worker[:worker]).to have_received(:perform_later)
       end
     end
   end

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Syncing providers', :sidekiq, :with_cache do
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_now
   end
 
   def then_it_updates_the_course_subjects

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -118,9 +118,9 @@ RSpec.describe 'Referee does not respond in time' do
   def advance_and_chase(duration)
     advance_time_to(@application.created_at + duration)
     TestSuiteTimeMachine.advance
-    ChaseReferences.perform_async
+    ChaseReferences.perform_now
     TestSuiteTimeMachine.advance
-    ChaseReferences.perform_async
+    ChaseReferences.perform_now
     TestSuiteTimeMachine.advance
   end
 end

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe 'Sync courses', :sidekiq, :with_cache do
   end
 
   def when_the_sync_runs
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_now
   end
 
   def then_it_creates_one_course

--- a/spec/system/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_provider_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Sync provider', :sidekiq, :with_cache do
     sync_subjects_service = instance_double(TeacherTrainingPublicAPI::SyncSubjects, perform: nil)
     allow(TeacherTrainingPublicAPI::SyncSubjects).to receive(:new).and_return(sync_subjects_service)
 
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_now
   end
 
   def then_it_creates_one_provider

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Sync sites', :sidekiq, :with_cache do
   end
 
   def when_the_sync_runs
-    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_now
   end
 
   def then_it_creates_one_site

--- a/spec/workers/end_of_cycle/next_year_full_sync_spec.rb
+++ b/spec/workers/end_of_cycle/next_year_full_sync_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
   describe '#perform' do
     before do
       allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-        .to receive(:perform_async).with(false, next_year)
+        .to receive(:perform_later).with(false, next_year)
     end
 
     context 'after find has closed' do
@@ -13,7 +13,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .not_to have_received(:perform_async)
+            .not_to have_received(:perform_later)
         end
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .not_to have_received(:perform_async)
+            .not_to have_received(:perform_later)
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe EndOfCycle::NextYearFullSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .to have_received(:perform_async).with(false, next_year)
+            .to have_received(:perform_later).with(false, next_year)
         end
       end
     end

--- a/spec/workers/end_of_cycle/next_year_incremental_sync_spec.rb
+++ b/spec/workers/end_of_cycle/next_year_incremental_sync_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
   describe '#perform' do
     before do
       allow(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-        .to receive(:perform_async).with(true, next_year)
+        .to receive(:perform_later).with(true, next_year)
     end
 
     context 'before full sync start start time' do
@@ -16,7 +16,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .not_to have_received(:perform_async)
+            .not_to have_received(:perform_later)
         end
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .not_to have_received(:perform_async)
+            .not_to have_received(:perform_later)
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe EndOfCycle::NextYearIncrementalSync do
           described_class.new.perform
 
           expect(TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker)
-            .to have_received(:perform_async).with(true, next_year)
+            .to have_received(:perform_later).with(true, next_year)
         end
       end
     end


### PR DESCRIPTION
## Context

We are gradually migrating jobs to solid_queue and monitoring the impact in production.

## Changes proposed in this pull request

Migrate the following regular jobs:
- `OfferWorker`
- `NextYearIncrementalSync`
- `SyncNextYearsCoursesAndProviders`
- `SyncAllProvidersAndCoursesWorker` ** - runs the full sync every Sunday
- `ChaseReferences`
- `DeleteExpiredSessionsWorker`
- `DetectInvariantsDailyCheck`
- `RemoveInactiveProviderUsersWorker`
- `RemoveInactiveSupportUsersWorker`
- `UpdateOutOfDateProviderIdsOnApplicationChoices`

## Guidance to review

- Check the jobs have run in the review app without failure (/support/jobs)
- Check that you agree that any jobs that are crucial and may fail have a backup plan (see comments)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
