### PR TITLE
Add previous last names to application form forms

### DIFF
--- a/app/components/provider_interface/personal_information_component.rb
+++ b/app/components/provider_interface/personal_information_component.rb
@@ -11,6 +11,7 @@ module ProviderInterface
 
     delegate :first_name,
              :last_name,
+             :previous_last_names,
              :candidate,
              to: :application_form
 
@@ -23,6 +24,7 @@ module ProviderInterface
       [
         first_name_row,
         last_name_row,
+        previous_last_names_row,
         date_of_birth_row,
         nationality_row,
         right_to_work_or_study_row,
@@ -47,6 +49,15 @@ module ProviderInterface
       {
         key: 'Last name',
         value: last_name,
+      }
+    end
+
+    def previous_last_names_row
+      return if previous_last_names.blank?
+
+      {
+        key: 'Previous last names',
+        value: previous_last_names,
       }
     end
 

--- a/app/components/support_interface/personal_information_component.rb
+++ b/app/components/support_interface/personal_information_component.rb
@@ -13,6 +13,7 @@ module SupportInterface
 
     delegate :first_name,
              :last_name,
+             :previous_last_names,
              :candidate,
              to: :application_form
 
@@ -24,6 +25,7 @@ module SupportInterface
       [
         first_name_row,
         last_name_row,
+        previous_last_names_row,
         date_of_birth_row,
         nationality_row,
         domicile_row,
@@ -61,6 +63,21 @@ module SupportInterface
         action: {
           href: support_interface_application_form_edit_applicant_details_path(application_form),
           visually_hidden_text: 'last name',
+        },
+      )
+    end
+
+    def previous_last_names_row
+      row = {
+        key: 'Previous last names',
+        value: previous_last_names,
+      }
+      return row unless editable?
+
+      row.merge(
+        action: {
+          href: support_interface_application_form_edit_applicant_details_path(application_form),
+          visually_hidden_text: 'previous last names',
         },
       )
     end

--- a/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module PersonalDetails
     class NameAndDobController < CandidateInterfaceController
       def new
-        @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
+        @personal_details_form = PersonalDetailsForm.build_from_application(current_application, state: :new)
       end
 
       def edit

--- a/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/name_and_dob_controller.rb
@@ -40,7 +40,7 @@ module CandidateInterface
       def personal_details_params
         strip_whitespace(
           params.expect(
-            candidate_interface_personal_details_form: %i[first_name last_name
+            candidate_interface_personal_details_form: %i[first_name last_name has_previous_last_names previous_last_names
                                                           date_of_birth(3i) date_of_birth(2i) date_of_birth(1i)],
           ).transform_keys { |key| dob_field_to_attribute(key) },
         )

--- a/app/controllers/support_interface/application_forms/applicant_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/applicant_details_controller.rb
@@ -26,7 +26,7 @@ module SupportInterface
 
       def edit_application_params
         params.expect(support_interface_application_forms_edit_applicant_details_form: %i[first_name last_name email_address date_of_birth(3i) date_of_birth(2i)
-                                                                                          date_of_birth(1i) phone_number audit_comment])
+                                                                                          date_of_birth(1i) phone_number audit_comment previous_last_names])
           .transform_keys { |key| dob_field_to_attribute(key) }
           .transform_values(&:strip)
       end

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -4,10 +4,11 @@ module CandidateInterface
 
     attr_accessor :first_name, :last_name, :has_previous_last_names, :previous_last_names, :day, :month, :year
 
-    validates :first_name, :last_name, presence: true, length: { maximum: 60 }
-    validates :date_of_birth, date: { date_of_birth: true, presence: true }
+    validates :first_name, presence: true, length: { maximum: 60 }
     validates :has_previous_last_names, presence: true
     validates :previous_last_names, presence: true, if: :previous_last_names_declared?
