### PR TITLE
Allow param for limiting states in current applications

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -24,6 +24,7 @@ module VendorAPI
         for_test_provider_courses: for_test_provider_courses_param,
         incomplete_references: with_incomplete_references_param,
         next_cycle: next_cycle_param,
+        received_state_only: received_state_only_param,
       ).call
 
       render json: { data: { message: 'Request submitted. Applications will appear once they have been generated' } }
@@ -83,6 +84,10 @@ module VendorAPI
 
     def next_cycle_param
       params[:next_cycle] == 'true'
+    end
+
+    def received_state_only_param
+      params[:received_state_only] == 'true'
     end
   end
 end

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -8,7 +8,8 @@ class GenerateTestApplicationsForProvider
     for_test_provider_courses: false,
     previous_cycle: false,
     incomplete_references: false,
-    next_cycle: false
+    next_cycle: false,
+    received_state_only: false
   )
     @provider = provider
     @courses_per_application = courses_per_application
@@ -23,6 +24,7 @@ class GenerateTestApplicationsForProvider
     @previous_cycle = previous_cycle
     @incomplete_references = incomplete_references
     @next_cycle = next_cycle
+    @received_state_only = received_state_only
   end
 
   def call
@@ -35,7 +37,7 @@ class GenerateTestApplicationsForProvider
       raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
 
       GenerateTestApplicationsForCourses.perform_async(
-        course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle
+        course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle, received_state_only
       )
     end
   end
@@ -44,7 +46,7 @@ private
 
   attr_reader :provider, :courses_per_application, :application_count, :for_training_courses,
               :for_ratified_courses, :for_test_provider_courses, :previous_cycle, :incomplete_references,
-              :next_cycle
+              :next_cycle, :received_state_only
 
   def random_course_ids_to_apply_for
     even_split = even_split_for_number_of_course_types

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -1,13 +1,13 @@
 class GenerateTestApplicationsForCourses
   include Sidekiq::Worker
 
-  def perform(course_ids, courses_per_application, previous_cycle, incomplete_references = false, next_cycle = false)
-    generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle)
+  def perform(course_ids, courses_per_application, previous_cycle, incomplete_references = false, next_cycle = false, received_state_only = false)
+    generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle, received_state_only)
   end
 
 private
 
-  def generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle)
+  def generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle, received_state_only)
     # For applications in the next cycle use courses from the previous cycle
     courses_to_apply_to = Course.where(id: course_ids, recruitment_cycle_year: TestProvider.recruitment_cycle_year(previous_cycle))
 
@@ -19,7 +19,7 @@ private
 
     factory.create_application(
       recruitment_cycle_year: recruitment_cycle_year,
-      states: application_state(previous_cycle, courses_per_application, next_cycle),
+      states: application_state(previous_cycle, courses_per_application, next_cycle, received_state_only),
       courses_to_apply_to:,
       incomplete_references:,
     )
@@ -29,18 +29,22 @@ private
     TestApplications.new
   end
 
-  def application_state(previous_cycle, courses_per_application, next_cycle)
+  def application_state(previous_cycle, courses_per_application, next_cycle, received_state_only)
     if next_cycle
       [states_for_next_cycle.sample] * courses_per_application
     elsif previous_cycle
       states_for_previous_cycle(courses_per_application)
     else
-      [states_for_this_cycle.sample] * courses_per_application
+      [states_for_this_cycle(received_state_only).sample] * courses_per_application
     end
   end
 
-  def states_for_this_cycle
-    ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - [:inactivate]
+  def states_for_this_cycle(received_state_only)
+    if received_state_only
+      [:awaiting_provider_decision]
+    else
+      ApplicationStateChange::ApplicationState.state_ids(:visible_to_provider) - [:inactivate]
+    end
   end
 
   def states_for_next_cycle

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -31,9 +31,9 @@ private
 
   def application_state(previous_cycle, courses_per_application, next_cycle, received_state_only)
     if next_cycle
-      [states_for_next_cycle.sample] * courses_per_application
+      [states_for_next_cycle(received_state_only).sample] * courses_per_application
     elsif previous_cycle
-      states_for_previous_cycle(courses_per_application)
+      states_for_previous_cycle(courses_per_application, received_state_only)
     else
       [states_for_this_cycle(received_state_only).sample] * courses_per_application
     end
@@ -47,13 +47,21 @@ private
     end
   end
 
-  def states_for_next_cycle
-    %i[pending_conditions awaiting_provider_decision]
+  def states_for_next_cycle(received_state_only)
+    if received_state_only
+      [:awaiting_provider_decision]
+    else
+      %i[pending_conditions awaiting_provider_decision]
+    end
   end
 
-  def states_for_previous_cycle(courses_per_application)
-    states = ([:awaiting_provider_decision] * (courses_per_application - 1)) << :pending_conditions
-    states.shuffle
+  def states_for_previous_cycle(courses_per_application, received_state_only)
+    if received_state_only
+      [:awaiting_provider_decision] * courses_per_application
+    else
+      states = ([:awaiting_provider_decision] * (courses_per_application - 1)) << :pending_conditions
+      states.shuffle
+    end
   end
 
   def next_year

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   context 'when received_state_only is true' do
-    it 'generates current state applications with only awaiting_provider_decision status' do
+    it 'generates current state applications with only awaiting_provider_decision status, current cycle' do
       create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
       post_api_request '/api/v1.0/test-data/generate?count=2&received_state_only=true'
