### PR TITLE
Add unique constraint and validation for application forms per candidate and recruitment cycle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,3 +113,7 @@ Rails/DangerousColumnNames:
 
 Naming/PredicateMethod:
   Enabled: false
+
+Rails/UniqueValidationWithoutIndex:
+  Exclude:
+    - app/models/application_form.rb

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -33,9 +33,8 @@ module CandidateInterface
     end
 
     def prefill_candidate_application_form
-      example_application_choices = factory.create_application(**test_application_options)
-
       destroy_blank_application
+      example_application_choices = factory.create_application(**test_application_options)
 
       example_application_form = example_application_choices.first.application_form
       current_candidate.application_forms << example_application_form

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -6,6 +6,8 @@ class ApplicationForm < ApplicationRecord
   before_validation :set_residency_date_from,
                     if: -> { FeatureFlag.active?('2027_application_form_contact_details_residency_questions') }
 
+  validates :candidate_id, uniqueness: { scope: :recruitment_cycle_year }
+
   include Chased
   include AdviserEligibility
   include HasApplicableDegreeForAdviser

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -6,7 +6,7 @@ class ApplicationForm < ApplicationRecord
   before_validation :set_residency_date_from,
                     if: -> { FeatureFlag.active?('2027_application_form_contact_details_residency_questions') }
 
-  validates :candidate_id, uniqueness: { scope: :recruitment_cycle_year }
+  validates :candidate_id, uniqueness: { scope: :recruitment_cycle_year }, on: :create
 
   include Chased
   include AdviserEligibility

