### PR TITLE
Add rate limiting

### DIFF
--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -12,4 +12,8 @@ module "domains" {
   null_host_header      = try(each.value.null_host_header, false)
   cached_paths          = try(each.value.cached_paths, [])
   redirect_rules        = try(each.value.redirect_rules, null)
+  allow_aks             = try(var.allow_aks, false)
+  block_ip              = try(var.block_ip, false)
+  rate_limit_max        = try(var.rate_limit_max, false)
+  rate_limit            = try(var.rate_limit, null)
 }

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -25,3 +25,34 @@ variable "alert_window_size" {
   default     = "PT15M"
   description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
 }
+
+variable "allow_aks" {
+  type = bool
+  default = false
+}
+
+variable "block_ip" {
+  type = bool
+  default = false
+}
+
+variable "rate_limit_max" {
+  type = number
+  default = null
+}
+
+variable "rate_limit" {
+  type = list(object({
+    agent          = optional(string)
+    priority       = optional(number)
+    duration       = optional(number)
+    limit          = optional(number)
+    selector       = optional(string)
+    operator       = optional(string)
+    match_values   = optional(string)
+    match_variable = optional(string)
+    type           = optional(string)
+    action         = optional(string)
+  }))
+  default = null
+}

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -45,5 +45,48 @@
         "to-domain": "www.apply-for-teacher-training.service.gov.uk"
       }]
     }
-  }
+  },
+  "allow_aks": true,
+  "block_ip": true,
+  "rate_limit": [
+    {
+      "agent": "ReqUriBlock",
+      "priority": 20,
+      "enabled": "true",
+      "duration": 0,
+      "limit": 0,
+      "match_variable": "RequestUri",
+      "type": "MatchRule",
+      "action": "Block",
+      "operator": "Contains",
+      "selector": null,
+      "match_values": "/OriginEmulator"
+    },
+    {
+      "agent": "ReqNotifyAllow",
+      "priority": 40,
+      "enabled": "true",
+      "duration": 0,
+      "limit": 0,
+      "match_variable": "RequestUri",
+      "type": "MatchRule",
+      "action": "Allow",
+      "operator": "Contains",
+      "selector": null,
+      "match_values": "/integrations/notify/callback"
+    },
+    {
+      "agent": "allLimit",
+      "priority": 60,
+      "enabled": "true",
+      "duration": 5,
+      "limit": 600,
+      "match_variable": "RequestHeader",
+      "type": "RateLimitRule",
+      "action": "Log",
+      "operator": "GreaterThanOrEqual",
+      "selector": "Host",
+      "match_values": "0"
+    }
+  ]
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
@@ -29,5 +29,48 @@
       "origin_hostname": "apply-qa.test.teacherservices.cloud",
       "null_host_header": true
     }
-  }
+  },
+  "allow_aks": true,
+  "block_ip": true,
+  "rate_limit": [
+    {
+      "agent": "ReqUriBlock",
+      "priority": 20,
+      "enabled": "true",
+      "duration": 0,
+      "limit": 0,
+      "match_variable": "RequestUri",
+      "type": "MatchRule",
+      "action": "Block",
+      "operator": "Contains",
+      "selector": null,
+      "match_values": "/OriginEmulator"
+    },
+    {
+      "agent": "ReqNotifyAllow",
+      "priority": 40,
+      "enabled": "true",
+      "duration": 0,
+      "limit": 0,
+      "match_variable": "RequestUri",
+      "type": "MatchRule",
+      "action": "Allow",
+      "operator": "Contains",
+      "selector": null,
+      "match_values": "/integrations/notify/callback"
+    },
+    {
+      "agent": "allLimit",
+      "priority": 60,
+      "enabled": "true",
+      "duration": 5,
+      "limit": 600,
+      "match_variable": "RequestHeader",
+      "type": "RateLimitRule",
+      "action": "Log",
+      "operator": "GreaterThanOrEqual",
+      "selector": "Host",
+      "match_values": "0"
+    }
+  ]
 }

--- a/terraform/custom_domains/infrastructure/workspace_variables/apply.tfvars.json
+++ b/terraform/custom_domains/infrastructure/workspace_variables/apply.tfvars.json
@@ -38,5 +38,6 @@
         "Service Offering": "Apply for postgraduate teacher training",
         "Environment": "Prod"
     },
-    "deploy_default_records": false
+    "deploy_default_records": false,
+    "azure_enable_monitoring": true
 }


### PR DESCRIPTION
## Context

Add rate limiting rules for qa and production

## Changes proposed in this pull request

Sets up some initial rate limiting 
- block specific path
- allow from aks
- also enables fd logging (card raised to remove this in a week or two)

This will be manually deployed to qa and tested, before merging to prod

## Guidance to review

make qa|production domains-plan
make domains-infra-plan

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
