### PR TITLE
2818 - Upgrade Postgres to v17 in qa and staging and enable WAL for Airbyte

### DIFF
--- a/.github/workflows/backup-db-sanitise.yml
+++ b/.github/workflows/backup-db-sanitise.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -38,16 +38,6 @@ jobs:
   backup:
     name: Backup database
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     environment:
       name: ${{ inputs.environment || 'production' }}
     env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -197,7 +197,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -21,4 +21,5 @@ module "postgres" {
   azure_maintenance_window       = var.azure_maintenance_window
   azure_extensions               = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "PGCRYPTO", "UNACCENT"]
   alert_window_size              = var.alert_window_size
+  use_airbyte                    = var.pg_airbyte_enabled
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -54,6 +54,8 @@ variable "redis_queue_sku_name" { default = "Standard" }
 variable "config_short" {}
 variable "service_short" {}
 variable "azure_maintenance_window" { default = null }
+# pg_airbyte_enabled used in the postgres module
+variable "pg_airbyte_enabled" { default = false }
 
 # NEW
 variable "service_name" {}

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -6,5 +6,6 @@
   "deploy_azure_backing_services": false,
   "create_storage_account": true,
   "data_exports_storage_account_name": "s189d01attrvexp",
-  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"
+  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
+  "postgres_server_version": 17
 }

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -20,6 +20,7 @@
   "data_exports_storage_account_name": "s189t01attqaexp",
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
+  "postgres_server_version": 17,
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -21,6 +21,7 @@
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
   "postgres_server_version": 17,
+  "pg_airbyte_enabled": "true",
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -8,5 +8,6 @@
   "create_storage_account": true,
   "data_exports_storage_account_name": "mystorageaccount",
   "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
-  "enable_logit": true
+  "enable_logit": true,
+  "postgres_server_version": 17
 }

--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -17,6 +17,7 @@
   "data_exports_storage_account_name": "s189t01attstgexp",
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
+  "postgres_server_version": 17,
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",

--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -18,6 +18,7 @@
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
   "postgres_server_version": 17,
+  "pg_airbyte_enabled": "true",
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",


### PR DESCRIPTION
## Context

We're looking to upgrade the Postgres version to 17 and in preparation for Airbyte deployment, this also enables WAL via the use_airbyte flag in the DFE postgres module.
https://trello.com/c/7uj01vtZ/2818-upgrade-att-postgres-version

## Changes proposed in this pull request
postgres upgrade
- Override the default version 16 with version 17 in the qa and staging environment.
- Update the version of Postgres referenced in workflows to the default 16.
- Remove the Postgress service section in backup-db workflow as it is not used. 
Airbyte 
- Add variable pg_airbyte_enabled with default of false linked to use_airbyte in DFE postgres module
- Set variable pg_airbyte_enabled to true for QA and Staging to enable
- 
## Guidance to review

- Run command `make qa terraform plan` locally on the branch. The only relevant changes should be to Postgres version change and Airbyte changes for postgres as per below output.
- Run command `make staging terraform-plan` locally on the branch. The only relevant changes should be to Postgres version change and Airbyte changes for postgres as per below output.
-  Run command `make sandbox terraform-plan` locally on the branch. There should be no relevant changes.
-  Run command `make production terraform-plan CONFIRM_PRODUCTION=YES` locally on the branch. There should be no relevant changes.

Airbyte expected changes (for QA and Staging only)
```
 # module.postgres.azurerm_postgresql_flexible_server_configuration.max_replication_slots[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_replication_slots" {
      + id        = (known after apply)
      + name      = "max_replication_slots"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_senders[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_senders" {
      + id        = (known after apply)
      + name      = "max_wal_senders"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_size" {
      + id        = (known after apply)
      + name      = "max_wal_size"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "4096"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.min_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "min_wal_size" {
      + id        = (known after apply)
      + name      = "min_wal_size"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "2048"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.wal_level[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
      + id        = (known after apply)
      + name      = "wal_level"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "logical"
    }
```

**Only merge after the manual upgrade has taken place.**

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