--- a/db/migrate/20260701120752_add_candidate_recruitment_cycle_index_to_applications.rb
+++ b/db/migrate/20260701120752_add_candidate_recruitment_cycle_index_to_applications.rb
@@ -1,7 +1,0 @@
-class AddCandidateRecruitmentCycleIndexToApplications < ActiveRecord::Migration[8.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :application_forms, [:recruitment_cycle_year, :candidate_id], unique: true, algorithm: :concurrently
-  end
-end

--- a/db/migrate/20260701120752_add_candidate_recruitment_cycle_index_to_applications.rb
+++ b/db/migrate/20260701120752_add_candidate_recruitment_cycle_index_to_applications.rb
@@ -1,0 +1,7 @@
+class AddCandidateRecruitmentCycleIndexToApplications < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :application_forms, [:recruitment_cycle_year, :candidate_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_120752) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_082943) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -268,7 +268,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_120752) do
     t.text "work_history_explanation"
     t.string "work_history_status"
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
-    t.index ["recruitment_cycle_year", "candidate_id"], name: "idx_on_recruitment_cycle_year_candidate_id_0a3728aa34", unique: true
     t.index ["recruitment_cycle_year"], name: "index_application_forms_on_recruitment_cycle_year"
     t.index ["submitted_at"], name: "index_application_forms_on_submitted_at"
     t.index ["updated_at"], name: "index_application_forms_on_updated_at", order: :desc

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_082943) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_120752) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -268,6 +268,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_082943) do
     t.text "work_history_explanation"
     t.string "work_history_status"
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
+    t.index ["recruitment_cycle_year", "candidate_id"], name: "idx_on_recruitment_cycle_year_candidate_id_0a3728aa34", unique: true
     t.index ["recruitment_cycle_year"], name: "index_application_forms_on_recruitment_cycle_year"
     t.index ["submitted_at"], name: "index_application_forms_on_submitted_at"
     t.index ["updated_at"], name: "index_application_forms_on_updated_at", order: :desc

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -1,0 +1,1052 @@
+erDiagram
+	direction TB
+	AccountRecoveryRequest {
+		string previous_account_email_address
+	}
+	AccountRecoveryRequestCode {
+		string code_digest
+	}
+	"ActiveStorage::Attachment" {
+		string name
+		string record_type
+	}
+	"ActiveStorage::Blob" {
+		integer byte_size
+		string checksum
+		string content_type
+		string filename
+		string key
+		text metadata
+		string service_name
+	}
+	"ActiveStorage::VariantRecord" {
+		string variation_digest
+	}
+	"Adviser::SignUpRequest" {
+		datetime sent_to_adviser_at
+	}
+	"Adviser::TeachingSubject" {
+		datetime discarded_at
+		string external_identifier
+		string level
+		string title
+	}
+	ApplicationChoice {
+		datetime accepted_at
+		datetime conditions_not_met_at
+		datetime course_changed_at
+		integer current_recruitment_cycle_year
+		datetime declined_at
+		boolean declined_by_default
+		datetime inactive_at
+		datetime offer_changed_at
+		datetime offer_deferred_at
+		string offer_withdrawal_reason
+		datetime offer_withdrawn_at
+		datetime offered_at
+		text personal_statement
+		integer provider_ids
+		datetime recruited_at
+		datetime reject_by_default_at
+		integer reject_by_default_days
+		datetime reject_by_default_feedback_sent_at
+		datetime rejected_at
+		boolean rejected_by_default
+		string rejection_reason
+		string rejection_reasons_type
+		boolean school_placement_auto_selected
+		datetime sent_to_provider_at
+		string status
+		string status_before_deferral
+		jsonb structured_rejection_reasons
+		text structured_withdrawal_reasons
+		string visa_explanation
+		string visa_explanation_details
+		jsonb withdrawal_feedback
+		datetime withdrawn_at
+		boolean withdrawn_or_declined_for_candidate_by_provider
+	}
+	ApplicationExperience {
+		string commitment
+		boolean currently_working
+		text details
+		datetime end_date
+		boolean end_date_unknown
+		string experienceable_type
+		string organisation
+		boolean relevant_skills
+		string role
+		datetime start_date
+		boolean start_date_unknown
+		string working_pattern
+		boolean working_with_children
+	}
+	ApplicationFeedback {
+		boolean consent_to_be_contacted
+		string feedback
+		string page_title
+		string path
+	}
+	ApplicationForm {
+		string address_line1
+		string address_line2
+		string address_line3
+		string address_line4
+		string address_type
+		boolean adviser_interruption_response
+		string adviser_status
+		text becoming_a_teacher
+		boolean becoming_a_teacher_completed
+		datetime becoming_a_teacher_completed_at
+		boolean contact_details_completed
+		datetime contact_details_completed_at
+		string country
+		datetime country_residency_date_from
+		boolean country_residency_since_birth
+		boolean course_choices_completed
+		datetime course_choices_completed_at
+		date date_of_birth
+		boolean degrees_completed
+		datetime degrees_completed_at
+		string disability_disclosure
+		boolean disclose_disability
+		datetime edit_by
+		jsonb editable_sections
+		datetime editable_until
+		boolean efl_completed
+		datetime efl_completed_at
+		boolean english_gcse_completed
+		datetime english_gcse_completed_at
+		text english_language_details
+		boolean english_main_language
+		jsonb equality_and_diversity
+		boolean equality_and_diversity_completed
+		datetime equality_and_diversity_completed_at
+		boolean feedback_form_complete
+		string feedback_satisfaction_level
+		text feedback_suggestions
+		string fifth_nationality
+		string first_name
+		string first_nationality
+		string fourth_nationality
+		text further_information
+		string immigration_status
+		string international_address
+		text interview_preferences
+		boolean interview_preferences_completed
+		datetime interview_preferences_completed_at
+		string last_name
+		float latitude
+		float longitude
+		boolean maths_gcse_completed
+		datetime maths_gcse_completed_at
+		boolean no_other_qualifications
+		text other_language_details
+		boolean other_qualifications_completed
+		datetime other_qualifications_completed_at
+		boolean personal_details_completed
+		datetime personal_details_completed_at
+		string phase
+		string phone_number
+		string postcode
+		boolean previous_teacher_training_completed
+		datetime previous_teacher_training_completed_at
+		boolean references_completed
+		datetime references_completed_at
+		string region_code
+		string right_to_work_or_study
+		string right_to_work_or_study_details
+		text safeguarding_issues
+		boolean safeguarding_issues_completed
+		datetime safeguarding_issues_completed_at
+		string safeguarding_issues_status
+		boolean science_gcse_completed
+		datetime science_gcse_completed_at
+		string second_nationality
+		text subject_knowledge
+		boolean subject_knowledge_completed
+		datetime subject_knowledge_completed_at
+		datetime submitted_at
+		string support_reference
+		string third_nationality
+		boolean training_with_a_disability_completed
+		datetime training_with_a_disability_completed_at
+		boolean university_degree
+		datetime visa_expired_at
+		boolean volunteering_completed
+		datetime volunteering_completed_at
+		boolean volunteering_experience
+		text work_history_breaks
+		boolean work_history_completed
+		datetime work_history_completed_at
+		text work_history_explanation
+		string work_history_status
+	}
+	ApplicationQualification {
+		string award_year
+		string comparable_uk_degree
+		string comparable_uk_qualification
+		jsonb constituent_grades
+		boolean currently_completing_qualification
+		uuid degree_grade_uuid
+		uuid degree_institution_uuid
+		uuid degree_subject_uuid
+		uuid degree_type_uuid
+		string enic_reason
+		string enic_reference
+		string grade
+		string grade_hesa_code
+		string institution_country
+		string institution_hesa_code
+		string institution_name
+		boolean international
+		string level
+		text missing_explanation
+		string non_uk_qualification_type
+		text not_completed_explanation
+		string other_uk_qualification_type
+		boolean predicted_grade
+		integer public_id
+		string qualification_level
+		uuid qualification_level_uuid
+		string qualification_type
+		string qualification_type_hesa_code
+		string start_year
+		string subject
+		string subject_hesa_code
+	}
+	ApplicationReference {
+		datetime cancelled_at
+		datetime cancelled_at_end_of_cycle_at
+		boolean confidential
+		boolean consent_to_be_contacted
+		boolean duplicate
+		string email_address
+		datetime email_bounced_at
+		string feedback
+		datetime feedback_provided_at
+		datetime feedback_refused_at
+		string feedback_status
+		string hashed_sign_in_token
+		string name
+		jsonb questionnaire
+		string referee_type
+		boolean refused
+		string relationship
+		string relationship_correction
+		datetime reminder_sent_at
+		boolean replacement
+		datetime requested_at
+		string safeguarding_concerns
+		string safeguarding_concerns_status
+		boolean selected
+	}
+	ApplicationVolunteeringExperience {
+	}
+	ApplicationWorkExperience {
+	}
+	ApplicationWorkHistoryBreak {
+		string breakable_type
+		datetime end_date
+		text reason
+		datetime start_date
+	}
+	AuthenticationToken {
+		string hashed_token
+		string path
+		datetime used_at
+		string user_type
+	}
+	"Blazer::Audit" {
+		string data_source
+		text statement
+		integer user_id
+	}
+	"Blazer::Check" {
+		string check_type
+		integer creator_id
+		text emails
+		datetime last_run_at
+		text message
+		string schedule
+		text slack_channels
+		string state
+	}
+	"Blazer::Dashboard" {
+		integer creator_id
+		string name
+	}
+	"Blazer::DashboardQuery" {
+		integer position
+	}
+	"Blazer::Query" {
+		integer creator_id
+		string data_source
+		text description
+		string name
+		text statement
+		string status
+	}
+	Candidate {
+		boolean account_locked
+		string account_recovery_status
+		datetime candidate_api_updated_at
+		string email_address
+		boolean hide_in_reporting
+		datetime last_signed_in_at
+		string magic_link_token
+		datetime magic_link_token_sent_at
+		boolean sign_up_email_bounced
+		boolean submission_blocked
+		boolean unsubscribed_from_emails
+	}
+	CandidateLocationPreference {
+		decimal latitude
+		decimal longitude
+		string name
+		float within
+	}
+	CandidatePoolApplication {
+		boolean course_funding_type_fee
+		boolean course_type_postgraduate
+		boolean course_type_undergraduate
+		boolean needs_visa
+		integer rejected_provider_ids
+		boolean study_mode_full_time
+		boolean study_mode_part_time
+		integer subject_ids
+	}
+	CandidatePreference {
+		boolean dynamic_location_preferences
+		string funding_type
+		text opt_out_reason
+		string pool_status
+		string status
+		string training_locations
+	}
+	ChaserSent {
+		string chased_type
+		string chaser_type
+		integer course_id
+	}
+	Course {
+		boolean accept_english_gcse_equivalency
+		boolean accept_gcse_equivalency
+		boolean accept_maths_gcse_equivalency
+		boolean accept_pending_gcse
+		boolean accept_science_gcse_equivalency
+		string additional_gcse_equivalencies
+		string age_range
+		integer application_status
+		datetime applications_open_from
+		boolean can_sponsor_skilled_worker_visa
+		boolean can_sponsor_student_visa
+		string code
+		string course_length
+		string degree_grade
+		string degree_subject_requirements
+		string description
+		boolean exposed_in_find
+		string fee_details
+		integer fee_domestic
+		integer fee_international
+		string financial_support
+		string funding_type
+		string level
+		string name
+		string program_type
+		jsonb qualifications
+		string salary_details
+		datetime start_date
+		string study_mode
+		uuid uuid
+		datetime visa_sponsorship_application_deadline_at
+		boolean withdrawn
+	}
+	CourseOption {
+		boolean site_still_valid
+		string study_mode
+		string vacancy_status
+	}
+	CourseSubject {
+	}
+	DataExport {
+		datetime completed_at
+		string export_type
+		integer initiator_id
+		string initiator_type
+		string name
+	}
+	DataMigration {
+		string service_name
+		string timestamp
+	}
+	DeferredOfferConfirmation {
+		string conditions_status
+		string study_mode
+	}
+	"DeferredOfferConfirmation::ConditionsForm" {
+		string conditions_status
+		integer course_id
+		integer offer_id
+		integer offered_course_option_id
+		integer provider_user_id
+		integer site_id
+		string study_mode
+	}
+	"DeferredOfferConfirmation::CourseForm" {
+		string conditions_status
+		integer course_id
+		integer offer_id
+		integer offered_course_option_id
+		integer provider_user_id
+		integer site_id
+		string study_mode
+	}
+	"DeferredOfferConfirmation::LocationForm" {
+		string conditions_status
+		integer course_id
+		integer offer_id
+		integer offered_course_option_id
+		integer provider_user_id
+		integer site_id
+		string study_mode
+	}
+	"DeferredOfferConfirmation::StudyModeForm" {
+		string conditions_status
+		integer course_id
+		integer offer_id
+		integer offered_course_option_id
+		integer provider_user_id
+		integer site_id
+		string study_mode
+	}
+	DsiSession {
+		string dfe_sign_in_uid
+		string email_address
+		string first_name
+		string id_token
+		string ip_address
+		datetime last_active_at
+		string last_name
+		string user_agent
+		string user_type
+	}
+	DuplicateMatch {
+		boolean blocked
+		datetime candidate_last_contacted_at
+		date date_of_birth
+		string last_name
+		string postcode
+		integer recruitment_cycle_year
+		boolean resolved
+	}
+	Email {
+		text body
+		string delivery_status
+		string mail_template
+		string mailer
+		string notify_reference
+		string subject
+		string to
+	}
+	EmailClick {
+		string path
+	}
+	EnglishProficiency {
+		boolean degree_taught_in_english
+		boolean draft
+		string efl_qualification_type
+		boolean has_qualification
+		text no_assessment_plan_details
+		boolean no_qualification
+		text no_qualification_details
+		boolean qualification_not_needed
+		string qualification_status
+	}
+	Feature {
+		boolean active
+		string name
+	}
+	"FieldTest::Event" {
+		string name
+	}
+	"FieldTest::Membership" {
+		boolean converted
+		string experiment
+		string participant_id
+		string participant_type
+		string variant
+	}
+	FindFeedback {
+		string email_address
+		string feedback
+		string find_controller
+		string path
+	}
+	IeltsQualification {
+		integer award_year
+		string band_score
+		string trf_number
+	}
+	Interview {
+		text additional_details
+		text cancellation_reason
+		datetime cancelled_at
+		datetime date_and_time
+		text location
+	}
+	Note {
+		text message
+		string user_type
+	}
+	Notification {
+		string notification_type
+		string notified_type
+	}
+	Offer {
+	}
+	OfferCondition {
+		jsonb details
+		string status
+	}
+	OneLoginAuth {
+		string email_address
+		string token
+	}
+	OtherEflQualification {
+		integer award_year
+		string grade
+		string name
+	}
+	"Pool::Invite" {
+		string candidate_decision
+		boolean course_open
+		text message_content
+		boolean provider_message
+		datetime sent_to_candidate_at
+		string status
+	}
+	"Pool::InviteDeclineReason" {
+		text comment
+		string reason
+	}
+	PoolEligibleApplicationForm {
+		integer application_form_id
+	}
+	PossiblePreviousTeacherTraining {
+		date ended_on
+		string provider_name
+		date started_on
+	}
+	PreviousTeacherTraining {
+		text details
+		datetime ended_at
+		string provider_name
+		string started
+		datetime started_at
+		string status
+	}
+	Provider {
+		string code
+		string email_address
+		enum handle_interviews
+		float latitude
+		float longitude
+		string name
+		string phone_number
+		string postcode
+		string provider_type
+		string region_code
+		boolean selectable_school
+	}
+	ProviderAgreement {
+		datetime accepted_at
+		string agreement_type
+	}
+	ProviderPermissions {
+		boolean make_decisions
+		boolean manage_api_tokens
+		boolean manage_organisations
+		boolean manage_users
+		boolean set_up_interviews
+		boolean view_diversity_information
+		boolean view_safeguarding_information
+	}
+	ProviderPoolAction {
+		integer recruitment_cycle_year
+		string status
+	}
+	ProviderRelationshipPermissions {
+		boolean ratifying_provider_can_make_decisions
+		boolean ratifying_provider_can_view_diversity_information
+		boolean ratifying_provider_can_view_safeguarding_information
+		datetime setup_at
+		boolean training_provider_can_make_decisions
+		boolean training_provider_can_view_diversity_information
+		boolean training_provider_can_view_safeguarding_information
+	}
+	ProviderUser {
+		string dfe_sign_in_uid
+		string email_address
+		jsonb find_a_candidate_filters
+		string first_name
+		string last_name
+		datetime last_signed_in_at
+	}
+	ProviderUserFilter {
+		jsonb filters
+		string kind
+		integer pagination_page
+	}
+	ProviderUserNotificationPreferences {
+		boolean application_received
+		boolean application_rejected_by_default
+		boolean application_withdrawn
+		boolean chase_provider_decision
+		boolean marketing_emails
+		boolean offer_accepted
+		boolean offer_declined
+		boolean reference_received
+	}
+	"Publications::MonthlyStatistics::MonthlyStatisticsReport" {
+		date generation_date
+		string month
+		date publication_date
+		json statistics
+	}
+	"Publications::NationalRecruitmentPerformanceReport" {
+		integer cycle_week
+		date generation_date
+		date publication_date
+		json statistics
+	}
+	"Publications::ProviderEdiReport" {
+		string category
+		integer cycle_week
+		date generation_date
+		date publication_date
+		json statistics
+	}
+	"Publications::ProviderRecruitmentPerformanceReport" {
+		integer cycle_week
+		date generation_date
+		date publication_date
+		json statistics
+	}
+	"Publications::RegionalEdiReport" {
+		string category
+		integer cycle_week
+		date generation_date
+		date publication_date
+		string region
+		json statistics
+	}
+	"Publications::RegionalRecruitmentPerformanceReport" {
+		integer cycle_week
+		date generation_date
+		date publication_date
+		string region
+		json statistics
+	}
+	RecruitmentCycleTimetable {
+		datetime apply_deadline_at
+		datetime apply_opens_at
+		datetime decline_by_default_at
+		datetime find_closes_at
+		datetime find_opens_at
+		datetime reject_by_default_at
+		datetime winter_decline_by_default_at
+		datetime winter_reject_by_default_at
+	}
+	ReferenceCondition {
+	}
+	ReferenceToken {
+		string hashed_token
+	}
+	RegionalReportFilter {
+		integer recruitment_cycle_year
+		string region
+	}
+	RejectionFeedback {
+		boolean helpful
+	}
+	ServiceBanner {
+		string body
+		string header
+		string interface
+		string status
+	}
+	Session {
+		string id_token_hint
+		string ip_address
+		string user_agent
+	}
+	SessionError {
+		string body
+		string error_type
+		string id_token_hint
+		json omniauth_hash
+	}
+	Site {
+		string address_line1
+		string address_line2
+		string address_line3
+		string address_line4
+		string code
+		float latitude
+		float longitude
+		string name
+		string postcode
+		string region
+		string uuid
+		boolean uuid_generated_by_apply
+	}
+	SiteSetting {
+		string name
+		text value
+	}
+	SkeCondition {
+	}
+	"SolidCache::Entry" {
+		integer byte_size
+		binary key
+		integer key_hash
+		binary value
+	}
+	"SolidCacheDashboard::CacheEvent" {
+		integer byte_size
+		float duration
+		string event_type
+		integer key_hash
+		string key_string
+	}
+	"SolidQueue::BlockedExecution" {
+		string concurrency_key
+		datetime expires_at
+		integer priority
+		string queue_name
+	}
+	"SolidQueue::ClaimedExecution" {
+	}
+	"SolidQueue::FailedExecution" {
+		text error
+	}
+	"SolidQueue::Job" {
+		string active_job_id
+		text arguments
+		string class_name
+		string concurrency_key
+		datetime finished_at
+		integer priority
+		string queue_name
+		datetime scheduled_at
+	}
+	"SolidQueue::Pause" {
+		string queue_name
+	}
+	"SolidQueue::Process" {
+		string hostname
+		string kind
+		datetime last_heartbeat_at
+		text metadata
+		string name
+		integer pid
+	}
+	"SolidQueue::ReadyExecution" {
+		integer priority
+		string queue_name
+	}
+	"SolidQueue::RecurringExecution" {
+		datetime run_at
+	}
+	"SolidQueue::RecurringTask" {
+		text arguments
+		string class_name
+		string command
+		text description
+		string key
+		integer priority
+		string queue_name
+		string schedule
+		boolean static
+	}
+	"SolidQueue::ScheduledExecution" {
+		integer priority
+		string queue_name
+		datetime scheduled_at
+	}
+	"SolidQueue::Semaphore" {
+		datetime expires_at
+		integer value
+	}
+	Subject {
+		string code
+		string name
+	}
+	"SupportInterface::NotifySendRequest" {
+		string email_addresses
+		string template_id
+	}
+	SupportUser {
+		string dfe_sign_in_uid
+		datetime discarded_at
+		string email_address
+		string first_name
+		string last_name
+		datetime last_signed_in_at
+	}
+	TextCondition {
+	}
+	ToeflQualification {
+		integer award_year
+		string registration_number
+		integer total_score
+	}
+	ValidationError {
+		jsonb details
+		string form_object
+		string request_path
+		string service
+		string user_type
+	}
+	Vendor {
+		string name
+	}
+	VendorAPIRequest {
+		jsonb request_body
+		jsonb request_headers
+		string request_method
+		string request_path
+		jsonb response_body
+		jsonb response_headers
+		integer status_code
+	}
+	VendorAPIToken {
+		string description
+		string hashed_token
+		datetime last_used_at
+	}
+	VendorApiUser {
+		string email_address
+		string full_name
+		string vendor_user_id
+	}
+	WithdrawalReason {
+		text comment
+		string reason
+		string status
+	}
+	ApplicationExperience ||--o{ ApplicationVolunteeringExperience : "specializes"
+	ApplicationExperience ||--o{ ApplicationWorkExperience : "specializes"
+	OfferCondition ||--o{ ReferenceCondition : "specializes"
+	OfferCondition ||--o{ SkeCondition : "specializes"
+	OfferCondition ||--o{ TextCondition : "specializes"
+	"FieldTest::Membership" ||--}o "FieldTest::Event" : ""
+	Auditable o|--}o "Audited::Audit" : ""
+	ApplicationChoice o|--}o "Audited::Audit" : ""
+	ApplicationExperience o|--}o "Audited::Audit" : ""
+	ApplicationForm o|--}o "Audited::Audit" : ""
+	ApplicationQualification o|--}o "Audited::Audit" : ""
+	ApplicationReference o|--}o "Audited::Audit" : ""
+	ApplicationWorkHistoryBreak o|--}o "Audited::Audit" : ""
+	Candidate o|--}o "Audited::Audit" : ""
+	CourseOption o|--}o "Audited::Audit" : ""
+	DataExport o|--}o "Audited::Audit" : ""
+	DataMigration o|--}o "Audited::Audit" : ""
+	DuplicateMatch o|--}o "Audited::Audit" : ""
+	EnglishProficiency o|--}o "Audited::Audit" : ""
+	Feature o|--}o "Audited::Audit" : ""
+	Interview o|--}o "Audited::Audit" : ""
+	OfferCondition o|--}o "Audited::Audit" : ""
+	PreviousTeacherTraining o|--}o "Audited::Audit" : ""
+	Provider o|--}o "Audited::Audit" : ""
+	ProviderAgreement o|--}o "Audited::Audit" : ""
+	ProviderPermissions o|--}o "Audited::Audit" : ""
+	ProviderRelationshipPermissions o|--}o "Audited::Audit" : ""
+	ProviderUser o|--}o "Audited::Audit" : ""
+	ProviderUserNotificationPreferences o|--}o "Audited::Audit" : ""
+	ServiceBanner o|--}o "Audited::Audit" : ""
+	SiteSetting o|--}o "Audited::Audit" : ""
+	SupportUser o|--}o "Audited::Audit" : ""
+	VendorAPIToken o|--}o "Audited::Audit" : ""
+	User o|--}o "Audited::Audit" : ""
+	Associated o|--}o "Audited::Audit" : ""
+	"Blazer::Query" ||--}o "Blazer::Check" : ""
+	"Blazer::Query" ||--}o "Blazer::DashboardQuery" : ""
+	"Blazer::Query" o|..}o "Blazer::Dashboard" : ""
+	"Blazer::Query" o|--}o "Blazer::Audit" : ""
+	"Blazer::Dashboard" ||--}o "Blazer::DashboardQuery" : ""
+	"SolidQueue::RecurringTask" o|--}o "SolidQueue::RecurringExecution" : ""
+	"SolidQueue::Process" ||--}o "SolidQueue::ClaimedExecution" : ""
+	"SolidQueue::Process" o|--}o "SolidQueue::Process" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::RecurringExecution" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::FailedExecution" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::ScheduledExecution" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::BlockedExecution" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::ReadyExecution" : ""
+	"SolidQueue::Job" o|--|o "SolidQueue::ClaimedExecution" : ""
+	"SolidQueue::BlockedExecution" o|--|o "SolidQueue::Semaphore" : ""
+	"ActiveStorage::VariantRecord" ||--}o "ActiveStorage::Blob" : ""
+	Record ||--|o "ActiveStorage::Attachment" : ""
+	"ActiveStorage::Blob" ||--|o "ActiveStorage::Attachment" : ""
+	"ActiveStorage::VariantRecord" ||--|o "ActiveStorage::Attachment" : ""
+	DataExport ||--|o "ActiveStorage::Attachment" : ""
+	"SupportInterface::NotifySendRequest" ||--|o "ActiveStorage::Attachment" : ""
+	"ActiveStorage::Blob" ||--}o "ActiveStorage::Attachment" : ""
+	"ActiveStorage::Blob" o|..|o "ActiveStorage::Blob" : ""
+	SupportUser ||--}o "SupportInterface::NotifySendRequest" : ""
+	"SupportInterface::NotifySendRequest" o|..|o "ActiveStorage::Blob" : ""
+	"Publications::RegionalRecruitmentPerformanceReport" o|--|o RecruitmentCycleTimetable : ""
+	"Publications::RegionalEdiReport" o|--|o RecruitmentCycleTimetable : ""
+	Provider ||--}o "Publications::ProviderRecruitmentPerformanceReport" : ""
+	"Publications::ProviderRecruitmentPerformanceReport" o|--|o RecruitmentCycleTimetable : ""
+	"Publications::ProviderEdiReport" o|--|o RecruitmentCycleTimetable : ""
+	Provider ||--}o "Publications::ProviderEdiReport" : ""
+	"Publications::NationalRecruitmentPerformanceReport" o|--|o RecruitmentCycleTimetable : ""
+	"Pool::Invite" ||--}o "Pool::InviteDeclineReason" : ""
+	Chased ||--}o ChaserSent : ""
+	ApplicationChoice ||--}o ChaserSent : ""
+	ApplicationForm ||--}o ChaserSent : ""
+	ApplicationReference ||--}o ChaserSent : ""
+	Candidate ||--}o ChaserSent : ""
+	"Pool::Invite" ||--}o ChaserSent : ""
+	Candidate ||--}o "Pool::Invite" : ""
+	ApplicationForm ||--}o "Pool::Invite" : ""
+	"Pool::Invite" o|--}o ApplicationChoice : ""
+	Provider ||--}o "Pool::Invite" : ""
+	ProviderUser ||--}o "Pool::Invite" : ""
+	Course ||--}o "Pool::Invite" : ""
+	"Pool::Invite" o|--|o RecruitmentCycleTimetable : ""
+	ApplicationForm ||--}o "Adviser::SignUpRequest" : ""
+	"Adviser::TeachingSubject" ||--}o "Adviser::SignUpRequest" : ""
+	VendorAPIToken ||--}o VendorApiUser : ""
+	Provider ||--}o VendorAPIToken : ""
+	Provider o|--}o VendorAPIRequest : ""
+	Vendor o|--}o Provider : ""
+	User o|--}o ValidationError : ""
+	Candidate o|--}o ValidationError : ""
+	ProviderUser o|--}o ValidationError : ""
+	SupportUser o|--}o ValidationError : ""
+	EflQualification o|--|o EnglishProficiency : ""
+	IeltsQualification o|--|o EnglishProficiency : ""
+	OtherEflQualification o|--|o EnglishProficiency : ""
+	ToeflQualification o|--|o EnglishProficiency : ""
+	User ||--}o AuthenticationToken : ""
+	Candidate ||--}o AuthenticationToken : ""
+	ProviderUser ||--}o AuthenticationToken : ""
+	SupportUser ||--}o AuthenticationToken : ""
+	User ||--}o DsiSession : ""
+	Candidate ||--}o DsiSession : ""
+	ProviderUser ||--}o DsiSession : ""
+	SupportUser ||--}o DsiSession : ""
+	Subject ||--}o CourseSubject : ""
+	Subject o|..}o Course : ""
+	Provider ||--}o Site : ""
+	Site ||--}o CourseOption : ""
+	Site o|..}o Course : ""
+	Candidate o|--}o SessionError : ""
+	Candidate ||--}o Session : ""
+	ApplicationChoice ||--}o RejectionFeedback : ""
+	ProviderUser ||--}o RegionalReportFilter : ""
+	Provider ||--}o RegionalReportFilter : ""
+	ApplicationReference ||--}o ReferenceToken : ""
+	ProviderUser ||--|o ProviderUserNotificationPreferences : ""
+	ProviderUser ||--}o ProviderUserFilter : ""
+	ProviderUser ||--}o ProviderPermissions : ""
+	ProviderUser o|..}o Provider : ""
+	ProviderUser o|--}o Note : ""
+	ProviderUser ||--}o ProviderPoolAction : ""
+	ApplicationForm ||--}o ProviderPoolAction : ""
+	Provider ||--}o ProviderPermissions : ""
+	Provider ||--}o ProviderAgreement : ""
+	ProviderUser ||--}o ProviderAgreement : ""
+	Provider ||--}o Course : ""
+	Provider o|..}o CourseOption : ""
+	Provider o|..}o ApplicationChoice : ""
+	Provider o|..}o ApplicationForm : ""
+	Provider o|..}o ApplicationReference : ""
+	Provider ||--}o ProviderRelationshipPermissions : ""
+	Candidate ||--}o PossiblePreviousTeacherTraining : ""
+	Provider o|--}o PossiblePreviousTeacherTraining : ""
+	Candidate ||--|o OneLoginAuth : ""
+	ApplicationChoice ||--|o Offer : ""
+	Offer ||--}o OfferCondition : ""
+	Offer ||--}o ReferenceCondition : ""
+	Offer ||--}o SkeCondition : ""
+	Offer ||--}o TextCondition : ""
+	Offer o|--}o TextCondition : ""
+	Offer o|--}o SkeCondition : ""
+	Offer o|--|o ReferenceCondition : ""
+	Offer o|..|o CourseOption : ""
+	Notified ||--}o Notification : ""
+	ApplicationForm ||--}o Notification : ""
+	ApplicationChoice ||--}o Note : ""
+	User ||--}o Note : ""
+	Candidate ||--}o Note : ""
+	ProviderUser ||--}o Note : ""
+	SupportUser ||--}o Note : ""
+	ApplicationChoice ||--}o Interview : ""
+	Provider ||--}o Interview : ""
+	Email ||--}o EmailClick : ""
+	ApplicationForm o|--}o Email : ""
+	DuplicateMatch o|--}o Candidate : ""
+	ProviderUser o|--}o DsiSession : ""
+	ProviderUser ||--}o DeferredOfferConfirmation : ""
+	Offer ||--}o DeferredOfferConfirmation : ""
+	Course ||--}o DeferredOfferConfirmation : ""
+	Site ||--}o DeferredOfferConfirmation : ""
+	CourseOption ||--}o DeferredOfferConfirmation : ""
+	DataExport o|..|o "ActiveStorage::Blob" : ""
+	Course ||--}o CourseSubject : ""
+	Course ||--}o CourseOption : ""
+	CourseOption ||--}o ApplicationChoice : ""
+	Course o|..}o ApplicationChoice : ""
+	Course o|--|o RecruitmentCycleTimetable : ""
+	ApplicationForm ||--}o CandidatePreference : ""
+	CandidatePreference ||--}o CandidateLocationPreference : ""
+	ApplicationForm ||--|o CandidatePoolApplication : ""
+	Candidate ||--}o CandidatePoolApplication : ""
+	Provider o|--}o CandidateLocationPreference : ""
+	Breakable ||--}o ApplicationWorkHistoryBreak : ""
+	ApplicationChoice ||--}o ApplicationWorkHistoryBreak : ""
+	ApplicationForm ||--}o ApplicationWorkHistoryBreak : ""
+	ApplicationForm ||--}o ApplicationReference : ""
+	ApplicationReference o|..}o Candidate : ""
+	ApplicationForm o|--|o RecruitmentCycleTimetable : ""
+	Candidate ||--}o ApplicationForm : ""
+	ApplicationForm ||--}o ApplicationChoice : ""
+	ApplicationForm o|..}o CourseOption : ""
+	ApplicationForm o|..}o Course : ""
+	Experienceable o|--}o ApplicationWorkExperience : ""
+	ApplicationChoice o|--}o ApplicationWorkExperience : ""
+	ApplicationForm o|--}o ApplicationWorkExperience : ""
+	Experienceable o|--}o ApplicationVolunteeringExperience : ""
+	ApplicationChoice o|--}o ApplicationVolunteeringExperience : ""
+	ApplicationForm o|--}o ApplicationVolunteeringExperience : ""
+	ApplicationForm ||--}o ApplicationQualification : ""
+	ApplicationForm o|..}o CandidateLocationPreference : ""
+	ApplicationForm ||--}o PreviousTeacherTraining : ""
+	ApplicationForm o|--|o ApplicationForm : ""
+	ApplicationForm ||--}o EnglishProficiency : ""
+	ApplicationForm ||--}o ApplicationFeedback : ""
+	ApplicationFeedback o|..|o Candidate : ""
+	Experienceable ||--}o ApplicationExperience : ""
+	ApplicationChoice ||--}o ApplicationExperience : ""
+	ApplicationForm ||--}o ApplicationExperience : ""
+	Experienceable ||--}o ApplicationVolunteeringExperience : ""
+	Experienceable ||--}o ApplicationWorkExperience : ""
+	ApplicationChoice o|..}o Candidate : ""
+	ApplicationChoice o|..|o Site : ""
+	ApplicationChoice ||--}o WithdrawalReason : ""
+	AccountRecoveryRequest ||--}o AccountRecoveryRequestCode : ""
+	Candidate ||--|o AccountRecoveryRequest : ""
+	OfferCondition o|..|o ApplicationChoice : ""
+	ReferenceCondition o|..|o ApplicationChoice : ""
+	SkeCondition o|..|o ApplicationChoice : ""
+	TextCondition o|..|o ApplicationChoice : ""
+	ApplicationQualification o|..}o Candidate : ""
+	Provider o|--}o PreviousTeacherTraining : ""
+	PreviousTeacherTraining o|--|o PreviousTeacherTraining : ""
+	Course o|--}o Candidate : ""
+	Candidate o|..}o PreviousTeacherTraining : ""

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -4,6 +4,13 @@ FactoryBot.define do
   factory :application_form do
     candidate
     address_type { :uk }
