### PR TITLE
Add hard limit to application choices

### DIFF
--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -33,7 +33,7 @@
 
   <%= govuk_button_link_to t('mid_cycle_content_component.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
-  <% if application_form_presenter.cannot_submit_more_choices? %>
+  <% if application_form_presenter.cannot_submit_more_choices? && application_form_presenter.can_add_more_choices? %>
     <p class="govuk-body">You have 4 applications in progress. This is the maximum allowed.</p>
   <% end %>
   <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_add_any_more_applications')) %>

--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -33,7 +33,9 @@
 
   <%= govuk_button_link_to t('mid_cycle_content_component.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
-  <p class="govuk-body">You have 4 applications in progress. This is the maximum allowed.</p>
+  <% if application_form_presenter.in_progress_limit_reached? %>
+    <p class="govuk-body">You have 4 applications in progress. This is the maximum allowed.</p>
+  <% end %>
   <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_add_any_more_applications')) %>
   <p class="govuk-body"><%= t('mid_cycle_content_component.you_can_add_more_applications_if') %></p>
 

--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -33,7 +33,7 @@
 
   <%= govuk_button_link_to t('mid_cycle_content_component.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
-  <% if application_form_presenter.in_progress_limit_reached? %>
+  <% if application_form_presenter.cannot_submit_more_choices? %>
     <p class="govuk-body">You have 4 applications in progress. This is the maximum allowed.</p>
   <% end %>
   <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_add_any_more_applications')) %>

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -3,21 +3,20 @@ module ChoiceLimitsCalculator
 
   IN_PROGRESS_LIMIT = 4
   TOTAL_CHOICE_LIMIT = 15
-  UNSUCCESSFUL_RETRY_LIMIT = TOTAL_CHOICE_LIMIT
   MID_CYCLE_UNSUCCESSFUL_RETRY_LIMIT = 0
 
-  delegate :unsuccessful_retry_limit, :in_progress_limit, :total_application_limit, to: :limits
+  delegate :in_progress_limit, :total_application_limit, to: :limits
 
-  Limits = Data.define(:in_progress_limit, :unsuccessful_retry_limit) do
-    def total_application_limit = TOTAL_CHOICE_LIMIT
-  end
+  Limits = Data.define(:in_progress_limit, :total_application_limit)
 
   def limits
     @limits ||= Limits.new(
-      unsuccessful_retry_limit: UNSUCCESSFUL_RETRY_LIMIT,
+      total_application_limit: TOTAL_CHOICE_LIMIT,
       in_progress_limit: IN_PROGRESS_LIMIT,
     )
   end
+
+  alias unsuccessful_retry_limit total_application_limit
 
   def unsuccessful_count
     application_choices.count(&:application_unsuccessful?)
@@ -40,8 +39,7 @@ module ChoiceLimitsCalculator
   end
 
   def cannot_submit_more_choices?
-    total_submitted_application_limit_reached? ||
-      unsuccessful_limit_reached? || in_progress_limit_reached?
+    total_submitted_application_limit_reached? || in_progress_limit_reached?
   end
 
   def can_submit_more_choices?

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -40,7 +40,8 @@ module ChoiceLimitsCalculator
   end
 
   def cannot_submit_more_choices?
-    unsuccessful_limit_reached? || in_progress_limit_reached?
+    total_submitted_application_limit_reached? ||
+      unsuccessful_limit_reached? || in_progress_limit_reached?
   end
 
   def can_submit_more_choices?

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -39,7 +39,11 @@ module ChoiceLimitsCalculator
   end
 
   def cannot_submit_more_choices?
-    total_submitted_application_limit_reached? || in_progress_limit_reached?
+    if recruitment_cycle_year > 2026
+      total_submitted_application_limit_reached? || in_progress_limit_reached?
+    else
+      unsuccessful_limit_reached? || in_progress_limit_reached?
+    end
   end
 
   def can_submit_more_choices?
@@ -67,7 +71,11 @@ module ChoiceLimitsCalculator
   end
 
   def can_add_more_choices?
-    !total_applications_reached? && can_submit_more_choices? && number_of_slots_left.positive?
+    if recruitment_cycle_year > 2026
+      !total_applications_reached? && can_submit_more_choices? && number_of_slots_left.positive?
+    else
+      can_submit_more_choices? && number_of_slots_left.positive?
+    end
   end
 
   def cannot_add_more_choices?
@@ -75,13 +83,13 @@ module ChoiceLimitsCalculator
   end
 
   def number_of_slots_left
-    return 0 if total_applications_reached?
+    return 0 if total_applications_reached? && recruitment_cycle_year > 2026
 
     slots_left = in_progress_limit - in_progress_count # in progress take up a slot
     slots_left -= draft_count # drafts take up a slot
     slots_left -= [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
     slots_left = [slots_left, 0].max
-    return slots_left if (total_applications_count + slots_left) < total_application_limit
+    return slots_left if recruitment_cycle_year <= 2026 || (total_applications_count + slots_left) < total_application_limit
 
     total_application_limit - total_applications_count
   end

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -71,11 +71,7 @@ module ChoiceLimitsCalculator
   end
 
   def can_add_more_choices?
-    if recruitment_cycle_year > 2026
-      !total_applications_reached? && can_submit_more_choices? && number_of_slots_left.positive?
-    else
-      can_submit_more_choices? && number_of_slots_left.positive?
-    end
+    can_submit_more_choices? && number_of_slots_left.positive?
   end
 
   def cannot_add_more_choices?

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -81,11 +81,11 @@ module ChoiceLimitsCalculator
   def number_of_slots_left
     slots_left = in_progress_limit - in_progress_count # in progress take up a slot
     slots_left -= draft_count # drafts take up a slot
-    slots_left -= if recruitment_cycle_year > 2026
-                    [(total_application_limit - total_applications_count), slots_left].min # Cannot have enough slots to take you over the limit
-                  else
-                    [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
-                  end
+    if recruitment_cycle_year > 2026
+      slots_left = [(total_application_limit - total_applications_count), slots_left].min # Cannot have enough slots to take you over the limit
+    else
+      slots_left -= [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
+    end
     [slots_left, 0].max
   end
 end

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -2,13 +2,14 @@ module ChoiceLimitsCalculator
   extend ActiveSupport::Concern
 
   IN_PROGRESS_LIMIT = 4
-  UNSUCCESSFUL_RETRY_LIMIT = 15
+  TOTAL_CHOICE_LIMIT = 15
+  UNSUCCESSFUL_RETRY_LIMIT = TOTAL_CHOICE_LIMIT
   MID_CYCLE_UNSUCCESSFUL_RETRY_LIMIT = 0
 
   delegate :unsuccessful_retry_limit, :in_progress_limit, :total_application_limit, to: :limits
 
   Limits = Data.define(:in_progress_limit, :unsuccessful_retry_limit) do
-    def total_application_limit = unsuccessful_retry_limit + in_progress_limit
+    def total_application_limit = TOTAL_CHOICE_LIMIT
   end
 
   def limits
@@ -28,6 +29,10 @@ module ChoiceLimitsCalculator
 
   def total_submitted_count
     unsuccessful_count + in_progress_count
+  end
+
+  def total_applications_count
+    application_choices.count
   end
 
   def draft_count
@@ -54,12 +59,16 @@ module ChoiceLimitsCalculator
     total_submitted_count >= total_application_limit
   end
 
+  def total_applications_reached?
+    total_applications_count >= total_application_limit
+  end
+
   def in_progress_limit_reached?
     in_progress_count >= in_progress_limit
   end
 
   def can_add_more_choices?
-    can_submit_more_choices? && number_of_slots_left.positive?
+    !total_applications_reached? && can_submit_more_choices? && number_of_slots_left.positive?
   end
 
   def cannot_add_more_choices?
@@ -67,9 +76,14 @@ module ChoiceLimitsCalculator
   end
 
   def number_of_slots_left
+    return 0 if total_applications_reached?
+
     slots_left = in_progress_limit - in_progress_count # in progress take up a slot
     slots_left -= draft_count # drafts take up a slot
     slots_left -= [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
-    [slots_left, 0].max
+    slots_left = [slots_left, 0].max
+    return slots_left if (total_applications_count + slots_left) < total_application_limit
+
+    total_application_limit - total_applications_count
   end
 end

--- a/app/models/concerns/choice_limits_calculator.rb
+++ b/app/models/concerns/choice_limits_calculator.rb
@@ -83,14 +83,13 @@ module ChoiceLimitsCalculator
   end
 
   def number_of_slots_left
-    return 0 if total_applications_reached? && recruitment_cycle_year > 2026
-
     slots_left = in_progress_limit - in_progress_count # in progress take up a slot
     slots_left -= draft_count # drafts take up a slot
-    slots_left -= [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
-    slots_left = [slots_left, 0].max
-    return slots_left if recruitment_cycle_year <= 2026 || (total_applications_count + slots_left) < total_application_limit
-
-    total_application_limit - total_applications_count
+    slots_left -= if recruitment_cycle_year > 2026
+                    [(total_application_limit - total_applications_count), slots_left].min # Cannot have enough slots to take you over the limit
+                  else
+                    [(unsuccessful_count - unsuccessful_retry_limit), 0].max # unsuccessful above the retry limit take up a slot
+                  end
+    [slots_left, 0].max
   end
 end

--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -73,7 +73,7 @@ class Pool::Candidates
                            status: ApplicationStateChange::ApplicationState.state_ids(:unsuccessful),
                          })
                          .group(:id)
-                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT)
+                         .having("count(CASE WHEN application_choices.status != 'inactive' THEN 1 END) < ?", ApplicationForm::TOTAL_CHOICE_LIMIT)
                          .select(:id)
 
     # Final query

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -20,6 +20,7 @@ module CandidateInterface
              :personal_details_completed,
              :no_degree_and_degree_not_completed?,
              :previous_teacher_training_completed,
+             :in_progress_limit_reached?,
              :support_reference, to: :application_form
 
     def initialize(application_form)

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -20,7 +20,7 @@ module CandidateInterface
              :personal_details_completed,
              :no_degree_and_degree_not_completed?,
              :previous_teacher_training_completed,
-             :in_progress_limit_reached?,
+             :cannot_submit_more_choices?,
              :support_reference, to: :application_form
 
     def initialize(application_form)

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -49,7 +49,7 @@
       <li>you withdraw an application</li>
     </ul>
 
-    <p class="govuk-body">You will not be able to submit another application in the same recruitment cycle if you have already submitted more than <%= ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT %> applications in that cycle that have a status of:</p>
+    <p class="govuk-body">You will not be able to submit another application in the same recruitment cycle if you have already submitted more than <%= ApplicationForm::TOTAL_CHOICE_LIMIT %> applications in that cycle that have a status of:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>withdrawn</li>

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChoiceLimitsCalculator do
     end
   end
 
-  describe '#maximum_number_of_choices_reached?' do
+  describe '#cannot_submit_more_choices?' do
     it 'only allows 15 unsuccessful applications' do
       application_form = create(:application_form)
       create_list(:application_choice, 14, :withdrawn, application_form:)

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ChoiceLimitsCalculator do
 
       it 'returns the total_application_limit' do
         expect(application_form.unsuccessful_retry_limit).to eq(
-          application_form.total_application_limit
+          application_form.total_application_limit,
         )
       end
     end

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -45,14 +45,26 @@ RSpec.describe ChoiceLimitsCalculator do
       expect(application_form.reload.cannot_submit_more_choices?).to be true
     end
 
-    it 'only allows 15 total submitted applications, regardless of state' do
+    it 'only allows 19 total submitted applications, regardless of state' do
       application_form = create(:application_form)
       create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-      create_list(:application_choice, 10, :rejected, application_form:)
+      create_list(:application_choice, 14, :rejected, application_form:)
       expect(application_form.reload.cannot_submit_more_choices?).to be false
 
       create_list(:application_choice, 2, :rejected, application_form:)
       expect(application_form.reload.cannot_submit_more_choices?).to be true
+    end
+
+    context 'when the application if after the 2026 recruitment cycle' do
+      it 'only allows 15 total submitted applications, regardless of state' do
+        application_form = create(:application_form, recruitment_cycle_year: 2027)
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form:, current_recruitment_cycle_year: 2027)
+        create_list(:application_choice, 10, :rejected, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.cannot_submit_more_choices?).to be false
+
+        create_list(:application_choice, 2, :rejected, application_form:)
+        expect(application_form.reload.cannot_submit_more_choices?).to be true
+      end
     end
   end
 
@@ -75,22 +87,33 @@ RSpec.describe ChoiceLimitsCalculator do
       expect(application_form.reload.number_of_slots_left).to eq 0
     end
 
-    it 'reduces the number of slots dependant on the number of maximum applications' do
+    it 'allows 15 unsuccessful before reducing slots' do
       application_form = create(:application_form)
-      create_list(:application_choice, 11, :withdrawn, application_form:)
+      create_list(:application_choice, 15, :withdrawn, application_form:)
       expect(application_form.reload.number_of_slots_left).to eq 4
 
       create(:application_choice, :rejected, application_form:)
       expect(application_form.reload.number_of_slots_left).to eq 3
+    end
 
-      create(:application_choice, :rejected, application_form:)
-      expect(application_form.reload.number_of_slots_left).to eq 2
+    context 'when the application if after the 2026 recruitment cycle' do
+      it 'reduces the number of slots dependant on the number of maximum applications' do
+        application_form = create(:application_form, recruitment_cycle_year: 2027)
+        create_list(:application_choice, 11, :withdrawn, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.number_of_slots_left).to eq 4
 
-      create(:application_choice, :rejected, application_form:)
-      expect(application_form.reload.number_of_slots_left).to eq 1
+        create(:application_choice, :rejected, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.number_of_slots_left).to eq 3
 
-      create(:application_choice, :rejected, application_form:)
-      expect(application_form.reload.number_of_slots_left).to eq 0
+        create(:application_choice, :rejected, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.number_of_slots_left).to eq 2
+
+        create(:application_choice, :rejected, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.number_of_slots_left).to eq 1
+
+        create(:application_choice, :rejected, application_form:, current_recruitment_cycle_year: 2027)
+        expect(application_form.reload.number_of_slots_left).to eq 0
+      end
     end
 
     it 'only allows more choices if the total of 4 slots in progress and draft' do

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -8,11 +8,21 @@ RSpec.describe ChoiceLimitsCalculator do
       unsubmitted_new_limits = create(:application_form, :unsubmitted).limits
 
       expect(previously_submitted_limits.to_h)
-        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        .to match({ total_application_limit: 15, in_progress_limit: 4 })
       expect(unsubmitted_new_limits.to_h)
-        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        .to match({ total_application_limit: 15, in_progress_limit: 4 })
       expect(future_submitted_new_limits.to_h)
-        .to match({ unsuccessful_retry_limit: 15, in_progress_limit: 4 })
+        .to match({ total_application_limit: 15, in_progress_limit: 4 })
+    end
+
+    describe '#unsuccessful_retry_limit' do
+      let(:application_form) { create(:application_form) }
+
+      it 'returns the total_application_limit' do
+        expect(application_form.unsuccessful_retry_limit).to eq(
+          application_form.total_application_limit
+        )
+      end
     end
   end
 

--- a/spec/models/concerns/choice_limits_calculator_spec.rb
+++ b/spec/models/concerns/choice_limits_calculator_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe ChoiceLimitsCalculator do
       expect(application_form.reload.cannot_submit_more_choices?).to be true
     end
 
-    it 'only allows 19 total submitted applications, regardless of state' do
+    it 'only allows 15 total submitted applications, regardless of state' do
       application_form = create(:application_form)
       create_list(:application_choice, 3, :awaiting_provider_decision, application_form:)
-      create_list(:application_choice, 14, :rejected, application_form:)
+      create_list(:application_choice, 10, :rejected, application_form:)
       expect(application_form.reload.cannot_submit_more_choices?).to be false
 
       create_list(:application_choice, 2, :rejected, application_form:)
@@ -65,13 +65,22 @@ RSpec.describe ChoiceLimitsCalculator do
       expect(application_form.reload.number_of_slots_left).to eq 0
     end
 
-    it 'allows 15 unsuccessful before reducing slots' do
+    it 'reduces the number of slots dependant on the number of maximum applications' do
       application_form = create(:application_form)
-      create_list(:application_choice, 15, :withdrawn, application_form:)
+      create_list(:application_choice, 11, :withdrawn, application_form:)
       expect(application_form.reload.number_of_slots_left).to eq 4
 
       create(:application_choice, :rejected, application_form:)
       expect(application_form.reload.number_of_slots_left).to eq 3
+
+      create(:application_choice, :rejected, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 2
+
+      create(:application_choice, :rejected, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 1
+
+      create(:application_choice, :rejected, application_form:)
+      expect(application_form.reload.number_of_slots_left).to eq 0
     end
 
     it 'only allows more choices if the total of 4 slots in progress and draft' do

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -467,13 +467,13 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         it 'adds error to application choice' do
           application_form.application_choices << build_list(
             :application_choice,
-            ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT,
+            ApplicationForm::TOTAL_CHOICE_LIMIT,
             :rejected,
           )
           expect(application_choice_submission).not_to be_valid
 
           expect(application_choice_submission.errors[:application_choice]).to include(
-            "You cannot submit this application because you have #{ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT} unsuccessful applications",
+            "You cannot submit this application because you have #{ApplicationForm::TOTAL_CHOICE_LIMIT} unsuccessful applications",
           )
         end
       end

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         it 'is valid' do
           application_form.application_choices << build_list(
             :application_choice,
-            ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT - 1,
+            10,
             :rejected,
           )
           expect(application_choice_submission).to be_valid

--- a/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT, :withdrawn, application_form:)
+      create_list(:application_choice, ApplicationForm::TOTAL_CHOICE_LIMIT, :withdrawn, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)

--- a/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
     end
 
     before do
-      create_list(:application_choice, ApplicationForm::UNSUCCESSFUL_RETRY_LIMIT, :withdrawn, application_form:)
+      create_list(:application_choice, ApplicationForm::TOTAL_CHOICE_LIMIT, :withdrawn, application_form:)
 
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -220,7 +220,6 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_can_no_longer_add_more_course_choices
     visit current_path
-    expect(page).to have_text 'You have 4 applications in progress'
     expect(page).to have_text 'You cannot create any more applications at the moment.'
   end
   alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe 'Candidate submits the application' do
 
   scenario 'Candidate with more than the max unsuccessful apps' do
     given_i_am_signed_in_with_one_login
-    and_i_have_19_unsuccessful_applications
+    and_i_have_14_unsuccessful_applications
 
     when_i_have_completed_my_application_and_added_primary_as_course_choice
     and_i_go_to_submit_my_application
     then_i_can_see_my_application_has_been_successfully_submitted
     when_i_click('Back to your applications')
-    and_i_can_see_i_have_three_choices_left
+    and_i_can_see_i_cannot_create_any_more_applications
 
     when_my_application_is_rejected
     then_i_am_unable_to_add_any_further_choices
   end
 
-  def and_i_have_19_unsuccessful_applications
+  def and_i_have_14_unsuccessful_applications
     @current_candidate.application_forms << create(:application_form, :completed, :with_degree)
     @current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
   end
@@ -65,8 +65,8 @@ RSpec.describe 'Candidate submits the application' do
     expect(page).to have_text 'Gorse SCITT'
   end
 
-  def and_i_can_see_i_have_three_choices_left
-    expect(page).to have_text 'You can submit 3 more applications.'
+  def and_i_can_see_i_cannot_create_any_more_applications
+    expect(page).to have_text 'You cannot create any more applications at the moment.'
   end
 
   def when_my_application_is_rejected

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
   include DfE::Bigquery::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
 
   before do
     stub_bigquery_non_disclosure_trainee_withdrawals_request
@@ -10,19 +11,42 @@ RSpec.describe 'Candidate submits the application' do
 
   scenario 'Candidate with more than the max unsuccessful apps' do
     given_i_am_signed_in_with_one_login
-    and_i_have_14_unsuccessful_applications
+    and_i_have_19_unsuccessful_applications
 
     when_i_have_completed_my_application_and_added_primary_as_course_choice
     and_i_go_to_submit_my_application
     then_i_can_see_my_application_has_been_successfully_submitted
     when_i_click('Back to your applications')
-    and_i_can_see_i_cannot_create_any_more_applications
+    and_i_can_see_i_have_three_choices_left
 
     when_my_application_is_rejected
     then_i_am_unable_to_add_any_further_choices
   end
 
+  context 'after the 2026 recruitment cycle' do
+    scenario 'Candidate with more than the max number of applications' do
+      travel_to(Time.zone.parse('2027-01-01 12:00:00')) do
+        given_i_am_signed_in_with_one_login
+        and_i_have_14_unsuccessful_applications
+
+        when_i_have_completed_my_application_and_added_primary_as_course_choice
+        and_i_go_to_submit_my_application
+        then_i_can_see_my_application_has_been_successfully_submitted
+        when_i_click('Back to your applications')
+        and_i_can_see_i_cannot_create_any_more_applications
+
+        when_my_application_is_rejected
+        then_i_am_unable_to_add_any_further_choices
+      end
+    end
+  end
+
   def and_i_have_14_unsuccessful_applications
+    @current_candidate.application_forms << create(:application_form, :completed, :with_degree)
+    @current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
+  end
+
+  def and_i_have_19_unsuccessful_applications
     @current_candidate.application_forms << create(:application_form, :completed, :with_degree)
     @current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
   end
@@ -67,6 +91,10 @@ RSpec.describe 'Candidate submits the application' do
 
   def and_i_can_see_i_cannot_create_any_more_applications
     expect(page).to have_text 'You cannot create any more applications at the moment.'
+  end
+
+  def and_i_can_see_i_have_three_choices_left
+    expect(page).to have_text 'You can submit 3 more applications.'
   end
 
   def when_my_application_is_rejected


### PR DESCRIPTION
## Context

- Add a hard limit of 15 applications per application form.

## Changes proposed in this pull request

- Add a hard limit of 15 applications per application form.

## Guidance to review

- Visit https://apply-review-12081.test.teacherservices.cloud/support
- Sign in as a Support user
- Click on any candidate (one which has not accepted an offer)
- Click on "Sign in as this candidate"
- Begin creating and withdrawing applications until you have 15
- You should no longer be able to create more applications


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/QMxs6s2j/1931-application-limit-hard-15-limit