### PR TITLE
Provider view changes for visa and rsidency information

### DIFF
--- a/app/components/provider_interface/contact_information_component.rb
+++ b/app/components/provider_interface/contact_information_component.rb
@@ -17,7 +17,6 @@ module ProviderInterface
         phone_number_row,
         email_row,
         address_row,
-        residency_row,
       ].compact
     end
 
@@ -41,16 +40,6 @@ module ProviderInterface
       {
         key: 'Address',
         value: application_form.full_address,
-      }
-    end
-
-    def residency_row
-      return unless FeatureFlag.active?('2027_application_form_contact_details_residency_questions')
-      return if @application_form.country_residency_date_from.blank?
-
-      {
-        key: "Lived in #{CountryFinder.find_name_from_hesa_code(@application_form.country)} since",
-        value: @application_form.country_residency_since_birth ? 'Birth' : @application_form.country_residency_date_from.to_fs(:month_and_year),
       }
     end
 

--- a/app/components/provider_interface/personal_information_component.rb
+++ b/app/components/provider_interface/personal_information_component.rb
@@ -26,10 +26,11 @@ module ProviderInterface
         date_of_birth_row,
         nationality_row,
         right_to_work_or_study_row,
-        residency_details_row,
-        candidate_id_number,
+        visa_status_row,
         visa_expiry_row,
         visa_explanation_row,
+        residency_row,
+        candidate_id_number,
       ].compact
     end
 
@@ -65,11 +66,11 @@ module ProviderInterface
       }
     end
 
-    def residency_details_row
+    def visa_status_row
       return unless application_form.right_to_work_or_study == 'yes'
 
       {
-        key: 'Residency details',
+        key: 'Visa type or immigration status',
         value: FormatResidencyDetailsService.new(application_form:).residency_details_value,
       }
     end
@@ -98,10 +99,19 @@ module ProviderInterface
          @application_choice&.visa_expires_soon?
 
         {
-          key: t('visa_expiry_form.visa_explanation_label'),
+          key: 'Visa status',
           value: render(VisaExplanationComponent.new(@application_choice)),
         }
       end
+    end
+
+    def residency_row
+      return if @application_form.country_residency_date_from.blank?
+
+      {
+        key: "Lived in #{CountryFinder.find_name_from_hesa_code(@application_form.country)} since",
+        value: @application_form.country_residency_since_birth ? 'Birth' : @application_form.country_residency_date_from.to_fs(:month_and_year),
+      }
     end
 
     def date_of_birth_row

--- a/spec/components/provider_interface/contact_information_component_spec.rb
+++ b/spec/components/provider_interface/contact_information_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProviderInterface::ContactInformationComponent do
   subject(:result) { render_inline(described_class.new(application_form:)) }
 
   it 'renders component with correct labels' do
-    ['Phone number', 'Email address', 'Address', 'Lived in Wales since'].each do |key|
+    ['Phone number', 'Email address', 'Address'].each do |key|
       expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
   end
@@ -29,9 +29,5 @@ RSpec.describe ProviderInterface::ContactInformationComponent do
     application_form.full_address.each do |address_line|
       expect(result.css('.govuk-summary-list__value').text).to include(address_line)
     end
-  end
-
-  it 'renders the residency start point' do
-    expect(result.css('.govuk-summary-list__value').text).to include('Birth')
   end
 end

--- a/spec/components/provider_interface/personal_information_component_spec.rb
+++ b/spec/components/provider_interface/personal_information_component_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
         application_form.right_to_work_or_study_details = nil
       end
 
-      it 'renders the residency_details_row' do
-        expect(result.css('.govuk-summary-list__key').text).to include('Residency details')
+      it 'renders the visa information row' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa type or immigration status')
         expect(result.css('.govuk-summary-list__value').text).to include('EU settled status')
       end
     end
@@ -135,8 +135,8 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
         application_form.right_to_work_or_study_details = 'Indefinite leave to remain'
       end
 
-      it 'renders the residency_details_row' do
-        expect(result.css('.govuk-summary-list__key').text).to include('Residency details')
+      it 'renders the visa information row' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa type or immigration status')
         expect(result.css('.govuk-summary-list__value').text).to include('Indefinite leave to remain')
       end
     end
@@ -144,16 +144,41 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
     context 'the right to work or study status is "no"' do
       before { application_form.right_to_work_or_study = 'no' }
 
-      it 'does not render the residency_details_row' do
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Residency details')
+      it 'does not render the visa information row' do
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa type or immigration status')
       end
     end
 
     context 'the right to work or study status is "decide_later"' do
       before { application_form.right_to_work_or_study = 'decide_later' }
 
-      it 'does not render the residency_details_row' do
+      it 'does not render the visa information row' do
         expect(result.css('.govuk-summary-list__key').text).not_to include('Residency details')
+      end
+    end
+
+    context 'lived in UK since birth' do
+      before do
+        application_form.country_residency_since_birth = true
+      end
+
+      it 'renders residency details for living in the UK since birth' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Lived in United Kingdom since')
+        expect(result.css('.govuk-summary-list__value').text).to include('Birth')
+      end
+    end
+
+    context 'lived in UK since 5 years ago' do
+      let(:residency_date) { 5.years.ago }
+
+      before do
+        application_form.country_residency_since_birth = false
+        application_form.country_residency_date_from = residency_date
+      end
+
+      it 'renders residency details for living in the UK since 5 years ago' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Lived in United Kingdom since')
+        expect(result.css('.govuk-summary-list__value').text).to include(residency_date.to_fs(:month_and_year))
       end
     end
   end


### PR DESCRIPTION
## Context

The provider view did not present the new visa and residency information sensibly.

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="706" height="875" alt="image" src="https://github.com/user-attachments/assets/46bb38eb-ab86-40f7-a18a-e467a91c7c3d" /> | <img width="720" height="888" alt="image" src="https://github.com/user-attachments/assets/14c37cf0-a906-4fc4-ae56-4989adf712d5" /> |

## Guidance to review

With visa and residency feature flags activated, add relevant details to a candidate.
Submit an application.
View the application as a provider
You should see the information presented correctly.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
