### PR TITLE
Content changes to the EOC mailers

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -110,12 +110,16 @@ class CandidateMailer < ApplicationMailer
     @reference_condition = @application_choice.offer.reference_condition
     @course_name_and_code = @application_choice.current_course_option.course.name_and_code
     @application_form = @application_choice.application_form
-    @show_deadline_reminder = (@application_form.decline_by_default_at - 4.weeks).before? Time.zone.now
     @conditions = @application_choice.offer.conditions.select do |c|
       c.pending? &&
         c.type != 'ReferenceCondition' &&
         !c.standard_condition?
     end
+    @deadline_date = if @application_choice.course.present? && @application_choice.starts_after_september?
+                       @application_form.winter_decline_by_default_at
+                     else
+                       @application_form.decline_by_default_at
+                     end.to_fs(:govuk_time_first_no_year_date_time)
     email_for_candidate(@application_form, subject: I18n.t('candidate_mailer.new_offer_made.subject', provider_name: @course.provider.name))
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -119,7 +119,7 @@ class CandidateMailer < ApplicationMailer
                        @application_form.winter_decline_by_default_at
                      else
                        @application_form.decline_by_default_at
-                     end.to_fs(:govuk_time_first_no_year_date_time)
+                     end.to_fs(:govuk_date_time_time_first)
     email_for_candidate(@application_form, subject: I18n.t('candidate_mailer.new_offer_made.subject', provider_name: @course.provider.name))
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -26,6 +26,8 @@ class ApplicationForm < ApplicationRecord
            :apply_reopens_at,
            :academic_year_range_name,
            :current_year?,
+           :winter_reject_by_default_at,
+           :winter_decline_by_default_at,
            to: :recruitment_cycle_timetable
 
   belongs_to :candidate, touch: true

--- a/app/views/candidate_mailer/end_of_cycle/_deadline_to_apply.text.erb
+++ b/app/views/candidate_mailer/end_of_cycle/_deadline_to_apply.text.erb
@@ -1,1 +1,9 @@
-The deadline to apply to courses starting by the end of September <%= "#{@timetable.recruitment_cycle_year}" %> is <%= "#{@application_form.apply_deadline_at.to_fs(:govuk_date_time_time_first)}" %>. You’ll be able to apply for more courses from <%= "#{@next_timetable.apply_opens_at.to_fs(:govuk_date)}" %>.
+[Submit your application for teacher training](<%= application_choices_link %>) when you’re ready. The deadline to apply to courses starting by the end of September <%= "#{@timetable.recruitment_cycle_year}" %> is <%= "#{@application_form.apply_deadline_at.to_fs(:govuk_date_time_time_first)}" %>.
+
+Courses fill up quickly and may close early. Courses that offer visa sponsorship may have already closed.
+
+# If you’re not ready to submit your application
+
+If you’re not ready to apply now, you can continue preparing your application.
+
+From <%= "#{@next_timetable.apply_opens_at.to_fs(:govuk_date)}" %> you’ll be able to apply for courses starting in the <%= "#{@next_timetable.academic_year_range_name}" %> academic year.

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -2,13 +2,7 @@
 Dear <%= @application_form.first_name %>
 <% end %>
 
-[Submit your application for teacher training](<%= application_choices_link %>) as soon as you can to get on a course starting in the <%= @application_form.academic_year_range_name %> academic year.
-
 <%= render 'candidate_mailer/end_of_cycle/deadline_to_apply' %>
-
-Courses that offer visa sponsorship may already be closed for this cycle.
-
-Courses fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until next year to apply.
 
 <%= render 'gain_insights_into_life_as_a_teacher' %>
 

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -4,18 +4,6 @@ Dear <%= @application_form.first_name %>
 
 <%= render 'candidate_mailer/end_of_cycle/deadline_to_apply' %>
 
-[Sign in to your account to submit your application](<%= application_choices_link %>).
-
-<% if @application_form.adviser_status_assigned? %>
-Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.
-<% else %>
-Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.
-<% end %>
-
-# If you’re not ready to submit your application
-
-If you’re not ready to apply now, you can continue preparing your application. <%= "From #{l(@timetable.apply_reopens_at.to_date, format: :no_year)} you’ll be able to apply for courses starting in the #{@timetable.next_available_academic_year_range} academic year." %>
-
 <%= render 'gain_insights_into_life_as_a_teacher' %>
 
 <%= render 'candidate_mailer/end_of_cycle/get_help_with_application' %>

--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -38,4 +38,4 @@ You can wait to hear back from any other courses you have submitted applications
 
 [Sign in to your account to respond to your offer](<%= application_choices_link %>).
 
-<%= render 'get_help_teacher_training_adviser' %>
+<%= render 'candidate_mailer/end_of_cycle/contact_us' %>

--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -9,9 +9,7 @@ Congratulations! You have an offer from <%= @provider_name %> to study <%= @cour
   <% end %>
 <% end %>
 
