### PR TITLE
Try seperate JS workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -243,7 +243,7 @@ jobs:
         id: set_flakey_test_results_var
         run: |
           file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
-          if [ ! -z "$file_text" ]
+          if [ ! -z "$file_text" ] && "${{ matrix.tests }}" != "javascript_tests"
           then
             echo "Flakey specs found"
             echo "file_text: $file_text"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -158,26 +158,38 @@ jobs:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb
             exclude-pattern: spec/(system|smoke|.*/(candidate_interface|provider_interface|support_interface|referee_interface|.*_api|api_.*|.*_api_.*))/.*_spec.rb
+            tags: ~js
           - tests: unit_candidate-provider
             include-pattern: spec/.*/(candidate_interface|provider_interface)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
+            tags: ~js
           - tests: unit_support-referee-api
             include-pattern: spec/.*/(support_interface|referee_interface|.*_api|api_.*|.*_api_.*)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
+            tags: ~js
           - tests: integration_shared
             include-pattern: spec/system/.*_spec.rb
             exclude-pattern: spec/system/(provider_interface|candidate_interface)/.*_spec.rb
+            tags: ~js
           - tests: integration_provider
             include-pattern: spec/system/provider_interface/.*_spec.rb
+            tags: ~js
           - tests: integration_candidate
             include-pattern: spec/system/candidate_interface/.*_spec.rb
             exclude-pattern: spec/system/candidate_interface/(entering_details|course_selection|adviser_sign_up).*_spec.rb
+            tags: ~js
           - tests: integration_candidate_entering_details
             include-pattern: spec/system/candidate_interface/entering_details.*_spec.rb
+            tags: ~js
           - tests: integration_candidate_course_selection
             include-pattern: spec/system/candidate_interface/course_selection.*_spec.rb
+            tags: ~js
           - tests: integration_candidate_adviser_sign_up
             include-pattern: spec/system/candidate_interface/adviser_sign_up.*_spec.rb
+            tags: ~js
+          - tests: javascript_tests
+            include-pattern: spec/.*_spec.rb
+            tags: js
     services:
       redis:
         image: redis:alpine
@@ -217,13 +229,14 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
+        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}" --tag "${{ env.TAGS }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           TEST_MATRIX_NODE_NAME: ${{ matrix.tests }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
           TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
+          TAGS: ${{ matrix.tags }}
 
       - name: Read flakey test results
         id: set_flakey_test_results_var

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -225,12 +225,6 @@ jobs:
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
           TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
 
-      - name: Javascript tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec -o "--tag js" --pattern "spec/.*_spec.rb"
-        env:
-          DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
-          TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
-
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |
@@ -247,6 +241,12 @@ jobs:
           else
             echo "No flakey tests logged"
           fi
+
+      - name: Javascript tests with feature flags ${{ matrix.feature-flags }}
+        run: bundle exec --verbose parallel_rspec -o "--tag js" --pattern "spec/.*_spec.rb"
+        env:
+          DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
+          TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
 
       - name: Install bash and curl
         if: failure() && github.event_name == 'push'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -147,7 +147,6 @@ jobs:
             integration_candidate_entering_details,
             integration_candidate_course_selection,
             integration_candidate_adviser_sign_up,
-            javascript_tests,
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -229,7 +229,7 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec --tag "${{ env.TAGS }}" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
+        run: bundle exec --verbose parallel_rspec -o "--tag ${{ env.TAGS }}" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -147,6 +147,7 @@ jobs:
             integration_candidate_entering_details,
             integration_candidate_course_selection,
             integration_candidate_adviser_sign_up,
+            javascript_tests,
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -229,7 +229,7 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}" --tag "${{ env.TAGS }}"
+        run: bundle exec --verbose parallel_rspec --tag "${{ env.TAGS }}" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -147,6 +147,7 @@ jobs:
             integration_candidate_entering_details,
             integration_candidate_course_selection,
             integration_candidate_adviser_sign_up,
+            javascript_tests,
           ]
         feature-flags: [on, off]
         # Use these offsets as the end of cycle approaches
@@ -158,26 +159,38 @@ jobs:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb
             exclude-pattern: spec/(system|smoke|.*/(candidate_interface|provider_interface|support_interface|referee_interface|.*_api|api_.*|.*_api_.*))/.*_spec.rb
+            tags: ~js
           - tests: unit_candidate-provider
             include-pattern: spec/.*/(candidate_interface|provider_interface)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
+            tags: ~js
           - tests: unit_support-referee-api
             include-pattern: spec/.*/(support_interface|referee_interface|.*_api|api_.*|.*_api_.*)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
+            tags: ~js
           - tests: integration_shared
             include-pattern: spec/system/.*_spec.rb
             exclude-pattern: spec/system/(provider_interface|candidate_interface)/.*_spec.rb
+            tags: ~js
           - tests: integration_provider
             include-pattern: spec/system/provider_interface/.*_spec.rb
+            tags: ~js
           - tests: integration_candidate
             include-pattern: spec/system/candidate_interface/.*_spec.rb
             exclude-pattern: spec/system/candidate_interface/(entering_details|course_selection|adviser_sign_up).*_spec.rb
+            tags: ~js
           - tests: integration_candidate_entering_details
             include-pattern: spec/system/candidate_interface/entering_details.*_spec.rb
+            tags: ~js
           - tests: integration_candidate_course_selection
             include-pattern: spec/system/candidate_interface/course_selection.*_spec.rb
+            tags: ~js
           - tests: integration_candidate_adviser_sign_up
             include-pattern: spec/system/candidate_interface/adviser_sign_up.*_spec.rb
