### PR TITLE
Remove stale service user tokens

### DIFF
--- a/app/workers/deactivate_stale_service_api_tokens_worker.rb
+++ b/app/workers/deactivate_stale_service_api_tokens_worker.rb
@@ -1,0 +1,23 @@
+class DeactivateStaleServiceAPITokensWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
+  queue_as :low_priority
+
+  INACTIVE_MONTHS_AGO = 3
+
+  def perform
+    tokens.destroy_all
+  end
+
+private
+
+  def tokens
+    scope.where('used_at < ?', INACTIVE_MONTHS_AGO.months.ago)
+      .or(AuthenticationToken
+            .where('used_at IS NULL AND created_at < ?', INACTIVE_MONTHS_AGO.months.ago))
+  end
+
+  def scope
+    AuthenticationToken.where(user_type: 'ServiceAPIUser')
+  end
+end

--- a/app/workers/deactivate_stale_service_api_tokens_worker.rb
+++ b/app/workers/deactivate_stale_service_api_tokens_worker.rb
@@ -13,8 +13,7 @@ private
 
   def tokens
     scope.where('used_at < ?', INACTIVE_MONTHS_AGO.months.ago)
-      .or(AuthenticationToken
-            .where('used_at IS NULL AND created_at < ?', INACTIVE_MONTHS_AGO.months.ago))
+      .or(scope.where('used_at IS NULL AND created_at < ?', INACTIVE_MONTHS_AGO.months.ago))
   end
 
   def scope

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -38,6 +38,7 @@ class Clock
   every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_later }
   every(1.day, 'RemoveInactiveSupportUsersWorker', at: '5:02') { RemoveInactiveSupportUsersWorker.perform_later }
   every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_later }
+  every(1.day, 'DeactivateStaleServiceAPITokensWorker', at: '5:06') { DeactivateStaleServiceAPITokensWorker.perform_later }
   every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_later }
   every(1.day, 'DeleteFinishedJobs', at: '19:00') { DeleteFinishedJobsWorker.perform_later }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_later }

--- a/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
+++ b/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
@@ -7,26 +7,26 @@ RSpec.describe DeactivateStaleServiceAPITokensWorker do
       used_more_than_three_months_ago = create(
         :authentication_token,
         user: ServiceAPIUser.last,
-        used_at: 3.months.ago + 1.day,
+        used_at: 3.months.ago - 1.day,
       )
       created_not_used_more_than_three_months_ago = create(
         :authentication_token,
         user: ServiceAPIUser.last,
         used_at: nil,
-        created_at: 3.months.ago + 1.day,
+        created_at: 3.months.ago - 1.day,
       )
 
       # keep these
       used_within_three_months_ago = create(
         :authentication_token,
         user: ServiceAPIUser.last,
-        used_at: 3.months.ago - 1.day,
+        used_at: 2.months.ago,
       )
       created_not_used_within_three_months_ago = create(
         :authentication_token,
         user: ServiceAPIUser.last,
         used_at: nil,
-        created_at: 3.months.ago - 1.day,
+        created_at:2.months.ago,
       )
 
       expect { described_class.new.perform }.to change { AuthenticationToken.count }.by(-2)

--- a/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
+++ b/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
@@ -28,11 +28,24 @@ RSpec.describe DeactivateStaleServiceAPITokensWorker do
         used_at: nil,
         created_at: 2.months.ago,
       )
+      not_service_user_used_over_three_months_ago = create(
+        :authentication_token,
+        user: build(:vendor_api_user),
+        used_at: 3.months.ago - 1.day,
+      )
+      not_service_user_created_over_three_months_ago = create(
+        :authentication_token,
+        user: build(:vendor_api_user),
+        used_at: nil,
+        created_at: 3.months.ago - 1.day,
+      )
 
       expect { described_class.new.perform }.to change { AuthenticationToken.count }.by(-2)
 
       expect(created_not_used_within_three_months_ago.reload.present?).to be true
       expect(used_within_three_months_ago.reload.present?).to be true
+      expect(not_service_user_created_over_three_months_ago.reload.present?).to be true
+      expect(not_service_user_used_over_three_months_ago.reload.present?).to be true
 
       expect { created_not_used_more_than_three_months_ago.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { used_more_than_three_months_ago.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
+++ b/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe DeactivateStaleServiceAPITokensWorker do
+  describe '#perform' do
+    it 'deletes stale tokens for service users' do
+      # delete these
+      used_more_than_three_months_ago = create(
+        :authentication_token,
+        user: ServiceAPIUser.last,
+        used_at: 3.months.ago + 1.day,
+      )
+      created_not_used_more_than_three_months_ago = create(
+        :authentication_token,
+        user: ServiceAPIUser.last,
+        used_at: nil,
+        created_at: 3.months.ago + 1.day,
+      )
+
+      # keep these
+      used_within_three_months_ago = create(
+        :authentication_token,
+        user: ServiceAPIUser.last,
+        used_at: 3.months.ago - 1.day,
+      )
+      created_not_used_within_three_months_ago = create(
+        :authentication_token,
+        user: ServiceAPIUser.last,
+        used_at: nil,
+        created_at: 3.months.ago - 1.day,
+      )
+
+      expect { described_class.new.perform }.to change { AuthenticationToken.count }.by(-2)
+
+      expect(created_not_used_within_three_months_ago.reload.present?).to be true
+      expect(used_within_three_months_ago.reload.present?).to be true
+
+      expect { created_not_used_more_than_three_months_ago.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { used_more_than_three_months_ago.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
+++ b/spec/workers/deactivate_stale_service_api_tokens_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DeactivateStaleServiceAPITokensWorker do
         :authentication_token,
         user: ServiceAPIUser.last,
         used_at: nil,
-        created_at:2.months.ago,
+        created_at: 2.months.ago,
       )
 
       expect { described_class.new.perform }.to change { AuthenticationToken.count }.by(-2)


### PR DESCRIPTION
## Context

I'm cleaning up a number of things related to our internal APIs (Data, Candidate, Register, Test). See the [checklist on this card](https://trello.com/c/8p5BxxMb).

## Changes proposed in this pull request

This job is for removing the stale tokens for service users to run daily. 

## Guidance to review

Create a token for a service user. 
Then create a token for a service user, but change the created_at date to +3months ago. 
Then create another token. This one with a created_at date a long time ago. But add a used_at date to something recent.
Run the job. The second token, is the only one that should be deleted.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
