### PR TITLE
Update language on EFL flow

### DIFF
--- a/app/components/candidate_interface/english_proficiencies/review_component.html.erb
+++ b/app/components/candidate_interface/english_proficiencies/review_component.html.erb
@@ -1,3 +1,3 @@
-<%= helpers.govuk_summary_card(title: 'English as a foreign language assessment', heading_level:) do |card| %>
+<%= helpers.govuk_summary_card(title: 'English language skills', heading_level:) do |card| %>
   <%= card.with_summary_list(rows:, actions:) %>
 <% end %>

--- a/app/components/candidate_interface/english_proficiencies/review_component.rb
+++ b/app/components/candidate_interface/english_proficiencies/review_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
       def rows
         [
           {
-            key: { text: 'Proving your level of English' },
+            key: { text: 'Proving your English language skills' },
             value: { text: english_proficiency_status },
             actions: [{ href: candidate_interface_english_proficiencies_edit_start_path(english_proficiency), visually_hidden_text: 'level of english' }],
           },
@@ -23,13 +23,12 @@ module CandidateInterface
     private
 
       def english_proficiency_status
-        content_tag(:p, class: 'govuk-body') do
-          simple_format(
-            english_proficiency.qualification_statuses.map do |status|
-              I18n.t("candidate_interface.english_proficiencies.review_component.qualification_status.#{status}")
-            end.sort.join("\n"),
-          )
-        end
+        simple_format(
+          english_proficiency.qualification_statuses.map do |status|
+            I18n.t("candidate_interface.english_proficiencies.review_component.qualification_status.#{status}")
+          end.sort.join("\n"),
+          class: 'govuk-body',
+        )
       end
 
       def no_qualification_details_rows
@@ -50,17 +49,17 @@ module CandidateInterface
             ],
           },
         ]
-        return row unless english_proficiency.no_qualification_details.present?
+        return row unless english_proficiency.no_qualification_details.present? || english_proficiency.no_assessment_plan_details.present?
 
         row << {
           key: { text: 'Details' },
-          value: { text: english_proficiency.no_qualification_details },
+          value: { text: english_proficiency.no_qualification_details.presence || english_proficiency.no_assessment_plan_details },
           actions: [
             {
               href: candidate_interface_english_proficiencies_no_qualification_details_path(
                 english_proficiency,
                 return_to: 'review',
-                ),
+              ),
               visually_hidden_text: 'plan to take an English as a foreign language assessment details',
             },
           ],

--- a/app/components/candidate_interface/english_proficiencies/review_component.rb
+++ b/app/components/candidate_interface/english_proficiencies/review_component.rb
@@ -35,52 +35,36 @@ module CandidateInterface
       def no_qualification_details_rows
         return [] if english_proficiency.has_qualification || english_proficiency.qualification_not_needed
 
-        if english_proficiency.no_qualification_details.present?
-          [
+        row = [
+          {
+            key: { text: 'Do you plan on taking an English as a foreign language assessment?' },
+            value: { text: english_proficiency.no_qualification_details.present? ? 'Yes' : 'No' },
+            actions: [
+              {
+                href: candidate_interface_english_proficiencies_no_qualification_details_path(
+                  english_proficiency,
+                  return_to: 'review',
+                ),
+                visually_hidden_text: 'plan to take an English as a foreign language assessment',
+              },
+            ],
+          },
+        ]
+        return row unless english_proficiency.no_qualification_details.present?
+
+        row << {
+          key: { text: 'Details' },
+          value: { text: english_proficiency.no_qualification_details },
+          actions: [
             {
-              key: { text: 'Do you plan on taking an English as a foreign language assessment?' },
-              value: { text: 'Yes' },
-              actions: [
-                {
-                  href: candidate_interface_english_proficiencies_no_qualification_details_path(
-                    english_proficiency,
-                    return_to: 'review',
-                  ),
-                  visually_hidden_text: 'plan to take an English as a foreign language assessment',
-                },
-              ],
+              href: candidate_interface_english_proficiencies_no_qualification_details_path(
+                english_proficiency,
+                return_to: 'review',
+                ),
+              visually_hidden_text: 'plan to take an English as a foreign language assessment details',
             },
-            {
-              key: { text: 'Details' },
-              value: { text: english_proficiency.no_qualification_details },
-              actions: [
-                {
-                  href: candidate_interface_english_proficiencies_no_qualification_details_path(
-                    english_proficiency,
-                    return_to: 'review',
-                  ),
-                  visually_hidden_text: 'plan to take an English as a foreign language assessment details',
-                },
-              ],
-            },
-          ]
-        else
-          [
-            {
-              key: { text: 'Do you plan on taking an English as a foreign language assessment?' },
-              value: { text: 'No' },
-              actions: [
-                {
-                  href: candidate_interface_english_proficiencies_no_qualification_details_path(
-                    english_proficiency,
-                    return_to: 'review',
-                  ),
-                  visually_hidden_text: 'plan to take an English as a foreign language assessment',
-                },
-              ],
-            },
-          ]
-        end
+          ],
+        }
       end
 
       def qualification_rows

--- a/app/controllers/candidate_interface/english_proficiencies/no_qualification_details_controller.rb
+++ b/app/controllers/candidate_interface/english_proficiencies/no_qualification_details_controller.rb
@@ -32,7 +32,7 @@ module CandidateInterface
       def no_qualification_details_params
         strip_whitespace params
           .fetch(:candidate_interface_english_proficiencies_no_qualification_details_form, {})
-          .permit(:declare_no_qualification_details, :no_qualification_details)
+          .permit(:declare_no_qualification_details, :no_qualification_details, :no_assessment_plan_details)
           .merge(application_form: current_application, english_proficiency:)
           .merge(return_to: params[:'return-to'])
       end

--- a/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
+++ b/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
@@ -19,6 +19,7 @@ module CandidateInterface
           application_form:,
           qualification_statuses: persisting_qualification_statuses,
           no_qualification_details:,
+          no_assessment_plan_details:,
           publish: true,
         ).call
       end
@@ -30,6 +31,7 @@ module CandidateInterface
 
         self.declare_no_qualification_details = english_proficiency.no_qualification_details.present? ? 1 : 0
         self.no_qualification_details = english_proficiency.no_qualification_details
+        self.no_assessment_plan_details = english_proficiency.no_assessment_plan_details
         self
       end
 

--- a/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
+++ b/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
@@ -18,7 +18,7 @@ module CandidateInterface
         UpdateEnglishProficiencies.new(
           application_form:,
           qualification_statuses: persisting_qualification_statuses,
-          no_qualification_details: qualification_details_declared? ? no_qualification_details : nil,
+          no_qualification_details:,
           publish: true,
         ).call
       end

--- a/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
+++ b/app/forms/candidate_interface/english_proficiencies/no_qualification_details_form.rb
@@ -4,7 +4,8 @@ module CandidateInterface
       include ActiveModel::Model
       include Rails.application.routes.url_helpers
 
-      attr_accessor :declare_no_qualification_details, :no_qualification_details, :english_proficiency, :application_form, :return_to
+      attr_accessor :declare_no_qualification_details, :no_qualification_details, :english_proficiency,
+                    :application_form, :return_to, :no_assessment_plan_details
 
       validates :declare_no_qualification_details, presence: true
       validates :no_qualification_details, presence: true, if: -> { qualification_details_declared? }
