### PR TITLE
Add previous last names to application forms

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -263,6 +263,7 @@ shared:
     - safeguarding_issues
     - country_residency_date_from
     - country_residency_since_birth
+    - previous_last_names
   application_qualifications:
     - application_form_id
     - award_year

--- a/db/migrate/20260714150623_add_previous_last_names_to_application_forms.rb
+++ b/db/migrate/20260714150623_add_previous_last_names_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddPreviousLastNamesToApplicationForms < ActiveRecord::Migration[8.1]
+  def change
+    add_column :application_forms, :previous_last_names, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_082943) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_150623) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -233,6 +233,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_082943) do
     t.string "phone_number"
     t.string "postcode"
     t.integer "previous_application_form_id"
+    t.string "previous_last_names"
     t.boolean "previous_teacher_training_completed"
     t.datetime "previous_teacher_training_completed_at", precision: nil
     t.integer "recruitment_cycle_year", null: false

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -149,6 +149,7 @@ erDiagram
 		string phase
 		string phone_number
 		string postcode
+		string previous_last_names
 		boolean previous_teacher_training_completed
 		datetime previous_teacher_training_completed_at
 		boolean references_completed


### PR DESCRIPTION
## Context

- Add `previous_last_names` to `application_forms` table

## Changes proposed in this pull request

- Migration to add `previous_last_names` column to `application_forms` table

## Guidance to review

- Review the migration


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
