### PR TITLE
Prompt inactive provider users 2 weeks before account closure

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -290,6 +290,17 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def inactive_user_prompt(provider_user, date)
+    @provider_user = provider_user
+    @providers = provider_user.providers.map(&:name).to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
+    @date = date.to_fs(:day_and_month)
+
+    provider_notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!('provider_mailer.inactive_user_prompt.subject', date: @date),
+    )
+  end
+
 private
 
   def current_timetable

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -292,7 +292,7 @@ class ProviderMailer < ApplicationMailer
 
   def inactive_user_prompt(provider_user, date)
     @provider_user = provider_user
-    @providers = provider_user.providers.map(&:name).to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
+    @providers = provider_user.providers.map(&:name).join("\n")
     @date = date.to_fs(:day_and_month)
 
     provider_notify_email(

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -291,6 +291,7 @@ class ProviderMailer < ApplicationMailer
   end
 
   def inactive_user_prompt(provider_user, date)
+    @get_help_title = 'Contact us'
     @provider_user = provider_user
     @providers = provider_user.providers.map(&:name).join("\n")
     @date = date.to_fs(:day_and_month)

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -291,7 +291,7 @@ class ProviderMailer < ApplicationMailer
   end
 
   def inactive_user_prompt(provider_user, date)
-    @get_help_title = 'Contact us'
+    @hide_get_help = true
     @provider_user = provider_user
     @providers = provider_user.providers.map(&:name).join("\n")
     @date = date.to_fs(:day_and_month)

--- a/app/views/layouts/provider_email.text.erb
+++ b/app/views/layouts/provider_email.text.erb
@@ -1,7 +1,9 @@
 <%= yield %>
 
-# <%= @get_help_title.presence || 'Get help' %>
+<% unless @hide_get_help %>
+  # <%= @get_help_title.presence || 'Get help' %>
 
-Get help, report a problem or give feedback at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+  Get help, report a problem or give feedback at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+<% end %>
 
 <%= yield :additional_footer_content %>

--- a/app/views/provider_mailer/inactive_user_prompt.text.erb
+++ b/app/views/provider_mailer/inactive_user_prompt.text.erb
@@ -1,0 +1,23 @@
+Dear <%= @provider_user.full_name %>
+
+We will delete your account on <%= @date %> if you do not sign in by then.
+
+If your account is deleted, you will no longer be able to manage teacher training applications for <%= @providers %>.
+
+We delete accounts that have not been signed in to for 12 months to protect your data and our service.
+
+# What you need to do
+
+Sign in to keep your account active at https://www.apply_for_teacher_training.service.gov.uk/provider.
+
+If you do not want to keep your account active, you do not need to do anything.
+
+# What happens if we delete your account
+
+Your account will be permanently deleted. You will need to create a new account to use the service again.
+
+If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Regards,
+
+Becoming a Teacher team

--- a/app/views/provider_mailer/inactive_user_prompt.text.erb
+++ b/app/views/provider_mailer/inactive_user_prompt.text.erb
@@ -1,10 +1,12 @@
 Dear <%= @provider_user.full_name %>
 
-We will delete your account on <%= @date %> if you do not sign in by then.
+We will remove your access to your Manage account on <%= @date %> if you do not sign in by then.
 
-If your account is deleted, you will no longer be able to manage teacher training applications for <%= @providers %>.
+If your access is removed, you will no longer be able to manage teacher training applications for:
 
-We delete accounts that have not been signed in to for 12 months to protect your data and our service.
+<%= @providers %>
+
+We remove access to accounts that have not been signed in to for 12 months to protect your data and our service.
 
 # What you need to do
 
@@ -12,9 +14,11 @@ Sign in to keep your account active at https://www.apply_for_teacher_training.se
 
 If you do not want to keep your account active, you do not need to do anything.
 
-# What happens if we delete your account
+# What happens if we remove your access
 
-Your account will be permanently deleted. You will need to create a new account to use the service again.
+You will need to contact us to get your access back.
+
+# Contact us
 
 If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 

--- a/app/views/provider_mailer/inactive_user_prompt.text.erb
+++ b/app/views/provider_mailer/inactive_user_prompt.text.erb
@@ -18,10 +18,6 @@ If you do not want to keep your account active, you do not need to do anything.
 
 You will need to contact us to get your access back.
 
-# Contact us
-
-If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-
 Regards,
 
 Becoming a Teacher team

--- a/app/views/provider_mailer/inactive_user_prompt.text.erb
+++ b/app/views/provider_mailer/inactive_user_prompt.text.erb
@@ -18,6 +18,10 @@ If you do not want to keep your account active, you do not need to do anything.
 
 You will need to contact us to get your access back.
 
+# Contact us
+
+If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
 Regards,
 
 Becoming a Teacher team

--- a/app/workers/prompt_inactive_provider_users_batch_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_batch_worker.rb
@@ -1,0 +1,13 @@
+class PromptInactiveProviderUsersBatchWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
+  queue_as :low_priority
+
+  def perform(provider_user_ids, inactive_date)
+    ProviderUser.where(id: provider_user_ids).find_each do |provider_user|
+      ProviderMailer
+        .inactive_user_prompt(provider_user, inactive_date)
+        .deliver_later
+    end
+  end
+end

--- a/app/workers/prompt_inactive_provider_users_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_worker.rb
@@ -1,0 +1,34 @@
+class PromptInactiveProviderUsersWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
+  queue_as :low_priority
+
+  INACTIVE_MONTHS_AGO = 12
+  PROMPT_WEEKS_BEFORE = 2
+
+  def perform
+    return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?
+
+    ProviderUser.where(last_signed_in_at: almost_inactive_date)
+      .or(
+        ProviderUser.where(
+          last_signed_in_at: nil,
+          created_at: almost_inactive_date,
+        ),
+      ).find_each do |provider_user|
+      ProviderMailer.inactive_user_prompt(provider_user, inactive_date).deliver_later
+    end
+  end
+
+private
+
+  def almost_inactive_date
+    # 11 months and 2 weeks ago
+    @prompt_date ||= INACTIVE_MONTHS_AGO.months.ago - PROMPT_WEEKS_BEFORE.weeks
+  end
+
+  def inactive_date
+    # 2 weeks from now, making it inactive for 12 months
+    PROMPT_WEEKS_BEFORE.weeks.from_now.to_date
+  end
+end

--- a/app/workers/prompt_inactive_provider_users_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_worker.rb
@@ -9,14 +9,23 @@ class PromptInactiveProviderUsersWorker < ApplicationJob
   def perform
     return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?
 
-    ProviderUser.where(last_signed_in_at: almost_inactive_date.all_day)
+    relation = ProviderUser.where(last_signed_in_at: almost_inactive_date.all_day)
       .or(
         ProviderUser.where(
           last_signed_in_at: nil,
           created_at: almost_inactive_date.all_day,
         ),
-      ).find_each do |provider_user|
-      ProviderMailer.inactive_user_prompt(provider_user, inactive_date).deliver_later
+      )
+
+    BatchDelivery.new(
+      relation:,
+      batch_size: 100,
+      stagger_over: 10.minutes,
+    ).each do |batch_time, provider_users|
+      PromptInactiveProviderUsersBatchWorker.set(wait_until: batch_time).perform_later(
+        provider_users.map(&:id),
+        inactive_date,
+      )
     end
   end
 