@@ -18,7 +19,7 @@ module CandidateInterface
         UpdateEnglishProficiencies.new(
           application_form:,
           qualification_statuses: persisting_qualification_statuses,
-          no_qualification_details:,
+          no_qualification_details: qualification_details_declared? ? no_qualification_details : nil,
           no_assessment_plan_details:,
           publish: true,
         ).call

--- a/app/services/candidate_interface/update_english_proficiencies.rb
+++ b/app/services/candidate_interface/update_english_proficiencies.rb
@@ -1,14 +1,15 @@
 module CandidateInterface
   class UpdateEnglishProficiencies
     attr_reader :application_form, :qualification_statuses, :efl_qualification, :no_qualification_details,
-                :english_proficiency, :persist, :publish
+                :english_proficiency, :persist, :publish, :no_assessment_plan_details
 
-    def initialize(application_form:, qualification_statuses:, english_proficiency: nil, efl_qualification: nil, no_qualification_details: nil, persist: false, publish: false)
+    def initialize(application_form:, qualification_statuses:, english_proficiency: nil, efl_qualification: nil, no_qualification_details: nil, no_assessment_plan_details: nil, persist: false, publish: false)
       @application_form = application_form
       @qualification_statuses = qualification_statuses
       @english_proficiency = english_proficiency
       @efl_qualification = efl_qualification
       @no_qualification_details = no_qualification_details
+      @no_assessment_plan_details = no_assessment_plan_details
       @persist = persist
       @publish = publish
     end
@@ -22,6 +23,7 @@ module CandidateInterface
         unless persist
           if new_english_proficiency.no_qualification || new_english_proficiency.degree_taught_in_english
             new_english_proficiency.no_qualification_details = no_qualification_details
+            new_english_proficiency.no_assessment_plan_details = no_assessment_plan_details
           end
 
           if new_english_proficiency.has_qualification
@@ -35,6 +37,7 @@ module CandidateInterface
 
         if new_english_proficiency.qualification_not_needed && new_english_proficiency.no_qualification_details.present?
           new_english_proficiency.no_qualification_details = nil
+          new_english_proficiency.no_assessment_plan_details = nil
         end
 
         if publish ||

--- a/app/services/candidate_interface/update_english_proficiencies.rb
+++ b/app/services/candidate_interface/update_english_proficiencies.rb
@@ -22,8 +22,13 @@ module CandidateInterface
 
         unless persist
           if new_english_proficiency.no_qualification || new_english_proficiency.degree_taught_in_english
-            new_english_proficiency.no_qualification_details = no_qualification_details
-            new_english_proficiency.no_assessment_plan_details = no_assessment_plan_details
+            if no_qualification_details.present?
+              new_english_proficiency.no_qualification_details = no_qualification_details
+              new_english_proficiency.no_assessment_plan_details = nil
+            else
+              new_english_proficiency.no_qualification_details = nil
+              new_english_proficiency.no_assessment_plan_details = no_assessment_plan_details
+            end
           end
 
           if new_english_proficiency.has_qualification

--- a/app/views/candidate_interface/english_proficiencies/ielts/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/ielts/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(model: @ielts_form, url: candidate_interface_english_proficiencies_ielts_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.english_language_skills') %></span>
         <%= t('page_titles.efl.ielts') %>
       </h1>
       <%= render 'form_fields', { f: f } %>

--- a/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
@@ -10,15 +10,17 @@
         You may need an English as a foreign language assessment
       </h1>
       <p class='govuk-body'>
-        Training providers may need to see evidence of your level of English. Contact them to find out about their requirements.
+        Training providers may need to see evidence of your English language skills. Contact them to find out about their requirements.
       </p>
 
       <%= f.govuk_radio_buttons_fieldset(:declare_no_qualification_details,
          legend: { text: 'Do you plan on taking an English as a foreign language assessment?', tag: 'h2' }) do %>
         <%= f.govuk_radio_button :declare_no_qualification_details, 1, label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :no_qualification_details, label: { text: 'Give details of when and what type of assessment you plan to take' } %>
+          <%= f.govuk_text_area :no_qualification_details, label: { text: 'Give details of the type of assessment you plan to take and when you plan to take it' } %>
         <% end %>
-        <%= f.govuk_radio_button :declare_no_qualification_details, 0, label: { text: 'No' } %>
+        <%= f.govuk_radio_button :declare_no_qualification_details, 0, label: { text: 'No' } do %>
+          <%= f.govuk_text_area :no_qualification_details, label: { text: 'Enter details to explain why you do not plan to take an assessment (optional)' } %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
@@ -19,7 +19,7 @@
           <%= f.govuk_text_area :no_qualification_details, label: { text: 'Give details of the type of assessment you plan to take and when you plan to take it' } %>
         <% end %>
         <%= f.govuk_radio_button :declare_no_qualification_details, 0, label: { text: 'No' } do %>
-          <%= f.govuk_text_area :no_qualification_details, label: { text: 'Enter details to explain why you do not plan to take an assessment (optional)' } %>
+          <%= f.govuk_text_area :no_assessment_plan_details, label: { text: 'Enter details to explain why you do not plan to take an assessment (optional)' } %>
         <% end %>
       <% end %>
 

--- a/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/no_qualification_details/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @no_qualification_details_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.efl.english_language_skills'), @no_qualification_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">
@@ -6,7 +6,7 @@
     <%= form_with(model: @no_qualification_details_form, url: candidate_interface_english_proficiencies_no_qualification_details_path(@english_proficiency), method: :patch) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
-        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.english_language_skills') %></span>
         You may need an English as a foreign language assessment
       </h1>
       <p class='govuk-body'>

--- a/app/views/candidate_interface/english_proficiencies/other_efl_qualification/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/other_efl_qualification/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(model: @other_qualification_form, url: candidate_interface_english_proficiencies_other_efl_qualification_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
-        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.english_language_skills') %></span>
         <%= t('page_titles.efl.other') %>
       </h1>
       <%= render 'form_fields', { f: f } %>

--- a/app/views/candidate_interface/english_proficiencies/review/show.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/review/show.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, t('page_titles.efl.review') %>
+<% content_for :title, t('page_titles.efl.check_your_english_language_skills') %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_english_proficiencies_complete_path(@return_to[:params]), method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>
+  <h1 class="govuk-heading-xl"><%= t('page_titles.efl.check_your_english_language_skills') %></h1>
 
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 

--- a/app/views/candidate_interface/english_proficiencies/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/start/_form_fields.html.erb
@@ -1,9 +1,9 @@
 <%= f.govuk_error_summary %>
 <%= f.govuk_check_boxes_fieldset :qualification_statuses,
-    caption: { text: t('page_titles.efl.start'), size: 'xl' },
-    legend: { text: 'Proving your level of English', size: 'xl', tag: 'h1' },
+    caption: { text: t('page_titles.efl.english_language_skills'), size: 'xl' },
+    legend: { text: 'Proving your English language skills', size: 'xl', tag: 'h1' },
     hint: { text: 'Select all that apply' } do %>
-  <%= f.govuk_check_box :qualification_statuses, 'qualification_not_needed', label: { text: 'English is my first language' }, link_errors: true %>
+  <%= f.govuk_check_box :qualification_statuses, 'qualification_not_needed', label: { text: 'English is my main language' }, link_errors: true %>
   <%= f.govuk_check_box :qualification_statuses, 'degree_taught_in_english', label: { text: 'My degree was taught in English' } %>
   <%= f.govuk_check_box :qualification_statuses, 'has_qualification', label: { text: 'I have an English as a foreign language (EFL) assessment' } %>
   <%= f.govuk_check_box_divider %>

--- a/app/views/candidate_interface/english_proficiencies/start/edit.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/start/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.efl.english_language_skills'), @start_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/english_proficiencies/start/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/start/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.efl.english_language_skills'), @start_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/english_proficiencies/toefl/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/toefl/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(model: @toefl_form, url: candidate_interface_english_proficiencies_toefl_path(@return_to[:params])) do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class='govuk-heading-xl'>
-        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.english_language_skills') %></span>
         <%= t('page_titles.efl.toefl') %>
       </h1>
       <%= render 'form_fields', { f: f } %>

--- a/app/views/candidate_interface/english_proficiencies/type/new.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/type/new.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :type,
                                          legend: { text: t('page_titles.efl.type'), size: 'xl', tag: 'h1' },
-                                         caption: { text: t('page_titles.efl.start'), size: 'xl' } do %>
+                                         caption: { text: t('page_titles.efl.english_language_skills'), size: 'xl' } do %>
         <%= f.govuk_radio_button :type, 'ielts', label: { text: 'International English Language Testing System (IELTS)' }, link_errors: true %>
         <%= f.govuk_radio_button :type, 'toefl', label: { text: 'Test of English as a Foreign Language (TOEFL)' } %>
         <%= f.govuk_radio_button :type, 'other', label: { text: 'Other' } %>

--- a/app/views/candidate_interface/shared/_task_list.html.erb
+++ b/app/views/candidate_interface/shared/_task_list.html.erb
@@ -11,7 +11,7 @@
     <% if application_form_presenter.display_efl_link? %>
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(
-          text: t('page_titles.efl.start'),
+          text: FeatureFlag.active?('2027_application_form_has_many_english_proficiencies') ? t('page_titles.efl.english_language_skills') : t('page_titles.efl.start'),
           completed: application_form_presenter.english_as_a_foreign_language_completed?,
           path: application_form_presenter.english_as_a_foreign_language_path,
         )) %>

