### PR TITLE
Increase sq memory allocation from 1Gi to 2Gi in non-prod envs

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -102,7 +102,7 @@ variable "enable_prometheus_monitoring" {
 
 variable "solid_queue_worker_memory_max" {
   type = string
-  default = "1Gi"
+  default = "2Gi"
 }
 
 variable "solid_queue_worker_replicas" {


### PR DESCRIPTION
## Context

Grafana currently shows that Sandbox is struggling with the Solid Queue worker's memory allowance. We need to increase the allowance as we migrate further jobs to Solid Queue.

## Changes proposed in this pull request

- Change the variable from 1Gi to 2Gi with a view to this taking effect across all non-prod envs.

## Guidance to review

- Check the small code change.
- To review with Infra that this is the correct place to change the variable to cascade to non-prod envs.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