--- a/app/workers/prompt_inactive_provider_users_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_worker.rb
@@ -3,7 +3,7 @@ class PromptInactiveProviderUsersWorker < ApplicationJob
 
   queue_as :low_priority
 
-  INACTIVE_MONTHS_AGO = 12
+  INACTIVE_MONTHS_AGO = RemoveInactiveProviderUsersWorker::INACTIVE_MONTHS_AGO
   PROMPT_WEEKS_BEFORE = 2
 
   def perform

--- a/app/workers/prompt_inactive_provider_users_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_worker.rb
@@ -9,11 +9,11 @@ class PromptInactiveProviderUsersWorker < ApplicationJob
   def perform
     return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?
 
-    ProviderUser.where(last_signed_in_at: almost_inactive_date)
+    ProviderUser.where(last_signed_in_at: almost_inactive_date.all_day)
       .or(
         ProviderUser.where(
           last_signed_in_at: nil,
-          created_at: almost_inactive_date,
+          created_at: almost_inactive_date.all_day,
         ),
       ).find_each do |provider_user|
       ProviderMailer.inactive_user_prompt(provider_user, inactive_date).deliver_later

--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -3,7 +3,7 @@ class RemoveInactiveProviderUsersWorker < ApplicationJob
 
   queue_as :low_priority
 
