### PR TITLE
Make clear which application candidate emails relate to

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -477,11 +477,15 @@ class CandidateMailer < ApplicationMailer
     timetable = application_form.recruitment_cycle_timetable
     @winter_decline_by_default_deadline = timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first)
     @next_recruitment_cycle_year = timetable.relative_next_year
+    @application_choices = application_form
+                             .application_choices
+                             .offer
+                             .course_starts_after_september(application_form.recruitment_cycle_year)
 
     email_for_candidate(
       application_form,
       subject: I18n.t!(
-        'candidate_mailer.respond_to_offer_before_deadline.subject',
+        'candidate_mailer.respond_to_offer_before_winter_deadline.subject',
         decline_by_default_date: @winter_decline_by_default_deadline,
       ),
     )
@@ -523,10 +527,14 @@ class CandidateMailer < ApplicationMailer
     timetable = application_form.recruitment_cycle_timetable
     @this_academic_year = timetable.academic_year_range_name
     @next_academic_year = timetable.next_available_academic_year_range
+    @application_choices = application_form
+                             .application_choices
+                             .rejected_by_default
+                             .course_starts_after_september(application_form.recruitment_cycle_year)
 
     email_for_candidate(
       application_form,
-      subject: I18n.t!('candidate_mailer.reject_by_default_explainer.subject'),
+      subject: I18n.t!('candidate_mailer.winter_reject_by_default_explainer.subject'),
     )
   end
 
@@ -535,10 +543,14 @@ class CandidateMailer < ApplicationMailer
     next_recruitment_cycle = timetable.relative_next_timetable
     @next_academic_year = next_recruitment_cycle.academic_year_range_name
     @apply_reopens_date = next_recruitment_cycle.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+    @application_choices = application_form
