### PR TITLE
Reuse candidate DuplicateMatch when processing duplicate groups

### DIFF
--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -6,8 +6,8 @@ class UpdateDuplicateMatches
   end
 
   def save!
-    @matches.each do |match|
-      save_match(match)
+    duplicate_groups.each_value do |group|
+      process_duplicate_group(group)
     end
   end
 
@@ -17,38 +17,67 @@ private
     @current_year ||= RecruitmentCycleTimetable.current_year
   end
 
-  def save_match(match)
-    ActiveRecord::Base.transaction do
-      create_or_update_duplicate_match(match)
+  # Process duplicate candidates as a group so an existing DuplicateMatch
+  # can be reused before creating a new one. Previously matches were
+  # processed individually and only reused a DuplicateMatch found via the
+  # current surname, date of birth and postcode.
+  def duplicate_groups
+    @matches.group_by do |match|
+      [
+        match['last_name'].to_s.downcase.strip,
+        match['date_of_birth'],
+        match['postcode'].to_s.upcase.gsub(' ', ''),
+      ]
     end
   end
 
-  def create_or_update_duplicate_match(match)
+  def process_duplicate_group(group)
+    ActiveRecord::Base.transaction do
+      candidates = Candidate.where(
+        id: group.map { |match| match['candidate_id'] },
+      )
+
+      duplicate_match = duplicate_match_for_group(
+        candidates:,
+        match: group.first,
+      )
+
+      candidates.each do |candidate|
+        next if duplicate_match.candidates.include?(candidate)
+
+        duplicate_match.candidates << candidate
+        process_match(candidate, duplicate_match)
+      end
+
+      unresolve_match(duplicate_match)
+    end
+  end
+
+  def duplicate_match_for_group(candidates:, match:)
+    # Reuse any DuplicateMatch already associated with this duplicate group.
+    candidate_duplicate_matches = candidates
+      .map(&:duplicate_match)
+      .compact
+      .uniq
+
+    return candidate_duplicate_matches.first if candidate_duplicate_matches.any?
+
+    # Fall back to the original behaviour: look for a DuplicateMatch
+    # matching the current surname, date of birth and postcode.
     existing_duplicate_match = DuplicateMatch.match_for(
       last_name: match['last_name'],
       postcode: match['postcode'],
       date_of_birth: match['date_of_birth'],
     )
-    candidate = Candidate.find(match['candidate_id'])
 
-    if existing_duplicate_match.present?
-      unless existing_duplicate_match.candidates.include?(candidate)
-        existing_duplicate_match.candidates << candidate
-        unresolve_match(existing_duplicate_match)
-        process_match(candidate, existing_duplicate_match)
-      end
-    else
-      new_duplicate_match = DuplicateMatch.create!(
-        recruitment_cycle_year: current_year,
-        last_name: match['last_name'],
-        postcode: match['postcode'],
-        date_of_birth: match['date_of_birth'],
-        candidates: [candidate],
-      )
-      process_match(candidate, new_duplicate_match)
-    end
+    return existing_duplicate_match if existing_duplicate_match.present?
 
-    candidate
+    DuplicateMatch.create!(
+      recruitment_cycle_year: current_year,
+      last_name: match['last_name'],
+      postcode: match['postcode'],
+      date_of_birth: match['date_of_birth'],
+    )
   end
 
   def notify_candidate(candidate, duplicate_match)

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe UpdateDuplicateMatches, :sidekiq do
         create(
           :application_form,
           :duplicate_candidates,
-          last_name: " #{ApplicationForm.last.last_name.upcase} ",
+          last_name: " #{ApplicationForm.last.last_name.downcase} ",
           postcode: "#{ApplicationForm.last.postcode.downcase} ",
           candidate: create(:candidate, email_address: 'exemplar3@example.com'),
         )
@@ -156,6 +156,41 @@ RSpec.describe UpdateDuplicateMatches, :sidekiq do
         described_class.new(block_submission: false).save!
         expect(candidate1.reload.submission_blocked).to be(false)
         expect(candidate2.reload.submission_blocked).to be(false)
+      end
+    end
+
+    context 'when a postcode change creates a new duplicate relationship for a candidate already assigned to a duplicate match' do
+      let!(:existing_match) do
+        create(
+          :duplicate_match,
+          candidates: [],
+          recruitment_cycle_year: current_year,
+          last_name: 'Thompson',
+          postcode: 'W6 9BH',
+          date_of_birth: Date.parse('1998-08-08'),
+        )
+      end
+
+      let!(:existing_duplicate_candidate) do
+        create(:candidate, email_address: 'existing_duplicate@example.com')
+      end
+
+      before do
+        existing_duplicate_candidate.update!(duplicate_match: existing_match)
+        candidate1.update!(duplicate_match: existing_match)
+      end
+
+      it 'reuses the existing duplicate match instead of creating a new one' do
+        expect { described_class.new.save! }.not_to change(DuplicateMatch, :count)
+
+        expect(candidate1.reload.duplicate_match).to eq(existing_match)
+        expect(candidate2.reload.duplicate_match).to eq(existing_match)
+
+        expect(existing_match.reload.candidates).to contain_exactly(
+          existing_duplicate_candidate,
+          candidate1,
+          candidate2,
+        )
       end
     end
   end


### PR DESCRIPTION
## Context

We broadened the scope of the query which identifies duplicate matches in #12070. It used to identify duplicates between originals and carried over applications only but now it can identify duplicates between carried over applications too.

There are some cases where a candidate account has been flagged as a duplicate on a certain set of attributes (last name, dob, and post code) and a DuplicateMatch is created. If they then update their postcode and a match is found on that set of attributes too, they are later flagged up again.

Because candidates can only belong to a single DuplicateMatch through the `fraud_match_id`, this can lead to a new DuplicateMatch being created without a valid pairing, even though it's a legitimate match.

## Changes proposed in this pull request

- Process duplicate candidates as a group so an existing `DuplicateMatch` can be reused before creating a new one. 

## Guidance to review

- Log into the review app as Support
- Visit the duplicate matches index 
- You should see 3 candidates attached to one DuplicateMatch showing that we have been able to track one candidate on a single `fraud_match_id` as they changed their postcode and later created an application form with attrs matching the updated record 

<img width="1170" height="627" alt="Screenshot 2026-07-09 at 12 02 14" src="https://github.com/user-attachments/assets/f6c114bb-df41-4d72-8f54-f5852d542e51" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