-  INACTIVE_MONTHS_AGO = 12
+  INACTIVE_MONTHS_AGO = 12 # Update PromptInactiveProviderUsersWorker if inactive period changes
 
   def perform
     return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?

--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -3,7 +3,7 @@ class RemoveInactiveProviderUsersWorker < ApplicationJob
 
   queue_as :low_priority
 
-  INACTIVE_MONTHS_AGO = 12 # Update PromptInactiveProviderUsersWorker if inactive period changes
+  INACTIVE_MONTHS_AGO = 12
 
   def perform
     return if HostingEnvironment.qa? || HostingEnvironment.review? || HostingEnvironment.development?

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -37,6 +37,7 @@ class Clock
   # Daily jobs
   every(1.day, 'DeleteExpiredSessionsWorker', at: '5:01') { DeleteExpiredSessionsWorker.perform_later }
   every(1.day, 'RemoveInactiveSupportUsersWorker', at: '5:02') { RemoveInactiveSupportUsersWorker.perform_later }
+  every(1.day, 'PromptInactiveProviderUsersWorker', at: '5:03') { PromptInactiveProviderUsersWorker.perform_later }
   every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_later }
   every(1.day, 'DeactivateStaleServiceAPITokensWorker', at: '5:06') { DeactivateStaleServiceAPITokensWorker.perform_later }
   every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_later }

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -61,3 +61,5 @@ en:
       subject: Offer places to candidates by %{winter_reject_by_default_at}
     recruitment_performance_report_reminder:
       subject: Your weekly recruitment performance report is now available
+    inactive_user_prompt:
+      subject: Your Manage account will be deleted on %{date} if you do not sign in

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -62,4 +62,4 @@ en:
     recruitment_performance_report_reminder:
       subject: Your weekly recruitment performance report is now available
     inactive_user_prompt:
-      subject: Your Manage account will be deleted on %{date} if you do not sign in
+      subject: Your access to your Manage account will be removed on %{date} if you do not sign in

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -14,6 +14,7 @@ en:
             organisation_permissions_updated: Sent to someone with the user permissions "manage_users" to let them know that either they, or someone else has updated permissions for another user.
             permissions_granted: Sent when someone receives permissions to manage applications for an organisation.
             permissions_granted_by_support: Sent when the support team give someone permissions to manage applications for an organisation.
+            inactive_user_prompt: Sent when permissions are due to be removed in two weeks time.
             permissions_removed: Sent when someone has their permissions removed and can no longer manage applications for an organisation.
             permissions_removed_by_support: Sent when someone has their permissions removed by the support team and can no longer manage applications for an organisation.
             permissions_updated: Sent when any user permissions are changed.

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -15,6 +15,7 @@ en:
             permissions_granted: Sent when someone receives permissions to manage applications for an organisation.
             permissions_granted_by_support: Sent when the support team give someone permissions to manage applications for an organisation.
             inactive_user_prompt: Sent when permissions are due to be removed in two weeks time.
+            inactive_user_prompt_multiple_providers: As above with multiple providers
             permissions_removed: Sent when someone has their permissions removed and can no longer manage applications for an organisation.
             permissions_removed_by_support: Sent when someone has their permissions removed by the support team and can no longer manage applications for an organisation.
             permissions_updated: Sent when any user permissions are changed.

--- a/spec/mailers/previews/provider/organisation_permissions_mailer_preview.rb
+++ b/spec/mailers/previews/provider/organisation_permissions_mailer_preview.rb
@@ -57,6 +57,14 @@ class Provider::OrganisationPermissionsMailerPreview < ActionMailer::Preview
     ProviderMailer.inactive_user_prompt(provider_user, date)
   end
 
+  def inactive_user_prompt_multiple_providers
+    providers = FactoryBot.create_list(:provider, 3)
+    provider_user = FactoryBot.create(:provider_user, providers:)
+    date = Date.new(2026, 1, 1)
+
+    ProviderMailer.inactive_user_prompt(provider_user, date)
+  end
+
   def permissions_removed
     provider = FactoryBot.create(:provider)
     permissions_revoked_by_user = FactoryBot.create(:provider_user)