--- a/config/locales/candidate_interface/english_proficiencies.yml
+++ b/config/locales/candidate_interface/english_proficiencies.yml
@@ -20,8 +20,8 @@ en:
         candidate_interface/english_proficiencies/start_form:
           attributes:
             qualification_statuses:
-              blank: Select a way of proving your level of English, or select ‘None of these’
-              inclusion: Select a way of proving your level of English, or select ‘None of these’
+              blank: Select a way of proving your English language skills, or select ‘None of these’
+              inclusion: Select a way of proving your English language skills, or select ‘None of these’
         candidate_interface/english_proficiencies/no_qualification_details_form:
           attributes:
             declare_no_qualification_details:

--- a/config/locales/components/candidate_interface/english_proficiencies/review_component.yml
+++ b/config/locales/components/candidate_interface/english_proficiencies/review_component.yml
@@ -3,7 +3,7 @@ en:
     english_proficiencies:
       review_component:
         qualification_status:
-          qualification_not_needed: English is my first language
+          qualification_not_needed: English is my main language
           degree_taught_in_english: My degree was taught in English
           has_qualification: I have an English as a foreign language (EFL) assessment
           no_qualification: None of these

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,7 @@ en:
       ielts: Your IELTS result
       other: Your English language assessment result
       review: Check your English as a foreign language assessment
+      check_your_english_language_skills: Check your English language skills
       start: English as a foreign language assessment
       english_language_skills: English language skills
       toefl: Your TOEFL result

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
       other: Your English language assessment result
       review: Check your English as a foreign language assessment
       start: English as a foreign language assessment
+      english_language_skills: English language skills
       toefl: Your TOEFL result
       type: What English language assessment did you do?
     error_prefix: "Error: "

--- a/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
+++ b/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
@@ -98,6 +98,32 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'No')
       end
 
+      context 'when "no_assessment_plan_details" are given' do
+        let(:english_proficiency) do
+          create(:english_proficiency, no_qualification: true, no_assessment_plan_details: 'Work in progress')
+        end
+
+        it 'renders the "no_assessment_plan_details"' do
+          render_inline described_class.new(english_proficiency)
+          expect(rendered_content).to have_css(
+            'h2.govuk-summary-card__title',
+            text: 'English language skills',
+          )
+          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
+          expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'None of these')
+          expect(rendered_content).to have_css(
+            'dt.govuk-summary-list__key',
+            text: 'Do you plan on taking an English as a foreign language assessment?',
+          )
+          expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'No')
+          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Details')
+          expect(rendered_content).to have_css(
+            'dd.govuk-summary-list__value',
+            text: 'Work in progress',
+          )
+        end
+      end
+
       context 'when "no_qualification_details" are given' do
         let(:english_proficiency) do
           create(:english_proficiency, no_qualification: true, no_qualification_details: 'Work in progress')

--- a/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
+++ b/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
       render_inline described_class.new(english_proficiency)
       expect(rendered_content).to have_css(
         'h2.govuk-summary-card__title',
-        text: 'English as a foreign language assessment',
+        text: 'English language skills',
       )
-      expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
-      expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'English is my first language')
+      expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
+      expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'English is my main language')
     end
   end
 
