### PR TITLE
use the same list for validation as options

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -40,6 +40,7 @@ module CandidateInterface
         ),
       )
 
+      debugger
       if @form.save
         if @form.choice == 'same_type'
           intermediate_data_service.clear_state!

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -40,7 +40,6 @@ module CandidateInterface
         ),
       )
 
-      debugger
       if @form.save
         if @form.choice == 'same_type'
           intermediate_data_service.clear_state!

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -20,7 +20,7 @@ module CandidateInterface
     validates :subject, :grade, length: { maximum: 255 }
     validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :institution_country, presence: true, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
-    validates :institution_country, inclusion: { in: COUNTRIES_AND_TERRITORIES }, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
+    validates :institution_country, inclusion: { in: DOMICILES }, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
     validate :grade_format_is_valid, if: :grade, on: :details
 
     def self.build_all(application_form)

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -90,16 +90,19 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
       context 'when it is a non-uk qualification' do
         it 'validates for presence and inclusion in the COUNTY_NAMES constant' do
           valid_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'GB')
+          kosovo_qualificaiton = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'QO')
           blank_country_qualification = described_class.new(nil, nil, qualification_type: 'non_uk')
-          inavlid_country_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'QQ')
+          invalid_country_qualification = described_class.new(nil, nil, qualification_type: 'non_uk', institution_country: 'QQ')
 
           valid_qualification.valid?(:details)
           blank_country_qualification.valid?(:details)
-          inavlid_country_qualification.valid?(:details)
+          invalid_country_qualification.valid?(:details)
+          kosovo_qualificaiton.valid?(:details)
 
           expect(valid_qualification.errors.full_messages_for(:institution_country)).to be_empty
           expect(blank_country_qualification.errors.full_messages_for(:institution_country)).not_to be_empty
-          expect(inavlid_country_qualification.errors.full_messages_for(:institution_country)).not_to be_empty
+          expect(invalid_country_qualification.errors.full_messages_for(:institution_country)).not_to be_empty
+          expect(kosovo_qualificaiton.errors.full_messages_for(:institution_country)).to be_empty
         end
       end
     end


### PR DESCRIPTION
## Context

Bug has been reported by a user trying to enter Kosovo as the country where their other qualification comes from. 

## Changes proposed in this pull request

The list of countries came from the DOMICILES list in the DFE reference gem. But we were validated against the COUNTRIES_AND_TERRITORIES list. Kosovo is in both lists, but is one of a handful of countries that has a different code as a domicile than as a country. 

## Guidance to review

Enter any qualification from Kosovo. You should not see an error. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