-<% if @show_deadline_reminder %>
-  If you want to accept this offer, you must do so by <%=@application_form.decline_by_default_at.to_fs(:govuk_time_first_no_year_date_time) %>. If you have not responded by then, the offer will be automatically declined on your behalf.
-<% end %>
+If you want to accept this offer, you must do so by <%= @deadline_date %>. If you have not responded by then, the offer will be automatically declined on your behalf.
 
 You will have to pass essential checks before you can start your training.
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe CandidateMailer do
       end
 
       it 'renders not ready content' do
-        expect(email.body).to include("If you’re not ready to submit your application")
-        expect(email.body).to include("If you’re not ready to apply now, you can continue preparing your application.")
+        expect(email.body).to include('If you’re not ready to submit your application')
+        expect(email.body).to include('If you’re not ready to apply now, you can continue preparing your application.')
         expect(email.body).to include("From #{next_timetable.apply_opens_at.to_fs(:govuk_date)} you’ll be able to apply for courses starting in the #{next_timetable.academic_year_range_name} academic year.")
       end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         'Submit your teacher training application before courses fill up',
         'heading' => 'Dear Fred',
-        'offer visa sponsorship' => 'Courses that offer visa sponsorship may already be closed for this cycle.',
-        'courses fill up' => 'Courses fill up quickly, so apply as soon as you are ready. If a course closes, you will need to wait until next year to apply.',
+        'submit' => 'Submit your application for teacher training',
+        'when ready' => 'when you’re ready.',
+        'courses fill up' => 'Courses fill up quickly and may close early. Courses that offer visa sponsorship may have already closed.',
         'realistic job preview heading' => 'Gain insights into life as a teacher',
         'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
@@ -24,10 +25,14 @@ RSpec.describe CandidateMailer do
 
       it_behaves_like 'an email with unsubscribe option'
 
-      it 'renders the correct dates' do
-        expect(email.body).to include("as soon as you can to get on a course starting in the #{current_timetable.academic_year_range_name} academic year.")
+      it 'renders the correct deadline' do
         expect(email.body).to include("The deadline to apply to courses starting by the end of September #{timetable.recruitment_cycle_year} is #{application_form.apply_deadline_at.to_fs(:govuk_date_time_time_first)}.")
-        expect(email.body).to include("You’ll be able to apply for more courses from #{next_timetable.apply_opens_at.to_fs(:govuk_date)}.")
+      end
+
+      it 'renders not ready content' do
+        expect(email.body).to include("If you’re not ready to submit your application")
+        expect(email.body).to include("If you’re not ready to apply now, you can continue preparing your application.")
+        expect(email.body).to include("From #{next_timetable.apply_opens_at.to_fs(:govuk_date)} you’ll be able to apply for courses starting in the #{next_timetable.academic_year_range_name} academic year.")
       end
 
       it 'renders get help with your application' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       "Submit your teacher training application before #{I18n.l(current_timetable.apply_deadline_at.to_date, format: :no_year)}",
       'heading' => 'Dear Fred',
-      'cycle_details' => "you’ll be able to apply for courses starting in the #{current_timetable.academic_year_range_name} academic year.",
+      'submit' => 'Submit your application for teacher training',
+      'when ready' => 'when you’re ready.',
+      'courses fill up' => 'Courses fill up quickly and may close early. Courses that offer visa sponsorship may have already closed.',
       'realistic job preview heading' => 'Gain insights into life as a teacher',
       'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
@@ -24,11 +26,12 @@ RSpec.describe CandidateMailer do
 
     it 'renders the correct dates' do
       expect(email.body).to include("The deadline to apply to courses starting by the end of September #{timetable.recruitment_cycle_year} is #{application_form.apply_deadline_at.to_fs(:govuk_date_time_time_first)}.")
-      expect(email.body).to include("You’ll be able to apply for more courses from #{next_timetable.apply_opens_at.to_fs(:govuk_date)}.")
     end
 
-    it 'renders adviser sign up text if not already assigned' do
-      expect(email.body).to include('Need help writing a strong application? You can [get a teacher training adviser]')
+    it 'renders not ready content' do
+      expect(email.body).to include("If you’re not ready to submit your application")
+      expect(email.body).to include("If you’re not ready to apply now, you can continue preparing your application.")
+      expect(email.body).to include("From #{next_timetable.apply_opens_at.to_fs(:govuk_date)} you’ll be able to apply for courses starting in the #{next_timetable.academic_year_range_name} academic year.")
     end
 
     it 'renders get help with your application' do
@@ -48,7 +51,7 @@ RSpec.describe CandidateMailer do
     subject(:email) { described_class.eoc_second_deadline_reminder(application_form_with_adviser_eligibility) }
 
     it 'refers to existing adviser' do
-      expect(email.body).to have_text 'Need help writing a strong application? You can get in touch with your teacher training adviser for one-to-one support.'
+      expect(email.body).to have_text 'You can also contact your teacher training adviser for support with writing your application.'
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe CandidateMailer do
     end
 
     it 'renders not ready content' do
