### PR TITLE
Add filters to mission control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,6 +201,6 @@ gem 'jsbundling-rails', '~> 1.3'
 gem 'propshaft', '~> 1.3'
 
 gem 'solid_queue', '~> 1.4'
-gem 'mission_control-jobs'
+gem 'mission_control-jobs', git: 'https://github.com/rails/mission_control-jobs.git', ref: '1648c005ecd2230b2f76779b7b95c259c43a6523'
 gem 'solid_cache', '~> 1.0'
 gem 'solid_cache_dashboard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,22 @@ GIT
     rspec-retry (0.7.0)
       rspec-core (> 3.3)
 
+GIT
+  remote: https://github.com/rails/mission_control-jobs.git
+  revision: 1648c005ecd2230b2f76779b7b95c259c43a6523
+  ref: 1648c005ecd2230b2f76779b7b95c259c43a6523
+  specs:
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -470,16 +486,6 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    mission_control-jobs (1.1.0)
-      actioncable (>= 7.1)
-      actionpack (>= 7.1)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      importmap-rails (>= 1.2.1)
-      irb (~> 1.13)
-      railties (>= 7.1)
-      stimulus-rails
-      turbo-rails
     multi_json (1.21.1)
     multi_xml (0.6.0)
     multipart-post (2.4.1)
@@ -966,7 +972,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.11)
   mail-notify
-  mission_control-jobs
+  mission_control-jobs!
   notifications-ruby-client
   oj
   okcomputer
@@ -1191,7 +1197,7 @@ CHECKSUMS
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
+  mission_control-jobs (1.1.0)
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   multi_xml (0.6.0) sha256=d24393cf958adb226db884b976b007914a89c53ad88718e25679d7008823ad52
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,6 +87,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.mission_control.jobs.adapters = [ :solid_queue ]
     config.mission_control.jobs.http_basic_auth_enabled = false
+    config.mission_control.jobs.filter_arguments = %w[email_address token]
 
     config.action_controller.perform_caching = true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,7 +87,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.mission_control.jobs.adapters = [ :solid_queue ]
     config.mission_control.jobs.http_basic_auth_enabled = false
-    config.mission_control.jobs.filter_arguments = %w[email_address token]
+    config.mission_control.jobs.filter_arguments = %w[email_address email code token]
 
     config.action_controller.perform_caching = true
 


### PR DESCRIPTION
## Context

When testing out [this pr](https://github.com/DFE-Digital/apply-for-teacher-training/pull/12063), I found that some ActionMailer details leaked into MissionControl.

Sadly, the [MissionControl PR](https://github.com/rails/mission_control-jobs/pull/277) to add the ability to remove specific keys from the UI was merged in just after the last release, which was a year ago. The repo itself hasn't been updated at all in the past 7 months, so it appears to be without a maintainer (hopefully just temporary)

## Changes proposed in this pull request

Pin the mission control gem so that we have the filter_arguments functionality
Add filter_arguments so that we won't show arguments that are problematic.

## Guidance to review

This will be difficult to test before this PR goes in. But I've tested this commit against  [this PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/12063) locally and it's fine. Once this gem update goes in, I'll rebase the first PR and we can test it more effectively. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