--- a/spec/mailers/previews/provider/organisation_permissions_mailer_preview.rb
+++ b/spec/mailers/previews/provider/organisation_permissions_mailer_preview.rb
@@ -49,6 +49,14 @@ class Provider::OrganisationPermissionsMailerPreview < ActionMailer::Preview
     ProviderMailer.permissions_granted(provider_user, provider, permissions, nil)
   end
 
+  def inactive_user_prompt
+    provider = FactoryBot.create(:provider)
+    provider_user = FactoryBot.create(:provider_user, providers: [provider])
+    date = Date.new(2026, 1, 1)
+
+    ProviderMailer.inactive_user_prompt(provider_user, date)
+  end
+
   def permissions_removed
     provider = FactoryBot.create(:provider)
     permissions_revoked_by_user = FactoryBot.create(:provider_user)

--- a/spec/mailers/provider_mailer/provider_mailer_inactive_user_prompt_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_inactive_user_prompt_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe ProviderMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
-        'providers list' => 'If your account is deleted, you will no longer be able to manage teacher training applications for UCL.',
+        'Your access to your Manage account will be removed on 10 July if you do not sign in - manage teacher training applications',
+        'providers list' => 'If your access is removed, you will no longer be able to manage teacher training applications for:',
+        'provider' => 'UCL',
       )
     end
 
@@ -28,26 +29,10 @@ RSpec.describe ProviderMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
-        'providers list' => "If your account is deleted, you will no longer be able to manage teacher training applications for UCL or King's College London.",
-      )
-    end
-
-    context 'with three providers' do
-      let(:providers) do
-        [
-          build_stubbed(:provider, code: 'LMN', name: 'UCL'),
-          build_stubbed(:provider, code: 'OPQ', name: "King's College London"),
-          build_stubbed(:provider, code: 'RST', name: 'Birkbeck'),
-        ]
-      end
-
-      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', last_signed_in_at: Date.new(2025, 7, 10), providers:) }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
-        'providers list' => "If your account is deleted, you will no longer be able to manage teacher training applications for UCL, King's College London or Birkbeck.",
+        'Your access to your Manage account will be removed on 10 July if you do not sign in - manage teacher training applications',
+        'providers list' => 'If your access is removed, you will no longer be able to manage teacher training applications for:',
+        'provider_1' => 'UCL',
+        'provider_2' => "King's College London",
       )
     end
   end

--- a/spec/mailers/provider_mailer/provider_mailer_inactive_user_prompt_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_inactive_user_prompt_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe ProviderMailer do
+  describe 'inactive_user_prompt' do
+    let(:date) { provider_user.last_signed_in_at }
+    let(:email) { described_class.inactive_user_prompt(provider_user, date) }
+
+    context 'with one provider' do
+      let(:providers) { [build_stubbed(:provider, code: 'LMN', name: 'UCL')] }
+      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', last_signed_in_at: Date.new(2025, 7, 10), providers:) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
+        'providers list' => 'If your account is deleted, you will no longer be able to manage teacher training applications for UCL.',
+      )
+    end
+
+    context 'with two providers' do
+      let(:providers) do
+        [
+          build_stubbed(:provider, code: 'LMN', name: 'UCL'),
+          build_stubbed(:provider, code: 'OPQ', name: "King's College London"),
+        ]
+      end
+
+      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', last_signed_in_at: Date.new(2025, 7, 10), providers:) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
+        'providers list' => "If your account is deleted, you will no longer be able to manage teacher training applications for UCL or King's College London.",
+      )
+    end
+
+    context 'with three providers' do
+      let(:providers) do
+        [
+          build_stubbed(:provider, code: 'LMN', name: 'UCL'),
+          build_stubbed(:provider, code: 'OPQ', name: "King's College London"),
+          build_stubbed(:provider, code: 'RST', name: 'Birkbeck'),
+        ]
+      end
+
+      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English', last_signed_in_at: Date.new(2025, 7, 10), providers:) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Your Manage account will be deleted on 10 July if you do not sign in - manage teacher training applications',
+        'providers list' => "If your account is deleted, you will no longer be able to manage teacher training applications for UCL, King's College London or Birkbeck.",
+      )
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Docs' do
       provider_mailer-permissions_removed
       provider_mailer-permissions_updated
       provider_mailer-reference_received
