### PR TITLE
Remove recruitment performance report feedback banner

### DIFF
--- a/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
@@ -10,13 +10,6 @@
 <% if @reports_ready %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
-        <% notification_banner.with_heading(text: 'Tell us what you think of the changes to this report') %>
-        <p class="govuk-body">
-          <%= govuk_link_to 'Give us your feedback', 'https://dferesearch.fra1.qualtrics.com/jfe/form/SV_cuOh0pL2oj64yKa' %> to help improve reports.
-        </p>
-      <% end %>
-
       <h1 class="govuk-heading-l">
         <%= t(
           'page_titles.provider_recruitment_performance_report',


### PR DESCRIPTION
## Context

The banner encouraging users to fill out the feedback form refers to new changes. The changes to the report are no longer new.

## Changes proposed in this pull request

- Remove the `govuk_notification_banner`

## Guidance to review

- View http://localhost:3000/provider/reports/1/recruitment-performance-report/2026 to verify that the banner has been removed and all other information is still intact.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