+                             .application_choices
+                             .declined_by_default
+                             .course_starts_after_september(application_form.recruitment_cycle_year)
 
     email_for_candidate(
       application_form,
-      subject: I18n.t!('candidate_mailer.decline_by_default_explainer.subject'),
+      subject: I18n.t!('candidate_mailer.winter_decline_by_default_explainer.subject'),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -460,6 +460,10 @@ class CandidateMailer < ApplicationMailer
     @this_academic_year = @timetable.previously_closed_academic_year_range
     @next_academic_year = @timetable.next_available_academic_year_range
     @apply_reopens_date = @timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+    @application_choices = application_form
+                             .application_choices
+                             .offer
+                             .course_start_in_september(application_form.recruitment_cycle_year)
     email_for_candidate(
       application_form,
       subject: I18n.t!(
@@ -488,6 +492,10 @@ class CandidateMailer < ApplicationMailer
     @this_academic_year = @timetable.previously_closed_academic_year_range
     @next_academic_year = @timetable.next_available_academic_year_range
     @apply_reopens_date = @timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+    @application_choices = application_form
+                             .application_choices
+                             .rejected_by_default
+                             .course_start_in_september(application_form.recruitment_cycle_year)
 
     email_for_candidate(
       application_form,
@@ -500,6 +508,10 @@ class CandidateMailer < ApplicationMailer
     @next_academic_year_range = @timetable.next_available_academic_year_range
     @next_recruitment_cycle_year = @timetable.relative_next_year
     @apply_reopens_date = @timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first)
+    @application_choices = application_form
+                             .application_choices
+                             .declined_by_default
+                             .course_start_in_september(application_form.recruitment_cycle_year)
 
     email_for_candidate(
       application_form,

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -93,6 +93,8 @@ class ApplicationChoice < ApplicationRecord
   scope :in_progress, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:in_progress)) }
   scope :active_previous, -> { where(status: ApplicationStateChange::ApplicationState.state_ids(:active_previous)) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
+  scope :rejected_by_default, -> { where(rejected_by_default: true) }
+  scope :declined_by_default, -> { where(declined_by_default: true) }
   scope :course_starts_after_september, lambda { |course_start_date_year|
     end_of_september = Date.parse("30/09/#{course_start_date_year}").at_end_of_day
     end_of_next_august = Date.parse("31/08/#{course_start_date_year + 1}").at_end_of_day

--- a/app/views/candidate_mailer/decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/decline_by_default_explainer.text.erb
@@ -2,7 +2,11 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-Your offer of a place on a teacher training course starting by the end of September <%= @timetable.recruitment_cycle_year %> has been declined automatically.
+<%= I18n.t('candidate_mailer.decline_by_default_explainer.declined_automatically', count: @application_choices.size) %>
+
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
 
 This is because you did not respond before the deadline.
 

--- a/app/views/candidate_mailer/reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/reject_by_default_explainer.text.erb
@@ -2,9 +2,13 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-Your application for teacher training starting by the end of September <%= "#{@timetable.recruitment_cycle_year}" %> has been rejected automatically.
+<%= I18n.t('candidate_mailer.reject_by_default_explainer.rejected_automatically', count: @application_choices.size) %>
 
-This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
+
+<%= I18n.t('candidate_mailer.reject_by_default_explainer.provider_did_not_respond', count: @application_choices.size) %>
 
 # What happens next?
 

--- a/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
@@ -2,11 +2,15 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-You have been offered a place on a teacher training course.
+<%= I18n.t('candidate_mailer.respond_to_offer_before_deadline.offered_a_place', count: @application_choices.size) %>
 
-If you want to accept this place, you must do so by <%= @decline_by_default_deadline %>.
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
 
-[Sign in to your account to review your offer](<%= application_choices_link %>)
+<%= I18n.t('candidate_mailer.respond_to_offer_before_deadline.accept_before', count: @application_choices.size, date: @decline_by_default_deadline) %>
+
+[<%= I18n.t('candidate_mailer.respond_to_offer_before_deadline.sign_in', count: @application_choices.size) %>](<%= application_choices_link %>)
 
 # Your other applications
 

--- a/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
@@ -2,11 +2,15 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-You have been offered a place on a teacher training course.
+<%= I18n.t('candidate_mailer.respond_to_offer_before_winter_deadline.offered_a_place', count: @application_choices.size) %>
 
-If you want to accept this place, you must do so by <%=  @winter_decline_by_default_deadline %>.
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
 
-[Sign in to your account to update your details](<%= application_choices_link %>)
+<%= I18n.t('candidate_mailer.respond_to_offer_before_winter_deadline.accept_before', count: @application_choices.size, date: @winter_decline_by_default_deadline) %>
+
+[<%= I18n.t('candidate_mailer.respond_to_offer_before_winter_deadline.sign_in', count: @application_choices.size) %>](<%= application_choices_link %>)
 
 # Your other applications
 

--- a/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_winter_deadline.text.erb
@@ -20,8 +20,6 @@ This is because the provider did not respond before their deadline. If you have 
 
 # What happens next?
 
-If you want to accept your offer of a place on a teacher training course, you must do so by <%= "#{@winter_decline_by_default_deadline}" %>.
-
 If you do not want to accept this offer, you can still apply to courses starting later in <%= "#{@next_recruitment_cycle_year}" %> and in <%= "#{@next_recruitment_cycle_year + 1}" %>.
 
 [Sign in to your account to apply for courses](<%= application_choices_link %>)

--- a/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_decline_by_default_explainer.text.erb
@@ -2,7 +2,11 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-Your offer of a place on a teacher training course has been declined automatically.
+<%= I18n.t('candidate_mailer.winter_decline_by_default_explainer.declined_automatically', count: @application_choices.size) %>
+
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
 
 This is because you did not respond before the deadline.
 

--- a/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/winter_reject_by_default_explainer.text.erb
@@ -2,9 +2,13 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-Your application for teacher training starting in the  <%= @this_academic_year %> academic year has been rejected automatically.
+<%= I18n.t('candidate_mailer.winter_reject_by_default_explainer.rejected_automatically', count: @application_choices.size) %>
 
-This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+<% @application_choices.each do |choice| %>
+  <%= choice.course.name_and_code %> at <%= choice.provider.name %>
+<% end %>
+
+<%= I18n.t('candidate_mailer.winter_reject_by_default_explainer.provider_did_not_respond', count: @application_choices.size) %>
 
 # What happens next?
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -100,6 +100,17 @@ en:
       sign_in:
         one: Sign in to your account to review your offer
         other: Sign in to your account to review your offers
+    respond_to_offer_before_winter_deadline:
+      subject: Accept your place on a teacher training course by %{decline_by_default_date}
+      offered_a_place:
+        one: 'You have been offered a place on the following teacher training course:'
+        other: 'You have been offered places on the following teacher training courses:'
+      accept_before:
+        one: If you want to accept this offer, you must do so before %{date}.
+        other: If you want to accept an offer, you must do so before %{date}. If you accept an offer, any other offers you have will be automatically declined.
+      sign_in:
+        one: Sign in to your account to review your offer
+        other: Sign in to your account to review your offers
     reject_by_default_explainer:
       subject: Your application has been rejected automatically
       rejected_automatically:
@@ -108,7 +119,20 @@ en:
       provider_did_not_respond:
         one: This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
         other: This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.
+    winter_reject_by_default_explainer:
+      subject: Your application has been rejected automatically
+      rejected_automatically:
+        one: 'Your application for the following teacher training course has been rejected automatically:'
+        other: 'Your applications for the following teacher training courses have been rejected automatically:'
+      provider_did_not_respond:
+        one: This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+        other: This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.
     decline_by_default_explainer:
+      subject: Your application has been declined automatically
+      declined_automatically:
+        one: 'Your offer of a place on the following teacher training course has been declined automatically:'
+        other: 'Your offers of places on the following teacher training courses have been declined automatically:'
+    winter_decline_by_default_explainer:
       subject: Your application has been declined automatically
       declined_automatically:
         one: 'Your offer of a place on the following teacher training course has been declined automatically:'

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -91,10 +91,28 @@ en:
       subject: The application deadline has passed
     respond_to_offer_before_deadline:
       subject: Accept your place on a teacher training course by %{decline_by_default_date}
+      offered_a_place:
+        one: 'You have been offered a place on the following teacher training course:'
+        other: 'You have been offered places on the following teacher training courses:'
+      accept_before:
+        one: If you want to accept this offer, you must do so before %{date}.
+        other: If you want to accept an offer, you must do so before %{date}. If you accept an offer, any other offers you have will be automatically declined.
+      sign_in:
+        one: Sign in to your account to review your offer
+        other: Sign in to your account to review your offers
     reject_by_default_explainer:
       subject: Your application has been rejected automatically
+      rejected_automatically:
+        one: 'Your application for the following teacher training course has been rejected automatically:'
+        other: 'Your applications for the following teacher training courses have been rejected automatically:'
+      provider_did_not_respond:
+        one: This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+        other: This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.
     decline_by_default_explainer:
       subject: Your application has been declined automatically
+      declined_automatically:
+        one: 'Your offer of a place on the following teacher training course has been declined automatically:'
+        other: 'Your offers of places on the following teacher training courses have been declined automatically:'
     new_cycle_has_started:
       subject: Apply for teacher training starting in the %{academic_year} academic year
     find_has_opened:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -95,8 +95,8 @@ en:
         one: 'You have been offered a place on the following teacher training course:'
         other: 'You have been offered places on the following teacher training courses:'
       accept_before:
-        one: If you want to accept this offer, you must do so before %{date}.
-        other: If you want to accept an offer, you must do so before %{date}. If you accept an offer, any other offers you have will be automatically declined.
+        one: If you want to accept this offer, you must do so by %{date}.
+        other: If you want to accept an offer, you must do so by %{date}. If you accept an offer, any other offers you have will be automatically declined.
       sign_in:
         one: Sign in to your account to review your offer
         other: Sign in to your account to review your offers
@@ -106,8 +106,8 @@ en:
         one: 'You have been offered a place on the following teacher training course:'
         other: 'You have been offered places on the following teacher training courses:'
       accept_before:
-        one: If you want to accept this offer, you must do so before %{date}.
-        other: If you want to accept an offer, you must do so before %{date}. If you accept an offer, any other offers you have will be automatically declined.
+        one: If you want to accept this offer, you must do so by %{date}.
+        other: If you want to accept an offer, you must do so by %{date}. If you accept an offer, any other offers you have will be automatically declined.
       sign_in:
         one: Sign in to your account to review your offer
         other: Sign in to your account to review your offers

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -125,12 +125,18 @@ en:
             find_has_opened: Candidates can now search for teacher training courses on Find teacher training courses.
             find_has_opened_no_name: Candidates can now search for teacher training courses on Find teacher training courses but we don't know the name of the candidate to personalise the email.
             new_cycle_has_started: Candidates can now submit applications for teacher training in the latest recruitment cycle.
-            reject_by_default_explainer: Applications that have not received a response by the end of the cycle are rejected by default.
-            respond_to_offer_before_deadline: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before the end of the cycle. Sent 2 weeks before the reject by default date before the end of the cycle.
-            respond_to_offer_before_winter_deadline: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before winter reject by default date. Sent 2 weeks before the winter reject by default date.
-            decline_by_default_explainer: A candidate is notified that there application has been declined. Sent after the decline by default date.
-            winter_reject_by_default_explainer: A candidate is notified that there application has been rejected by default. Sent after the winter reject by default date.
-            winter_decline_by_default_explainer: A candidate is notified that there application has been declined by default. Sent after the winter decline by default date.
+            reject_by_default_explainer_one_application_choice: Application that has not received a response by the end of the cycle are rejected by default.
+            reject_by_default_explainer_many_application_choices: Applications that have not received a response by the end of the cycle are rejected by default.
+            respond_to_offer_before_deadline_one_application_choice: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before the end of the cycle. Sent 2 weeks before the reject by default date before the end of the cycle.
+            respond_to_offer_before_deadline_many_application_choices: A candidate has offers to train to teach that they have not responded to, they are encouraged to respond before the end of the cycle. Sent 2 weeks before the reject by default date before the end of the cycle.
+            respond_to_offer_before_winter_deadline_one_application_choice: A candidate has an offer to train to teach that they have not responded to, they are encouraged to respond before winter reject by default date. Sent 2 weeks before the winter reject by default date.
+            respond_to_offer_before_winter_deadline_many_application_choices: A candidate has offers to train to teach that they have not responded to, they are encouraged to respond before winter reject by default date. Sent 2 weeks before the winter reject by default date.
+            decline_by_default_explainer_one_application_choice: A candidate is notified that there application has been declined. Sent after the decline by default date.
+            decline_by_default_explainer_many_application_choices: A candidate is notified that there applications have been declined. Sent after the decline by default date.
+            winter_reject_by_default_explainer_one_application_choice: A candidate is notified that there application has been rejected by default. Sent after the winter reject by default date.
+            winter_reject_by_default_explainer_many_application_choices: A candidate is notified that there applications have been rejected by default. Sent after the winter reject by default date.
+            winter_decline_by_default_explainer_one_application_choice: A candidate is notified that there application has been declined by default. Sent after the winter decline by default date.
+            winter_decline_by_default_explainer_many_application_choices: A candidate is notified that there applications have been declined by default. Sent after the winter decline by default date.
           candidate_interview:
             interview_cancelled: A scheduled interview has been cancelled.
             interview_updated: Details about a scheduled interview have been changed.

--- a/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for one application choice' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your offer of a place on the following teacher training course has been declined automatically:",
+          'Your offer of a place on the following teacher training course has been declined automatically:',
         )
         expect(email.body).to include(
           "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
@@ -62,7 +62,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for many application choices' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your offers of places on the following teacher training courses have been declined automatically:",
+          'Your offers of places on the following teacher training courses have been declined automatically:',
         )
         expect(email.body).to include(
           "#{application_choice_1.course.name_and_code} at #{application_choice_1.provider.name}",

--- a/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_decline_by_default_explainer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.decline_by_default_explainer' do
+    let(:application_form) { create(:completed_application_form) }
     let(:email) { described_class.decline_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:next_academic_year_range) { timetable.next_available_academic_year_range }
@@ -13,14 +14,67 @@ RSpec.describe CandidateMailer do
     it_behaves_like(
       'a mail with subject and content',
       'Your application has been declined automatically',
-      'greeting' => 'Dear Fred',
-      'details' => "Your offer of a place on a teacher training course starting by the end of September #{current_timetable.recruitment_cycle_year} has been declined automatically.",
       'cause' => 'This is because you did not respond before the deadline.',
       'what happens next' => 'What happens next?',
       'sign in' => 'Sign in to your account to update your details',
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
     )
+
+    context 'with one application choice' do
+      let(:application_choice) { create(:application_choice, :declined_by_default, application_form:) }
+      let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option) { create(:course_option, course: jan_course) }
+      let(:jan_choice) { create(:application_choice, :declined_by_default, application_form:, course_option: jan_course_option) }
+
+      before do
+        application_choice
+        jan_choice
+      end
+
+      it 'renders content for one application choice' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your offer of a place on the following teacher training course has been declined automatically:",
+        )
+        expect(email.body).to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:application_choice_1) { create(:application_choice, :declined_by_default, application_form:) }
+      let(:application_choice_2) { create(:application_choice, :declined_by_default, application_form:) }
+      let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option) { create(:course_option, course: jan_course) }
+      let(:jan_choice) { create(:application_choice, :declined_by_default, course_option: jan_course_option) }
+
+      before do
+        application_choice_1
+        application_choice_2
+        jan_choice
+      end
+
+      it 'renders content for many application choices' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your offers of places on the following teacher training courses have been declined automatically:",
+        )
+        expect(email.body).to include(
+          "#{application_choice_1.course.name_and_code} at #{application_choice_1.provider.name}",
+        )
+        expect(email.body).to include(
+          "#{application_choice_2.course.name_and_code} at #{application_choice_2.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+      end
+    end
 
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(

--- a/spec/mailers/candidate_mailer/candidate_mailer_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_reject_by_default_explainer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for one application choice' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your application for the following teacher training course has been rejected automatically:",
+          'Your application for the following teacher training course has been rejected automatically:',
         )
         expect(email.body).to include(
           "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
@@ -43,7 +43,7 @@ RSpec.describe CandidateMailer do
           "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
         )
         expect(email.body).to include(
-          "This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.",
+          'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
         )
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for many application choices' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your applications for the following teacher training courses have been rejected automatically:",
+          'Your applications for the following teacher training courses have been rejected automatically:',
         )
         expect(email.body).to include(
           "#{application_choice_1.course.name_and_code} at #{application_choice_1.provider.name}",
@@ -76,7 +76,7 @@ RSpec.describe CandidateMailer do
           "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
         )
         expect(email.body).to include(
-          "This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.",
+          'This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.',
         )
       end
     end

