### PR TITLE
Implement new mailer for winter reject by default

### DIFF
--- a/app/lib/end_of_cycle/candidate_email_timetabler.rb
+++ b/app/lib/end_of_cycle/candidate_email_timetabler.rb
@@ -14,28 +14,39 @@ module EndOfCycle
     def email_schedule
       {
         # All dates should be reviewed as part of end-of / start-of cycle planning
+        # We have delayed the "apply has opened" email in the past to deal with rate limiting from Notify on the first day of applications.
+        find_has_opened_announcement_date: find_opens_at.to_date,
+        apply_has_opened_announcement_date: (apply_opens_at + 2.days).to_date,
         apply_deadline_first_reminder_date: get_weekday(apply_deadline_at - 2.months).to_date,
         apply_deadline_second_reminder_date: get_weekday(apply_deadline_at - 1.month).to_date,
         application_deadline_has_passed_email_date: (apply_deadline_at + 1.day).to_date,
         reject_by_default_explainer_date: (reject_by_default_at + 1.day).to_date,
         decline_by_default_explainer_date: (decline_by_default_at + 1.day).to_date,
-        find_has_opened_announcement_date: find_opens_at.to_date,
-        # We have delayed the "apply has opened" email in the past to deal with rate limiting from Notify on the first day of applications.
-        apply_has_opened_announcement_date: (apply_opens_at + 2.days).to_date,
         winter_reject_by_default_explainer_date:,
         winter_decline_by_default_explainer_date:,
       }
     end
 
     def winter_reject_by_default_explainer_date
-      if timetable.try(:winter_reject_by_default_at).present?
-        (timetable.try(:winter_reject_by_default_at) + 1.day).to_date
+      [].tap do |possible_dates|
+        possible_dates << (previous_timetable.winter_reject_by_default_at + 1.day).to_date if previous_timetable.winter_reject_by_default_at.present?
+        possible_dates << (timetable.winter_reject_by_default_at + 1.day).to_date
+      end.rfind do |possible_date|
+        possible_date.before?(winter_decline_by_default_explainer_date)
       end
     end
 
     def winter_decline_by_default_explainer_date
-      if timetable.try(:winter_decline_by_default_at).present?
-        (timetable.try(:winter_decline_by_default_at) + 1.day).to_date
+      if timetable.current_year?
+
+        [].tap do |possible_dates|
+          possible_dates << (previous_timetable.winter_decline_by_default_at + 1.day).to_date if previous_timetable.winter_decline_by_default_at.present?
+          possible_dates << (timetable.winter_decline_by_default_at + 1.day).to_date
+        end.find do |possible_date|
+          current_date == possible_date || current_date.before?(possible_date)
+        end
+      else
+        (timetable.winter_decline_by_default_at + 1.day).to_date
       end
     end
 
@@ -76,6 +87,10 @@ module EndOfCycle
     end
 
   private
+
+    def previous_timetable
+      @previous_timetable ||= timetable.relative_previous_timetable
+    end
 
     def current_date
       Time.zone.now.to_date

--- a/app/lib/end_of_cycle/candidate_email_timetabler.rb
+++ b/app/lib/end_of_cycle/candidate_email_timetabler.rb
@@ -38,7 +38,6 @@ module EndOfCycle
 
     def winter_decline_by_default_explainer_date
       if timetable.current_year?
-
         [].tap do |possible_dates|
           possible_dates << (previous_timetable.winter_decline_by_default_at + 1.day).to_date if previous_timetable.winter_decline_by_default_at.present?
           possible_dates << (timetable.winter_decline_by_default_at + 1.day).to_date

--- a/app/lib/end_of_cycle/candidate_email_timetabler.rb
+++ b/app/lib/end_of_cycle/candidate_email_timetabler.rb
@@ -28,20 +28,23 @@ module EndOfCycle
     end
 
     def winter_reject_by_default_explainer_date
-      [].tap do |possible_dates|
+      dates = [].tap do |possible_dates|
         possible_dates << (previous_timetable.winter_reject_by_default_at + 1.day).to_date if previous_timetable.winter_reject_by_default_at.present?
         possible_dates << (timetable.winter_reject_by_default_at + 1.day).to_date