@@ -23,9 +23,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'My degree was taught in English')
         expect(rendered_content).to have_css(
           'dt.govuk-summary-list__key',
@@ -44,9 +44,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'My degree was taught in English')
         expect(rendered_content).to have_css(
           'dt.govuk-summary-list__key',
@@ -70,12 +70,12 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css(
           'dd.govuk-summary-list__value',
-          text: 'English is my first language My degree was taught in English',
+          text: 'English is my main language My degree was taught in English',
         )
       end
     end
@@ -87,9 +87,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'None of these')
         expect(rendered_content).to have_css(
           'dt.govuk-summary-list__key',
@@ -107,9 +107,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
           render_inline described_class.new(english_proficiency)
           expect(rendered_content).to have_css(
             'h2.govuk-summary-card__title',
-            text: 'English as a foreign language assessment',
+            text: 'English language skills',
           )
-          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
           expect(rendered_content).to have_css('dd.govuk-summary-list__value', text: 'None of these')
           expect(rendered_content).to have_css(
             'dt.govuk-summary-list__key',
@@ -143,9 +143,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css(
           'dd.govuk-summary-list__value',
           text: 'I have an English as a foreign language (EFL) assessment',
@@ -182,12 +182,12 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css(
           'dd.govuk-summary-list__value',
-          text: 'English is my first language I have an English as a foreign language (EFL) assessment',
+          text: 'English is my main language I have an English as a foreign language (EFL) assessment',
         )
         expect(rendered_content).to have_css(
           'dt.govuk-summary-list__key',
@@ -221,12 +221,12 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
           render_inline described_class.new(english_proficiency)
           expect(rendered_content).to have_css(
             'h2.govuk-summary-card__title',
-            text: 'English as a foreign language assessment',
+            text: 'English language skills',
           )
-          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+          expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
           expect(rendered_content).to have_css(
             'dd.govuk-summary-list__value',
-            text: 'English is my first language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+            text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
           )
           expect(rendered_content).to have_css(
             'dt.govuk-summary-list__key',
@@ -267,9 +267,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css('dd.govuk-summary-list__value',
                                              text: 'I have an English as a foreign language (EFL) assessment')
         expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Type of assessment')
@@ -301,9 +301,9 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
         render_inline described_class.new(english_proficiency)
         expect(rendered_content).to have_css(
           'h2.govuk-summary-card__title',
-          text: 'English as a foreign language assessment',
+          text: 'English language skills',
         )
-        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your level of English')
+        expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
         expect(rendered_content).to have_css(
           'dd.govuk-summary-list__value',
           text: 'I have an English as a foreign language (EFL) assessment',

--- a/spec/forms/candidate_interface/english_proficiencies/no_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/english_proficiencies/no_qualification_details_form_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe CandidateInterface::EnglishProficiencies::NoQualificationDetailsF
       expect(application_form.english_proficiency.qualification_statuses).to contain_exactly('no_qualification')
       expect(application_form.english_proficiency.draft).to be false
       expect(application_form.english_proficiency.no_qualification_details).to eq('Work in progress')
+      expect(application_form.english_proficiency.no_assessment_plan_details).to be_nil
+    end
+
+    it 'saves the no assessment plan details' do
+      application_form = create(:application_form)
+      english_proficiency = create(:english_proficiency, :draft, application_form:, no_qualification: true)
+
+      form = valid_form.tap do |f|
+        f.declare_no_qualification_details = 0
+        f.no_qualification_details = nil
+        f.no_assessment_plan_details = 'Work in progress'
+      end
+
+      form.application_form = application_form
+      form.english_proficiency = english_proficiency
+
+      form.save
+      application_form.reload
+
+      expect(application_form.english_proficiency.qualification_statuses).to contain_exactly('no_qualification')
+      expect(application_form.english_proficiency.draft).to be false
+      expect(application_form.english_proficiency.no_qualification_details).to be_nil
+      expect(application_form.english_proficiency.no_assessment_plan_details).to eq('Work in progress')
     end
 
     context 'user does not enter any no qualification details' do

--- a/spec/forms/candidate_interface/english_proficiencies/start_form_spec.rb
+++ b/spec/forms/candidate_interface/english_proficiencies/start_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::EnglishProficiencies::StartForm,
       expect(form).not_to be_valid
       expect(
         form.errors.full_messages,
-      ).to include('Qualification statuses Select a way of proving your level of English, or select ‘None of these’')
+      ).to include('Qualification statuses Select a way of proving your English language skills, or select ‘None of these’')
     end
 
     it 'is invalid if qualification status is not valid' do
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::EnglishProficiencies::StartForm,
       expect(form).not_to be_valid
       expect(
         form.errors.full_messages,
-      ).to eq  ['Qualification statuses Select a way of proving your level of English, or select ‘None of these’']
+      ).to eq  ['Qualification statuses Select a way of proving your English language skills, or select ‘None of these’']
     end
   end
 

--- a/spec/services/candidate_interface/update_english_proficiencies_spec.rb
+++ b/spec/services/candidate_interface/update_english_proficiencies_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CandidateInterface::UpdateEnglishProficiencies,
         english_proficiency:,
         efl_qualification:,
         no_qualification_details:,
+        no_assessment_plan_details:,
         persist:,
         publish:,
       ).call
@@ -22,6 +23,7 @@ RSpec.describe CandidateInterface::UpdateEnglishProficiencies,
     let(:no_qualification_details) { nil }
     let(:persist) { false }
     let(:publish) { false }
+    let(:no_assessment_plan_details) { nil }
 
     context 'when a english proficiency is not given' do
       context 'when the qualification statuses is "qualification_not_needed"' do
@@ -306,6 +308,67 @@ RSpec.describe CandidateInterface::UpdateEnglishProficiencies,
 
           new_english_proficiency = application_form.english_proficiencies.last
           expect(new_english_proficiency.no_qualification_details).to be_nil
+        end
+      end
+    end
+
+    context 'when "no_assessment_plan_details" are given' do
+      let(:no_assessment_plan_details) { 'Work in progress' }
+
+      context 'when the qualification status is "no_qualification"' do
+        let(:qualification_statuses) { ['no_qualification'] }
+
+        it 'assigns the "no_assessment_plan_details"' do
+          expect { call }.to change(application_form.english_proficiencies, :count).by(1)
+
+          expect(application_form.english_proficiency).to be_nil
+
+          new_english_proficiency = application_form.english_proficiencies.last
+          expect(new_english_proficiency.no_qualification_details).to be_nil
+          expect(new_english_proficiency.no_assessment_plan_details).to eq('Work in progress')
+        end
+      end
+
+      context 'when the qualification status is "degree_taught_in_english"' do
+        let(:qualification_statuses) { ['degree_taught_in_english'] }
+
+        it 'assigns the "no_assessment_plan_details"' do
+          expect { call }.to change(application_form.english_proficiencies, :count).by(1)
+
+          expect(application_form.english_proficiency).to be_nil
+
+          new_english_proficiency = application_form.english_proficiencies.last
+          expect(new_english_proficiency.no_qualification_details).to be_nil
+          expect(new_english_proficiency.no_assessment_plan_details).to eq('Work in progress')
+        end
+      end
+
+      context 'when the qualification status is no "degree_taught_in_english" or "no_qualification"' do
+        let(:qualification_statuses) { ['has_qualification'] }
+
+        it 'does not assign the "no_assessment_plan_details"' do
+          expect { call }.to change(application_form.english_proficiencies, :count).by(1)
+
+          expect(application_form.english_proficiency).to be_nil
+
+          new_english_proficiency = application_form.english_proficiencies.last
+          expect(new_english_proficiency.no_qualification_details).to be_nil
+          expect(new_english_proficiency.no_assessment_plan_details).to be_nil
+        end
+      end
+
+      context 'when persist is true' do
+        let(:qualification_statuses) { ['degree_taught_in_english'] }
+        let(:persist) { true }
+
+        it 'does not assign the "no_assessment_plan_details"' do
+          expect { call }.to change(application_form.english_proficiencies, :count).by(1)
+
+          expect(application_form.english_proficiency).to be_nil
+
+          new_english_proficiency = application_form.english_proficiencies.last
+          expect(new_english_proficiency.no_qualification_details).to be_nil
+          expect(new_english_proficiency.no_assessment_plan_details).to be_nil
         end
       end
     end

--- a/spec/support/test_helpers/efl_helper.rb
+++ b/spec/support/test_helpers/efl_helper.rb
@@ -28,6 +28,10 @@ module EFLHelper
   end
 
   def efl_link_text
-    'English as a foreign language'
+    if FeatureFlag.active? '2027_application_form_has_many_english_proficiencies'
+      'English language skills'
+    else
+      'English as a foreign language'
+    end
   end
 end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_degree_taught_in_english_and_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_degree_taught_in_english_and_english_is_my_first_language_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as degree taught in E
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_degree_taught_in_english
@@ -32,8 +32,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -48,10 +48,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -62,7 +62,7 @@ private
   end
 
   def and_i_select_english_is_my_first_language
-    check 'English is my first language'
+    check 'English is my main language'
   end
 
   def and_i_click_on_continue
@@ -85,7 +85,7 @@ private
   def then_i_see_the_may_need_to_an_efl_assessment_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_no_qualification_details_path(english_proficiency.id))
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'You may need an English as a foreign language assessment', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('Yes', type: 'radio')
@@ -101,19 +101,19 @@ private
   end
 
   def and_i_enter_the_details_of_my_assessment
-    fill_in 'Give details of when and what type of assessment you plan to take', with: 'Work in progress'
+    fill_in 'Give details of the type of assessment you plan to take and when you plan to take it', with: 'Work in progress'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_and_english_is_my_first_language
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
-      expect(page).to have_element(:dd, text: 'English is my first language My degree was taught in English', class: 'govuk-summary-list__value')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'English is my main language My degree was taught in English', class: 'govuk-summary-list__value')
     end
   end
 
@@ -124,7 +124,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_degree_taught_in_english_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as degree taught in E
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_degree_taught_in_english
@@ -36,7 +36,7 @@ RSpec.describe 'Candidate enters their english proficiency as degree taught in E
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_degree_taught_in_english
@@ -71,8 +71,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -87,10 +87,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -116,11 +116,11 @@ private
   def then_i_see_the_may_need_to_an_efl_assessment_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_no_qualification_details_path(english_proficiency.id))
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'You may need an English as a foreign language assessment', class: 'govuk-heading-xl')
     expect(page).to have_element(
       :p,
-      text: 'Training providers may need to see evidence of your level of English. Contact them to find out about their requirements.',
+      text: 'Training providers may need to see evidence of your English language skills. Contact them to find out about their requirements.',
       class: 'govuk-body',
     )
     expect(page).to have_element(:h2, text: 'Do you plan on taking an English as a foreign language assessment?', class: 'govuk-fieldset__heading')
