### PR TITLE
Remove = to stop footer rendering in body

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_footer(classes: 'govuk-!-display-none-print') do |footer| %>
-  <%= footer.with_meta do %>
+  <% footer.with_meta do %>
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
       <% case try(:current_namespace) %>
       <% when 'candidate_interface' %>


### PR DESCRIPTION
## Context

- Remove `=` in render code, to stop footer rending in body.

## Changes proposed in this pull request

- Remove `=` in render code, to stop footer rending in body.

## Guidance to review

- Check the environments of the review app to ensure the footer doesn't render in the body and footer.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

_With `=`_
<img width="1555" height="641" alt="Screenshot 2026-06-10 at 15 54 42" src="https://github.com/user-attachments/assets/06741fe5-4c4c-48d3-8cda-40ede2b70c54" />

_Without `=`_
<img width="1560" height="385" alt="Screenshot 2026-06-10 at 15 54 56" src="https://github.com/user-attachments/assets/680c12a9-39c6-437d-bccb-0a19fe2e608e" />