-      end.rfind do |possible_date|
+      end
+
+      dates.rfind do |possible_date|
         possible_date.before?(winter_decline_by_default_explainer_date)
       end
     end
 
     def winter_decline_by_default_explainer_date
       if timetable.current_year?
-        [].tap do |possible_dates|
+        dates = [].tap do |possible_dates|
           possible_dates << (previous_timetable.winter_decline_by_default_at + 1.day).to_date if previous_timetable.winter_decline_by_default_at.present?
           possible_dates << (timetable.winter_decline_by_default_at + 1.day).to_date
-        end.find do |possible_date|
+        end
+        dates.find do |possible_date|
           current_date == possible_date || current_date.before?(possible_date)
         end
       else

--- a/app/lib/end_of_cycle/provider_email_timetabler.rb
+++ b/app/lib/end_of_cycle/provider_email_timetabler.rb
@@ -3,6 +3,10 @@ module EndOfCycle
     attr_reader :timetable, :previous_timetable
     delegate_missing_to :timetable
 
+    def initialize(timetable: nil)
+      @timetable = timetable || RecruitmentCycleTimetable.current_timetable
+    end
+
     def send_reject_by_default_reminder_to_providers?
       current_date == reject_by_default_reminder_provider_date
     end
@@ -16,26 +20,33 @@ module EndOfCycle
     end
 
     def winter_reject_by_default_reminder_provider_date
-      # We only care about current cycle date AFTER the previous cycle has come to a complete end, eg after the winter decline by default event
-      if previous_cycle_closed?
-        get_weekday(timetable.winter_reject_by_default_at - 2.weeks).to_date
-      else
-        get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
-      end
+      [].tap do |possible_dates|
+        if previous_timetable.winter_reject_by_default_at.present?
+          possible_dates << get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
+        end
+        possible_dates << get_weekday(timetable.winter_reject_by_default_at - 2.weeks).to_date
+      end.rfind { |possible_date| possible_date.before?(next_winter_decline_by_default_at) }
     end
 
   private
-
-    def timetable
-      @timetable ||= RecruitmentCycleTimetable.current_timetable
-    end
 
     def previous_timetable
       @previous_timetable ||= timetable.relative_previous_timetable
     end
 
-    def previous_cycle_closed?
-      current_date.after? previous_timetable.winter_decline_by_default_at.to_date
+    def next_winter_decline_by_default_at
+      if timetable.current_year?
+        [].tap do |possible_dates|
+          if previous_timetable.winter_decline_by_default_at.present?
+            possible_dates << previous_timetable.winter_decline_by_default_at.to_date
+          end
+          possible_dates << timetable.winter_decline_by_default_at.to_date
+        end.find do |possible_date|
+          current_date == possible_date || current_date.before?(possible_date)
+        end
+      else
+        timetable.winter_decline_by_default_at
+      end
     end
 
     def current_date

--- a/app/lib/end_of_cycle/provider_email_timetabler.rb
+++ b/app/lib/end_of_cycle/provider_email_timetabler.rb
@@ -1,10 +1,11 @@
 module EndOfCycle
   class ProviderEmailTimetabler
-    attr_reader :timetable
+    attr_reader :timetable, :previous_timetable
     delegate_missing_to :timetable
 
     def initialize(timetable: nil)
       @timetable = timetable || RecruitmentCycleTimetable.current_timetable
+      @previous_timetable = @timetable.relative_previous_timetable
     end
 
     def send_reject_by_default_reminder_to_providers?
@@ -20,9 +21,7 @@ module EndOfCycle
     end
 
     def winter_reject_by_default_reminder_provider_date
-      return if timetable.try(:winter_reject_by_default_at).blank?
-
-      get_weekday(timetable.winter_reject_by_default_at - 2.weeks).to_date
+      get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
     end
 
   private

--- a/app/lib/end_of_cycle/provider_email_timetabler.rb
+++ b/app/lib/end_of_cycle/provider_email_timetabler.rb
@@ -1,6 +1,6 @@
 module EndOfCycle
   class ProviderEmailTimetabler
-    attr_reader :timetable, :previous_timetable
+    attr_reader :timetable
     delegate_missing_to :timetable
 
     def initialize(timetable: nil)