@@ -138,18 +138,18 @@ private
   end
 
   def and_i_enter_the_details_of_my_assessment
-    fill_in 'Give details of when and what type of assessment you plan to take', with: 'Work in progress'
+    fill_in 'Give details of the type of assessment you plan to take and when you plan to take it', with: 'Work in progress'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_no_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -162,8 +162,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -187,7 +187,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_english_is_my_first_language_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as English is my firs
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_click_on_continue
@@ -34,23 +34,23 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_start_path
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
   end
 
   def when_i_select_english_is_my_first_language
-    check 'English is my first language'
+    check 'English is my main language'
   end
 
   def and_i_click_on_continue
@@ -60,14 +60,14 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_english_is_my_first_language
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
-      expect(page).to have_element(:dd, text: 'English is my first language', class: 'govuk-summary-list__value')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'English is my main language', class: 'govuk-summary-list__value')
     end
   end
 
@@ -76,13 +76,13 @@ private
   end
 
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
-    expect(page).to have_element(:div, text: 'English as a foreign language assessment Completed', class: 'app-task-list__content')
+    expect(page).to have_element(:div, text: 'English language skillsCompleted', class: 'app-task-list__content')
   end
 
   def and_i_see_validation_errors_for_not_selecting_a_level_of_english
     expect(page).to have_element(
       :div,
-      text: 'Select a way of proving your level of English, or select ‘None of these’',
+      text: 'Select a way of proving your English language skills, or select ‘None of these’',
       class: 'govuk-error-summary__body',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_another_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_another_efl_qualification_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has another EFL qu
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -61,8 +61,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -77,10 +77,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -98,7 +98,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -121,7 +121,7 @@ private
   def then_i_see_the_other_efl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_other_efl_qualification_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your English language assessment result', class: 'govuk-heading-xl')
     expect(page).to have_field('Assessment name', type: 'text')
     expect(page).to have_field('Score or grade', type: 'text')
@@ -145,13 +145,13 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -175,7 +175,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_and_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_and_english_is_my_first_language_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has IELTS qualific
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -56,8 +56,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -72,10 +72,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -90,7 +90,7 @@ private
   end
 
   def and_i_select_english_is_my_first_language
-    check 'English is my first language'
+    check 'English is my main language'
   end
 
   def and_i_click_on_continue
@@ -101,7 +101,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -122,7 +122,7 @@ private
   end
 
   def and_i_see_english_is_my_first_language_selected
-    expect(page).to have_checked_field('English is my first language', type: 'checkbox')
+    expect(page).to have_checked_field('English is my main language', type: 'checkbox')
   end
 
   def when_i_select_ielts
@@ -132,7 +132,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')
@@ -155,16 +155,16 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment_and_degree_taught_in_english_and_english_is_my_first_language
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
-        text: 'English is my first language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+        text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
         class: 'govuk-summary-list__value',
       )
       expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
@@ -185,7 +185,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has IELTS qualific
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -54,8 +54,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -70,10 +70,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -95,7 +95,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -122,7 +122,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')
@@ -145,13 +145,13 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment_and_degree_taught_in_english
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment My degree was taught in English',
@@ -175,7 +175,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_english_is_my_first_language_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has IELTS qualific
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -54,8 +54,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -70,10 +70,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -84,7 +84,7 @@ private
   end
 
   def and_i_select_english_is_my_first_language
-    check 'English is my first language'
+    check 'English is my main language'
   end
 
   def and_i_click_on_continue
@@ -95,7 +95,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -112,7 +112,7 @@ private
   end
 
   def and_i_see_english_is_my_first_language_selected
-    expect(page).to have_checked_field('English is my first language', type: 'checkbox')
+    expect(page).to have_checked_field('English is my main language', type: 'checkbox')
   end
 
   def when_i_select_ielts
@@ -122,7 +122,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')
@@ -145,16 +145,16 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment_and_english_is_my_first_language
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
-        text: 'English is my first language I have an English as a foreign language (EFL) assessment',
+        text: 'English is my main language I have an English as a foreign language (EFL) assessment',
         class: 'govuk-summary-list__value',
       )
       expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
@@ -175,7 +175,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has IELTS qualific
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -65,8 +65,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -81,10 +81,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -102,7 +102,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -125,7 +125,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')
@@ -149,13 +149,13 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -179,7 +179,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_toefl_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_toefl_qualification_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as has TOEFL qualific
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_i_have_an_efl_assessment
@@ -60,8 +60,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -76,10 +76,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -97,7 +97,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -120,7 +120,7 @@ private
   def then_i_see_the_toefl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_toefl_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your TOEFL result', class: 'govuk-heading-xl')
     expect(page).to have_field('TOEFL registration number', type: 'text')
     expect(page).to have_field('Total score', type: 'text')
@@ -144,13 +144,13 @@ private
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -171,10 +171,10 @@ private
     choose 'Yes, I have completed this section'
   end
 
-  def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
+  def then_i_see_the_english_language_skills_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_none_of_these_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_none_of_these_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Candidate enters their english proficiency as none of these',
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_none_of_these
@@ -36,7 +36,7 @@ RSpec.describe 'Candidate enters their english proficiency as none of these',
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_proving_your_level_of_english_page
 
     when_i_select_none_of_these
@@ -79,8 +79,8 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_proving_your_level_of_english_page
@@ -95,10 +95,10 @@ private
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -124,11 +124,11 @@ private
   def then_i_see_the_may_need_to_an_efl_assessment_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_no_qualification_details_path(english_proficiency.id))
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'You may need an English as a foreign language assessment', class: 'govuk-heading-xl')
     expect(page).to have_element(
       :p,
-      text: 'Training providers may need to see evidence of your level of English. Contact them to find out about their requirements.',
+      text: 'Training providers may need to see evidence of your English language skills. Contact them to find out about their requirements.',
       class: 'govuk-body',
     )
     expect(page).to have_element(:h2, text: 'Do you plan on taking an English as a foreign language assessment?', class: 'govuk-fieldset__heading')