+      provider_mailer-inactive_user_prompt
       candidate_mailer-application_rejected
       candidate_mailer-application_choice_submitted
       candidate_mailer-offer_10_day

--- a/spec/workers/prompt_inactive_provider_users_batch_worker_spec.rb
+++ b/spec/workers/prompt_inactive_provider_users_batch_worker_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe PromptInactiveProviderUsersBatchWorker do
+  describe '#perform' do
+    before do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+      allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+    end
+
+    it 'prompts provider users in the batch' do
+      provider_users = create_list(:provider_user, 2, :with_provider)
+
+      described_class.perform_now(
+        provider_users.pluck(:id),
+        Date.new(2026, 1, 15),
+      )
+
+      expect(ProviderMailer).to have_received(:inactive_user_prompt).with(
+        provider_users[0],
+        Date.new(2026, 1, 15),
+      )
+
+      expect(ProviderMailer).to have_received(:inactive_user_prompt).with(
+        provider_users[1],
+        Date.new(2026, 1, 15),
+      )
+    end
+  end
+end

--- a/spec/workers/prompt_inactive_provider_users_worker_spec.rb
+++ b/spec/workers/prompt_inactive_provider_users_worker_spec.rb
@@ -85,5 +85,23 @@ RSpec.describe PromptInactiveProviderUsersWorker do
         expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(active_user, anything)
       end
     end
+
+    it 'prompts users regardless of the time they signed in 11 months and 2 weeks ago' do
+      travel_to Time.zone.parse('2026-01-01 12:00:00') do
+        should_prompt = create(
+          :provider_user,
+          :with_provider,
+          last_signed_in_at: Time.zone.parse('2024-12-18 15:59:59'),
+        )
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).to have_received(:inactive_user_prompt).with(should_prompt, 2.weeks.from_now.to_date)
+      end
+    end
   end
 end

--- a/spec/workers/prompt_inactive_provider_users_worker_spec.rb
+++ b/spec/workers/prompt_inactive_provider_users_worker_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe PromptInactiveProviderUsersWorker do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '#perform' do
+    it 'prompts soon-to-be inactive provider users' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 1.day)
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
+        expect(mail).to have_received(:deliver_later).once
+
+        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+      end
+    end
+
+    it 'prompts users who have never signed in but were created almost a year ago' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks)
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks - 1.day)
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
+        expect(mail).to have_received(:deliver_later).once
+
+        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+      end
+    end
+
+    it 'only prompts users on the prompt date and not again at a later date' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 3.days)
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
+        expect(mail).to have_received(:deliver_later).once
+
+        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+      end
+    end
+
+    it 'does not prompt a recently added but never signed in user' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        recently_added = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 2.months.ago)
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(recently_added, anything)
+      end
+    end
+
+    it 'does not prompt an active user' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        active_user = create(:provider_user, :with_provider, last_signed_in_at: 1.week.ago)
+
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+
+        described_class.new.perform
+
+        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(active_user, anything)
+      end
+    end
+  end
+end

--- a/spec/workers/prompt_inactive_provider_users_worker_spec.rb
+++ b/spec/workers/prompt_inactive_provider_users_worker_spec.rb
@@ -3,22 +3,25 @@ require 'rails_helper'
 RSpec.describe PromptInactiveProviderUsersWorker do
   include ActiveSupport::Testing::TimeHelpers
 
+  let(:worker) { instance_double(ActiveJob::ConfiguredJob) }
+
+  before do
+    allow(PromptInactiveProviderUsersBatchWorker).to receive(:set).and_return(worker)
+    allow(worker).to receive(:perform_later)
+  end
+
   describe '#perform' do
     it 'prompts soon-to-be inactive provider users' do
       travel_to Time.zone.parse('2026-1-1 12:00:00') do
         should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
         should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 1.day)
 
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
-
         described_class.new.perform
 
-        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
-        expect(mail).to have_received(:deliver_later).once
+        expect(PromptInactiveProviderUsersBatchWorker).to have_received(:set)
+        expect(worker).to have_received(:perform_later).with([should_prompt.id], 2.weeks.from_now.to_date)
 
