### PR TITLE
More memory before moving the rest of the workers over to solid queue

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -10,7 +10,7 @@
   "webapp_memory_max": "3Gi",
   "worker_memory_max": "2Gi",
   "secondary_worker_memory_max": "2Gi",
-  "solid_queue_worker_memory_max": "2Gi",
+  "solid_queue_worker_memory_max": "3Gi",
   "clock_worker_memory_max": "1Gi",
   "webapp_replicas": 4,
   "worker_replicas": 2,


### PR DESCRIPTION
## Context

I've got a [PR open](https://github.com/DFE-Digital/apply-for-teacher-training/pull/12063) to move the rest of the normal workers to solid queue. In preparation for that, think it's probably a good idea to increase our worker memory and see how it goes. 

## Changes proposed in this pull request

Just a change in the production var, sandbox and lower environments will stay the same.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
