### PR TITLE
Migration to run manually to fix some duplicate matches

### DIFF
--- a/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
+++ b/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
@@ -1,0 +1,27 @@
+module DataMigrations
+  class ResolveMistakenlyUnresolvedDuplicates
+    TIMESTAMP = 20260709184810
+    MANUAL_RUN = true
+
+    def change
+      duplicates.update_all(resolved: true)
+    end
+
+    def dry_run
+      [
+        duplicates.count, # Should be about 10334
+        duplicates.pluck(:id).includes(11910), # Should be false
+        duplicates.pluck(:id).include?(11909), # Should be false
+      ]
+    end
+
+  private
+
+    def duplicates
+      @duplicates ||= DuplicateMatch
+        .where(resolved: false)
+        .where('updated_at > ?',Time.zone.local(2026, 7, 9, 15, 21)) # Should be'2026-07-09 14:20:21.0 +0100',
+        .where('updated_at < ?', Time.zone.local(2026, 7, 9, 16, 21)) # Should be'2026-07-09 15:20:21.0 +0100',
+    end
+  end
+end

--- a/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
+++ b/app/services/data_migrations/resolve_mistakenly_unresolved_duplicates.rb
@@ -20,7 +20,7 @@ module DataMigrations
     def duplicates
       @duplicates ||= DuplicateMatch
         .where(resolved: false)
-        .where('updated_at > ?',Time.zone.local(2026, 7, 9, 15, 21)) # Should be'2026-07-09 14:20:21.0 +0100',
+        .where('updated_at > ?', Time.zone.local(2026, 7, 9, 15, 21)) # Should be'2026-07-09 14:20:21.0 +0100',
         .where('updated_at < ?', Time.zone.local(2026, 7, 9, 16, 21)) # Should be'2026-07-09 15:20:21.0 +0100',
     end
   end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ResolveMistakenlyUnresolvedDuplicates',
   'DataMigrations::ResolveDuplicateMatchesFrom2024AndEarlier',
   'DataMigrations::RemoveInterviewHandlingFeatureFlag',
   'DataMigrations::NormalizeNamesOnApplicationForm',

--- a/spec/services/data_migrations/resolve_mistakenly_unresolved_duplicates_spec.rb
+++ b/spec/services/data_migrations/resolve_mistakenly_unresolved_duplicates_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ResolveMistakenlyUnresolvedDuplicates do
+  it 'only resolves duplicates updated in the window' do
+    too_early_duplicate = create(:duplicate_match, resolved: false, updated_at: Time.zone.local(2026, 7, 9, 15, 20))
+    too_late_duplicate = create(:duplicate_match, resolved: false, updated_at: Time.zone.local(2026, 7, 9, 16, 22))
+    just_right_duplicate = create(:duplicate_match, resolved: false, updated_at: Time.zone.local(2026, 7, 9, 16, 0o0))
+
+    described_class.new.change
+
+    expect(too_early_duplicate.reload.resolved).to be(false)
+    expect(too_late_duplicate.reload.resolved).to be(false)
+    expect(just_right_duplicate.reload.resolved).to be(true)
+  end
+end


### PR DESCRIPTION
## Context

A change in the duplicate matches script, which has since been reverted, unresolved a bunch of duplicate matches. 

## Changes proposed in this pull request
This migration re-resolves the un-resolved.

I want to run this manually. There is a dry-run method so we can assure ourselves we are grabbing the correct duplicate matches before we run them. 

## Guidance to review

The tricky bit is the time window, correcting for BST. To review, open the rails console, in the review app or whatever. 
Run 
```
DuplicateMatch
        .where(resolved: false)
        .where('updated_at > ?',Time.zone.local(2026, 7, 9, 15, 21)) # Should be'2026-07-09 14:20:21.0 +0100',
        .where('updated_at < ?', Time.zone.local(2026, 7, 9, 16, 21))
        .to_sql
```

What you get should look very much like what is in the [blazer query](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1494-duplicate-matches-unresolved-in-error). Check the times very carefully.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