@@ -146,18 +146,18 @@ private
   end
 
   def and_i_enter_the_details_of_my_assessment
-    fill_in 'Give details of when and what type of assessment you plan to take', with: 'Work in progress'
+    fill_in 'Give details of the type of assessment you plan to take and when you plan to take it', with: 'Work in progress'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_none_of_these_with_no_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'None of these', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -170,8 +170,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_none_of_these_with_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'None of these', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -195,7 +195,7 @@ private
   def then_i_see_the_english_as_a_foreign_language_assessment_section_completed
     expect(page).to have_element(
       :div,
-      text: 'English as a foreign language assessment Completed',
+      text: 'English language skills Completed',
       class: 'app-task-list__content',
     )
   end

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_none_of_these_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_none_of_these_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Candidate enters their english proficiency as none of these',
     and_i_click_on_continue
   end
 
-  scenario 'with details' do
+  scenario 'with details about the type of assessment' do
     given_i_am_signed_in_with_one_login
     and_english_is_not_my_first_language
     and_visit_my_details
@@ -64,6 +64,39 @@ RSpec.describe 'Candidate enters their english proficiency as none of these',
 
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_none_of_these_with_details
+
+    when_i_select_yes_i_have_completed_this_section
+    and_i_click_on_continue
+  end
+
+  scenario 'with details explaining no plan to take an assessment' do
+    given_i_am_signed_in_with_one_login
+    and_english_is_not_my_first_language
+    and_visit_my_details
+    when_i_click_on_english_language_skills
+    then_i_see_the_proving_your_level_of_english_page
+
+    when_i_select_none_of_these
+    and_i_click_on_continue
+    then_i_see_the_may_need_to_an_efl_assessment_page
+
+    when_i_click_on_back
+    then_i_see_the_proving_your_level_of_english_edit_page
+    and_i_see_none_of_these_selected
+
+    when_i_click_on_continue
+    then_i_see_the_may_need_to_an_efl_assessment_page
+
+    when_i_click_on_continue
+    then_i_see_the_may_need_to_an_efl_assessment_page
+    and_i_see_validation_errors_for_not_selecting_whether_or_not_i_plan_to_take_an_assessment
+
+    when_i_select_no
+    and_i_enter_the_details_why_i_do_not_plan_to_take_an_assessment
+    and_i_click_on_continue
+
+    then_i_see_the_review_page
+    and_i_see_that_my_level_of_english_is_none_of_these_with_no_plan_to_take_one
 
     when_i_select_yes_i_have_completed_this_section
     and_i_click_on_continue
@@ -188,6 +221,26 @@ private
     end
   end
 
+  def and_i_see_that_my_level_of_english_is_none_of_these_with_no_plan_to_take_one
+    within('.govuk-summary-card') do
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'None of these', class: 'govuk-summary-list__value')
+      expect(page).to have_element(
+        :dt,
+        text: 'Do you plan on taking an English as a foreign language assessment?',
+        class: 'govuk-summary-list__key',
+      )
+      expect(page).to have_element(:dd, text: 'No', class: 'govuk-summary-list__value')
+      expect(page).to have_element(
+        :dt,
+        text: 'Details',
+        class: 'govuk-summary-list__key',
+      )
+      expect(page).to have_element(:dd, text: 'I do not need one', class: 'govuk-summary-list__value')
+    end
+  end
+
   def when_i_select_yes_i_have_completed_this_section
     choose 'Yes, I have completed this section'
   end
@@ -214,5 +267,9 @@ private
       text: 'Enter the details of the assessment you plan to take',
       class: 'govuk-error-summary__body',
     )
+  end
+
+  def and_i_enter_the_details_why_i_do_not_plan_to_take_an_assessment
+    fill_in 'Enter details to explain why you do not plan to take an assessment (optional)', with: 'I do not need one'
   end
 end

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_ielts_results_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates the ielts results',
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_ielts_efl_assessment
 
@@ -64,19 +64,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_ielts_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -100,7 +100,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency), ignore_query: true
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
   end
 
@@ -134,8 +134,8 @@ private
 
   def and_i_see_that_my_ielts_results_have_been_updated
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_other_efl_qualification_results_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_other_efl_qualification_results_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates the other efl qualification results',
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
 
@@ -64,19 +64,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -100,7 +100,7 @@ private
   def then_i_see_the_other_efl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_other_efl_qualification_path(english_proficiency), ignore_query: true
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your English language assessment result', class: 'govuk-heading-xl')
   end
 
@@ -134,8 +134,8 @@ private
 
   def and_i_see_that_my_ielts_results_have_been_updated
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_toefl_results_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_the_toefl_results_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates the toefl results',
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_a_toefl_efl_assessment
 
@@ -64,19 +64,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_a_toefl_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -100,7 +100,7 @@ private
   def then_i_see_the_toefl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_toefl_path(english_proficiency), ignore_query: true
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your TOEFL result', class: 'govuk-heading-xl')
   end
 
@@ -134,8 +134,8 @@ private
 
   def and_i_see_that_my_ielts_results_have_been_updated
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_efl_assessment_type_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_efl_assessment_type_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates their efl assessment type',
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_ielts_efl_assessment
 
@@ -107,19 +107,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_ielts_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -143,7 +143,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -171,7 +171,7 @@ private
   def then_i_see_the_toefl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_toefl_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your TOEFL result', class: 'govuk-heading-xl')
     expect(page).to have_field('TOEFL registration number', type: 'text')
     expect(page).to have_field('Total score', type: 'text')
@@ -194,8 +194,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_i_have_a_toefl_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -219,7 +219,7 @@ private
   def then_i_see_the_other_efl_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_other_efl_qualification_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your English language assessment result', class: 'govuk-heading-xl')
     expect(page).to have_field('Assessment name', type: 'text')
     expect(page).to have_field('Score or grade', type: 'text')
@@ -238,8 +238,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_i_have_another_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -263,7 +263,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_no_qualification_details_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_no_qualification_details_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates their english proficiency no qualification det
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
 
@@ -67,19 +67,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -112,11 +112,11 @@ private
   end
 
   def and_i_see_the_may_need_to_an_efl_assessment_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'You may need an English as a foreign language assessment', class: 'govuk-heading-xl')
     expect(page).to have_element(
       :p,
-      text: 'Training providers may need to see evidence of your level of English. Contact them to find out about their requirements.',
+      text: 'Training providers may need to see evidence of your English language skills. Contact them to find out about their requirements.',
       class: 'govuk-body',
     )
     expect(page).to have_element(:h2, text: 'Do you plan on taking an English as a foreign language assessment?', class: 'govuk-fieldset__heading')
@@ -130,7 +130,7 @@ private
   end
 
   def and_i_see_the_details_of_my_efl_assessment
-    expect(page).to have_field('Give details of when and what type of assessment you plan to take', text: 'Work in progress')
+    expect(page).to have_field('Give details of the type of assessment you plan to take and when you plan to take it', text: 'Work in progress')
   end
 
   def when_i_click_on_back
@@ -147,8 +147,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_no_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -168,6 +168,6 @@ private
   end
 
   def and_i_enter_the_details_of_my_assessment
-    fill_in 'Give details of when and what type of assessment you plan to take', with: 'Work in progress'
+    fill_in 'Give details of the type of assessment you plan to take and when you plan to take it', with: 'Work in progress'
   end
 end

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_degree_taught_in_english_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates their english proficiency to degree taught in 
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
 