-      expect(email.body).to include("If you’re not ready to submit your application")
-      expect(email.body).to include("If you’re not ready to apply now, you can continue preparing your application.")
+      expect(email.body).to include('If you’re not ready to submit your application')
+      expect(email.body).to include('If you’re not ready to apply now, you can continue preparing your application.')
       expect(email.body).to include("From #{next_timetable.apply_opens_at.to_fs(:govuk_date)} you’ll be able to apply for courses starting in the #{next_timetable.academic_year_range_name} academic year.")
     end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateMailer do
 
   describe '.new_offer_made well in advance of the decline by default date' do
     let(:application_choices) do
-      [build_stubbed(
+      [create(
         :application_choice,
         :offered,
         status: 'offer',
@@ -34,8 +34,8 @@ RSpec.describe CandidateMailer do
       )
     end
 
-    it 'does not render offer deadline text' do
-      expect(email.body).not_to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_time_first_no_year_date_time)}. If you have not responded by then, the offer will be automatically declined on your behalf."
+    it 'renders offer deadline text' do
+      expect(email.body).to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_time_first_no_year_date_time)}. If you have not responded by then, the offer will be automatically declined on your behalf."
     end
 
     context 'when the offer has a reference condition' do
@@ -56,7 +56,7 @@ RSpec.describe CandidateMailer do
   describe '.new_offer_made within 4 weeks of decline by default date' do
     let(:email) { described_class.new_offer_made(application_form.application_choices.first) }
     let(:application_choices) do
-      [build_stubbed(
+      [create(
         :application_choice,
         :offered,
         status: 'offer',
@@ -78,7 +78,7 @@ RSpec.describe CandidateMailer do
   describe '.new_offer_made with ske conditions' do
     let(:email) { described_class.new_offer_made(application_form.application_choices.first) }
     let(:application_choices) do
-      [build_stubbed(
+      [create(
         :application_choice,
         :offered,
         status: 'offer',

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_offer_made_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateMailer do
     end
 
     it 'renders offer deadline text' do
-      expect(email.body).to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_time_first_no_year_date_time)}. If you have not responded by then, the offer will be automatically declined on your behalf."
+      expect(email.body).to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. If you have not responded by then, the offer will be automatically declined on your behalf."
     end
 
     context 'when the offer has a reference condition' do
@@ -71,7 +71,7 @@ RSpec.describe CandidateMailer do
     it 'renders essential checks and deadline reminder text' do
       expect(email.body).to include 'An enhanced disclosure and barring service (DBS) check. This is a criminal records check to make sure it is safe for you to work with children. If you are from outside of the UK and Ireland then the training provider will request a criminal records check from your home country.'
       expect(email.body).to include 'A fitness to train to teach check. These are questions to check your ability to meet teaching standards, both physically and mentally.'
-      expect(email.body).to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_time_first_no_year_date_time)}. If you have not responded by then, the offer will be automatically declined on your behalf."
+      expect(email.body).to include "If you want to accept this offer, you must do so by #{current_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. If you have not responded by then, the offer will be automatically declined on your behalf."
     end
   end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe ApplicationForm do
     it { is_expected.to delegate_method(:apply_reopens_at).to(:recruitment_cycle_timetable) }
     it { is_expected.to delegate_method(:academic_year_range_name).to(:recruitment_cycle_timetable) }
     it { is_expected.to delegate_method(:current_year?).to(:recruitment_cycle_timetable) }
+    it { is_expected.to delegate_method(:winter_reject_by_default_at).to(:recruitment_cycle_timetable) }
+    it { is_expected.to delegate_method(:winter_decline_by_default_at).to(:recruitment_cycle_timetable) }
     it { is_expected.to delegate_method(:opt_in?).to(:published_preference).with_prefix.allow_nil }
   end
 


### PR DESCRIPTION
## Context

- Changes to the EOC reminder and offer made emails.

## Changes proposed in this pull request

- Make changes to the EOC reminder emails and offer made email to what is requested in the [trello ticket](https://trello.com/c/REdA7nzV/1893-comms-check-to-15th-september-apply-deadline).

## Guidance to review

- Visit https://apply-review-12062.test.teacherservices.cloud/support/sign-in
- Sign in as a Support user
- First deadline reminder email
  - Visit https://apply-review-12062.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/eoc_first_deadline_reminder
  - Check the content is correct
- Second deadline reminder email
  - Visit https://apply-review-12062.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/eoc_second_deadline_reminder
  - Check the content is correct
- Offer email
  - Visit https://apply-review-12062.test.teacherservices.cloud/rails/mailers/candidate/offers/new_offer_made
  - Check the content is correct  


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/REdA7nzV/1893-comms-check-to-15th-september-apply-deadline

## Screenshots
_First deadline reminder email_
<img width="292" height="666" alt="Screenshot 2026-06-24 at 16 42 51" src="https://github.com/user-attachments/assets/8a9ebaab-3bd9-401e-80ee-dd9a3a4f2872" />

_Second deadline reminder email_
<img width="303" height="665" alt="Screenshot 2026-06-24 at 16 44 12" src="https://github.com/user-attachments/assets/7f90f563-62bd-4b53-aacc-8d1faa1104dd" />

_Offer email_
<img width="296" height="666" alt="Screenshot 2026-06-24 at 16 44 48" src="https://github.com/user-attachments/assets/d3f65db1-28af-4de5-a53c-d6d766e9ba31" />