+    validates :last_name, presence: true, length: { maximum: 60 }
+    validates :date_of_birth, date: { date_of_birth: true, presence: true }
 
     def self.build_from_application(application_form, state: :edit)
       new(

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -9,11 +9,11 @@ module CandidateInterface
     validates :has_previous_last_names, presence: true
     validates :previous_last_names, presence: true, if: :previous_last_names_declared?
 
-    def self.build_from_application(application_form)
+    def self.build_from_application(application_form, state: :edit)
       new(
         first_name: application_form.first_name,
         last_name: application_form.last_name,
-        has_previous_last_names: application_form.previous_last_names.present? ? 1 : 0,
+        has_previous_last_names: assign_has_previous_last_names(state, application_form),
         previous_last_names: application_form.previous_last_names,
         day: application_form.date_of_birth&.day,
         month: application_form.date_of_birth&.month,
@@ -56,6 +56,12 @@ module CandidateInterface
     end
 
   private
+
+    def self.assign_has_previous_last_names(state, application_form)
+      return unless state == :edit
+
+      application_form.previous_last_names.present? ? 1 : 0
+    end
 
     def previous_last_names_declared?
       has_previous_last_names.to_i.positive?

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -2,15 +2,19 @@ module CandidateInterface
   class PersonalDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :first_name, :last_name, :day, :month, :year
+    attr_accessor :first_name, :last_name, :has_previous_last_names, :previous_last_names, :day, :month, :year
 
     validates :first_name, :last_name, presence: true, length: { maximum: 60 }
     validates :date_of_birth, date: { date_of_birth: true, presence: true }
+    validates :has_previous_last_names, presence: true
+    validates :previous_last_names, presence: true, if: :previous_last_names_declared?
 
     def self.build_from_application(application_form)
       new(
         first_name: application_form.first_name,
         last_name: application_form.last_name,
+        has_previous_last_names: application_form.previous_last_names.present? ? 1 : 0,
+        previous_last_names: application_form.previous_last_names,
         day: application_form.date_of_birth&.day,
         month: application_form.date_of_birth&.month,
         year: application_form.date_of_birth&.year,
@@ -23,6 +27,7 @@ module CandidateInterface
       application_form.update(
         first_name:,
         last_name:,
+        previous_last_names: previous_last_names_declared? ? previous_last_names : nil,
         date_of_birth:,
       )
     end
@@ -48,6 +53,12 @@ module CandidateInterface
 
     def valid_for_submission?
       all_errors.blank?
+    end
+
+  private
+
+    def previous_last_names_declared?
+      has_previous_last_names.to_i.positive?
     end
   end
 end

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -55,13 +55,11 @@ module CandidateInterface
       all_errors.blank?
     end
 
-    def assign_has_previous_last_names(state, application_form)
+    def self.assign_has_previous_last_names(state, application_form)
       return unless state == :edit
 
       application_form.previous_last_names.present? ? 1 : 0
     end
-
-    private_class_method :assign_has_previous_last_names
 
   private
 

--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -55,13 +55,15 @@ module CandidateInterface
       all_errors.blank?
     end
 
-  private
-
-    def self.assign_has_previous_last_names(state, application_form)
+    def assign_has_previous_last_names(state, application_form)
       return unless state == :edit
 
       application_form.previous_last_names.present? ? 1 : 0
     end
+
+    private_class_method :assign_has_previous_last_names
+
+  private
 
     def previous_last_names_declared?
       has_previous_last_names.to_i.positive?

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -4,7 +4,7 @@ module SupportInterface
       include ActiveModel::Model
 
       attr_accessor :first_name, :last_name, :email_address, :phone_number, :audit_comment,
-                    :day, :month, :year
+                    :day, :month, :year, :previous_last_names
       attr_reader :application_form
 
       validates :first_name, :last_name, presence: true, length: { maximum: 60 }
@@ -22,6 +22,7 @@ module SupportInterface
         super(
           first_name: @application_form.first_name,
           last_name: @application_form.last_name,
+          previous_last_names: @application_form.previous_last_names,
           email_address: @application_form.candidate.email_address,
           day: @application_form.date_of_birth&.day,
           month: @application_form.date_of_birth&.month,
@@ -34,6 +35,7 @@ module SupportInterface
         @application_form.update!(
           first_name:,
           last_name:,
+          previous_last_names:,
           date_of_birth:,
           phone_number:,
           audit_comment:,

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -27,6 +27,7 @@ module CandidateInterface
     def rows
       assembled_rows = [
         name_row,
+        previous_last_names_row,
         date_of_birth_row,
         nationality_row,
       ]
@@ -54,6 +55,26 @@ module CandidateInterface
             {
               href: candidate_interface_edit_name_and_dob_path(return_to_params),
               visually_hidden_text: I18n.t('application_form.personal_details.name.change_action'),
+            }
+        end
+      end
+    end
+
+    def previous_last_names_row
+      {
+        key: I18n.t('application_form.personal_details.previous_last_names.name'),
+        value: @personal_details_form.previous_last_names.presence || 'None',
+        html_attributes: {
+          data: {
+            qa: 'personal-details-previous-last-names',
+          },
+        },
+      }.tap do |row|
+        if @editable
+          row[:action] =
+            {
+              href: candidate_interface_edit_name_and_dob_path(return_to_params),
+              visually_hidden_text: I18n.t('application_form.personal_details.previous_last_names.change_action'),
             }
         end
       end

--- a/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
@@ -4,9 +4,20 @@
     <%= t('page_titles.personal_information.heading') %>
   </h1>
 
+  <p class="govuk-hint">
+    <%= t('page_titles.personal_information.hint') %>
+  </p>
+
   <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>
 
   <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
+
+  <%= f.govuk_radio_buttons_fieldset :has_previous_last_names, legend: { text: t('application_form.personal_details.previous_last_names.label'), size: 'm' } do %>
+    <%= f.govuk_radio_button :has_previous_last_names, 1, label: { text: t('application_form.personal_details.previous_last_names.yes') }, link_errors: true do %>
+      <%= f.govuk_text_field :previous_last_names, label: { text:  t('application_form.personal_details.previous_last_names.input') } %>
+    <% end %>
+    <%= f.govuk_radio_button :has_previous_last_names, 0, label: { text: t('application_form.personal_details.previous_last_names.no') } %>
+  <% end %>
 
   <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), size: 'm' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
 

--- a/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
@@ -14,7 +14,7 @@
 
   <%= f.govuk_radio_buttons_fieldset :has_previous_last_names, legend: { text: t('application_form.personal_details.previous_last_names.label'), size: 'm' } do %>
     <%= f.govuk_radio_button :has_previous_last_names, 1, label: { text: t('application_form.personal_details.previous_last_names.yes') }, link_errors: true do %>
-      <%= f.govuk_text_field :previous_last_names, label: { text:  t('application_form.personal_details.previous_last_names.input') } %>
+      <%= f.govuk_text_field :previous_last_names, label: { text: t('application_form.personal_details.previous_last_names.input') } %>
     <% end %>
     <%= f.govuk_radio_button :has_previous_last_names, 0, label: { text: t('application_form.personal_details.previous_last_names.no') } %>
   <% end %>

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -10,6 +10,7 @@
 
       <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>
       <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
+      <%= f.govuk_text_field :previous_last_names, label: { text: t('application_form.personal_details.previous_last_names.name'), size: 'm' }, autocomplete: 'previous-last-names' %>
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, autocomplete: 'email', spellcheck: false %>
       <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), size: 'm' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
       <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint: { text: t('application_form.contact_details.phone_number.hint_text') }, autocomplete: 'tel' %>

--- a/config/locales/candidate_interface/personal_details.yml
+++ b/config/locales/candidate_interface/personal_details.yml
@@ -7,6 +7,13 @@ en:
       last_name:
         label: Last name
         hint_text: Or family name
+      previous_last_names:
+        label: Have you ever had a different last name?
+        name: Previous last names
+        'yes': 'Yes'
+        'no': 'No'
+        input: 'Enter your previous last name. If you have had more than one, enter them separated by commas.'
+        change_action: previous last names
       name:
         label: Name
         change_action: name
@@ -70,6 +77,10 @@ en:
             last_name:
               blank: Enter your last name or family name
               too_long: Last name must be %{count} characters or fewer
+            previous_last_names:
+              blank: Enter your previous last names
+            has_previous_last_names:
+              blank: Select if you have ever had a different last name
         candidate_interface/nationalities_form:
           attributes:
             nationalities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,6 +172,7 @@ en:
     personal_details: Personal details
     personal_information:
       heading: Personal information
+      hint: Enter your name as it appears in official documents. Do not enter nicknames or initials.
       edit: Edit your personal information
       review: Check your personal information
     nationalities: What is your nationality?

--- a/spec/components/provider_interface/personal_information_component_spec.rb
+++ b/spec/components/provider_interface/personal_information_component_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
     ['First name', 'Last name', 'Date of birth', 'Nationality'].each do |key|
       expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
+    expect(result.css('.govuk-summary-list__key').text).not_to include('Previous last names')
   end
 
   it 'renders the candidate first name' do
@@ -48,6 +49,26 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
 
   it 'renders the candidate id' do
     expect(result.css('.govuk-summary-list__value').text).to include(candidate_id)
+  end
+
+  context 'when the application form has previous last names' do
+    let(:application_form) do
+      build_stubbed(
+        :completed_application_form,
+        :with_previous_last_names,
+        support_reference: 'AB123',
+        date_of_birth: Date.new(2000, 1, 1),
+        first_nationality: 'British',
+        second_nationality: 'Irish',
+        third_nationality: 'Spanish',
+        candidate_id:,
+      )
+    end
+
+    it 'renders the candidate previous last names' do
+      expect(result.css('.govuk-summary-list__key').text).to include('Previous last names')
+      expect(result.css('.govuk-summary-list__value').text).to include(application_form.previous_last_names)
+    end
   end
 
   context 'with visa expiry flag on and candidate is international' do

--- a/spec/components/support_interface/personal_information_component_spec.rb
+++ b/spec/components/support_interface/personal_information_component_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
       SupportInterface::PersonalInformationComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
         result = render_inline(described_class.new(application_form:))
-        row_title = result.css('.govuk-summary-list__row')[5].css('dt').text
-        row_value = result.css('.govuk-summary-list__row')[5].css('dd').text
+        row_title = result.css('.govuk-summary-list__row')[6].css('dt').text
+        row_value = result.css('.govuk-summary-list__row')[6].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'
         expect(row_value).to include value
       end

--- a/spec/components/support_interface/personal_information_component_spec.rb
+++ b/spec/components/support_interface/personal_information_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
   subject(:result) { render_inline(described_class.new(application_form:)) }
 
   it 'renders component with correct labels' do
-    ['First name', 'Last name', 'Date of birth', 'Nationality'].each do |key|
+    ['First name', 'Last name', 'Previous last names', 'Date of birth', 'Nationality'].each do |key|
       expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
   end
@@ -47,6 +47,24 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
 
   it 'shows change links' do
     expect(result.css('a').first.text).to eq('Change first name')
+  end
+
+  context 'when the application form has previous last names' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        :with_previous_last_names,
+        support_reference: 'AB123',
+        date_of_birth: Date.new(2000, 1, 1),
+        first_nationality: 'British',
+        second_nationality: 'Irish',
+        third_nationality: 'Spanish',
+      )
+    end
+
+    it 'renders the candidate previous last names' do
+      expect(result.css('.govuk-summary-list__value').text).to include(application_form.previous_last_names)
+    end
   end
 
   context 'when the application form has a subsequent application' do

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -458,6 +458,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_previous_last_names do
+      previous_last_names { "#{Faker::Name.last_name}, #{Faker::Name.last_name}" }
+    end
+
     trait :not_started_previous_teacher_training do
       completed
       previous_teacher_training_started { false }

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     {
       first_name: data[:first_name],
       last_name: data[:last_name],
+      has_previous_last_names: 0,
       day: data[:date_of_birth].day,
       month: data[:date_of_birth].month,
       year: data[:date_of_birth].year,

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       first_name: data[:first_name],
       last_name: data[:last_name],
       has_previous_last_names: 0,
+      previous_last_names: nil,
       day: data[:date_of_birth].day,
       month: data[:date_of_birth].month,
       year: data[:date_of_birth].year,
@@ -37,6 +38,38 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
 
       expect(personal_details).to have_attributes(form_data)
     end
+
+    context 'when given previous last names' do
+      let(:data) do
+        {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          previous_last_names: Faker::Name.last_name,
+          date_of_birth: Faker::Date.birthday,
+        }
+      end
+
+      let(:form_data) do
+        {
+          first_name: data[:first_name],
+          last_name: data[:last_name],
+          has_previous_last_names: 1,
+          previous_last_names: data[:previous_last_names],
+          day: data[:date_of_birth].day,
+          month: data[:date_of_birth].month,
+          year: data[:date_of_birth].year,
+        }
+      end
+
+      it 'creates an object based on the provided ApplicationForm' do
+        application_form = ApplicationForm.new(data)
+        personal_details = described_class.build_from_application(
+          application_form,
+        )
+
+        expect(personal_details).to have_attributes(form_data)
+      end
+    end
   end
 
   describe '#save' do
@@ -53,14 +86,63 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       expect(personal_details.save(application_form)).to be(true)
       expect(application_form).to have_attributes(data)
     end
+
+    context 'when given previous last names' do
+      let(:data) do
+        {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          previous_last_names: Faker::Name.last_name,
+          date_of_birth: Faker::Date.birthday,
+        }
+      end
+
+      let(:form_data) do
+        {
+          first_name: data[:first_name],
+          last_name: data[:last_name],
+          has_previous_last_names: 1,
+          previous_last_names: data[:previous_last_names],
+          day: data[:date_of_birth].day,
+          month: data[:date_of_birth].month,
+          year: data[:date_of_birth].year,
+        }
+      end
+
+      it 'updates the provided ApplicationForm if valid' do
+        application_form = create(:application_form)
+        personal_details = described_class.new(form_data)
+
+        expect(personal_details.save(application_form)).to be(true)
+        expect(application_form).to have_attributes(data)
+      end
+    end
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:has_previous_last_names) }
 
     it { is_expected.to validate_length_of(:first_name).is_at_most(60) }
     it { is_expected.to validate_length_of(:last_name).is_at_most(60) }
+
+    describe '#previous_last_names' do
+      context 'when previous last names are declared' do
+        it 'validates the presence of the previous last names' do
+          model = described_class.new(has_previous_last_names: 1)
+          expect(model).not_to be_valid
+          expect(model.errors.messages[:previous_last_names]).to include('Enter your previous last names')
+        end
+      end
+
+      context 'when previous last name are not declared' do
+        it 'does not validate the presence of the previous last names' do
+          model = described_class.new(form_data)
+          expect(model).to be_valid
+        end
+      end
+    end
 
     describe 'date of birth' do
       let(:model) { described_class.new(day:, month:, year:) }

--- a/spec/forms/support_interface/application_forms/edit_applicant_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_applicant_details_form_spec.rb
@@ -42,4 +42,43 @@ RSpec.describe SupportInterface::ApplicationForms::EditApplicantDetailsForm, typ
       end
     end
   end
+
+  describe '#save!' do
+    let(:attributes) do
+      {
+        first_name: 'Cloud',
+        last_name: 'Strife',
+        email_address: 'cloud.strife@example.com',
+        phone_number: '99999 1111111',
+        audit_comment: 'Audit comment',
+      }
+    end
+
+    it 'updates the attributes of an application form' do
+      model.assign_attributes(attributes)
+      model.save!
+      expect(application_form.reload).to have_attributes(attributes.except(:email_address, :audit_comment))
+      expect(application_form.candidate.reload.email_address).to eq('cloud.strife@example.com')
+    end
+
+    context 'when given previous last names' do
+      let(:attributes) do
+        {
+          first_name: 'Gandalf',
+          last_name: 'The White',
+          previous_last_names: 'The Grey',
+          email_address: 'gandalf.the.white@example.com',
+          phone_number: '99999 1111111',
+          audit_comment: 'Audit comment',
+        }
+      end
+
+      it 'updates the attributes of an application form' do
+        model.assign_attributes(attributes)
+        model.save!
+        expect(application_form.reload).to have_attributes(attributes.except(:email_address, :audit_comment))
+        expect(application_form.candidate.reload.email_address).to eq('gandalf.the.white@example.com')
+      end
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, :mid_cycle do
             value: 'Jackson, Avery',
             html_attributes: { data: { qa: 'personal-details-previous-last-names' } },
             action: {
-              href: "/candidate/application/personal-information/edit?return-to=application-review",
-              visually_hidden_text: "previous last names",
+              href: '/candidate/application/personal-information/edit?return-to=application-review',
+              visually_hidden_text: 'previous last names',
             },
           ),
         )
