### PR TITLE
Lb/2013 bug fix solidqueue dispatcher config in production

### DIFF
--- a/app/workers/test_job/dispatcher_test_job.rb
+++ b/app/workers/test_job/dispatcher_test_job.rb
@@ -1,0 +1,26 @@
+module TestJob
+  class DispatcherTestJob < ApplicationJob
+    self.queue_adapter = :solid_queue
+
+    def perform
+      ids = Candidate.last(10).pluck(:id)
+      BatchDelivery.new(
+        relation: Candidate.where(id: ids),
+        batch_size: 2,
+        stagger_over: 30.minutes,
+      ).each do |batch_time, records|
+        DeliveryJob
+          .set(wait_until: batch_time)
+          .perform_later(records.pluck(:id))
+      end
+    end
+  end
+
+  class DeliveryJob < ApplicationJob
+    self.queue_adapter = :solid_queue
+
+    def perform(_ids)
+      true
+    end
+  end
+end

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,4 +1,8 @@
 default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+      concurrency_maintenance_interval: 300
   workers:
     - queues: [default, low_priority]
       threads: <%= ENV.fetch("DEFAULT_QUEUE_THREADS", 1) %>


### PR DESCRIPTION
## Context

We tried to run the EoC email job in solid queue. it scheduled, but was never dispatched. Have found that the dispatcher is set up by default in the non-prod environments, but is not set up in prod. So testing made it appear that things would work just fine. But failed in prod (moved job the sidekiq, emails have been sent).

## Changes proposed in this pull request

- Dispatcher config
- A test job that uses scheduling to run in production to ensure the dispatcher config works

## Guidance to review

You can run the job locally or in the review app and it will work -- but it would have done anyway. We'll have to see how things go in production.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