+    recruitment_cycle_year {
+      if candidate.application_forms.exists?
+        candidate.application_forms.maximum(:recruitment_cycle_year).next
+      else
+        CycleTimetableHelper.current_year
+      end
+    }
 
     trait :minimum_info do
       first_name { Faker::Name.first_name }
@@ -293,7 +300,6 @@ FactoryBot.define do
       work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
       phase { :apply_1 }
-      recruitment_cycle_year { CycleTimetableHelper.current_year }
 
       right_to_work_or_study {
         if first_nationality != 'British'
@@ -436,13 +442,12 @@ FactoryBot.define do
       completed
       created_at { CycleTimetableHelper.before_apply_deadline }
       updated_at { CycleTimetableHelper.before_apply_deadline }
-      recruitment_cycle_year { CycleTimetableHelper.current_year }
       phase { 'apply_2' }
 
       previous_application_form do
         association(
           :completed_application_form,
-          recruitment_cycle_year:,
+          recruitment_cycle_year: recruitment_cycle_year - 1,
           submitted_at: submitted_at - 10.days,
           first_name:,
           last_name:,

--- a/spec/factory_specs/application_form_factory_spec.rb
+++ b/spec/factory_specs/application_form_factory_spec.rb
@@ -345,9 +345,9 @@ RSpec.describe 'ApplicationForm factory' do
     field :created_at, value: CycleTimetableHelper.before_apply_deadline
     field :updated_at, value: CycleTimetableHelper.before_apply_deadline
 
-    it 'associates a previous application form in the current year' do
+    it 'associates a previous application form in the previous year' do
       expect(record.previous_application_form).to be_present
-      expect(record.previous_application_form.recruitment_cycle_year).to eq(current_year)
+      expect(record.previous_application_form.recruitment_cycle_year).to eq(previous_year)
     end
   end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -30,6 +30,27 @@ RSpec.describe ApplicationForm do
   it { is_expected.to have_many(:notifications) }
   it { is_expected.to have_many(:english_proficiencies) }
 
+  describe 'validations' do
+    subject(:application_form) { build(:application_form) }
+
+    it { is_expected.to validate_uniqueness_of(:candidate_id).scoped_to(:recruitment_cycle_year) }
+
+    describe 'one application form per candidate and recruitment cycle' do
+      let(:candidate) { build(:candidate) }
+      let(:recruitment_cycle_year) { 2026 }
+      let(:application_form) { create(:application_form, candidate:, recruitment_cycle_year:) }
+      let(:duplicate) { create(:application_form, candidate:, recruitment_cycle_year:) }
+
+      before do
+        application_form
+      end
+
+      it 'raises an error if another application form is created for the same candidate and recruitment cycle' do
+        expect{ duplicate }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
   describe 'delegations' do
     it { is_expected.to delegate_method(:apply_deadline_at).to(:recruitment_cycle_timetable) }
     it { is_expected.to delegate_method(:apply_opens_at).to(:recruitment_cycle_timetable) }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ApplicationForm do
       end
 
       it 'raises an error if another application form is created for the same candidate and recruitment cycle' do
-        expect{ duplicate }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { duplicate }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
     end
 
     it 'returns a history of rejection reasons from previous applications' do
-      previous_application_form1 = create(:application_form)
+      previous_application_form1 = create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.current_year - 2)
       choice1 = create(:application_choice, :with_old_structured_rejection_reasons, application_form: previous_application_form1)
       choice2 = create(:application_choice, :with_old_structured_rejection_reasons, application_form: previous_application_form1)
-      previous_application_form2 = apply_again!(previous_application_form1)
+      previous_application_form2 = apply_again!(previous_application_form1, RecruitmentCycleTimetable.current_year - 1)
       choice3 = create(:application_choice, :with_old_structured_rejection_reasons, application_form: previous_application_form2)
       %w[Bad Good Amazing].zip([choice1, choice2, choice3]).each do |feedback, choice|
         choice.update!(structured_rejection_reasons: choice.structured_rejection_reasons.merge(quality_of_application_personal_statement_what_to_improve: feedback))
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
     end
 
     context 'for current rejection reasons' do
-      let(:previous_application_form) { create(:application_form) }
+      let(:previous_application_form) { create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
       let!(:application_choice1) { create(:application_choice, :with_structured_rejection_reasons, application_form: previous_application_form, structured_rejection_reasons: rejection_reasons) }
       let(:current_application_form) { apply_again!(previous_application_form) }
       let!(:application_choice2) { create(:application_choice, :with_structured_rejection_reasons, application_form: current_application_form) }
@@ -135,7 +135,7 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
     end
 
     it 'ignores application choices with no relevant feedback' do
-      previous_application_form = create(:application_form)
+      previous_application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.current_year - 1)
       choice = create(:application_choice, :with_old_structured_rejection_reasons, application_form: previous_application_form)
       create(:application_choice, structured_rejection_reasons: { 'safeguarding_y_n' => 'No' }, application_form: previous_application_form)
       create(:application_choice, application_form: previous_application_form)
@@ -149,7 +149,7 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
     end
 
     context 'for vendor_api rejection reasons' do
-      let(:previous_application_form) { create(:application_form) }
+      let(:previous_application_form) { create(:application_form, recruitment_cycle_year: RecruitmentCycleTimetable.current_year - 1) }
       let!(:application_choice1) { create(:application_choice, :with_vendor_api_rejection_reasons, application_form: previous_application_form, structured_rejection_reasons: rejection_reasons) }
       let(:current_application_form) { apply_again!(previous_application_form) }
       let!(:application_choice2) { create(:application_choice, :with_vendor_api_rejection_reasons, application_form: current_application_form) }
@@ -195,8 +195,8 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
 
   private
 
-    def apply_again!(application_form)
-      DuplicateApplication.new(application_form).duplicate
+    def apply_again!(application_form, recruitment_cycle_year = RecruitmentCycleTimetable.current_year)
+      DuplicateApplication.new(application_form, recruitment_cycle_year:).duplicate
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe Candidate do
       let(:application_choice_1) { create(:application_choice, candidate:) }
       let(:application_choice_2) { create(:application_choice, candidate:) }
       let(:application_choice_3) { create(:application_choice, candidate:) }
-      let!(:application_form_apply_1) { create(:application_form, candidate:, application_choices: [application_choice_1], created_at: 1.week.ago) }
+      let!(:application_form_apply_1) { create(:application_form, candidate:, application_choices: [application_choice_1], created_at: 1.week.ago, recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
       let!(:application_form_apply_2) { create(:application_form, phase: 'apply_2', candidate:, application_choices: [application_choice_2, application_choice_3]) }
 
       it 'returns the most recent application choices' do

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DuplicateApplication do
     described_class.new(@original_application_form).duplicate
   end
 
-  let(:recruitment_cycle_year) { current_year }
+  let(:recruitment_cycle_year) { current_year - 1 }
 
   it 'marks reference as incomplete' do
     expect(duplicate_application_form).not_to be_references_completed

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
   end
 
   def when_i_have_an_unsubmitted_application_without_a_course
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :completed_application_form,
       :with_gcses,

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Carry over application and submit new application choices' do
 private
 
   def when_i_have_an_unsubmitted_application
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :completed_application_form,
       :eligible_for_free_school_meals,

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def and_i_have_completed_the_degree_section
+    @current_candidate.application_forms.destroy_all
     @application_form = create(:application_form, candidate: @current_candidate)
     create(:application_qualification,
            level: 'degree',

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -77,6 +77,7 @@ private
 
   def given_i_am_signed_in
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
 
     course = create(:course, :open)
     create(:course_option, course:)
@@ -252,6 +253,7 @@ private
 
   def given_i_am_signed_in_without_in_flight_applications
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
 
     application_form = create(:application_form, :completed, candidate: @current_candidate)
 

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Candidate views their invites' do
 
   def given_i_am_signed_in
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
 
     application_form = create(
       :application_form,
@@ -135,6 +136,7 @@ RSpec.describe 'Candidate views their invites' do
 
   def given_i_am_signed_in_without_in_flight_applications
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
 
     create(:application_form, :completed, candidate: @current_candidate)
     visit root_path

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -3,16 +3,18 @@ require 'rails_helper'
 RSpec.describe 'Primary Navigation' do
   include CandidateHelper
 
-  scenario 'highlights the primary navigation for pre continuous applications' do
+  before do
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
+  end
 
+  scenario 'highlights the primary navigation for pre continuous applications' do
     and_i_have_pre_continuous_applications_submitted
     when_i_visit_the_application_dashboard
     then_i_see_your_application_as_active
   end
 
   scenario 'highlights the primary navigation correct item for continuous applications' do
-    given_i_am_signed_in_with_one_login
     and_i_have_submitted_applications
     when_i_visit_the_application_dashboard
     then_i_see_your_details_as_active

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_updates_referee_email_addresses_when_accepting_offer_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Candidate accepts an offer' do
 private
 
   def and_i_have_an_offer
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :completed_application_form,
       first_name: 'Harry',

--- a/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
+++ b/spec/system/candidate_interface/preferences/candidate_adds_preferences_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   def given_i_am_signed_in(funding_type: 'salary')
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
     @application = create(
       :application_form,
       :completed,
@@ -272,6 +273,7 @@ RSpec.describe 'Candidate adds preferences' do
 
   def given_i_am_a_candidate_who_has_opted_in_with_a_dynamic_location
     given_i_am_signed_in
+
     given_courses_exist
     given_i_am_on_the_share_details_page
     and_i_click('Back')

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_have_an_application_with_a_rejection_and_references
+    @current_candidate.application_forms.destroy_all
     @application_form = create(:application_form, :with_completed_references, candidate: @current_candidate)
     create(:application_choice, :rejected, application_form: @application_form)
 

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_a_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_a_degree_taught_in_english_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Candidate reviews an application with a degree taught in English
 private
 
   def and_english_is_not_my_first_nationality
+    current_candidate.application_forms.destroy_all
     @application_form = create(
       :application_form,
       :completed,

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Candidate reviews an application with an IELTS qualification',
 private
 
   def and_english_is_not_my_first_nationality
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :application_form,
       :completed,

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_english_as_their_first_language_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_english_as_their_first_language_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Candidate reviews an application with English as their first lan
 private
 
   def and_english_is_not_my_first_nationality
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :application_form,
       :completed,

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_no_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_no_efl_qualification_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Candidate reviews an application with no EFL qualification',
 private
 
   def and_english_is_not_my_first_nationality
+    @current_candidate.application_forms.destroy_all
     @application_form = create(
       :application_form,
       :completed,

--- a/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate submits the application' do
 
   before do
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
   end
 
   scenario 'Candidate with incomplete application seeing the error message' do

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Candidate with submitted applications' do
   end
 
   def and_i_have_submitted_applications
+    current_candidate.application_forms.destroy_all
     current_candidate.application_forms << build(:application_form, :completed)
     current_candidate.current_application.application_choices << build_list(:application_choice, 4, :awaiting_provider_decision, sent_to_provider_at: 1.day.ago)
     @application_choice = current_candidate.current_application.application_choices.last

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits the application with interruption pages' do
   include CandidateHelper
 
-  scenario 'Candidate submits an application with all applications having an enic_reason of not_needed and personal statement less than 500 words', :js, time: mid_cycle do
+  before do
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
+  end
 
+  scenario 'Candidate submits an application with all applications having an enic_reason of not_needed and personal statement less than 500 words', :js, time: mid_cycle do
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_not_needed_qualification
     and_i_continue_with_my_application
 
@@ -22,8 +25,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement less than 500 words', :js, time: mid_cycle do
-    given_i_am_signed_in_with_one_login
-
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification
     and_i_continue_with_my_application
 
@@ -40,7 +41,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an application for a course whose required grade is higher than their highest recorded undergrad degree grade', time: mid_cycle do
-    given_i_am_signed_in_with_one_login
     and_i_have_one_application_in_draft
 
     when_i_visit_my_applications
@@ -54,8 +54,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement of 500 words', :js, time: mid_cycle do
-    given_i_am_signed_in_with_one_login
-
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification_and_personal_statement_500_words
     and_i_continue_with_my_application
 
@@ -70,8 +68,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits a teacher degree apprenticeship course having a personal statement less than 500 words and a degree', :js, time: mid_cycle do
-    given_i_am_signed_in_with_one_login
-
     when_i_have_completed_application_to_primary_course_choice_with_short_personal_statement
     and_course_choice_is_undergraduate
     and_i_have_a_degree
@@ -91,8 +87,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   end
 
   scenario 'Candidate submits a teacher degree apprenticeship course having a degree with long personal statement and with ENIC', :js, time: mid_cycle do
-    given_i_am_signed_in_with_one_login
-
     when_i_have_completed_application_to_primary_course_choice_with_long_personal_statement
     and_i_have_a_degree
     and_course_choice_is_undergraduate

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'Candidate submits the application' do
     )
     @course = create(:course, :teacher_degree_apprenticeship, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
+    @current_candidate.application_forms.destroy_all
     @current_candidate.application_forms << build(:application_form, completed_section_trait, university_degree: false)
     @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
   end

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
 
   before do
     given_i_am_signed_in_with_one_login
+    @current_candidate.application_forms.destroy_all
     and_i_have_one_application_in_draft
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe 'Candidate with no right to work or study' do
   end
 
   def when_i_have_completed_my_foreign_application
+    current_candidate.application_forms.destroy_all
+
     @application_form = create(
       :application_form,
       :completed,
@@ -125,6 +127,8 @@ RSpec.describe 'Candidate with no right to work or study' do
   end
 
   def when_i_complete_an_application_with_skilled_worker_visa
+    current_candidate.application_forms.destroy_all
+
     @application_form = create(
       :application_form,
       :completed,
@@ -139,6 +143,8 @@ RSpec.describe 'Candidate with no right to work or study' do
   end
 
   def when_i_complete_an_application_with_student_visa
+    current_candidate.application_forms.destroy_all
+
     @application_form = create(
       :application_form,
       :completed,

--- a/spec/system/candidate_interface/viewing-application-choices/candidate_views_their_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/viewing-application-choices/candidate_views_their_previous_applications_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Candidate views their previous applications' do
 private
 
   def and_i_have_some_previous_application_forms
+    @current_candidate.application_forms.destroy_all
     @application_form = create(:application_form, :submitted, recruitment_cycle_year: RecruitmentCycleTimetable.current_year)
     @application_form_previous_two_years = create(:application_form, recruitment_cycle_year: @application_form.recruitment_cycle_year - 2, submitted_at: 2.years.ago, candidate: @current_candidate)
     @application_form_previous_year = create(:application_form, recruitment_cycle_year: @application_form.recruitment_cycle_year - 1, submitted_at: 1.year.ago, candidate: @current_candidate, previous_application_form_id: @application_form_previous_two_years.id)


### PR DESCRIPTION
## Context

- Add unique validation to application forms per candidate and recruitment cycle

## Changes proposed in this pull request

- Add unique validation to application forms per candidate and recruitment cycle

## Guidance to review

- Check the validation and migration

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/nATzL2Eg/1970-bug-users-are-able-to-create-multiple-2026-applications