@@ -20,12 +20,13 @@ module EndOfCycle
     end
 
     def winter_reject_by_default_reminder_provider_date
-      [].tap do |possible_dates|
+      dates = [].tap do |possible_dates|
         if previous_timetable.winter_reject_by_default_at.present?
           possible_dates << get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
         end
         possible_dates << get_weekday(timetable.winter_reject_by_default_at - 2.weeks).to_date
-      end.rfind { |possible_date| possible_date.before?(next_winter_decline_by_default_at) }
+      end
+      dates.rfind { |possible_date| possible_date.before?(next_winter_decline_by_default_at) }
     end
 
   private
@@ -36,12 +37,14 @@ module EndOfCycle
 
     def next_winter_decline_by_default_at
       if timetable.current_year?
-        [].tap do |possible_dates|
+        dates = [].tap do |possible_dates|
           if previous_timetable.winter_decline_by_default_at.present?
             possible_dates << previous_timetable.winter_decline_by_default_at.to_date
           end
           possible_dates << timetable.winter_decline_by_default_at.to_date
-        end.find do |possible_date|
+        end
+
+        dates.find do |possible_date|
           current_date == possible_date || current_date.before?(possible_date)
         end
       else

--- a/app/lib/end_of_cycle/provider_email_timetabler.rb
+++ b/app/lib/end_of_cycle/provider_email_timetabler.rb
@@ -3,11 +3,6 @@ module EndOfCycle
     attr_reader :timetable, :previous_timetable
     delegate_missing_to :timetable
 
-    def initialize(timetable: nil)
-      @timetable = timetable || RecruitmentCycleTimetable.current_timetable
-      @previous_timetable = @timetable.relative_previous_timetable
-    end
-
     def send_reject_by_default_reminder_to_providers?
       current_date == reject_by_default_reminder_provider_date
     end
@@ -21,10 +16,27 @@ module EndOfCycle
     end
 
     def winter_reject_by_default_reminder_provider_date
-      get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
+      # We only care about current cycle date AFTER the previous cycle has come to a complete end, eg after the winter decline by default event
+      if previous_cycle_closed?
+        get_weekday(timetable.winter_reject_by_default_at - 2.weeks).to_date
+      else
+        get_weekday(previous_timetable.winter_reject_by_default_at - 2.weeks).to_date
+      end
     end
 
   private
+
+    def timetable
+      @timetable ||= RecruitmentCycleTimetable.current_timetable
+    end
+
+    def previous_timetable
+      @previous_timetable ||= timetable.relative_previous_timetable
+    end
+
+    def previous_cycle_closed?
+      current_date.after? previous_timetable.winter_decline_by_default_at.to_date
+    end
 
     def current_date
       Time.zone.now.to_date

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -262,8 +262,21 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
-  def respond_to_applications_before_winter_reject_by_default_date(_provider_user)
-    raise 'Mailer still in development'
+  def respond_to_applications_before_winter_reject_by_default_date(provider_user)
+    @get_help_title = 'Contact us'
+    @winter_reject_by_default_at = previous_timetable.winter_reject_by_default_at
+    @winter_decline_by_default_at = previous_timetable.winter_decline_by_default_at
+    @provider_user = provider_user
+    @notifications_url = provider_interface_notifications_url
+    @applications_url = provider_interface_applications_url
+
+    provider_notify_email(
+      to: @provider_user.email_address,
+      subject: I18n.t!(
+        'provider_mailer.respond_to_applications_before_winter_reject_by_default_date.subject',
+        winter_reject_by_default_at: @winter_reject_by_default_at.to_fs(:day_and_month),
+      ),
+    )
   end
 
   def recruitment_performance_report_reminder(provider_user)
@@ -281,6 +294,10 @@ private
 
   def current_timetable
     @current_timetable = RecruitmentCycleTimetable.current_timetable
