### PR TITLE
Add selected_grade_schema_id field to ApplicationQualification

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -300,6 +300,7 @@ shared:
     - degree_subject_uuid
     - degree_institution_uuid
     - degree_grade_uuid
+    - selected_grade_schema_id
   application_work_history_breaks:
     - breakable_type
     - breakable_id

--- a/db/migrate/20260715105421_add_selected_grade_schema_id_to_application_qualification.rb
+++ b/db/migrate/20260715105421_add_selected_grade_schema_id_to_application_qualification.rb
@@ -1,0 +1,5 @@
+class AddSelectedGradeSchemaIdToApplicationQualification < ActiveRecord::Migration[8.1]
+  def change
+    add_column :application_qualifications, :selected_grade_schema_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_150623) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_15_105421) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -305,6 +305,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_150623) do
     t.uuid "qualification_level_uuid"
     t.string "qualification_type"
     t.string "qualification_type_hesa_code"
+    t.string "selected_grade_schema_id"
     t.string "start_year"
     t.string "subject"
     t.string "subject_hesa_code"

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -212,6 +212,7 @@ erDiagram
 		uuid qualification_level_uuid
 		string qualification_type
 		string qualification_type_hesa_code
+		string selected_grade_schema_id
 		string start_year
 		string subject
 		string subject_hesa_code


### PR DESCRIPTION
## Context

This is a migration relating to #12103. You can see its use for storing the uuid of a selected grade schema on ApplicationQualification in the related PR.

## Changes proposed in this pull request

- Add `selected_grade_schema_id` to ApplicationQualification

## Guidance to review

- See its use in the related PR 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [x] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