@@ -154,16 +154,16 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, :mid_cycle do
           day: nil,
           month: nil,
           year: nil,
-          )
+        )
 
         expect(rows(personal_details_form:)).to include(
-        hash_including(
-          key: 'Previous last names',
-          value: 'None',
-          html_attributes: { data: { qa: 'personal-details-previous-last-names' } },
-          action: {
-              href: "/candidate/application/personal-information/edit?return-to=application-review",
-              visually_hidden_text: "previous last names",
+          hash_including(
+            key: 'Previous last names',
+            value: 'None',
+            html_attributes: { data: { qa: 'personal-details-previous-last-names' } },
+            action: {
+              href: '/candidate/application/personal-information/edit?return-to=application-review',
+              visually_hidden_text: 'previous last names',
             },
           ),
         )

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -117,6 +117,58 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, :mid_cycle do
         ),
       )
     end
+
+    context 'with previous last names' do
+      it 'returns the correct link when previous first names are present' do
+        personal_details_form = build(
+          :personal_details_form,
+          first_name: nil,
+          last_name: nil,
+          previous_last_names: 'Jackson, Avery',
+          day: nil,
+          month: nil,
+          year: nil,
+        )
+
+        expect(rows(personal_details_form:)).to include(
+          hash_including(
+            key: 'Previous last names',
+            value: 'Jackson, Avery',
+            html_attributes: { data: { qa: 'personal-details-previous-last-names' } },
+            action: {
+              href: "/candidate/application/personal-information/edit?return-to=application-review",
+              visually_hidden_text: "previous last names",
+            },
+          ),
+        )
+      end
+    end
+
+    context 'without previous last names' do
+      it 'returns the correct link when previous first names are present' do
+        personal_details_form = build(
+          :personal_details_form,
+          first_name: nil,
+          last_name: nil,
+          previous_last_names: nil,
+          day: nil,
+          month: nil,
+          year: nil,
+          )
+
+        expect(rows(personal_details_form:)).to include(
+        hash_including(
+          key: 'Previous last names',
+          value: 'None',
+          html_attributes: { data: { qa: 'personal-details-previous-last-names' } },
+          action: {
+              href: "/candidate/application/personal-information/edit?return-to=application-review",
+              visually_hidden_text: "previous last names",
+            },
+          ),
+        )
+      end
+    end
   end
 
   context 'when presenting nationality' do

