### PR TITLE
Carry over logic only considers September start dates

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -408,12 +408,16 @@ class ApplicationForm < ApplicationRecord
     previous_application_form&.submitted?
   end
 
+  def september_application_choices
+    @september_application_choices ||= application_choices.course_start_in_september(recruitment_cycle_year)
+  end
+
   def carry_over?
     return false unless after_apply_deadline?
 
     !submitted? ||
-      application_choices.blank? ||
-      application_choices.all?(&:state_carry_over?)
+      september_application_choices.blank? ||
+      september_application_choices.all?(&:state_carry_over?)
   end
 
   def unsuccessful_and_apply_deadline_has_passed?

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1090,7 +1090,7 @@ RSpec.describe ApplicationForm do
               :application_form,
               :submitted,
               application_choices: [application_choice],
-              )
+            )
             travel_temporarily_to(application_form.apply_deadline_at + 1.second) do
               expect(application_form.carry_over?).to be(true)
             end
@@ -2257,7 +2257,7 @@ RSpec.describe ApplicationForm do
         application_form:,
         current_recruitment_cycle_year: recruitment_cycle_year,
         course_option: create(:course_option, course: september_course),
-        )
+      )
     end
 
     before do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1004,9 +1004,11 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#carry_over?' do
+    let(:january_course) { build(:course, start_date: "1/1/#{Date.current.year + 1}") }
+
     context 'application is unsubmitted' do
       let(:unsubmitted_application_form) do
-        build(:application_form, :unsubmitted, application_choices: [build(:application_choice)])
+        create(:application_form, :unsubmitted, application_choices: [build(:application_choice, :unsubmitted)])
       end
 
       it 'true when application deadline has passed' do
@@ -1023,7 +1025,7 @@ RSpec.describe ApplicationForm do
     end
 
     context 'application does not have application choices' do
-      let(:no_choices_application_form) { build(:application_form, :submitted, application_choices: []) }
+      let(:no_choices_application_form) { create(:application_form, :submitted, application_choices: []) }
 
       it 'true when application deadline has passed' do
         travel_temporarily_to(no_choices_application_form.apply_deadline_at + 1.second) do
@@ -1040,26 +1042,58 @@ RSpec.describe ApplicationForm do
 
     context 'an application choice is awaiting candidate decision' do
       let(:submitted_application_form) do
-        build(:application_form, :submitted, application_choices: [build(:application_choice, :offered)])
+        create(:application_form, :submitted, application_choices: [application_choice])
       end
 
-      it 'returns false after the application deadline has passed' do
-        travel_temporarily_to(submitted_application_form.apply_deadline_at + 1.second) do
-          expect(submitted_application_form.carry_over?).to be(false)
+      context 'when the course of the application choice starts in september' do
+        let(:application_choice) { build(:application_choice, :offered) }
+
+        it 'returns false after the application deadline has passed' do
+          travel_temporarily_to(submitted_application_form.apply_deadline_at + 1.second) do
+            expect(submitted_application_form.carry_over?).to be(false)
+          end
+        end
+      end
+
+      context 'when the course of the application choice starts after september' do
+        let(:application_choice) { build(:application_choice, :offered, course_option: build(:course_option, course: january_course)) }
+
+        it 'returns false after the application deadline has passed' do
+          travel_temporarily_to(submitted_application_form.apply_deadline_at + 1.second) do
+            expect(submitted_application_form.carry_over?).to be(true)
+          end
         end
       end
     end
 
     context 'an application choice is awaiting provider decision' do
-      it 'returns false after the application deadline has passed', :aggregate_failures do
-        %i[awaiting_provider_decision interviewing inactive].each do |awaiting_decision_status|
-          application_form = build(
-            :application_form,
-            :submitted,
-            application_choices: [build(:application_choice, awaiting_decision_status)],
-          )
-          travel_temporarily_to(application_form.apply_deadline_at + 1.second) do
-            expect(application_form.carry_over?).to be(false)
+      context 'when the course of the application choice starts in september' do
+        it 'returns false after the application deadline has passed', :aggregate_failures do
+          %i[awaiting_provider_decision interviewing inactive].each do |awaiting_decision_status|
+            application_form = create(
+              :application_form,
+              :submitted,
+              application_choices: [build(:application_choice, awaiting_decision_status)],
+            )
+            travel_temporarily_to(application_form.apply_deadline_at + 1.second) do
+              expect(application_form.carry_over?).to be(false)
+            end
+          end
+        end
+      end
+
+      context 'when the course of the application choice starts after september' do
+        it 'returns true after the application deadline has passed', :aggregate_failures do
+          %i[awaiting_provider_decision interviewing inactive].each do |awaiting_decision_status|
+            application_choice = build(:application_choice, awaiting_decision_status, course_option: build(:course_option, course: january_course))
+            application_form = create(
+              :application_form,
+              :submitted,
+              application_choices: [application_choice],
+              )
+            travel_temporarily_to(application_form.apply_deadline_at + 1.second) do
+              expect(application_form.carry_over?).to be(true)
+            end
           end
         end
       end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -2237,4 +2237,36 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#september_application_choices' do
