### PR TITLE
Add method to detect any sections completed

### DIFF
--- a/app/presenters/candidate_interface/application_form_sections.rb
+++ b/app/presenters/candidate_interface/application_form_sections.rb
@@ -7,6 +7,7 @@ module CandidateInterface
 
     def science_gcse_incomplete_and_others?
       primary_course? &&
+        any_completed? &&
         incomplete_sections.size > 1 &&
         incomplete_sections.any?(science_gcse?)
     end
@@ -41,6 +42,10 @@ module CandidateInterface
 
     def presenter
       @presenter ||= ApplicationFormPresenter.new(application_form)
+    end
+
+    def any_completed?
+      all_sections.map(&:second).any?
     end
 
     def sections_with_completion

--- a/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
@@ -24,12 +24,38 @@ RSpec.describe 'Candidate submits the application' do
     then_i_see_an_error_message
   end
 
+  scenario 'Candidate with primary application has completed one section of their application' do
+    and_i_have_completed_a_section_which_is_not_science_gcse
+    and_i_have_a_primary_and_secondary_application_choice
+    when_i_go_to_primary_review_page
+    then_i_see_an_error_message_about_completing_my_science_gcse_details
+    when_i_go_to_secondary_review_page
+    then_i_see_an_error_message
+  end
+
+  scenario 'Candidate with primary application has not started their application' do
+    and_i_have_no_complete_sections
+    and_i_have_a_primary_and_secondary_application_choice
+    when_i_go_to_primary_review_page
+    then_i_see_an_error_message
+    when_i_go_to_secondary_review_page
+    then_i_see_an_error_message
+  end
+
   def and_i_have_incomplete_sections_on_my_personal_statement
     @current_candidate.application_forms << build(:application_form, :minimum_info, submitted_at: nil, becoming_a_teacher: 'I want to teach')
   end
 
   def and_i_have_incomplete_sections_which_is_not_science_gcse
     @current_candidate.application_forms << build(:application_form, :completed, science_gcse_completed: true, degrees_completed: false, submitted_at: nil)
+  end
+
+  def and_i_have_completed_a_section_which_is_not_science_gcse
+    @current_candidate.application_forms << build(:application_form, :minimum_info, becoming_a_teacher_completed: true)
+  end
+
+  def and_i_have_no_complete_sections
+    @current_candidate.application_forms << build(:application_form)
   end
 
   def and_i_have_a_primary_and_secondary_application_choice
@@ -53,5 +79,16 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_see_an_error_message
     expect(page).to have_text('You cannot submit this application until you complete your details.')
+    expect(page).to have_text('Your application will be saved as a draft while you finish adding your details.')
+  end
+
+  def then_i_see_an_error_message_about_completing_my_science_gcse_details
+    expect(page).to have_text(
+      'To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent.',
+    )
+    expect(page).to have_text(
+      'Add your science GCSE grade (or equivalent) and complete the rest of your details. You can then submit your application.',
+    )
+    expect(page).to have_text('Your application will be saved as a draft while you finish adding your details.')
   end
 end


### PR DESCRIPTION
## Context

- Add a method to check if ANY sections of an application have been completed, so that GCSE section guidance is different IF the candidate has completed ANY sections.

## Changes proposed in this pull request

- Add a method to check if ANY sections of an application have been completed, so that GCSE section guidance is different IF the candidate has completed ANY sections.

## Guidance to review

- Visit https://apply-review-12083.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-12083.test.teacherservices.cloud/support/applications/78
- Click "Sign in as this candidate"
- Visit https://apply-review-12083.test.teacherservices.cloud/candidate/application/course-choices/160/review
- Note that the review page shows the text:
"You cannot submit this application until you [complete your details](https://apply-review-12083.test.teacherservices.cloud/candidate/application/details).

Your application will be saved as a draft while you finish adding your details."

- Navigate to "Your details"
- Complete a section of the application form
- Return to https://apply-review-12083.test.teacherservices.cloud/candidate/application/course-choices/160/review
- Note that the content has changed.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/gsjVXlPt/1976-bug-science-gcse-checked-before-my-details-checked-on-draft-page

## Screenshot
_No sections completed_
<img width="2916" height="5204" alt="screencapture-localhost-3000-candidate-application-details-2026-07-07-14_02_34" src="https://github.com/user-attachments/assets/367f0130-b136-48b6-9c3f-8a90f0425370" />

<img width="2916" height="2988" alt="screencapture-localhost-3000-candidate-application-course-choices-171-review-2026-07-07-14_04_48" src="https://github.com/user-attachments/assets/41692149-4493-497f-bb56-b50cf1356900" />

_A section completed_
<img width="1457" height="678" alt="Screenshot 2026-07-07 at 14 06 02" src="https://github.com/user-attachments/assets/9e45e832-bc6b-4257-a9d8-52485af9ff3f" />

<img width="2916" height="2908" alt="screencapture-localhost-3000-candidate-application-course-choices-171-review-2026-07-07-14_06_26" src="https://github.com/user-attachments/assets/874c1eed-1043-4f8d-9c05-d1c684e0b5f6" />
