### PR TITLE
Add no_assessment_plan_details to API

### DIFF
--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -14,6 +14,8 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
   end
 
   def obtaining_english_language_qualification_details
-    english_proficiency&.no_qualification_details
+    return nil unless english_proficiency.present?
+
+    english_proficiency.no_qualification_details.presence || english_proficiency.no_assessment_plan_details
   end
 end

--- a/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
+++ b/app/presenters/vendor_api/application_presenter/english_as_a_foreign_language_candidate_response.rb
@@ -14,7 +14,7 @@ module VendorAPI::ApplicationPresenter::EnglishAsAForeignLanguageCandidateRespon
   end
 
   def obtaining_english_language_qualification_details
-    return nil unless english_proficiency.present?
+    return nil if english_proficiency.blank?
 
     english_proficiency.no_qualification_details.presence || english_proficiency.no_assessment_plan_details
   end

--- a/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.8/application_presenter_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe VendorAPI::ApplicationPresenter do
           expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to be_nil
         end
       end
+
+      context 'when the candidate has given details why' do
+        it 'returns correct response' do
+          application_form = create(:application_form, :submitted)
+          _english_proficiency = create(
+            :english_proficiency,
+            :no_qualification,
+            draft: false,
+            no_assessment_plan_details: 'I do not need one.',
+            application_form:,
+          )
+          application_choice = create(:application_choice, application_form:)
+          result = described_class.new('1.8', application_choice).as_json
+
+          expect(result.dig(:attributes, :candidate, :obtaining_english_language_qualification_details)).to eq(
+            'I do not need one.',
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

- Add no_assessment_plan_details to API

## Changes proposed in this pull request

- Add no_assessment_plan_details to API

## Guidance to review

- Review the code

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/s2PJXbC4/1971-add-efl-no-plan-to-take-an-assessment-details-to-api