--- a/spec/requests/candidate_interface/audit_trail_spec.rb
+++ b/spec/requests/candidate_interface/audit_trail_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Candidate interface - audit trail', :with_audited do
     {
       first_name: 'Bob',
       last_name: 'Smith',
+      has_previous_last_names: 0,
+      previous_last_names: '',
       english_main_language: 'yes',
       first_nationality: 'British',
       'date_of_birth(1i)': '2000',

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -333,6 +333,7 @@ module CandidateHelper
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope:), with: 'Lando'
     fill_in t('last_name.label', scope:), with: 'Calrissian'
+    choose 'No' # Have you ever had a different last name?
 
     fill_in 'Day', with: '6'
     fill_in 'Month', with: '4'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -55,6 +55,31 @@ RSpec.describe 'Entering their personal details' do
     then_i_do_not_see_the_complete_section_component
   end
 
+  scenario 'Candidate enters their previous last names' do
+    given_i_am_signed_in_with_one_login
+    and_i_visit_the_site
+    when_i_click_on_personal_information
+    and_i_fill_in_some_details_but_omit_my_previous_last_names
+    and_i_submit_the_form
+    then_i_see_validation_errors_for_not_choosing_to_enter_my_previous_last_names
+
+    when_i_choose_yes_to_having_a_different_last_name
+    and_i_submit_the_form
+    then_i_see_validation_errors_for_not_entering_my_previous_last_names
+
+    when_i_fill_in_my_previous_last_names
+    and_i_submit_the_form
+    then_i_see_the_nationality_page
+
+    when_i_input_my_nationalities
+    and_i_submit_the_form
+    then_i_see_the_review_page
+    and_i_can_check_my_answers
+    and_my_previous_last_names_are_displayed
+  end
+
+private
+
   def then_i_do_not_see_the_complete_section_component
     expect(page).to have_no_text('Have you completed this section?')
   end
