### PR TITLE
Remove more duplicate matches

### DIFF
--- a/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
+++ b/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
@@ -1,0 +1,31 @@
+module DataMigrations
+  class ResolveDuplicateMatchesUnsubmitted2025OrBefore2025
+    TIMESTAMP = 20260709134923
+    MANUAL_RUN = false
+
+    def change
+      duplicate_matches = DuplicateMatch
+        .joins(candidates: :application_forms)
+        .where(resolved: false)
+        .group('fraud_matches.id')
+        .having(<<~SQL)
+          (
+            MAX(application_forms.recruitment_cycle_year) < 2025
+            OR (
+              MAX(application_forms.recruitment_cycle_year) = 2025
+              AND MAX(
+                CASE
+                  WHEN application_forms.recruitment_cycle_year = 2025
+                   AND application_forms.submitted_at IS NOT NULL
+                  THEN 1
+                  ELSE 0
+                END
+              ) = 0
+            )
+          )
+        SQL
+
+      duplicate_matches.update_all(resolved: true)
+    end
+  end
+end

--- a/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
+++ b/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
@@ -1,10 +1,20 @@
 module DataMigrations
   class ResolveDuplicateMatchesUnsubmitted2025OrBefore2025
     TIMESTAMP = 20260709134923
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
-      duplicate_matches = DuplicateMatch
+      duplicates.update_all(resolved: true)
+    end
+
+    def dry_run
+      duplicates.count
+    end
+
+    private
+
+    def duplicates
+      @duplicates ||= DuplicateMatch
         .joins(candidates: :application_forms)
         .where(resolved: false)
         .group('fraud_matches.id')
@@ -24,8 +34,6 @@ module DataMigrations
             )
           )
         SQL
-
-      duplicate_matches.update_all(resolved: true)
     end
   end
 end

--- a/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
+++ b/app/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025.rb
@@ -11,7 +11,7 @@ module DataMigrations
       duplicates.count
     end
 
-    private
+  private
 
     def duplicates
       @duplicates ||= DuplicateMatch

--- a/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
+++ b/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
@@ -10,7 +10,7 @@ module DataMigrations
     def dry_run
       [
         duplicates.count, # Should be about 10334
-        duplicates.pluck(:id).includes(11910), # Should be false
+        duplicates.pluck(:id).include?(11910), # Should be false
         duplicates.pluck(:id).include?(11909), # Should be false
       ]
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::ResolveMistakenlyUnresolvedDuplicates',
+  'DataMigrations::ResolveDuplicateMatchesUnsubmitted2025OrBefore2025',
   'DataMigrations::ResolveDuplicateMatchesFrom2024AndEarlier',
   'DataMigrations::RemoveInterviewHandlingFeatureFlag',
   'DataMigrations::NormalizeNamesOnApplicationForm',

--- a/spec/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025_spec.rb
+++ b/spec/services/data_migrations/resolve_duplicate_matches_unsubmitted2025_or_before2025_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ResolveDuplicateMatchesUnsubmitted2025OrBefore2025 do
+  it 'resolves only if unsubmitted in 2025' do
+    to_resolve_duplicate_match = create(:duplicate_match, resolved: false)
+
+    create(
+      :application_form,
+      candidate: to_resolve_duplicate_match.candidates.first,
+      recruitment_cycle_year: 2025,
+      submitted_at: nil,
+    )
+
+    not_to_resolve_duplicate_match = create(:duplicate_match, resolved: false)
+
+    create(
+      :application_form,
+      candidate: not_to_resolve_duplicate_match.candidates.first,
+      recruitment_cycle_year: 2025,
+      submitted_at: Time.zone.now,
+    )
+
+    described_class.new.change
+
+    expect(not_to_resolve_duplicate_match.reload.resolved?).to be(false)
+    expect(to_resolve_duplicate_match.reload.resolved?).to be(true)
+  end
+
+  it 'resolves if all applications forms are before 2025' do
+    to_resolve_duplicate_match = create(:duplicate_match, resolved: false)
+    create(
+      :application_form,
+      candidate: to_resolve_duplicate_match.candidates.first,
+      recruitment_cycle_year: 2024,
+      submitted_at: Time.zone.now,
+    )
+
+    not_to_resolve_duplicate_match = create(:duplicate_match, resolved: false)
+
+    create(
+      :application_form,
+      candidate: not_to_resolve_duplicate_match.candidates.first,
+      recruitment_cycle_year: 2024,
+      submitted_at: Time.zone.now,
+    )
+
+    create(
+      :application_form,
+      candidate: not_to_resolve_duplicate_match.candidates.first,
+      recruitment_cycle_year: 2026,
+      submitted_at: Time.zone.now,
+    )
+
+    described_class.new.change
+
+    expect(not_to_resolve_duplicate_match.reload.resolved?).to be(false)
+    expect(to_resolve_duplicate_match.reload.resolved?).to be(true)
+  end
+end


### PR DESCRIPTION
## Context

We have made some improvements to the duplicate matching, but it has raised a bunch of historical issues that we don't really care too much about. We have already done one PR that reduced the number from about 1200 to 800. This will reduce it further to 700. 

## Changes proposed in this pull request

Resolve duplicate matches if 
- All the application forms are for recruitment cycle year 2024 or before
OR
- there is a 2025 application that hasn't been submitted

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
