### PR TITLE
Lb/2003 cycle switcher add winter rbd and dbd to job

### DIFF
--- a/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
+++ b/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
@@ -17,13 +17,23 @@ module EndOfCycle
         EndOfCycle::CancelReferenceRequestsWorker.perform_async
       end
 
-      # TODO: Add the Winter reject by / decline by default workers when the dates of been added to database
+      if previous_timetable.winter_reject_by_default_at.present? && Time.zone.now.after?(previous_timetable.winter_reject_by_default_at)
+        EndOfCycle::WinterRejectByDefaultWorker.perform_async(true)
+      end
+
+      if previous_timetable.winter_decline_by_default_at.present? && Time.zone.now.after?(previous_timetable.winter_decline_by_default_at)
+        EndOfCycle::WinterDeclineByDefaultWorker.perform_async(true)
+      end
     end
 
   private
 
     def current_timetable
       @current_timetable ||= RecruitmentCycleTimetable.current_timetable
+    end
+
+    def previous_timetable
+      @previous_timetable ||= current_timetable.relative_previous_timetable
     end
   end
 end

--- a/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
+++ b/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
@@ -21,7 +21,7 @@ module EndOfCycle
         EndOfCycle::WinterRejectByDefaultWorker.perform_async(true)
       end
 
-      if previous_timetable.winter_decline_by_default_at.present? && Time.zone.now.after?(previous_timetable.winter_decline_by_default_at)
+      if Time.zone.now.after?(previous_timetable.winter_decline_by_default_at)
         EndOfCycle::WinterDeclineByDefaultWorker.perform_async(true)
       end
     end

--- a/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
+++ b/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
@@ -17,7 +17,7 @@ module EndOfCycle
         EndOfCycle::CancelReferenceRequestsWorker.perform_async
       end
 
-      if previous_timetable.winter_reject_by_default_at.present? && Time.zone.now.after?(previous_timetable.winter_reject_by_default_at)
+      if Time.zone.now.after?(previous_timetable.winter_reject_by_default_at)
         EndOfCycle::WinterRejectByDefaultWorker.perform_async(true)
       end
 

--- a/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
+++ b/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
     allow(EndOfCycle::RejectByDefaultWorker).to receive(:perform_async).with(true)
     allow(EndOfCycle::CancelReferenceRequestsWorker).to receive(:perform_async)
     allow(EndOfCycle::DeclineByDefaultWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::WinterRejectByDefaultWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::WinterDeclineByDefaultWorker).to receive(:perform_async).with(true)
   end
 
   describe '#perform' do
     context 'in mid-cycle' do
       it 'does not run any jobs' do
-        date = current_timetable.apply_opens_at + 30.weeks
+        date = current_timetable.apply_opens_at + 2.months
         travel_temporarily_to(date) do
           described_class.new.perform
           expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async)
@@ -20,6 +22,8 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -36,6 +40,8 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -53,6 +59,8 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           # Not these
           expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -70,6 +78,29 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           # And the decline by default worker related jobs
           expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_async).with(true)
           expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_async)
+          # But not the winter jobs
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
+        end
+      end
+    end
+
+    context 'into the next cycle, after the previous cycle winter reject by default at' do
+      it 'runs the winter jobs only' do
+        date = current_timetable.winter_reject_by_default_at + 1.minute
+        travel_temporarily_to(date) do
+          described_class.new.perform
+          # Apply deadline jobs
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
+          # And the reject by default worker
+          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_async).with(true)
+          # And the decline by default worker related jobs
+          expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_async)
+          # But not the winter jobs
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end

--- a/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
+++ b/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         date = current_timetable.apply_deadline_at + 1.minute
         travel_temporarily_to(date) do
           described_class.new.perform
+          # The winter jobs from the previous year will run
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # These jobs run on the apply deadline
           expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
           expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
@@ -40,8 +43,6 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
-          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -51,6 +52,9 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         date = current_timetable.reject_by_default_at + 1.minute
         travel_temporarily_to(date) do
           described_class.new.perform
+          # The winter jobs from the previous year will run
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # These jobs run on the apply deadline
           expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
           expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
@@ -59,8 +63,6 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           # Not these
           expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
           expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
-          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -70,6 +72,9 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         date = current_timetable.decline_by_default_at + 1.minute
         travel_temporarily_to(date) do
           described_class.new.perform
+          # The winter jobs from the previous year will run
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # Apply deadline jobs
           expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
           expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
@@ -78,29 +83,43 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
           # And the decline by default worker related jobs
           expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_async).with(true)
           expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_async)
-          # But not the winter jobs
-          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
 
     context 'into the next cycle, after the previous cycle winter reject by default at' do
-      it 'runs the winter jobs only' do
+      it 'runs the winter reject by default only' do
         date = current_timetable.winter_reject_by_default_at + 1.minute
         travel_temporarily_to(date) do
           described_class.new.perform
-          # Apply deadline jobs
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
-          # And the reject by default worker
-          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_async).with(true)
-          # And the decline by default worker related jobs
-          expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_async).with(true)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_async)
-          # But not the winter jobs
-          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          # The winter reject by default worker will run
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          # But not the winter decline by default worker
           expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
+          # Or anything else
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
+        end
+      end
+    end
+
+    context 'into the next cycle, after the previous cycle winter decline by default at' do
+      it 'runs winter jobs only' do
+        date = current_timetable.winter_decline_by_default_at + 1.minute
+        travel_temporarily_to(date) do
+          described_class.new.perform
+          # Both winter jobs run
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
+          # But nothing else
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
         end
       end
     end


### PR DESCRIPTION
## Context

We have a handy button for bringing applications up to date when we are messing about with cycle dates in qa / review apps. It was written before we had Winter Reject By Default or Decline by Default related jobs.

## Changes proposed in this pull request

Add the winter reject / decline by default jobs to the job

## Guidance to review

Mess around with the cycle dates and run the jobs. Does it does what you expect it to do.
Note, the job anticipates the cycle looking realistic. Ie, one cycle's winter dates after AFTER another cycle has started.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
