### PR TITLE
Data migration: resolve outstanding DuplicateMatches from 2024 cycle and earlier

### DIFF
--- a/app/services/data_migrations/resolve_duplicate_matches_from2024_and_earlier.rb
+++ b/app/services/data_migrations/resolve_duplicate_matches_from2024_and_earlier.rb
@@ -1,0 +1,19 @@
+module DataMigrations
+  class ResolveDuplicateMatchesFrom2024AndEarlier
+    TIMESTAMP = 20260708135913
+    MANUAL_RUN = false
+
+    def change
+      duplicate_match_ids = DuplicateMatch
+        .joins(candidates: :application_forms)
+        .where(resolved: false)
+        .group(:id)
+        .having('MAX(application_forms.updated_at) < ?', Date.new(2024, 9, 30))
+        .pluck(:id)
+
+      DuplicateMatch
+        .where(id: duplicate_match_ids)
+        .update_all(resolved: true)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ResolveDuplicateMatchesFrom2024AndEarlier',
   'DataMigrations::RemoveInterviewHandlingFeatureFlag',
   'DataMigrations::NormalizeNamesOnApplicationForm',
   'DataMigrations::SetHideInReportingToFalse',

--- a/spec/services/data_migrations/resolve_duplicate_matches_from2024_and_earlier_spec.rb
+++ b/spec/services/data_migrations/resolve_duplicate_matches_from2024_and_earlier_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ResolveDuplicateMatchesFrom2024AndEarlier do
+  describe '#change' do
+    let(:end_of_2024_cycle) { Date.new(2024, 9, 30) }
+
+    it 'resolves an unresolved duplicate match when all application forms were last updated before the end of the 2024 cycle' do
+      duplicate_match = create(:duplicate_match, resolved: false)
+
+      candidate = create(:candidate, fraud_match_id: duplicate_match.id)
+      create(
+        :application_form,
+        candidate:,
+        updated_at: end_of_2024_cycle - 1.day,
+      )
+
+      expect { described_class.new.change }.to change { duplicate_match.reload.resolved }.from(false).to(true)
+    end
+
+    it 'does not resolve an unresolved duplicate match when an application form was updated after the cutoff date' do
+      duplicate_match = create(:duplicate_match, resolved: false)
+
+      candidate = create(:candidate, fraud_match_id: duplicate_match.id)
+      create(
+        :application_form,
+        candidate:,
+        updated_at: end_of_2024_cycle + 1.day,
+      )
+
+      expect { described_class.new.change }.not_to(change { duplicate_match.reload.resolved })
+    end
+
+    it 'does not resolve a duplicate match when one application form is newer than the cutoff date' do
+      duplicate_match = create(:duplicate_match, resolved: false)
+
+      old_candidate = create(:candidate, fraud_match_id: duplicate_match.id)
+      recent_candidate = create(:candidate, fraud_match_id: duplicate_match.id)
+
+      create(
+        :application_form,
+        candidate: old_candidate,
+        updated_at: end_of_2024_cycle - 1.day,
+      )
+
+      create(
+        :application_form,
+        candidate: recent_candidate,
+        updated_at: end_of_2024_cycle + 1.day,
+      )
+
+      expect { described_class.new.change }.not_to(change { duplicate_match.reload.resolved })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We broadened the query for finding duplicate matches in #12070. This resulted in many new duplicates being found in the first run of the query in production. We have decided to set `resolved` to `true` for all those outstanding DuplicateMatches where none of the associated candidates' application forms have been updated since the end of the 2024 cycle. 

## Changes proposed in this pull request

- Identify all duplicate matches where associated candidates' application forms have not been updated since the end of the 2024 cycle
- Update all so that `resolved` is `true`.

## Guidance to review

- Please review the migration file and accompanying spec. 
- This should only affect 425 records so I have not including any batching logic.
- This is based on a query initially run in blazer to identify the relevant duplicate matches: https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1492-stale-unresolved-duplicate-matches

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
