### PR TITLE
Remove unused ServiceUser accounts

### DIFF
--- a/app/models/service_api_user.rb
+++ b/app/models/service_api_user.rb
@@ -27,10 +27,6 @@ class ServiceAPIUser < ActiveHash::Base
     find(4)
   end
 
-  def self.teacher_success_user
-    find(5)
-  end
-
   # Fix a bug in ActiveHash that causes the user_type in a AuthenticationToken to
   # be set to `ActiveHash::Base` instead of `ServiceAPIUser`.
   def self.polymorphic_name

--- a/app/models/service_api_user.rb
+++ b/app/models/service_api_user.rb
@@ -10,11 +10,9 @@ class ServiceAPIUser < ActiveHash::Base
   include AuthenticatedUsingMagicLinks
 
   self.data = [
-    { id: 1, name: 'User for testing, not used in production', authorized_api: 'TestAPI' },
     { id: 2, name: 'DfE TAD', authorized_api: 'DataAPI' },
     { id: 3, name: 'DfE Register', authorized_api: 'RegisterAPI' },
     { id: 4, name: 'DfE Candidate', authorized_api: 'CandidateAPI' },
-    { id: 5, name: 'DfE Teacher Success', authorized_api: 'CandidateAPI' },
   ]
 
   def self.test_data_user

--- a/app/models/service_api_user.rb
+++ b/app/models/service_api_user.rb
@@ -15,10 +15,6 @@ class ServiceAPIUser < ActiveHash::Base
     { id: 4, name: 'DfE Candidate', authorized_api: 'CandidateAPI' },
   ]
 
-  def self.test_data_user
-    find(1)
-  end
-
   def self.tad_user
     find(2)
   end

--- a/spec/requests/candidate_api/get_candidate_spec.rb
+++ b/spec/requests/candidate_api/get_candidate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'GET /candidate-api/:versions/candidates/:candidate_id' do
   versions.each do |version|
     context "for version #{version}" do
       it 'does not allow access to the API from other data users' do
-        service_api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
+        service_api_token = ServiceAPIUser.register_user.create_magic_link_token!
         candidate = create(:candidate)
         candidate_id_param = "C#{candidate.id}"
 
@@ -22,15 +22,6 @@ RSpec.describe 'GET /candidate-api/:versions/candidates/:candidate_id' do
         candidate_id_param = "C#{candidate.id}"
 
         get_api_request "/candidate-api/#{version}/candidates/#{candidate_id_param}", token: candidate_api_token
-
-        expect(response).to have_http_status(:success)
-      end
-
-      it 'allows access to the API for Teacher Success users' do
-        candidate = create(:candidate)
-        candidate_id_param = "C#{candidate.id}"
-
-        get_api_request "/candidate-api/#{version}/candidates/#{candidate_id_param}", token: teacher_success_api_token
 
         expect(response).to have_http_status(:success)
       end

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'GET /register-api/applications' do
   end
 
   it 'does not allow access to the API from other data users' do
-    api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
+    api_token = ServiceAPIUser.candidate_user.create_magic_link_token!
     get_api_request "/register-api/applications?recruitment_cycle_year=#{current_year}", token: api_token
     expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')

--- a/spec/support/candidate_api/candidate_api_spec_helper.rb
+++ b/spec/support/candidate_api/candidate_api_spec_helper.rb
@@ -13,10 +13,6 @@ module CandidateAPISpecHelper
     @candidate_api_token = ServiceAPIUser.candidate_user.create_magic_link_token!
   end
 
-  def teacher_success_api_token
-    @teacher_success_api_token = ServiceAPIUser.teacher_success_user.create_magic_link_token!
-  end
-
   def parsed_response
     JSON.parse(response.body)
   end

--- a/spec/support/shared_examples/a_candidate_api_endpoint.rb
+++ b/spec/support/shared_examples/a_candidate_api_endpoint.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'a candidate API endpoint' do |path, _date_param, api_vers
   include CycleTimetableHelper
 
   it 'does not allow access to the API from other data users' do
-    api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
+    api_token = ServiceAPIUser.register_user.create_magic_link_token!
     get_api_request "#{path}?updated_since=#{CGI.escape(1.month.ago.iso8601)}", token: api_token
     expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse', api_version)


### PR DESCRIPTION
## Context

Before merging make sure the count on [this blazer query](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1443-2026-service-api-tokens-for-invalid-users) is 0

I'm cleaning up a number of things related to our internal APIs (Data, Candidate, Register, Test). See the [checklist on this card](https://trello.com/c/8p5BxxMb).

## Changes proposed in this pull request

A couple of the ServiceUser definitions are no longer valid. The Teacher Success team is no longer hitting our Candidate API (the team no longer exists) and the Test API no longer exists, so the service user is no longer necessary.

Next step is getting rid of the Data API, but that is slightly extra challenge.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
