### PR TITLE
Fix SQL bug in duplicate matches

### DIFF
--- a/app/queries/get_duplicate_matches.rb
+++ b/app/queries/get_duplicate_matches.rb
@@ -1,39 +1,36 @@
 class GetDuplicateMatches
   def self.call
     ActiveRecord::Base.connection.exec_query(
-      "SELECT DISTINCT application_details.candidate_id,
-          application_details.first_name,
-          application_details.last_name last_name,
-          COALESCE(TRIM(UPPER(application_details.postcode)), '') postcode,
-          application_details.date_of_birth,
-          email_address,
-          submitted_at
-        FROM application_forms application_details
-        JOIN(
-          SELECT TRIM(UPPER(unaccent(application_forms.last_name))) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
-          FROM application_forms
-          WHERE application_forms.previous_application_form_id IS NULL
-          GROUP BY TRIM(UPPER(unaccent(application_forms.last_name))), application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '')
-          HAVING (count(*) > 1)
-        ) duplicate_attributes
-        ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_attributes.postcode
-        AND application_details.date_of_birth = duplicate_attributes.date_of_birth
-        AND TRIM(UPPER(unaccent(application_details.last_name))) = duplicate_attributes.last_name
-        JOIN(
-          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
-          FROM application_forms
-          WHERE application_forms.previous_application_form_id IS NULL
-        ) duplicate_submitted_attributes
-        ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_submitted_attributes.postcode
-        AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
-        AND TRIM(UPPER(application_details.last_name)) = duplicate_submitted_attributes.last_name
-        JOIN(
-          SELECT candidates.id, candidates.email_address
-          FROM candidates
-        ) candidate_details
-        ON application_details.candidate_id = candidate_details.id
-        WHERE application_details.previous_application_form_id IS NULL
-        ORDER BY last_name, application_details.date_of_birth, postcode;",
+      "SELECT DISTINCT ON (application_details.candidate_id) application_details.candidate_id,
+        application_details.first_name,
+        application_details.last_name last_name,
+        COALESCE(TRIM(UPPER(application_details.postcode)), '') postcode,
+        application_details.date_of_birth,
+        email_address,
+        submitted_at
+      FROM application_forms application_details
+      JOIN(
+        SELECT TRIM(UPPER(unaccent(application_forms.last_name))) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
+        FROM application_forms
+        GROUP BY TRIM(UPPER(unaccent(application_forms.last_name))), application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '')
+        HAVING (COUNT(DISTINCT application_forms.candidate_id) > 1)
+      ) duplicate_attributes
+      ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_attributes.postcode
+      AND application_details.date_of_birth = duplicate_attributes.date_of_birth
+      AND TRIM(UPPER(unaccent(application_details.last_name))) = duplicate_attributes.last_name
+      JOIN(
+        SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
+        FROM application_forms
+      ) duplicate_submitted_attributes
+      ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_submitted_attributes.postcode
+      AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
+      AND TRIM(UPPER(application_details.last_name)) = duplicate_submitted_attributes.last_name
+      JOIN(
+        SELECT candidates.id, candidates.email_address
+        FROM candidates
+      ) candidate_details
+      ON application_details.candidate_id = candidate_details.id
+      ORDER BY application_details.candidate_id, last_name, application_details.date_of_birth, postcode, application_details.submitted_at DESC;",
     ).to_a
   end
 end

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -187,6 +187,58 @@ RSpec.describe GetDuplicateMatches do
       end
     end
 