@@ -57,6 +57,16 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
       expect(Candidate.count).to eq(1)
       expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: next_year }).count).to eq(1)
       expect(ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: previous_year }).count).to eq(0)
+    end
+
+    it 'generates current state applications with only awaiting_provider_decision status when received_state_only is true' do
+      create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+
+      post_api_request '/api/v1.0/test-data/generate?count=1&next_cycle=true&received_state_only=true'
+
+      choices = ApplicationChoice.joins(:application_form).where(application_form: { recruitment_cycle_year: next_year })
+
+      expect(choices.pluck(:status).uniq).to eq(['awaiting_provider_decision'])
     end
   end
 

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
     expect(ApplicationChoice.count).to eq(1)
   end
 
+  context 'when received_state_only is true' do
+    it 'generates current state applications with only awaiting_provider_decision status' do
+      create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+
+      post_api_request '/api/v1.0/test-data/generate?count=2&received_state_only=true'
+
+      expect(ApplicationChoice.distinct.pluck(:status)).to eq(['awaiting_provider_decision'])
+    end
+  end
+
   it 'generates test data in previous cycle' do
     create(:course_option, course: create(:course, :previous_year, provider: currently_authenticated_provider))
 

--- a/spec/services/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/generate_test_applications_for_provider_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
   let(:for_ratified_courses) { false }
   let(:for_test_provider_courses) { false }
   let(:previous_cycle) { false }
+  let(:next_cycle) { false }
   let(:received_state_only) { false }
   let(:service_params) do
     {
@@ -28,6 +29,7 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
       for_ratified_courses:,
       for_test_provider_courses:,
       previous_cycle:,
+      next_cycle:,
       received_state_only:,
     }
   end
@@ -135,7 +137,20 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
       end
     end
 
-    context 'when received_state_only is true' do
+    context 'when previous_cycle is true and received_state_only is true' do
+      let(:previous_cycle) { true }
+      let(:received_state_only) { true }
+
+      it 'generates applications to courses in the previous recruitment cycle, awaiting_provider_decision state only' do
+        described_class.new(**service_params).call
+        application_form = provider.application_choices.last.application_form
+
+        expect(application_form.application_choices.pluck(:status).uniq).to eq(['awaiting_provider_decision'])
+        expect(application_form.recruitment_cycle_year).to eq(previous_year)
+      end
+    end
+
+    context 'when received_state_only is true, next cycle false' do
       let(:received_state_only) { true }
 
       it 'generates "awaiting_provider_decision" applications only' do
@@ -143,6 +158,19 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
         choices = provider.application_choices.last.application_form.application_choices
 
         expect(choices.pluck(:status).uniq).to eq(['awaiting_provider_decision'])
+      end
+    end
+
+    context 'when received_state_only is true next cycle true' do
+      let(:received_state_only) { true }
+      let(:next_cycle) { true }
+
+      it 'only creates applications with awaiting_provider_decision' do
+        described_class.new(**service_params).call
+        application_form = provider.application_choices.last.application_form
+
+        expect(application_form.application_choices.pluck(:status).uniq).to eq(['awaiting_provider_decision'])
+        expect(application_form.recruitment_cycle_year).to eq(next_year)
       end
     end
 

--- a/spec/services/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/generate_test_applications_for_provider_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
   let(:for_ratified_courses) { false }
   let(:for_test_provider_courses) { false }
   let(:previous_cycle) { false }
+  let(:received_state_only) { false }
   let(:service_params) do
     {
       provider:,
@@ -27,6 +28,7 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
       for_ratified_courses:,
       for_test_provider_courses:,
       previous_cycle:,
+      received_state_only:,
     }
   end
 
@@ -130,6 +132,17 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
         # despite it not being in the states list of `GenerateTestApplicationsForCourses`.
         expect(choices.map(&:status).uniq).to include('pending_conditions', 'withdrawn')
         expect(choices.pluck(:current_recruitment_cycle_year).uniq).to eq([previous_year])
+      end
+    end
+
+    context 'when received_state_only is true' do
+      let(:received_state_only) { true }
+
+      it 'generates "awaiting_provider_decision" applications only' do
+        described_class.new(**service_params).call
+        choices = provider.application_choices.last.application_form.application_choices
+
+        expect(choices.pluck(:status).uniq).to eq(['awaiting_provider_decision'])
       end
     end
 


### PR DESCRIPTION
## Context

At the request of a provider, we updated the [end point ](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.8/reference#post-test-data-generate)for generating test data to generate applications in a variety of states. [See this ticket](https://trello.com/c/zsL2JldU).

Technology one has come back to say they preferred it the other way, they only want received applications.

## Changes proposed in this pull request

We’ve added an optional param received_state_only , that defaults to false (current behaviour). If it is true, we only generate awaiting_provider_decision (previous behaviour).

## Guidance to review
Generate applications for Durham in the review app
API token: qgyxEy_BzCWCshjjtDDT
url: `https://apply-review-12024.test.teacherservices.cloud/api/v1.0/test-data/generate?count=1&received_state_only=true`
The newly generated application choices should all be in an awaiting_provider_decision state.

## Things to check

I'm not updating the release notes yet -- we'll do it retrospectively with v1.9. This is just to allow Tech1 to crack on, it doesn't break anything and I don't want to go through the whole release process. 

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