+    let(:recruitment_cycle_year) { 2026 }
+    let(:application_form) { create(:application_form, recruitment_cycle_year: recruitment_cycle_year) }
+    let(:january_course) { build(:course, start_date: "1/1/#{recruitment_cycle_year + 1}") }
+    let(:september_course) { build(:course, start_date: "1/9/#{recruitment_cycle_year}") }
+    let(:january_choice) do
+      create(
+        :application_choice,
+        application_form:,
+        current_recruitment_cycle_year: recruitment_cycle_year,
+        course_option: create(:course_option, course: january_course),
+      )
+    end
+    let(:september_choice) do
+      create(
+        :application_choice,
+        application_form:,
+        current_recruitment_cycle_year: recruitment_cycle_year,
+        course_option: create(:course_option, course: september_course),
+        )
+    end
+
+    before do
+      september_choice
+      january_choice
+    end
+
+    it 'returns only the application choices with september start dates' do
+      expect(application_form.september_application_choices).to contain_exactly(september_choice)
+    end
+  end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -15,41 +15,49 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
     given_i_have_an_empty_submitted_application_from_last_cycle
     and_i_am_signed_in_as_a_candidate
     then_i_see_your_applications_page
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over empty application to new cycle through the carry over interstitial' do
     given_i_have_an_empty_application_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over unsubmitted application to new cycle through the carry over interstitial' do
     given_i_have_an_unsubmitted_application_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over application_not_sent application to new cycle' do
     given_i_have_an_application_not_sent_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over conditions_not_met application to new cycle' do
     given_i_have_an_application_conditions_not_met_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over offer_withdrawn application to new cycle' do
     given_i_have_an_application_offer_withdrawn_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over declined application to new cycle' do
     given_i_have_an_application_declined_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate carries over withdrawn application to new cycle' do
     given_i_have_an_application_withdrawn_from_last_cycle
     then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_has_no_active_application_choices
   end
 
   scenario 'Candidate does not need to carry over recruited application' do
@@ -64,6 +72,12 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
     and_i_am_signed_in_as_a_candidate
     when_i_visit_any_page
     then_i_am_on_the_post_offer_dashboard
+  end
+
+  scenario 'Candidate is carried over, despite having active applications in January start dates' do
+    given_i_have_an_in_flight_application_for_a_course_starting_in_january_from_last_cycle
+    then_i_can_carry_over_my_application_to_the_new_cycle
+    and_the_candidates_an_active_application_choice_from_the_previous_cycle
   end
 
   def given_i_have_an_empty_submitted_application_from_last_cycle
@@ -82,31 +96,42 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   end
 
   def given_i_have_an_application_conditions_not_met_from_last_cycle
-    create(:application_choice, :conditions_not_met, application_form: @application_form)
+    create(:application_choice, :conditions_not_met, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_offer_withdrawn_from_last_cycle
-    create(:application_choice, :offer_withdrawn, application_form: @application_form)
+    create(:application_choice, :offer_withdrawn, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_declined_from_last_cycle
-    create(:application_choice, :declined, application_form: @application_form)
+    create(:application_choice, :declined, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_withdrawn_from_last_cycle
-    create(:application_choice, :withdrawn, application_form: @application_form)
+    create(:application_choice, :withdrawn, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_not_sent_from_last_cycle
-    create(:application_choice, :application_not_sent, application_form: @application_form)
+    create(:application_choice, :application_not_sent, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_recruited_from_last_cycle
-    create(:application_choice, :recruited, application_form: @application_form)
+    create(:application_choice, :recruited, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
   end
 
   def given_i_have_an_application_pending_conditions_from_last_cycle
-    create(:application_choice, :accepted, application_form: @application_form)
+    create(:application_choice, :accepted, current_recruitment_cycle_year: @previous_year, application_form: @application_form)
+  end
+
+  def given_i_have_an_in_flight_application_for_a_course_starting_in_january_from_last_cycle
+    course = build(:course, start_date: "1/1/#{@current_year}")
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      current_recruitment_cycle_year: @previous_year,
+      application_form: @application_form,
+      course_option: build(:course_option, course: course),
+    )
   end
 
   def then_i_can_carry_over_my_application_to_the_new_cycle
@@ -204,5 +229,13 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_link('Add application', class: 'govuk-button')
+  end
+
+  def and_the_candidates_has_no_active_application_choices
+    expect(@candidate.active_application_choices).to eq([])
+  end
+
+  def and_the_candidates_an_active_application_choice_from_the_previous_cycle
+    expect(@candidate.active_application_choices).to contain_exactly(@application_choice)
   end
 end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe 'Candidate accepts an offer' do
       candidate: @current_candidate,
       submitted_at: Time.zone.now,
       support_reference: '123A',
-      recruitment_cycle_year: 2024,
     )
 
     @application_form.application_references.update_all(feedback_status: 'not_requested_yet')
@@ -153,6 +152,7 @@ RSpec.describe 'Candidate accepts an offer' do
       :offered,
       course_option: @course_option,
       application_form: @application_form,
+      current_recruitment_cycle_year: @application_form.recruitment_cycle_year,
     )
 
     @other_application_choice = create(
@@ -160,6 +160,7 @@ RSpec.describe 'Candidate accepts an offer' do
       :offered,
       course_option: other_course_option,
       application_form: @application_form,
+      current_recruitment_cycle_year: @application_form.recruitment_cycle_year,
     )
   end
 
@@ -168,6 +169,7 @@ RSpec.describe 'Candidate accepts an offer' do
       :application_choice,
       status: 'awaiting_provider_decision',
       application_form: @application_form,
+      current_recruitment_cycle_year: @application_form.recruitment_cycle_year,
     )
   end
 


### PR DESCRIPTION
## Context

- Change the carry over logic so that application forms carry over into the next recruitment cycle even if they have in-flight applications with January start dates.

## Changes proposed in this pull request

- Change the carry over logic so that application forms carry over into the next recruitment cycle even if they have in-flight applications with January start dates.

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/AfFtj2iK/1916-carry-over-logic-to-only-consider-application-choices-with-september-start-dates