### PR TITLE
Fix condition to show max 4 in progress warning

### DIFF
--- a/app/components/candidate_interface/mid_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/mid_cycle_content_component.html.erb
@@ -33,7 +33,7 @@
 
   <%= govuk_button_link_to t('mid_cycle_content_component.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
 <% else %>
-  <% if application_form_presenter.cannot_submit_more_choices? && application_form_presenter.can_add_more_choices? %>
+  <% if application_form_presenter.cannot_submit_more_choices? && !application_form_presenter.total_submitted_application_limit_reached? %>
     <p class="govuk-body">You have 4 applications in progress. This is the maximum allowed.</p>
   <% end %>
   <%= govuk_warning_text(text: t('mid_cycle_content_component.you_cannot_add_any_more_applications')) %>

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -21,6 +21,7 @@ module CandidateInterface
              :no_degree_and_degree_not_completed?,
              :previous_teacher_training_completed,
              :cannot_submit_more_choices?,
+             :total_submitted_application_limit_reached?,
              :support_reference, to: :application_form
 
     def initialize(application_form)


### PR DESCRIPTION
## Context

- Due to an earlier line, the logic was never being reached. Now fixed.

## Changes proposed in this pull request

- Maximum 4 in progress applications content shows only when the 4 applications are in progress.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Screenshot

<img width="1153" height="2522" alt="screencapture-localhost-3000-candidate-application-choices-2026-07-09-16_48_15" src="https://github.com/user-attachments/assets/5054596b-8115-40b9-9612-084dac73d548" />