+  end
+
+  def previous_timetable
+    @previous_timetable ||= RecruitmentCycleTimetable.previous_timetable
   end
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/views/provider_mailer/respond_to_applications_before_winter_reject_by_default_date.text.erb
+++ b/app/views/provider_mailer/respond_to_applications_before_winter_reject_by_default_date.text.erb
@@ -1,0 +1,18 @@
+Dear <%= @provider_user.full_name %>
+
+The deadline for offering teacher training places for courses starting in <%= @winter_reject_by_default_at.to_fs(:month_and_year) %> is <%= @winter_reject_by_default_at.to_fs(:govuk_date) %>.
+
+This includes candidates you are interviewing.
+
+If you do not make an offer by <%= @winter_reject_by_default_at.to_fs(:govuk_date) %>, any applications for January marked as ‘received’ or ‘interviewing’ will be automatically rejected. This means you may miss out on high-quality candidates.
+
+If you offer a candidate a January place, they will have until <%= @winter_decline_by_default_at.to_fs(:govuk_date) %> to accept it.
+
+[Sign in to your account to review your applications](<%= @applications_url %>)
+
+
+<% content_for :additional_footer_content do %>
+  ---
+
+  If you want to unsubscribe from these emails, [sign in to update your notification preferences](<%= @notifications_url %>).
+<% end %>

--- a/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
@@ -13,27 +13,16 @@ module EndOfCycle
     end
 
     def relation
-      if winter_reject_by_default_set?
-        ids = ApplicationChoice.joins(:provider).course_start_in_september(RecruitmentCycleTimetable.current_year)
-          .where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
-                         .pluck('providers.id').uniq
-        Provider.where(id: ids)
-      else
-        Provider
-          .joins(:application_choices)
-          .where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
-          .distinct
-      end
+      ids = ApplicationChoice.joins(:provider).course_start_in_september(RecruitmentCycleTimetable.current_year)
+        .where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
+                       .pluck('providers.id').uniq
+      Provider.where(id: ids)
     end
 
   private
 
     def send_email?
       EndOfCycle::ProviderEmailTimetabler.new.send_reject_by_default_reminder_to_providers?
-    end
-
-    def winter_reject_by_default_set?
-      EndOfCycle::ProviderEmailTimetabler.new.winter_reject_by_default_reminder_provider_date.present?
     end
   end
 

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -59,7 +59,7 @@ class Clock
 
   # End of cycle january start dates/winter end dates jobs
   # every(1.day, 'EndOfCycle:SendWinterRejectByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
-  # every(1.day, 'EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker', at: '09:04') { EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker.new.perform }
+  every(1.day, 'EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker', at: '09:04') { EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker.new.perform }
   # every(1.day, 'EndOfCycle:WinterDeclineByDefaultWorker', at: '09:05') { EndOfCycle::WinterDeclineByDefaultWorker.new.perform }
   # every(1.day, 'EndOfCycle::WinterRejectByDefaultWorker', at: '09:06') { EndOfCycle::WinterRejectByDefaultWorker.new.perform }
   # every(1.day, 'EndOfCycle::CancelReferenceRequestsWorker', at: '09:07') { EndOfCycle::CancelReferenceRequestsWorker.new.perform }

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -57,5 +57,7 @@ en:
       subject: Sign in
     respond_to_applications_before_reject_by_default_date:
       subject: Offer places to candidates by %{reject_by_default_date}
+    respond_to_applications_before_winter_reject_by_default_date:
+      subject: Offer places to candidates by %{winter_reject_by_default_at}
     recruitment_performance_report_reminder:
       subject: Your weekly recruitment performance report is now available

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -36,7 +36,8 @@ en:
           provider_deadlines_mailer:
             find_service_is_now_open: Candidates can now search for teacher training courses on Find teacher training applications.
             apply_service_is_now_open: Candidates can now apply for teacher training courses on Apply for teacher training courses.
-            respond_to_applications_before_reject_by_default_date: The deadline to respond to applications a provider has received is approaching. Any applications that they do not respond to will be rejected by default on this date.
+            respond_to_applications_before_reject_by_default_date: The deadline to respond to applications with a Summer / Autumn start date a provider has received is approaching. Any application that they do not respond to will be rejected by default on this date.
+            respond_to_applications_before_winter_reject_by_default_date: The deadline to respond to applications with Winter start dates is approaching. Any application that they do not respond to will be rejected by default on this date.
           provider_references_mailer:
             reference_received: A referee has provided a reference for a candidate who has accepted an offer to train to teach with you.
           referee_references_mailer:

--- a/spec/lib/end_of_cycle/candidate_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/candidate_email_timetabler_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EndOfCycle::CandidateEmailTimetabler do
-  let(:instance) { described_class.new(timetable:) }
-  let(:timetable) { RecruitmentCycleTimetable.previous_timetable }
+  let(:instance) { described_class.new }
 
   describe '.email_schedule' do
     subject(:email_schedule) { instance.email_schedule }
@@ -11,46 +10,106 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
       it 'returns the decline_by_default_at plus one day' do
         expect(
           email_schedule[:decline_by_default_explainer_date],
-        ).to eq timetable.decline_by_default_at.to_date + 1.day
+        ).to eq current_timetable.decline_by_default_at.to_date + 1.day
       end
     end
 
     describe 'winter_reject_by_default_explainer_date' do
-      context 'when the timetable winter_reject_by_default_at attribute is nil' do
-        before do
-          allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new)
-        end
-
-        it 'returns nil' do
-          expect(instance.winter_reject_by_default_explainer_date).to be_nil
+      context 'it is at the start of new cycle' do
+        it 'returns date calculated on previous cycle winter reject by default at' do
+          travel_temporarily_to(2026, 10, 10) do
+            expect(
+              email_schedule[:winter_reject_by_default_explainer_date],
+            ).to eq Date.new(2027, 1, 21)
+          end
         end
       end
 
-      context 'when the timetable winter_reject_by_default_at attribute is not nil' do
-        it 'returns the winter_reject_by_default_at plus one day' do
-          expect(
-            email_schedule[:winter_reject_by_default_explainer_date],
-          ).to eq timetable.winter_reject_by_default_at.to_date + 1.day
+      context 'it is in Jan, before the winter reject by default at' do
+        it 'returns date calculated on previous cycle winter reject by default at' do
+          travel_temporarily_to(2027, 1, 19) do
+            expect(
+              email_schedule[:winter_reject_by_default_explainer_date],
+            ).to eq Date.new(2027, 1, 21)
+          end
+        end
+      end
+
+      context 'it is in Jan, between the winter reject by default and winter decline by default dates' do
+        it 'returns date calculated on previous cycle winter reject by default at' do
+          travel_temporarily_to(2027, 1, 24) do
+            expect(
+              email_schedule[:winter_reject_by_default_explainer_date],
+            ).to eq Date.new(2027, 1, 21)
+          end
+        end
+      end
+
+      context 'it is after winter dates have passed' do
+        it 'returns date calculated on current cycle winter reject by default at' do
+          travel_temporarily_to(2027, 2, 1) do
+            expect(
+              email_schedule[:winter_reject_by_default_explainer_date],
+            ).to eq Date.new(2028, 1, 27)
+          end
+        end
+      end
+
+      context 'when a specific, future timetable is provided' do
+        it 'returns date calculated on given timetable' do
+          timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: current_year + 2)
+          schedule = described_class.new(timetable:).email_schedule
+          expect(schedule[:winter_reject_by_default_explainer_date]).to eq((timetable.winter_reject_by_default_at + 1.day).to_date)
         end
       end
     end
 
     describe 'winter_decline_by_default_explainer_date' do
-      context 'when the timetable winter_decline_by_default_at attribute is nil' do
-        before do
-          allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new)
-        end
-
-        it 'returns nil' do
-          expect(instance.winter_decline_by_default_explainer_date).to be_nil
+      context 'it is at the start of new cycle' do
+        it 'returns date calculated on the previous cycle' do
+          travel_temporarily_to(2026, 10, 10) do
+            expected_date = Date.new(2027, 1, 25)
+            expect(
+              email_schedule[:winter_decline_by_default_explainer_date],
+            ).to eq(expected_date)
+            expect(expected_date).to eq((previous_timetable.winter_decline_by_default_at + 1.day).to_date)
+          end
         end
       end
 
