### PR TITLE
Data migration for removing interview_handling feature flag

### DIFF
--- a/app/services/data_migrations/remove_interview_handling_feature_flag.rb
+++ b/app/services/data_migrations/remove_interview_handling_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveInterviewHandlingFeatureFlag
+    TIMESTAMP = 20260611102613
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :interview_handling)&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveInterviewHandlingFeatureFlag',
   'DataMigrations::NormalizeNamesOnApplicationForm',
   'DataMigrations::SetHideInReportingToFalse',
   'DataMigrations::RemoveProviderEdiReportFeatureFlag',

--- a/spec/services/data_migrations/remove_interview_handling_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_interview_handling_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveInterviewHandlingFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'interview_handling')
+      create(:feature, name: 'foo')
+    end
+
+    it 'removes the relevant feature flag' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'interview_handling')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Data migration for removing `interview_handling` feature flag

## Changes proposed in this pull request

- Data migration for removing `interview_handling` feature flag

## Guidance to review

- Check the migration code.


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