-        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+        expect(worker).not_to have_received(:perform_later).with([should_not_prompt.id], anything)
       end
     end
 
@@ -27,16 +30,12 @@ RSpec.describe PromptInactiveProviderUsersWorker do
         should_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks)
         should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks - 1.day)
 
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
-
         described_class.new.perform
 
-        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
-        expect(mail).to have_received(:deliver_later).once
+        expect(PromptInactiveProviderUsersBatchWorker).to have_received(:set)
+        expect(worker).to have_received(:perform_later).with([should_prompt.id], 2.weeks.from_now.to_date)
 
-        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+        expect(worker).not_to have_received(:perform_later).with([should_not_prompt.id], anything)
       end
     end
 
@@ -45,44 +44,32 @@ RSpec.describe PromptInactiveProviderUsersWorker do
         should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
         should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 3.days)
 
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
-
         described_class.new.perform
 
-        expect(ProviderMailer).to have_received(:inactive_user_prompt).once.with(should_prompt, 2.weeks.from_now.to_date)
-        expect(mail).to have_received(:deliver_later).once
+        expect(PromptInactiveProviderUsersBatchWorker).to have_received(:set)
+        expect(worker).to have_received(:perform_later).with([should_prompt.id], 2.weeks.from_now.to_date)
 
-        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(should_not_prompt, anything)
+        expect(worker).not_to have_received(:perform_later).with([should_not_prompt.id], anything)
       end
     end
 
     it 'does not prompt a recently added but never signed in user' do
       travel_to Time.zone.parse('2026-1-1 12:00:00') do
-        recently_added = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 2.months.ago)
-
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+        create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 2.months.ago)
 
         described_class.new.perform
 
-        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(recently_added, anything)
+        expect(PromptInactiveProviderUsersBatchWorker).not_to have_received(:set)
       end
     end
 
     it 'does not prompt an active user' do
       travel_to Time.zone.parse('2026-1-1 12:00:00') do
-        active_user = create(:provider_user, :with_provider, last_signed_in_at: 1.week.ago)
-
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+        create(:provider_user, :with_provider, last_signed_in_at: 1.week.ago)
 
         described_class.new.perform
 
-        expect(ProviderMailer).not_to have_received(:inactive_user_prompt).with(active_user, anything)
+        expect(PromptInactiveProviderUsersBatchWorker).not_to have_received(:set)
       end
     end
 
@@ -94,13 +81,24 @@ RSpec.describe PromptInactiveProviderUsersWorker do
           last_signed_in_at: Time.zone.parse('2024-12-18 15:59:59'),
         )
 
-        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        described_class.new.perform
 
-        allow(ProviderMailer).to receive(:inactive_user_prompt).and_return(mail)
+        expect(worker).to have_received(:perform_later).with([should_prompt.id], 2.weeks.from_now.to_date)
+      end
+    end
+
+    it 'batches users in groups of 100' do
+      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+        create_list(
+          :provider_user,
+          101,
+          :with_provider,
+          last_signed_in_at: 12.months.ago - 2.weeks,
+        )
 
         described_class.new.perform
 
-        expect(ProviderMailer).to have_received(:inactive_user_prompt).with(should_prompt, 2.weeks.from_now.to_date)
+        expect(worker).to have_received(:perform_later).twice
       end
     end
   end


### PR DESCRIPTION
## Context

We have a worker that removes provider users from their provider who have not signed into the service for a full year.

We should prompt them two weeks before their access is removed in case they would like to keep their account, e.g. for receiving emails but not actively processing candidates.

## Changes proposed in this pull request

- Add new mailer, worker, specs, and preview
- Add worker as a daily job in `clock.rb`

## Guidance to review

- Check the worker logic and that the spec adequately tests happy and unhappy paths
- Compare the text with that given in the Trello card

Previews:
- https://apply-review-12093.test.teacherservices.cloud/rails/mailers/provider/organisation_permissions_mailer/inactive_user_prompt
- https://apply-review-12093.test.teacherservices.cloud/rails/mailers/provider/organisation_permissions_mailer/inactive_user_prompt_multiple_providers

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