-      context 'when the timetable winter_decline_by_default_at attribute is not nil' do
-        it 'returns the winter_decline_by_default_at plus one day' do
-          expect(
-            email_schedule[:winter_decline_by_default_explainer_date],
-          ).to eq timetable.winter_decline_by_default_at.to_date + 1.day
+      context 'it is in Jan, before the winter reject by default at' do
+        it 'returns date calculated on previous cycle winter reject by default at' do
+          travel_temporarily_to(2027, 1, 19) do
+            expected_date = Date.new(2027, 1, 25)
+            expect(
+              email_schedule[:winter_decline_by_default_explainer_date],
+            ).to eq(expected_date)
+            expect(expected_date).to eq((previous_timetable.winter_decline_by_default_at.to_date + 1.day).to_date)
+          end
+        end
+      end
+
+      context 'it is in Jan, between the winter reject by default and winter decline by default dates' do
+        it 'returns date calculated on previous cycle winter reject by default at' do
+          travel_temporarily_to(2027, 1, 24) do
+            expected_date = Date.new(2027, 1, 25)
+            expect(
+              email_schedule[:winter_decline_by_default_explainer_date],
+            ).to eq(expected_date)
+            expect(expected_date).to eq((previous_timetable.winter_decline_by_default_at.to_date + 1.day).to_date)
+          end
+        end
+      end
+
+      context 'it is after winter dates have passed' do
+        it 'returns date calculated on current cycle winter reject by default at' do
+          travel_temporarily_to(2027, 2, 1) do
+            expected_date = Date.new(2028, 1, 31)
+            expect(
+              email_schedule[:winter_decline_by_default_explainer_date],
+            ).to eq expected_date
+            expect(expected_date).to eq((current_timetable.winter_decline_by_default_at + 1.day).to_date)
+          end
         end
       end
     end
@@ -89,16 +148,6 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
   describe 'send_winter_decline_by_default_explainer?' do
     subject(:send_winter_decline_by_default_explainer?) { instance.send_winter_decline_by_default_explainer? }
 
-    context 'when winter_decline_by_default_explainer_date is nil' do
-      before do
-        allow(instance).to receive(:winter_decline_by_default_explainer_date).and_return(nil)
-      end
-
-      it 'returns false' do
-        expect(send_winter_decline_by_default_explainer?).to be(false)
-      end
-    end
-
     context 'when the current date does not match the winter decline by default explainer date' do
       it 'returns false' do
         travel_temporarily_to(current_timetable.winter_decline_by_default_at + 1.month, freeze: true) do
@@ -118,8 +167,6 @@ RSpec.describe EndOfCycle::CandidateEmailTimetabler do
 
   describe 'send_decline_by_default_explainer?' do
     subject(:send_decline_by_default_explainer?) { instance.send_decline_by_default_explainer? }
-
-    let(:timetable) { current_timetable }
 
     context 'when the current date does not match the decline by default explainer date' do
       it 'returns false' do

--- a/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
@@ -6,19 +6,10 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
   describe '.send_winter_reject_by_default_reminder_to_providers?' do
     subject(:send_winter_reject_by_default_reminder_to_providers?) { instance.send_winter_reject_by_default_reminder_to_providers? }
 
-    context 'when winter_reject_by_default_explainer_date is nil' do
-      it 'returns false' do
-        expect(send_winter_reject_by_default_reminder_to_providers?).to be(false)
-      end
-    end
-
     context 'when the current date does not match the winter reject by default explainer date' do
       before do
-        TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.next_weekday.to_date)
-        allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new(winter_reject_by_default_at:))
+        TestSuiteTimeMachine.travel_permanently_to(current_timetable.winter_reject_by_default_at + 1.day)
       end
-
-      let(:winter_reject_by_default_at) { 1.month.ago.to_date }
 
       it 'returns false' do
         expect(send_winter_reject_by_default_reminder_to_providers?).to be(false)
@@ -27,11 +18,8 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
 
     context 'when the current date matches the winter reject by default explainer date' do
       before do
-        TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.next_weekday.to_date)
-        allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new(winter_reject_by_default_at:))
+        TestSuiteTimeMachine.travel_permanently_to(current_timetable.winter_reject_by_default_at - 2.weeks)
       end
-
-      let(:winter_reject_by_default_at) { 2.weeks.from_now.to_date }
 
       it 'returns false' do
         expect(send_winter_reject_by_default_reminder_to_providers?).to be(true)
@@ -42,22 +30,13 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
   describe '.winter_reject_by_default_reminder_provider_date' do
     subject(:winter_reject_by_default_reminder_provider_date) { instance.winter_reject_by_default_reminder_provider_date }
 