@@ -41,7 +41,7 @@ RSpec.describe 'Candidate updates their english proficiency to degree taught in 
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
 
@@ -94,19 +94,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -129,22 +129,22 @@ private
 
   def then_i_see_the_proving_your_level_of_english_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_edit_start_path(@english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     and_i_see_the_proving_your_level_of_english_form
   end
 
   def then_i_see_the_proving_your_level_of_english_edit_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_edit_start_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     and_i_see_the_proving_your_level_of_english_form
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -177,11 +177,11 @@ private
   def then_i_see_the_may_need_to_an_efl_assessment_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_no_qualification_details_path(english_proficiency.id))
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'You may need an English as a foreign language assessment', class: 'govuk-heading-xl')
     expect(page).to have_element(
       :p,
-      text: 'Training providers may need to see evidence of your level of English. Contact them to find out about their requirements.',
+      text: 'Training providers may need to see evidence of your English language skills. Contact them to find out about their requirements.',
       class: 'govuk-body',
     )
     expect(page).to have_element(:h2, text: 'Do you plan on taking an English as a foreign language assessment?', class: 'govuk-fieldset__heading')
@@ -199,13 +199,13 @@ private
   end
 
   def and_i_enter_the_details_of_my_assessment
-    fill_in 'Give details of when and what type of assessment you plan to take', with: 'Work in progress'
+    fill_in 'Give details of the type of assessment you plan to take and when you plan to take it', with: 'Work in progress'
   end
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_no_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,
@@ -218,8 +218,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_english_is_my_first_language_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates their english proficiency to English is my fir
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
 
@@ -49,19 +49,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -84,10 +84,10 @@ private
 
   def then_i_see_the_proving_your_level_of_english_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_edit_start_path(@english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -102,7 +102,7 @@ private
   end
 
   def and_i_select_english_is_my_first_language
-    check 'English is my first language'
+    check 'English is my main language'
   end
 
   def and_i_click_on_continue
@@ -111,9 +111,9 @@ private
 
   def and_i_see_that_english_is_my_first_language
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
-      expect(page).to have_element(:dd, text: 'English is my first language', class: 'govuk-summary-list__value')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'English is my main language', class: 'govuk-summary-list__value')
     end
   end
 end

--- a/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_has_ielts_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/update_english_proficiencies/candidate_updates_their_english_proficiency_to_has_ielts_qualification_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Candidate updates their english proficiency to degree taught in 
     and_english_is_not_my_first_language
     and_i_have_previous_entered_my_english_proficiency
     and_visit_my_details
-    when_i_click_on_english_as_a_foreign_language
+    when_i_click_on_english_language_skills
     then_i_see_the_review_page
     and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
 
@@ -71,19 +71,19 @@ private
     visit candidate_interface_details_path
   end
 
-  def when_i_click_on_english_as_a_foreign_language
-    click_on 'English as a foreign language'
+  def when_i_click_on_english_language_skills
+    click_on 'English language skills'
   end
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_review_path
-    expect(page).to have_element(:h1, text: 'Check your English as a foreign language assessment', class: 'govuk-heading-xl')
+    expect(page).to have_element(:h1, text: 'Check your English language skills', class: 'govuk-heading-xl')
   end
 
   def and_i_see_that_my_level_of_english_is_i_have_an_efl_assessment
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
         text: 'I have an English as a foreign language (EFL) assessment',
@@ -106,22 +106,22 @@ private
 
   def then_i_see_the_proving_your_level_of_english_page
     expect(page).to have_current_path candidate_interface_english_proficiencies_edit_start_path(@english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     and_i_see_the_proving_your_level_of_english_form
   end
 
   def then_i_see_the_proving_your_level_of_english_edit_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_edit_start_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     and_i_see_the_proving_your_level_of_english_form
   end
 
   def and_i_see_the_proving_your_level_of_english_form
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
-    expect(page).to have_element(:h1, text: 'Proving your level of English', class: 'govuk-fieldset__heading')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
+    expect(page).to have_element(:h1, text: 'Proving your English language skills', class: 'govuk-fieldset__heading')
 
-    expect(page).to have_field('English is my first language', type: 'checkbox')
+    expect(page).to have_field('English is my main language', type: 'checkbox')
     expect(page).to have_field('My degree was taught in English', type: 'checkbox')
     expect(page).to have_field('I have an English as a foreign language (EFL) assessment', type: 'checkbox')
     expect(page).to have_field('None of these', type: 'checkbox')
@@ -155,7 +155,7 @@ private
   def then_i_see_the_efl_assessment_type_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path(candidate_interface_english_proficiencies_type_path(english_proficiency), ignore_query: true)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'What English language assessment did you do?', class: 'govuk-fieldset__heading')
 
     expect(page).to have_field('International English Language Testing System (IELTS)', type: 'radio')
@@ -170,7 +170,7 @@ private
   def then_i_see_the_ielts_results_page
     english_proficiency = @application_form.english_proficiencies.last
     expect(page).to have_current_path candidate_interface_english_proficiencies_ielts_path(english_proficiency)
-    expect(page).to have_element(:span, text: 'English as a foreign language assessment', class: 'govuk-caption-xl')
+    expect(page).to have_element(:span, text: 'English language skills', class: 'govuk-caption-xl')
     expect(page).to have_element(:h1, text: 'Your IELTS result', class: 'govuk-heading-xl')
     expect(page).to have_field('Test report form (TRF) number', type: 'text')
     expect(page).to have_field('Overall band score', type: 'text')
@@ -193,8 +193,8 @@ private
 
   def and_i_see_that_my_level_of_english_is_degree_taught_in_english_with_details
     within('.govuk-summary-card') do
-      expect(page).to have_element(:h2, text: 'English as a foreign language assessment', class: 'govuk-summary-card__title')
-      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:h2, text: 'English language skills', class: 'govuk-summary-card__title')
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(:dd, text: 'My degree was taught in English', class: 'govuk-summary-list__value')
       expect(page).to have_element(
         :dt,

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_a_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_a_degree_taught_in_english_spec.rb
@@ -65,10 +65,10 @@ private
   def then_i_can_see_a_degree_taught_in_english_with_no_details
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
       text: 'My degree was taught in English',
@@ -89,10 +89,10 @@ private
   def then_i_can_see_a_degree_taught_in_english_with_details
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
       text: 'My degree was taught in English',

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
@@ -130,10 +130,10 @@ private
   def then_i_can_see_my_ielts_qualification
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: 'I have an English as a foreign language (EFL) assessment', class: 'govuk-summary-list__value')
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: 'IELTS', class: 'govuk-summary-list__value')
@@ -148,10 +148,10 @@ private
   def then_i_can_see_my_toefl_qualification
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: 'I have an English as a foreign language (EFL) assessment', class: 'govuk-summary-list__value')
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: 'TOEFL', class: 'govuk-summary-list__value')
@@ -166,10 +166,10 @@ private
   def then_i_can_see_my_efl_qualification
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: 'I have an English as a foreign language (EFL) assessment', class: 'govuk-summary-list__value')
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
     expect(page).to have_element(:dd, text: @efl_qualification.name, class: 'govuk-summary-list__value')