--- a/spec/mailers/candidate_mailer/candidate_mailer_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_reject_by_default_explainer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.reject_by_default_explainer' do
+    let(:application_form) { create(:completed_application_form) }
     let(:email) { described_class.reject_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:next_academic_year_range) { timetable.next_available_academic_year_range }
@@ -13,14 +14,72 @@ RSpec.describe CandidateMailer do
     it_behaves_like(
       'a mail with subject and content',
       'Your application has been rejected automatically',
-      'greeting' => 'Dear Fred',
-      'details' => "Your application for teacher training starting by the end of September #{current_timetable.recruitment_cycle_year} has been rejected automatically.",
-      'cause' => 'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
       'what happens next' => 'What happens next?',
       'sign in' => 'Sign in to your account to update your details',
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
     )
+
+    context 'with one application choice' do
+      let(:application_choice) { create(:application_choice, :rejected_by_default, application_form:) }
+      let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option) { create(:course_option, course: jan_course) }
+      let(:jan_choice) { create(:application_choice, :rejected_by_default, application_form:, course_option: jan_course_option) }
+
+      before do
+        application_choice
+        jan_choice
+      end
+
+      it 'renders content for one application choice' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your application for the following teacher training course has been rejected automatically:",
+        )
+        expect(email.body).to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+        expect(email.body).to include(
+          "This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.",
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:application_choice_1) { create(:application_choice, :rejected_by_default, application_form:) }
+      let(:application_choice_2) { create(:application_choice, :rejected_by_default, application_form:) }
+      let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option) { create(:course_option, course: jan_course) }
+      let(:jan_choice) { create(:application_choice, :rejected_by_default, course_option: jan_course_option) }
+
+      before do
+        application_choice_1
+        application_choice_2
+        jan_choice
+      end
+
+      it 'renders content for many application choices' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your applications for the following teacher training courses have been rejected automatically:",
+        )
+        expect(email.body).to include(
+          "#{application_choice_1.course.name_and_code} at #{application_choice_1.provider.name}",
+        )
+        expect(email.body).to include(
+          "#{application_choice_2.course.name_and_code} at #{application_choice_2.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+        expect(email.body).to include(
+          "This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.",
+        )
+      end
+    end
 
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_deadline_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateMailer do
     let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
     let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
     let(:jan_course_option) { create(:course_option, course: jan_course) }