-    context 'when the timetable winter_reject_by_default_at attribute is nil' do
-      before do
-        allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new(winter_reject_by_default_at:))
-      end
-
-      let(:winter_reject_by_default_at) { nil }
-
-      it 'returns nil' do
-        expect(winter_reject_by_default_reminder_provider_date).to be_nil
-      end
-    end
-
     context 'when the timetable winter_reject_by_default_at attribute is not nil' do
       it 'returns a date 2 weeks before the timetable winter_reject_by_default_at attribute' do
-        allow(instance).to receive(:timetable).and_return(RecruitmentCycleTimetable.new(winter_reject_by_default_at: Time.zone.parse('01/09/2026')))
-        expect(winter_reject_by_default_reminder_provider_date).to eq(Date.parse('18/08/2026'))
+        if previous_timetable.winter_reject_by_default_at.nil?
+          previous_timetable.update(winter_reject_by_default_at: previous_timetable.reject_by_default_at + 17.weeks)
+        end
+
+        expect(winter_reject_by_default_reminder_provider_date.to_date).to eq((previous_timetable.winter_reject_by_default_at - 2.weeks).to_date)
       end
     end
   end

--- a/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
       end
     end
 
+    context 'between winter reject by default and decline by default dates' do
+      it 'returns date calculated based on the previous cycle' do
+        travel_temporarily_to(2027, 1, 24) do
+          expected_date = Date.new(2027, 1, 6)
+          expect(winter_reject_by_default_reminder_provider_date.to_date).to eq(expected_date)
+          expect(expected_date).to eq((previous_timetable.winter_reject_by_default_at - 2.weeks).to_date)
+        end
+      end
+    end
+
     context 'after the previous cycle has completely closed' do
       it 'returns the winter reject by default at date from the current cycle - 2 weeks' do
         travel_temporarily_to(current_timetable.winter_decline_by_default_at + 1.day) do

--- a/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
@@ -30,13 +30,23 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
   describe '.winter_reject_by_default_reminder_provider_date' do
     subject(:winter_reject_by_default_reminder_provider_date) { instance.winter_reject_by_default_reminder_provider_date }
 
-    context 'when the timetable winter_reject_by_default_at attribute is not nil' do
-      it 'returns a date 2 weeks before the timetable winter_reject_by_default_at attribute' do
-        if previous_timetable.winter_reject_by_default_at.nil?
-          previous_timetable.update(winter_reject_by_default_at: previous_timetable.reject_by_default_at + 17.weeks)
-        end
+    context 'before the previous cycle has completely closed' do
+      it 'returns the winter reject by default at date from the previous cycle - 2 weeks' do
+        travel_temporarily_to(current_timetable.winter_decline_by_default_at - 1.month) do
+          if previous_timetable.winter_reject_by_default_at.nil?
+            previous_timetable.update(winter_reject_by_default_at: previous_timetable.reject_by_default_at + 17.weeks)
+          end
 
-        expect(winter_reject_by_default_reminder_provider_date.to_date).to eq((previous_timetable.winter_reject_by_default_at - 2.weeks).to_date)
+          expect(winter_reject_by_default_reminder_provider_date.to_date).to eq((previous_timetable.winter_reject_by_default_at - 2.weeks).to_date)
+        end
+      end
+    end
+
+    context 'after the previous cycle has completely closed' do
+      it 'returns the winter reject by default at date from the current cycle - 2 weeks' do
+        travel_temporarily_to(current_timetable.winter_decline_by_default_at + 1.day) do
+          expect(winter_reject_by_default_reminder_provider_date.to_date).to eq((current_timetable.winter_reject_by_default_at - 2.weeks).to_date)
+        end
       end
     end
   end

--- a/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
+++ b/spec/lib/end_of_cycle/provider_email_timetabler_spec.rb
@@ -59,5 +59,13 @@ RSpec.describe EndOfCycle::ProviderEmailTimetabler do
         end
       end
     end
+
+    context 'a future timetable is provided as a kwarg' do
+      it 'returns date calculated on that timetable regardless of current date' do
+        timetable = RecruitmentCycleTimetable.find_by(recruitment_cycle_year: current_year + 2)
+        date = described_class.new(timetable:).winter_reject_by_default_reminder_provider_date
+        expect(date).to eq((timetable.winter_reject_by_default_at - 2.weeks).to_date)
+      end
+    end
   end
 end