+    context 'when the previous application has a different postcode' do
+      before do
+        form_1 = application_form(candidate_1, postcode: 'SA1 1AA')
+        application_form(candidate_1, previous_application_form: form_1)
+
+        application_form(candidate_2)
+      end
+
+      it 'returns all duplicates' do
+        expect(candidate_ids).to contain_exactly(candidate_1.id, candidate_2.id)
+      end
+    end
+
+    context 'when one candidate has a carried-over application matching another candidate' do
+      before do
+        original = application_form(candidate_1, postcode: nil, address_type: 'international')
+        application_form(candidate_1, previous_application_form: original, postcode: 'LS1 1AA')
+
+        application_form(candidate_2, postcode: 'LS1 1AA')
+      end
+
+      it 'returns both candidates' do
+        expect(candidate_ids).to contain_exactly(candidate_1.id, candidate_2.id)
+      end
+    end
+
+    context 'when the same candidate has multiple applications with matching attributes' do
+      before do
+        form_1 = application_form(candidate_1)
+        application_form(candidate_1, previous_application_form: form_1)
+      end
+
+      it 'does not treat them as duplicates' do
+        expect(candidate_ids).not_to include(candidate_1.id)
+      end
+    end
+
+    context 'when candidates have multiple matching applications each' do
+      before do
+        form_1 = application_form(candidate_1)
+        application_form(candidate_1, previous_application_form: form_1)
+
+        form_2 = application_form(candidate_2)
+        application_form(candidate_2, previous_application_form: form_2)
+      end
+
+      it 'returns each candidate only once' do
+        expect(candidate_ids.count(candidate_1.id)).to eq(1)
+        expect(candidate_ids.count(candidate_2.id)).to eq(1)
+      end
+    end
+
     def application_form(candidate, first_name: 'Jeffrey', last_name: 'Thompson', date_of_birth: '1998-08-08', postcode: 'w6 9bh', submitted_at: Time.zone.now, **attributes)
       create(:application_form, candidate:, first_name:, last_name:, date_of_birth:, postcode:, submitted_at:, **attributes)
     end


### PR DESCRIPTION
## Context

The query was unable to detect duplicates that occurred between a carried over application and its duplicate (original or carried over). 

This PR fixes duplicate detection to identify matching candidates across all applications, while avoiding self-matching from carried-over applications.

## Changes proposed in this pull request

- Use candidate to avoid self matching, rather than filtering out all rolled over applications from the outset

## Step-by-step explanation of the query

This updated query improves how we detect potential duplicate people across different candidate accounts.
Previously, we avoided self-matching by excluding all rolled-over applications (`previous_application_form_id IS NULL`). This meant some valid duplicates could be missed when relevant data (e.g. postcode) was only present on a carried-over application.

The new approach includes all applications in the matching logic, and instead avoids self-matching by only considering cases where multiple distinct `candidate_ids` share the same last name, date of birth, and postcode.
The query also ensures we return a single row per candidate, rather than multiple application rows. This aligns with how `UpdateDuplicateMatches` works, which operates at the candidate account level (e.g. blocking submissions, sending emails), rather than on individual application forms.

⚠️ I have used Copilot to help with understanding and editing the query, so please review with care. I have reasoned about the changes separately in a comment on the [Trello ticket](https://trello.com/c/CGc1U1Ji/1953-bug-duplicate-accounts-are-not-flagged-if-they-have-previous-applications).

_Step 1: Build a set of "duplicate identity groups"_
- Cleans up last_name and postcode for consistent matching
- Groups by last_name, date_of_birth, and postcode
- Keeps only groups with more than one candidate_id
  → unlike the old query, this only keeps groups that contain multiple distinct candidate_ids

_Step 2: Join application_forms back onto those duplicate groups_
- Returns all applications that belong to these duplicate groups
- The old query only looked at original submissions; this uses all records

_Step 3: Join candidates table_
- Adds email_address (same as before)

_Step 4: DISTINCT ON (candidate_id)_
- Returns one row per candidate
- Replaces the previous DISTINCT, which could in theory return multiple rows per candidate but was limited to one by only comparing current with originals

_Step 5: ORDER BY ... submitted_at DESC_
- Determines which application row is selected per candidate for the DISTINCT ON, but does not affect duplicate detection
- The selected row is effectively a representative record rather than a meaningful ‘source’ of the duplicate

_Final result:_
- One row per candidate who shares (last_name, DOB, postcode) with at least one other candidate

## Guidance to review

- Please carefully review the SQL
- Consider whether more specs are needed to assure the query is doing what is expected

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
