### PR TITLE
Upgrade sandbox Postgres SKU

### DIFF
--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -15,7 +15,7 @@
   "worker_replicas": 1,
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "postgres_enable_high_availability": true,
   "enable_alerting": true,
   "create_storage_account": true,


### PR DESCRIPTION
## Context
Upgrading the Postgres Flexible Server SKU for the sandbox environment from GP_Standard_D2ds_v4 to GP_Standard_D2ds_v5. This is a hardware generation upgrade, same compute tier and size, just moving to the newer v5 generation. The upgrade requires an approximately 10 minute outage window which needs to be agreed with Lori Bailey (dev team) before merging and deploying.

## Changes proposed in this pull request

terraform/aks/workspace_variables/sandbox.tfvars.json - updating postgres_flexible_server_sku from GP_Standard_D2ds_v4 to GP_Standard_D2ds_v5.

## Guidance to review

Terraform plan has been run locally and confirms only 2 changes - the SKU update (in-place, no recreation) and an Azure Monitor diagnostic setting drift fix. No data risk. Plan output: 0 to add, 2 to change, 0 to destroy.

## Things to check

- [ ]  No feature flags removed
- [ ]  No API changes - infrastructure only
- [ ]  No user-facing changes - no CHANGELOG entry needed
- [ ]  No database schema changes - no migrations, no analytics yml changes required
- [ ]  Attach the PR to the Trello card
- [ ]  Outage window to be agreed with Lori Bailey before this PR is merged and deployed