--- a/spec/mailers/previews/provider/deadlines_mailer_preview.rb
+++ b/spec/mailers/previews/provider/deadlines_mailer_preview.rb
@@ -13,4 +13,9 @@ class Provider::DeadlinesMailerPreview < ActionMailer::Preview
     provider_user = FactoryBot.build(:provider_user)
     ProviderMailer.respond_to_applications_before_reject_by_default_date(provider_user)
   end
+
+  def respond_to_applications_before_winter_reject_by_default_date
+    provider_user = FactoryBot.build(:provider_user)
+    ProviderMailer.respond_to_applications_before_winter_reject_by_default_date(provider_user)
+  end
 end

--- a/spec/mailers/provider_mailer/provider_mailer_respond_to_applications_before_winter_reject_by_default_date_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_respond_to_applications_before_winter_reject_by_default_date_spec.rb
@@ -4,11 +4,30 @@ RSpec.describe ProviderMailer do
   include TestHelpers::MailerSetupHelper
 
   describe '.respond_to_applications_before_winter_reject_by_default_date' do
-    it 'raises an error' do
-      provider_user = build(:provider_user)
-      expect {
-        described_class.respond_to_applications_before_winter_reject_by_default_date(provider_user).deliver_now
-      }.to raise_error('Mailer still in development')
+    let(:provider_user) { create(:provider_user, first_name: 'Rocket', last_name: 'The Dog') }
+    let(:email) { described_class.respond_to_applications_before_winter_reject_by_default_date(provider_user) }
+    let(:timetable) { previous_timetable }
+    let(:winter_reject_by_default_date) { I18n.l(timetable.winter_reject_by_default_at.to_date, format: :no_year) }
+
+    it 'renders the content' do
+      expect(email.subject).to eq("Offer places to candidates by #{winter_reject_by_default_date} - manage teacher training applications")
+      expect(email.body).to include('Dear Rocket The Dog')
+      expect(email.body).to include(
+        "The deadline for offering teacher training places for courses starting in #{timetable.winter_reject_by_default_at.to_fs(:month_and_year)} is #{timetable.winter_reject_by_default_at.to_fs(:govuk_date)}.",
+      )
+      expect(email.body).to include(
+        "If you do not make an offer by #{timetable.winter_reject_by_default_at.to_fs(:govuk_date)}, any applications for January marked as ‘received’ or ‘interviewing’ will be automatically rejected.",
+      )
+      expect(email.body).to include(
+        "If you offer a candidate a January place, they will have until #{timetable.winter_decline_by_default_at.to_fs(:govuk_date)} to accept it.",
+      )
+      expect(email.body).to include('Sign in to your account to review your applications')
+      expect(email.body).to include('Contact us')
+      expect(email.body).to include(
+        'Get help, report a problem or give feedback at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).',
+      )
+      expect(email.body).to include('If you want to unsubscribe from these emails')
+      expect(email.body).to include('sign in to update your notification preferences')
     end
   end
 end

--- a/spec/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe EndOfCycle::SendRejectByDefaultReminderToProvidersWorker do
       let(:instance) { described_class.new }
 
       it 'calls batch worker with application choices' do
-        allow(instance).to receive(:winter_reject_by_default_set?).and_return(false)
         travel_temporarily_to(email_send_date) do
           inactive_application = create(:application_choice, :inactive)
           interview_application = create(:application_choice, :interviewing)


### PR DESCRIPTION
## Context

We have an email that goes out to providers in advance of the standard reject by default date. We also need one that goes out before the winter reject by default at.

## Changes proposed in this pull request

- implemented the mailer and updated the job for sending it
- Updated the logic in both the provider email timetabler, and then I got carried away and did the same for the candidate email timetable as it suffers from the same problem. I've drawn some pretty pictures about what dates to pick when if you want me to walk through it. Also, added loads of tests, so hopefully it all makes sense and we can be confident things will just go forward as planned. 

## Guidance to review

[The preview is here](https://apply-review-12095.test.teacherservices.cloud/rails/mailers/provider/deadlines_mailer/respond_to_applications_before_winter_reject_by_default_date) 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