@@ -184,13 +184,13 @@ private
   def then_i_can_see_my_ielts_qualification_with_english_is_my_first_language
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
-      text: 'English is my first language I have an English as a foreign language (EFL) assessment',
+      text: 'English is my main language I have an English as a foreign language (EFL) assessment',
       class: 'govuk-summary-list__value',
     )
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
@@ -206,10 +206,10 @@ private
   def then_i_can_see_my_ielts_qualification_with_degree_taught_in_english
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
       text: 'I have an English as a foreign language (EFL) assessment My degree was taught in English',
@@ -228,13 +228,13 @@ private
   def then_i_can_see_my_ielts_qualification_with_degree_taught_in_english_and_english_is_my_first_language
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
-      text: 'English is my first language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+      text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
       class: 'govuk-summary-list__value',
     )
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_english_as_their_first_language_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_english_as_their_first_language_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Candidate reviews an application with English as their first lan
     and_i_have_previously_entered_my_english_proficiency
     and_i_have_an_unsubmitted_application_choice
     when_i_review_my_application
-    then_i_can_see_english_is_my_first_language
+    then_i_can_see_english_is_my_main_language
   end
 
   scenario 'English is my first language and degree taught in English' do
@@ -20,7 +20,7 @@ RSpec.describe 'Candidate reviews an application with English as their first lan
     and_my_degree_was_taught_in_english
     and_i_have_an_unsubmitted_application_choice
     when_i_review_my_application
-    then_i_can_see_english_is_my_first_language_with_a_degree_taught_in_english
+    then_i_can_see_english_is_my_main_language_with_a_degree_taught_in_english
   end
 
 private
@@ -66,26 +66,26 @@ private
     click_on 'Review application'
   end
 
-  def then_i_can_see_english_is_my_first_language
+  def then_i_can_see_english_is_my_main_language
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
-    expect(page).to have_element(:dd, text: 'English is my first language', class: 'govuk-summary-list__value')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dd, text: 'English is my main language', class: 'govuk-summary-list__value')
   end
 
-  def then_i_can_see_english_is_my_first_language_with_a_degree_taught_in_english
+  def then_i_can_see_english_is_my_main_language_with_a_degree_taught_in_english
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
-      text: 'English is my first language My degree was taught in English',
+      text: 'English is my main language My degree was taught in English',
       class: 'govuk-summary-list__value',
     )
   end

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_no_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_no_efl_qualification_spec.rb
@@ -65,10 +65,10 @@ private
   def then_i_can_see_a_degree_taught_in_english_with_no_details
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
       text: 'None of these',
@@ -89,10 +89,10 @@ private
   def then_i_can_see_a_degree_taught_in_english_with_details
     expect(page).to have_element(
       :h3,
-      text: 'English as a foreign language assessment',
+      text: 'English language skills',
       class: 'govuk-summary-card__title',
     )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+    expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
       text: 'None of these',

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -138,7 +138,11 @@ RSpec.describe 'International candidate submits the application', :with_cache do
   end
 
   def then_i_see_the_efl_and_other_qualifications_section_is_incomplete
-    expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
+    if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
+      expect(page).to have_css('#english-language-skills-badge-id', text: 'Incomplete')
+    else
+      expect(page).to have_css('#english-as-a-foreign-language-assessment-badge-id', text: 'Incomplete')
+    end
     expect(page).to have_css('#other-qualifications-badge-id', text: 'Incomplete')
   end
 
@@ -156,8 +160,8 @@ RSpec.describe 'International candidate submits the application', :with_cache do
   end
 
   def and_i_complete_my_efl_assessment
-    click_link_or_button 'English as a foreign language'
-    check 'English is my first language'
+    click_link_or_button 'English language skills'
+    check 'English is my main language'
     click_link_or_button t('continue')
     choose 'Yes, I have completed this section'
     click_link_or_button t('continue')
@@ -203,12 +207,22 @@ RSpec.describe 'International candidate submits the application', :with_cache do
   end
 
   def and_i_can_see_my_efl_assessment_qualification
-    expect(page).to have_element(
-      :h3,
-      text: 'English as a foreign language assessment',
-      class: 'govuk-summary-card__title',
-    )
-    expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
-    expect(page).to have_element(:dd, text: 'English is my first language', class: 'govuk-summary-list__value')
+    if FeatureFlag.active?('2027_application_form_has_many_english_proficiencies')
+      expect(page).to have_element(
+        :h3,
+        text: 'English language skills',
+        class: 'govuk-summary-card__title',
+      )
+      expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'English is my main language', class: 'govuk-summary-list__value')
+    else
+      expect(page).to have_element(
+        :h3,
+        text: 'English as a foreign language assessment',
+        class: 'govuk-summary-card__title',
+      )
+      expect(page).to have_element(:dt, text: 'Proving your level of English', class: 'govuk-summary-list__key')
+      expect(page).to have_element(:dd, text: 'English is my first language', class: 'govuk-summary-list__value')
+    end
   end
 end


### PR DESCRIPTION
## Context

- Content changes to the EFL flow.

## Changes proposed in this pull request

- Change content to the EFL flow, as requested
- Add additional (optional) text input if the candidate does not plan to take a EFL assessment

## Guidance to review

- Visit https://apply-review-12074.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-12074.test.teacherservices.cloud/support/applications/71
- Click "Sign in as this candidate"
- Click "English language skills" (Note that the text has been changed)
- Proving your English language skills page
  - Check the content
  - DO NOT select an option
  - Click "Continue"
  - Check the error message content
  - Select "None of these" or "My degree was taught in English"
  - Click "Continue"
- You may need an English as a foreign language assessment
  - Select "Yes"
  - Check the content
  - Select "No"
  - Check the content
  - Enter something into the textbox
  - Click "Continue"
- Check your English language skills
  - Check the content

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/uD5H95Dv/1871-review-language-on-english-proficiency-flow

## Screenshots
_Details page_
<img width="653" height="294" alt="Screenshot 2026-07-03 at 09 38 44" src="https://github.com/user-attachments/assets/49502c1f-b9a1-408f-a090-c420f70d0680" />

_Proving your English language skills_
<img width="1153" height="1159" alt="screencapture-localhost-3000-candidate-application-english-proficiencies-edit-73-2026-07-03-09_39_36" src="https://github.com/user-attachments/assets/15c92a14-7e84-4657-906c-129d03005e44" />

Error:
<img width="1153" height="1429" alt="screencapture-localhost-3000-candidate-application-english-proficiencies-edit-74-2026-07-03-09_42_13" src="https://github.com/user-attachments/assets/c69ecd64-ace2-44fa-946b-32cf95d71686" />

_You may need an English as a foreign language assessment_
Yes:
<img width="1153" height="1389" alt="screencapture-localhost-3000-candidate-application-english-proficiencies-no-qualification-details-74-2026-07-03-09_40_23" src="https://github.com/user-attachments/assets/ca77d4ae-6542-428e-bd52-881e1cc2817a" />

No:
<img width="1153" height="1389" alt="screencapture-localhost-3000-candidate-application-english-proficiencies-no-qualification-details-74-2026-07-03-09_41_21" src="https://github.com/user-attachments/assets/c292e186-515e-4c72-8247-164884d06c74" />

_Check your English language skills_
<img width="1153" height="1316" alt="screencapture-localhost-3000-candidate-application-english-proficiencies-review-2026-07-03-09_42_59" src="https://github.com/user-attachments/assets/c7c02f52-eb6b-413a-b6da-f90c67b8bb88" />