-    let(:jan_choice) { create(:application_choice, :offer, course_option: jan_course_option) }
+    let(:jan_choice) { create(:application_choice, :offer, course_option: jan_course_option, application_form:) }
 
     before { jan_choice }
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_deadline_spec.rb
@@ -6,28 +6,74 @@ RSpec.describe CandidateMailer do
   describe '.respond_to_offer_before_deadline' do
     let(:email) { described_class.respond_to_offer_before_deadline(application_form) }
 
+    let(:application_form) { create(:completed_application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:this_academic_year) { timetable.previously_closed_academic_year_range }
     let(:next_academic_year) { timetable.next_available_academic_year_range }
     let(:apply_reopens_date) { timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
+    let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+    let(:jan_course_option) { create(:course_option, course: jan_course) }
+    let(:jan_choice) { create(:application_choice, :offer, course_option: jan_course_option) }
 
-    it 'renders the content' do
-      expect(email.subject).to eq("Accept your place on a teacher training course by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}")
-      expect(email.body).to include("Dear #{application_form.first_name}")
-      expect(email.body).to include('You have been offered a place on a teacher training course.')
-      expect(email.body).to include("If you want to accept this place, you must do so by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}.")
-      expect(email.body).to include('Sign in to your account to review your offer')
-      expect(email.body).to include('Your other applications')
-      expect(email.body).to include("Your other applications for teacher training starting in September #{timetable.recruitment_cycle_year} have been automatically rejected.")
-      expect(email.body).to include('This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.')
-      expect(email.body).to include('If you do not accept your offer')
-      expect(email.body).to include("You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.")
-      expect(email.body).to include("You will be able to apply for these courses from #{apply_reopens_date}.")
-      expect(email.body).to include('Sign in to your account to update your details')
-      expect(email.body).to include('Contact us')
-      expect(email.body).to include(
-        'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
-      )
+    before { jan_choice }
+
+    context 'with one application choice' do
+      let(:application_choice) { create(:application_choice, :offer, application_form:) }
+
+      before { application_choice }
+
+      it 'renders the content' do
+        expect(email.subject).to eq("Accept your place on a teacher training course by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}")
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include('You have been offered a place on the following teacher training course:')
+        expect(email.body).to include("#{application_choice.course.name_and_code} at #{application_choice.provider.name}")
+        expect(email.body).not_to include("#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}")
+        expect(email.body).to include("If you want to accept this offer, you must do so by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}.")
+        expect(email.body).to include('Sign in to your account to review your offer')
+        expect(email.body).to include('Your other applications')
+        expect(email.body).to include("Your other applications for teacher training starting in September #{timetable.recruitment_cycle_year} have been automatically rejected.")
+        expect(email.body).to include('This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.')
+        expect(email.body).to include('If you do not accept your offer')
+        expect(email.body).to include("You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.")
+        expect(email.body).to include("You will be able to apply for these courses from #{apply_reopens_date}.")
+        expect(email.body).to include('Sign in to your account to update your details')
+        expect(email.body).to include('Contact us')
+        expect(email.body).to include(
+          'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:application_choice_1) { create(:application_choice, :offer, application_form:) }
+      let(:application_choice_2) { create(:application_choice, :offer, application_form:) }
+
+      before do
+        application_choice_1
+        application_choice_2
+      end
+
+      it 'renders the content' do
+        expect(email.subject).to eq("Accept your place on a teacher training course by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}")
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include('You have been offered places on the following teacher training courses:')
+        expect(email.body).to include("#{application_choice_1.course.name_and_code} at #{application_choice_1.provider.name}")
+        expect(email.body).to include("#{application_choice_2.course.name_and_code} at #{application_choice_2.provider.name}")
+        expect(email.body).not_to include("#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}")
+        expect(email.body).to include("If you want to accept an offer, you must do so by #{timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}.")
+        expect(email.body).to include('Sign in to your account to review your offer')
+        expect(email.body).to include('Your other applications')
+        expect(email.body).to include("Your other applications for teacher training starting in September #{timetable.recruitment_cycle_year} have been automatically rejected.")
+        expect(email.body).to include('This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.')
+        expect(email.body).to include('If you do not accept your offer')
+        expect(email.body).to include("You can update your details to get ready to apply for courses starting in the #{next_academic_year} academic year.")
+        expect(email.body).to include("You will be able to apply for these courses from #{apply_reopens_date}.")
+        expect(email.body).to include('Sign in to your account to update your details')
+        expect(email.body).to include('Contact us')
+        expect(email.body).to include(
+          'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+        )
+      end
     end
 
     it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
@@ -4,37 +4,90 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   let(:email) { described_class.respond_to_offer_before_winter_deadline(application_form) }
+  let(:application_form) { create(:completed_application_form) }
   let(:timetable) { application_form.recruitment_cycle_timetable }
   let(:winter_deadline) { timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first) }
   let(:next_recruitment_cycle_year) { timetable.relative_next_year }
+  let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+  let(:jan_course_option) { create(:course_option, course: jan_course) }
+  let(:application_choice) { create(:application_choice, :offer, application_form:) }
+  let(:jan_choice) { create(:application_choice, :offer, course_option: jan_course_option, application_form:) }
+
+  before { application_choice }
 
   describe '.respond_to_offer_before_winter_deadline' do
-    it 'renders the content' do
-      expect(email.subject).to eq(
-        "Accept your place on a teacher training course by #{winter_deadline}",
-      )
-      expect(email.body).to include("Dear #{application_form.first_name}")
-      expect(email.body).to include('You have been offered a place on a teacher training course.')
-      expect(email.body).to include("If you want to accept this place, you must do so by #{winter_deadline}.")
-      expect(email.body).to include('Sign in to your account to update your details')
-      expect(email.body).to include('Your other applications')
-      expect(email.body).to include(
-        "Your other applications for teacher training starting in January #{next_recruitment_cycle_year} have been automatically rejected.",
-      )
-      expect(email.body).to include(
-        'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
-      )
-      expect(email.body).to include('What happens next?')
-      expect(email.body).to include(
-        "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
-      )
-      expect(email.body).to include(
-        "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
-      )
-      expect(email.body).to include('Sign in to your account to apply for courses')
-      expect(email.body).to include(
-        'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
-      )
+    before { jan_choice }
+
+    context 'with one application choice' do
+      it 'renders the content' do
+        expect(email.subject).to eq(
+          "Accept your place on a teacher training course by #{winter_deadline}",
+        )
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include('You have been offered a place on the following teacher training course:')
+        expect(email.body).to include("#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}")
+        expect(email.body).not_to include("#{application_choice.course.name_and_code} at #{application_choice.provider.name}")
+        expect(email.body).to include("If you want to accept this offer, you must do so by #{winter_deadline}.")
+        expect(email.body).to include('Sign in to your account to review your offer')
+        expect(email.body).to include('Your other applications')
+        expect(email.body).to include(
+          "Your other applications for teacher training starting in January #{next_recruitment_cycle_year} have been automatically rejected.",
+        )
+        expect(email.body).to include(
+          'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
+        )
+        expect(email.body).to include('What happens next?')
+        expect(email.body).to include(
+          "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
+        )
+        expect(email.body).to include(
+          "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
+        )
+        expect(email.body).to include('Sign in to your account to apply for courses')
+        expect(email.body).to include(
+          'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:jan_choice) { create(:application_choice, :offer, course_option: jan_course_option, application_form:) }
+      let(:jan_course_2) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option_2) { create(:course_option, course: jan_course_2) }
+      let(:jan_choice_2) { create(:application_choice, :offer, application_form:, course_option: jan_course_option_2) }
+
+      before do
+        jan_choice
+        jan_choice_2
+      end
+
+      it 'renders the content' do
+        expect(email.subject).to eq("Accept your place on a teacher training course by #{winter_deadline}")
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include('You have been offered places on the following teacher training courses:')
+        expect(email.body).to include("#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}")
+        expect(email.body).to include("#{jan_choice_2.course.name_and_code} at #{jan_choice_2.provider.name}")
+        expect(email.body).not_to include("#{application_choice.course.name_and_code} at #{application_choice.provider.name}")
+        expect(email.body).to include("If you want to accept an offer, you must do so by #{winter_deadline}.")
+        expect(email.body).to include('Your other applications')
+        expect(email.body).to include(
+          "Your other applications for teacher training starting in January #{next_recruitment_cycle_year} have been automatically rejected.",
+        )
+        expect(email.body).to include(
+          'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
+        )
+        expect(email.body).to include('What happens next?')
+        expect(email.body).to include(
+          "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
+        )
+        expect(email.body).to include(
+          "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
+        )
+        expect(email.body).to include('Sign in to your account to apply for courses')
+        expect(email.body).to include(
+          'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
+        )
+      end
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_respond_to_offer_before_winter_deadline_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe CandidateMailer do
         )
         expect(email.body).to include('What happens next?')
         expect(email.body).to include(
-          "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
-        )
-        expect(email.body).to include(
           "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
         )
         expect(email.body).to include('Sign in to your account to apply for courses')
@@ -77,9 +74,6 @@ RSpec.describe CandidateMailer do
           'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
         )
         expect(email.body).to include('What happens next?')
-        expect(email.body).to include(
-          "If you want to accept your offer of a place on a teacher training course, you must do so by #{winter_deadline}.",
-        )
         expect(email.body).to include(
           "If you do not want to accept this offer, you can still apply to courses starting later in #{next_recruitment_cycle_year} and in #{next_recruitment_cycle_year + 1}.",
         )

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for one application choice' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your offer of a place on the following teacher training course has been declined automatically:",
+          'Your offer of a place on the following teacher training course has been declined automatically:',
         )
         expect(email.body).to include(
           "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
@@ -64,7 +64,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for many application choices' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your offers of places on the following teacher training courses have been declined automatically:",
+          'Your offers of places on the following teacher training courses have been declined automatically:',
         )
         expect(email.body).to include(
           "#{jan_choice_1.course.name_and_code} at #{jan_choice_1.provider.name}",

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_decline_by_default_explainer_spec.rb
@@ -4,17 +4,18 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.winter_decline_by_default_explainer' do
+    let(:application_form) { create(:completed_application_form) }
     let(:email) { described_class.winter_decline_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:next_timetable) { timetable.relative_next_timetable }
     let(:next_academic_year) { next_timetable.academic_year_range_name }
     let(:apply_reopens_date) { next_timetable.apply_reopens_at.to_fs(:govuk_date_time_time_first) }
+    let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+    let(:jan_course_option) { create(:course_option, course: jan_course) }
 
     it_behaves_like(
       'a mail with subject and content',
       'Your application has been declined automatically',
-      'greeting' => 'Dear Fred',
-      'details' => 'Your offer of a place on a teacher training course has been declined automatically.',
       'cause' => 'This is because you did not respond before the deadline.',
       'what happens next' => 'What happens next?',
       'providers make offers' => 'Training providers make offers throughout the year. Providers may close applications early if a course fills up.',
@@ -23,6 +24,59 @@ RSpec.describe CandidateMailer do
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
     )
+
+    context 'with one application choice' do
+      let(:application_choice) { create(:application_choice, :declined_by_default, application_form:) }
+      let(:jan_choice) { create(:application_choice, :declined_by_default, application_form:, course_option: jan_course_option) }
+
+      before do
+        application_choice
+        jan_choice
+      end
+
+      it 'renders content for one application choice' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your offer of a place on the following teacher training course has been declined automatically:",
+        )
+        expect(email.body).to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:application_choice) { create(:application_choice, :declined_by_default, application_form:) }
+      let(:jan_choice_1) { create(:application_choice, :declined_by_default, application_form:, course_option: jan_course_option) }
+      let(:jan_course_2) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option_2) { create(:course_option, course: jan_course_2) }
+      let(:jan_choice_2) { create(:application_choice, :declined_by_default, application_form:, course_option: jan_course_option_2) }
+
+      before do
+        application_choice
+        jan_choice_1
+        jan_choice_2
+      end
+
+      it 'renders content for many application choices' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your offers of places on the following teacher training courses have been declined automatically:",
+        )
+        expect(email.body).to include(
+          "#{jan_choice_1.course.name_and_code} at #{jan_choice_1.provider.name}",
+        )
+        expect(email.body).to include(
+          "#{jan_choice_2.course.name_and_code} at #{jan_choice_2.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+      end
+    end
 
     it 'renders content for updating the recipients details' do
       expect(email.body).to include(

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -4,26 +4,80 @@ RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.winter_reject_by_default_explainer' do
+    let(:application_form) { create(:completed_application_form) }
     let(:email) { described_class.winter_reject_by_default_explainer(application_form) }
     let(:timetable) { application_form.recruitment_cycle_timetable }
     let(:this_academic_year) { timetable.academic_year_range_name }
     let(:next_academic_year) { timetable.next_available_academic_year_range }
+    let(:jan_course) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+    let(:jan_course_option) { create(:course_option, course: jan_course) }
 
     it_behaves_like(
       'a mail with subject and content',
       'Your application has been rejected automatically',
-      'greeting' => 'Dear Fred',
-      'cause' => 'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
       'what happens next' => 'What happens next?',
       'sign in' => 'Sign in to your account to apply for courses',
       'contact us' => 'Contact us',
       'contact details' => 'Call 0800 389 2500 or [chat online](https://getintoteaching.education.gov.uk/help-and-support) (Monday to Friday, 8:30am to 5:30pm UK time except on [bank holidays](https://www.gov.uk/bank-holidays))',
     )
 
-    it 'renders content for application rejected automatically' do
-      expect(email.body).to include(
-        "Your application for teacher training starting in the  #{this_academic_year} academic year has been rejected automatically.",
-      )
+    context 'with one application choice' do
+      let(:application_choice) { create(:application_choice, :rejected_by_default, application_form:) }
+      let(:jan_choice) { create(:application_choice, :rejected_by_default, application_form:, course_option: jan_course_option) }
+
+      before do
+        application_choice
+        jan_choice
+      end
+
+      it 'renders content for one application choice' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your application for the following teacher training course has been rejected automatically:",
+        )
+        expect(email.body).to include(
+          "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+        expect(email.body).to include(
+          "This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.",
+        )
+      end
+    end
+
+    context 'with many application choices' do
+      let(:application_choice) { create(:application_choice, :rejected_by_default, application_form:) }
+      let(:jan_choice_1) { create(:application_choice, :rejected_by_default, application_form:, course_option: jan_course_option) }
+      let(:jan_course_2) { create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+      let(:jan_course_option_2) { create(:course_option, course: jan_course_2) }
+      let(:jan_choice_2) { create(:application_choice, :rejected_by_default, application_form:, course_option: jan_course_option_2) }
+
+      before do
+        application_choice
+        jan_choice_1
+        jan_choice_2
+      end
+
+      it 'renders content for many application choices' do
+        expect(email.body).to include("Dear #{application_form.first_name}")
+        expect(email.body).to include(
+          "Your applications for the following teacher training courses have been rejected automatically:",
+        )
+        expect(email.body).to include(
+          "#{jan_choice_1.course.name_and_code} at #{jan_choice_1.provider.name}",
+        )
+        expect(email.body).to include(
+          "#{jan_choice_2.course.name_and_code} at #{jan_choice_2.provider.name}",
+        )
+        expect(email.body).not_to include(
+          "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
+        )
+        expect(email.body).to include(
+          "This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.",
+        )
+      end
     end
 
     it 'renders content for open courses' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_winter_reject_by_default_explainer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for one application choice' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your application for the following teacher training course has been rejected automatically:",
+          'Your application for the following teacher training course has been rejected automatically:',
         )
         expect(email.body).to include(
           "#{jan_choice.course.name_and_code} at #{jan_choice.provider.name}",
@@ -42,7 +42,7 @@ RSpec.describe CandidateMailer do
           "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
         )
         expect(email.body).to include(
-          "This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.",
+          'This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.',
         )
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe CandidateMailer do
       it 'renders content for many application choices' do
         expect(email.body).to include("Dear #{application_form.first_name}")
         expect(email.body).to include(
-          "Your applications for the following teacher training courses have been rejected automatically:",
+          'Your applications for the following teacher training courses have been rejected automatically:',
         )
         expect(email.body).to include(
           "#{jan_choice_1.course.name_and_code} at #{jan_choice_1.provider.name}",
@@ -75,7 +75,7 @@ RSpec.describe CandidateMailer do
           "#{application_choice.course.name_and_code} at #{application_choice.provider.name}",
         )
         expect(email.body).to include(
-          "This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.",
+          'This is because the providers did not respond before their deadline. If you have any questions about this, please contact the providers.',
         )
       end
     end

--- a/spec/mailers/previews/candidate/end_of_cycle_preview.rb
+++ b/spec/mailers/previews/candidate/end_of_cycle_preview.rb
@@ -69,7 +69,7 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.respond_to_offer_before_deadline(application_form)
   end
 
-  def respond_to_offer_before_deadline_many_application_choice
+  def respond_to_offer_before_deadline_many_application_choices
     application_form = FactoryBot.build(:application_form, first_name: 'Bart')
     FactoryBot.create_list(:application_choice, 2, :offer, application_form:)
 
@@ -126,27 +126,73 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.visa_sponsorship_deadline_change(application_form, course)
   end
 
-  def winter_reject_by_default_explainer
+  def winter_reject_by_default_explainer_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option = FactoryBot.build(:course_option, course:)
+    FactoryBot.create(:application_choice, :rejected_by_default, application_form:, course_option:)
 
     CandidateMailer.winter_reject_by_default_explainer(application_form)
   end
 
-  def respond_to_offer_before_winter_deadline
+  def winter_reject_by_default_explainer_many_application_choices
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option = FactoryBot.build(:course_option, course:)
+    FactoryBot.create_list(:application_choice, 2, :rejected_by_default, application_form:, course_option:)
+
+    CandidateMailer.winter_reject_by_default_explainer(application_form)
+  end
+
+  def respond_to_offer_before_winter_deadliner_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+    course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option = FactoryBot.build(:course_option, course:)
+    FactoryBot.create(:application_choice, :offer, application_form:, course_option:)
+
+    CandidateMailer.respond_to_offer_before_winter_deadline(application_form)
+  end
+
+  def respond_to_offer_before_winter_deadliner_many_application_choices
+    application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+    course_1 = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option_1 = FactoryBot.build(:course_option, course: course_1)
+    FactoryBot.create(:application_choice, :offer, application_form:, course_option: course_option_1)
+    course_2 = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option_2 = FactoryBot.build(:course_option, course: course_2)
+    FactoryBot.create(:application_choice, :offer, application_form:, course_option: course_option_2)
 
     CandidateMailer.respond_to_offer_before_winter_deadline(application_form)
   end
 
   def decline_by_default_explainer_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
-    FactoryBot.create(:application_choice, :rejected_by_default, application_form:)
+    FactoryBot.create(:application_choice, :declined_by_default, application_form:)
 
     CandidateMailer.decline_by_default_explainer(application_form)
   end
 
-  def winter_decline_by_default_explainer
+  def decline_by_default_explainer_many_application_choices
     application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    FactoryBot.create_list(:application_choice, 2, :declined_by_default, application_form:)
+
+    CandidateMailer.decline_by_default_explainer(application_form)
+  end
+
+  def winter_decline_by_default_explainer_one_application_choice
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option = FactoryBot.build(:course_option, course:)
+    FactoryBot.create(:application_choice, :declined_by_default, application_form:, course_option:)
+
+    CandidateMailer.winter_decline_by_default_explainer(application_form)
+  end
+
+  def winter_decline_by_default_explainer_many_application_choices
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
+    course_option = FactoryBot.build(:course_option, course:)
+    FactoryBot.create_list(:application_choice, 2, :declined_by_default, application_form:, course_option:)
 
     CandidateMailer.winter_decline_by_default_explainer(application_form)
   end

--- a/spec/mailers/previews/candidate/end_of_cycle_preview.rb
+++ b/spec/mailers/previews/candidate/end_of_cycle_preview.rb
@@ -62,14 +62,30 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.application_deadline_has_passed(application_form)
   end
 
-  def respond_to_offer_before_deadline
+  def respond_to_offer_before_deadline_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+    FactoryBot.create(:application_choice, :offer, application_form:)
 
     CandidateMailer.respond_to_offer_before_deadline(application_form)
   end
 
-  def reject_by_default_explainer
+  def respond_to_offer_before_deadline_many_application_choice
+    application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+    FactoryBot.create_list(:application_choice, 2, :offer, application_form:)
+
+    CandidateMailer.respond_to_offer_before_deadline(application_form)
+  end
+
+  def reject_by_default_explainer_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    FactoryBot.create(:application_choice, :rejected_by_default, application_form:)
+
+    CandidateMailer.reject_by_default_explainer(application_form)
+  end
+
+  def reject_by_default_explainer_many_application_choices
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    FactoryBot.create_list(:application_choice, 2, :rejected_by_default, application_form:)
 
     CandidateMailer.reject_by_default_explainer(application_form)
   end
@@ -122,8 +138,9 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.respond_to_offer_before_winter_deadline(application_form)
   end
 
-  def decline_by_default_explainer
+  def decline_by_default_explainer_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+    FactoryBot.create(:application_choice, :rejected_by_default, application_form:)
 
     CandidateMailer.decline_by_default_explainer(application_form)
   end

--- a/spec/mailers/previews/candidate/end_of_cycle_preview.rb
+++ b/spec/mailers/previews/candidate/end_of_cycle_preview.rb
@@ -144,7 +144,7 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.winter_reject_by_default_explainer(application_form)
   end
 
-  def respond_to_offer_before_winter_deadliner_one_application_choice
+  def respond_to_offer_before_winter_deadline_one_application_choice
     application_form = FactoryBot.build(:application_form, first_name: 'Bart')
     course = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
     course_option = FactoryBot.build(:course_option, course:)
@@ -153,7 +153,7 @@ class Candidate::EndOfCyclePreview < ActionMailer::Preview
     CandidateMailer.respond_to_offer_before_winter_deadline(application_form)
   end
 
-  def respond_to_offer_before_winter_deadliner_many_application_choices
+  def respond_to_offer_before_winter_deadline_many_application_choices
     application_form = FactoryBot.build(:application_form, first_name: 'Bart')
     course_1 = FactoryBot.build(:course, start_date: "01/01/#{RecruitmentCycleTimetable.current_year + 1}")
     course_option_1 = FactoryBot.build(:course_option, course: course_1)


### PR DESCRIPTION
## Context

- Improve the clarity of emails by specifying which applications they relate to.

## Changes proposed in this pull request

- Change mailer content to include the course name and provider of each related application choice.

## Guidance to review

- Visit https://apply-review-12092.test.teacherservices.cloud/support
- Sign in as a Support user
---------
**Reject by default 1**
_One application_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/reject_by_default_explainer_one_application_choice
<img width="456" height="519" alt="Screenshot 2026-07-14 at 13 09 45" src="https://github.com/user-attachments/assets/3d09aac2-acf1-4b7d-8c2c-1d729376e5d8" />

_Many applications_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/reject_by_default_explainer_many_application_choices
<img width="434" height="526" alt="Screenshot 2026-07-14 at 13 10 52" src="https://github.com/user-attachments/assets/53849d3b-4340-4ba7-b847-10dede5d154a" />

---------
**Respond to offer before decline by default 1**
_One application_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/respond_to_offer_before_deadline_one_application_choice
<img width="293" height="530" alt="Screenshot 2026-07-14 at 13 11 56" src="https://github.com/user-attachments/assets/74b9d4e7-f303-403c-88f0-0c3df908cc3c" />

_Many applications_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/respond_to_offer_before_deadline_many_application_choices
<img width="300" height="549" alt="Screenshot 2026-07-14 at 13 12 30" src="https://github.com/user-attachments/assets/1169bff7-d328-4ede-9b98-0e0413c2e6ed" />

---------
**Decline by default 1**
_One application_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/decline_by_default_explainer_one_application_choice
<img width="460" height="496" alt="Screenshot 2026-07-14 at 13 13 02" src="https://github.com/user-attachments/assets/d1c6f6fd-85bc-42b9-854d-e58bf68b335f" />

_Many applications_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/decline_by_default_explainer_many_application_choices
<img width="463" height="507" alt="Screenshot 2026-07-14 at 13 13 34" src="https://github.com/user-attachments/assets/ae0e847a-3e2c-4129-a4e5-2bdd662f8a44" />

-----------
**Reject by default 2**
_One application_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_reject_by_default_explainer_one_application_choice
<img width="457" height="499" alt="Screenshot 2026-07-14 at 13 14 08" src="https://github.com/user-attachments/assets/dd5a80da-7c72-477b-8772-c424d9a67fd4" />

_Many applications_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_reject_by_default_explainer_many_application_choices
<img width="458" height="542" alt="Screenshot 2026-07-14 at 13 14 47" src="https://github.com/user-attachments/assets/6be63e19-049d-4f13-81e9-3417e359cd80" />

---------------
**Respond to offer before decline by default 2**
_One application_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/respond_to_offer_before_winter_deadline_one_application_choice
<img width="430" height="649" alt="Screenshot 2026-07-14 at 16 26 40" src="https://github.com/user-attachments/assets/fca6a8cf-d834-4bea-8053-c0673556643f" />

_Many applications_
- Visit https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/respond_to_offer_before_winter_deadline_many_application_choices
<img width="394" height="612" alt="Screenshot 2026-07-14 at 16 28 11" src="https://github.com/user-attachments/assets/e6a1b39a-1329-4672-974d-7fc06a1cef25" />

-------------------
**Decline by default 2**
_One application_
https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_decline_by_default_explainer_one_application_choice
<img width="462" height="591" alt="Screenshot 2026-07-14 at 13 16 48" src="https://github.com/user-attachments/assets/d6b8f852-326a-425a-a4af-809784af96cf" />

_Many applications_
https://apply-review-12092.test.teacherservices.cloud/rails/mailers/candidate/end_of_cycle/winter_decline_by_default_explainer_many_application_choices
<img width="463" height="612" alt="Screenshot 2026-07-14 at 13 17 15" src="https://github.com/user-attachments/assets/93ba879c-70c1-4df2-bd76-dd172cf4e051" />

-------------------

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/k69dYlqy/1884-design-content-that-makes-clear-which-applications-candidate-emails-relate-to