@@ -86,6 +111,11 @@ RSpec.describe 'Entering their personal details' do
 
   def then_i_see_validation_errors
     expect(page).to have_text t('errors.messages.invalid_date', article: 'a', attribute: 'date of birth')
+    then_i_see_validation_errors_for_not_choosing_to_enter_my_previous_last_names
+  end
+
+  def then_i_see_validation_errors_for_not_choosing_to_enter_my_previous_last_names
+    expect(page).to have_text('Select if you have ever had a different last name')
   end
 
   def and_i_see_the_completed_fields
@@ -96,12 +126,23 @@ RSpec.describe 'Entering their personal details' do
 
   def when_i_fill_in_the_rest_of_my_details
     fill_in t('first_name.label', scope: @scope), with: "La\u200Bndo"
+    choose 'No'
     fill_in 'Day', with: '6'
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'
   end
 
   def and_i_fill_in_all_my_details
+    @scope = 'application_form.personal_details'
+    fill_in t('first_name.label', scope: @scope), with: 'Lando'
+    fill_in t('last_name.label', scope: @scope), with: 'Calrissian'
+    choose 'No'
+    fill_in 'Day', with: '10'
+    fill_in 'Month', with: '11'
+    fill_in 'Year', with: '1975'
+  end
+
+  def and_i_fill_in_some_details_but_omit_my_previous_last_names
     @scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: @scope), with: 'Lando'
     fill_in t('last_name.label', scope: @scope), with: 'Calrissian'
