### PR TITLE
Resolve bug by defaulting to application choice course option

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -109,7 +109,7 @@ module ProviderInterface
     end
 
     def course_option
-      CourseOption.find_by(id: course_option_id)
+      CourseOption.find_by(id: course_option_id) || application_choice.current_course_option
     end
 
     def ske_conditions_attributes=(attributes)


### PR DESCRIPTION
## Context

- If the OfferWizard can not find a selected course option, revert to the current course option for the application choice.

## Changes proposed in this pull request

- If the OfferWizard can not find a selected course option, revert to the current course option for the application choice.

## Guidance to review

- Check the code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Screen recording

https://github.com/user-attachments/assets/daefb58f-fd45-4b0e-8d45-0c5aa0a7e91d