+            tags: ~js
+          - tests: javascript_tests
+            include-pattern: spec/.*_spec.rb
+            tags: js
     services:
       redis:
         image: redis:alpine
@@ -217,13 +230,14 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec -o "--tag ~js" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
+        run: bundle exec --verbose parallel_rspec -o "--tag ${{ env.TAGS }}" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           TEST_MATRIX_NODE_NAME: ${{ matrix.tests }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
           TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
+          TAGS: ${{ matrix.tags }}
 
       - name: Read flakey test results
         id: set_flakey_test_results_var
@@ -241,12 +255,6 @@ jobs:
           else
             echo "No flakey tests logged"
           fi
-
-      - name: Javascript tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec -o "--tag js" --pattern "spec/.*_spec.rb"
-        env:
-          DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
-          TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
 
       - name: Install bash and curl
         if: failure() && github.event_name == 'push'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -159,38 +159,26 @@ jobs:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb
             exclude-pattern: spec/(system|smoke|.*/(candidate_interface|provider_interface|support_interface|referee_interface|.*_api|api_.*|.*_api_.*))/.*_spec.rb
-            tags: ~js
           - tests: unit_candidate-provider
             include-pattern: spec/.*/(candidate_interface|provider_interface)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
-            tags: ~js
           - tests: unit_support-referee-api
             include-pattern: spec/.*/(support_interface|referee_interface|.*_api|api_.*|.*_api_.*)/.*_spec.rb
             exclude-pattern: spec/(system|smoke)/.*_spec.rb
-            tags: ~js
           - tests: integration_shared
             include-pattern: spec/system/.*_spec.rb
             exclude-pattern: spec/system/(provider_interface|candidate_interface)/.*_spec.rb
-            tags: ~js
           - tests: integration_provider
             include-pattern: spec/system/provider_interface/.*_spec.rb
-            tags: ~js
           - tests: integration_candidate
             include-pattern: spec/system/candidate_interface/.*_spec.rb
             exclude-pattern: spec/system/candidate_interface/(entering_details|course_selection|adviser_sign_up).*_spec.rb
-            tags: ~js
           - tests: integration_candidate_entering_details
             include-pattern: spec/system/candidate_interface/entering_details.*_spec.rb
-            tags: ~js
           - tests: integration_candidate_course_selection
             include-pattern: spec/system/candidate_interface/course_selection.*_spec.rb
-            tags: ~js
           - tests: integration_candidate_adviser_sign_up
             include-pattern: spec/system/candidate_interface/adviser_sign_up.*_spec.rb
-            tags: ~js
-          - tests: javascript_tests
-            include-pattern: spec/.*_spec.rb
-            tags: js
     services:
       redis:
         image: redis:alpine
@@ -230,14 +218,19 @@ jobs:
         run: apk add chromium chromium-chromedriver
 
       - name: ${{ matrix.tests }} tests with feature flags ${{ matrix.feature-flags }}
-        run: bundle exec --verbose parallel_rspec -o "--tag ${{ env.TAGS }}" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
+        run: bundle exec --verbose parallel_rspec -o "--tag ~js" --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
         env:
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           TEST_MATRIX_NODE_NAME: ${{ matrix.tests }}
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
           TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
-          TAGS: ${{ matrix.tags }}
+
+      - name: Javascript tests with feature flags ${{ matrix.feature-flags }}
+        run: bundle exec --verbose parallel_rspec -o "--tag js" --pattern "spec/.*_spec.rb"
+        env:
+          DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
+          TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
 
       - name: Read flakey test results
         id: set_flakey_test_results_var

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -89,7 +89,7 @@ class Clock
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_later(false)
   end
 
-  every(7.days, 'EndOfCycle::NextYearFullSync', at: 'Friday 00:05') { EndOfCycle::NextYearFullSync.perform_async }
+  every(7.days, 'EndOfCycle::NextYearFullSync', at: 'Friday 00:05') { EndOfCycle::NextYearFullSync.perform_later }
 
   every(7.days, 'TADSubjectDomicileNationalityExport', at: 'Sunday 23:59') do
     DataAPI::TADSubjectDomicileNationalityExport.run_weekly

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
     config.retry_reporter = reporter
 
     config.around do |ex|
-      ex.run_with_retry retry: 5
+      ex.run_with_retry retry: 3
     end
   end
 

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Provider shares candidate profile', :with_cache do
   let(:current_provider) { create(:provider) }
 
   scenario 'View a candidate', :js do
+    raise 'Fake error'
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Provider shares candidate profile', :with_cache do
     then_i_am_redirected_to_the_share_page
     when_i_click('Copy link to clipboard')
     then_i_can_see_success_message
-    raise 'Fake error'
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in

--- a/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
+++ b/spec/system/provider_interface/candidate_pool/provider_shares_candidate_profile_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Provider shares candidate profile', :with_cache do
   let(:current_provider) { create(:provider) }
 
   scenario 'View a candidate', :js do
-    raise 'Fake error'
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_user_exists
     and_there_are_candidates_for_candidate_pool
@@ -22,6 +21,7 @@ RSpec.describe 'Provider shares candidate profile', :with_cache do
     then_i_am_redirected_to_the_share_page
     when_i_click('Copy link to clipboard')
     then_i_can_see_success_message
+    raise 'Fake error'
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in


### PR DESCRIPTION
## Context

- Separate RSpec tests, which run with JavaScript, to run separately
- Prevent JavaScript from being included in the flaky test reporting

## Changes proposed in this pull request

- Separate RSpec tests, which run with JavaScript, to run separately
- Prevent JavaScript from being included in the flaky test reporting

## Guidance to review

- CI should run without identifying flaky tests on RSpec tests, which run with JavaScript

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