@@ -187,5 +228,22 @@ RSpec.describe 'Entering their personal details' do
 
   def and_i_choose_yes_to_having_the_right_to_work_in_the_uk
     choose('Yes')
+  end
+
+  def when_i_choose_yes_to_having_a_different_last_name
+    choose('Yes')
+  end
+
+  def then_i_see_validation_errors_for_not_entering_my_previous_last_names
+    expect(page).to have_text('Enter your previous last names')
+  end
+
+  def when_i_fill_in_my_previous_last_names
+    fill_in 'Enter your previous last name. If you have had more than one, enter them separated by commas.',
+            with: 'Jackson, Avery'
+  end
+
+  def and_my_previous_last_names_are_displayed
+    expect(page).to have_text 'Jackson, Avery'
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope:), with: 'Lando'
     fill_in t('last_name.label', scope:), with: 'Calrissian'
+    choose 'No' # Have you ever had a different last name?
     fill_in 'Day', with: '6'
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Entering personal details' do
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope:), with: 'Lando'
     fill_in t('last_name.label', scope:), with: 'Calrissian'
+    choose 'No' # Have you ever had a different last name?
     fill_in 'Day', with: '6'
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'

--- a/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'Candidate account' do
     click_link_or_button 'Personal information'
     fill_in 'First name', with: name
     fill_in 'Last name', with: 'Smith'
+    choose 'No' # Have you ever had a different last name?
     fill_in 'Day', with: '1'
     fill_in 'Month', with: '1'
     fill_in 'Year', with: '1990'

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe 'Editing application details' do
 
     when_i_update_the_applicant_nationality
     then_i_see_the_updated_nationality
+
+    when_i_update_the_applicant_previous_last_names
+    then_i_see_the_updated_previous_last_names
   end
 
   def when_i_update_the_applicant_nationality
@@ -48,6 +51,15 @@ RSpec.describe 'Editing application details' do
 
     click_link_or_button 'History'
     expect(page).to have_text 'Changed nationality details - zendesk ticket 1234'
+  end
+
+  def then_i_see_the_updated_previous_last_names
+    within('[data-qa="personal-information"]') do
+      expect(page).to have_text 'Jackson, Avery'
+    end
+
+    click_link_or_button 'History'
+    expect(page).to have_text 'Changed previous last names - zendesk ticket 1234'
   end
 
   def given_i_am_a_support_user
@@ -167,5 +179,13 @@ RSpec.describe 'Editing application details' do
     and_i_see_the_new_phone_number
     and_i_see_the_new_email_address
     and_i_see_my_comment_in_the_audit_log
+  end
+
+  def when_i_update_the_applicant_previous_last_names
+    click_link_or_button 'Details'
+    click_link_or_button 'Change previous last names'
+    fill_in 'Previous last names', with: 'Jackson, Avery'
+    fill_in 'Audit log comment', with: 'Changed previous last names - zendesk ticket 1234'
+    and_i_submit_the_update_form
   end
 end


### PR DESCRIPTION
## Context

- Add a text field to allow candidates to enter their previous last names.

## Changes proposed in this pull request

- Add a text field and conditional radio buttons to allow candidates to enter their previous last names.
- Display the previous last names across the interfaces.

## Guidance to review

- Visit https://apply-review-12104.test.teacherservices.cloud/support/applications?commit=Apply+filters&q=&application_choice_id=&year%5B%5D=&year%5B%5D=2026&phase%5B%5D=&interviews%5B%5D=&status%5B%5D=&status%5B%5D=unsubmitted&opt_in_status%5B%5D=&subject%5B%5D=&nationality%5B%5D=
- Sign in as a Support user
- Click on any candidate with all their applications in `Not submitted yet` state.
- Click on "Sign in as this candidate"
- Navigate to "Your details"
- Click on "Personal information"
- Click "Change" to change the Previous last names
- Test the radio buttons and validation behave as expected
- Enter a name/names into "Have you ever had a different last name?"
- Click on "Save and continue"
- Make sure the Check your answers page reflects your changes.
----------
- Visit https://apply-review-12104.test.teacherservices.cloud/support/applications
- Click on the Candidate you just changed the details of
- Check the Personal Details show the changes you made
- Click "Change" to change the Previous last names
- Fill in the form to change the Previous last names
- Click "Update details
- Check that the changes you made are reflected in the Personal details
-------------

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/1DUJisjZ/1935-how-can-we-ensure-we-capture-the-most-valuable-name-data-to-drive-efficiencies-downstream

## Screen recordings & screenshots

_Candidate enters details_

https://github.com/user-attachments/assets/d519ad23-ecca-40f7-aa6c-0027aa104c7c

_Candidate Application Review page_

<img width="733" height="497" alt="Screenshot 2026-07-16 at 16 47 53" src="https://github.com/user-attachments/assets/388ba359-4493-4c29-9759-9d26d4473880" />

_Support edits details_

https://github.com/user-attachments/assets/4fa68218-1557-452e-8a7b-135c67ac25dd

_Provider views application with no previous last names_

<img width="668" height="362" alt="Screenshot 2026-07-16 at 16 52 04" src="https://github.com/user-attachments/assets/467dd5ce-e7b0-41e4-bfdc-f3d13a77a722" />

_Provider views application with previous last names_

<img width="673" height="418" alt="Screenshot 2026-07-16 at 16 55 14" src="https://github.com/user-attachments/assets/d72a5349-d018-4691-811d-f79c278c03e6" />
