### PR TITLE
2818 - Upgrade Postgres to v17 and enable Airbyte in sandbox and prod

### DIFF
--- a/.github/workflows/backup-db-sanitise.yml
+++ b/.github/workflows/backup-db-sanitise.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -197,7 +197,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/Makefile
+++ b/Makefile
@@ -335,8 +335,8 @@ show-service: get-cluster-credentials
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/aks/workspace_variables/$(CONFIG).tfvars.json))
 	echo "Show service deployments"
 	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}
-	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-worker
-	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-secondary-worker
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-worker
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-secondary-worker
 	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-clock-worker
 
 scale-app: get-cluster-credentials
@@ -351,6 +351,6 @@ scale-workers: get-cluster-credentials
 	$(if $(REPLICAS),,$(error Missing REPLICAS))
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/aks/workspace_variables/$(CONFIG).tfvars.json))
 	echo "Scaling workers to ${REPLICAS}"
-	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-worker --replicas ${REPLICAS}
-	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-secondary-worker --replicas ${REPLICAS}
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-worker --replicas ${REPLICAS}
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-secondary-worker --replicas ${REPLICAS}
 	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-clock-worker --replicas ${REPLICAS}

--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,8 @@ show-service: get-cluster-credentials
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/aks/workspace_variables/$(CONFIG).tfvars.json))
 	echo "Show service deployments"
 	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}
-	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-worker
-	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-secondary-worker
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-worker
+	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-secondary-worker
 	kubectl -n ${NAMESPACE} get deployment/${SERVICE_NAME}${DSUFFIX}-clock-worker
 
 scale-app: get-cluster-credentials
@@ -350,6 +350,6 @@ scale-workers: get-cluster-credentials
 	$(if $(REPLICAS),,$(error Missing REPLICAS))
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/aks/workspace_variables/$(CONFIG).tfvars.json))
 	echo "Scaling workers to ${REPLICAS}"
-	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-worker --replicas ${REPLICAS}
-	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-secondary-worker --replicas ${REPLICAS}
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-worker --replicas ${REPLICAS}
+	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-solid-queue-secondary-worker --replicas ${REPLICAS}
 	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-clock-worker --replicas ${REPLICAS}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -40,7 +40,7 @@ variable "clock_worker_replicas" { default = 1 }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
 variable "postgres_flexible_server_storage_mb" { default = 32768 }
 variable "postgres_enable_high_availability" { default = false }
-variable "postgres_server_version" { default = "16" }
+variable "postgres_server_version" { default = "17" }
 variable "config_short" {}
 variable "service_short" {}
 variable "azure_maintenance_window" { default = null }

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -63,5 +63,6 @@
       ]
     }
   },
-  "enable_logit": true
+  "enable_logit": true,
+  "pg_airbyte_enabled": "true"
 }

--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -48,5 +48,6 @@
       ]
     }
   },
-  "enable_logit": true
+  "enable_logit": true,
+  "pg_airbyte_enabled": "true"
 }


### PR DESCRIPTION
## Context

We're looking to upgrade the Postgres version to 17 and in enable Airbyte, this change enables WAL via the use_airbyte flag in the DFE postgres module.
https://trello.com/c/7uj01vtZ/2818-upgrade-att-postgres-version

## Changes proposed in this pull request
- Update the default version to 17 which will update sandbox and production environment.
- Update the version of Postgres referenced in workflows to the default 17.
- Add variable pg_airbyte_enabled with default of false linked to use_airbyte in DFE postgres module
- Set variable pg_airbyte_enabled to true for Production and Sandbox to enable
- Update Makefile Show-Service to use new worker deployment names

## Guidance to review

- Run command `make qa terraform plan` locally on the branch. There should be no relevant changes.
- Run command `make staging terraform-plan` locally on the branch. There should be no relevant changes.
-  Run command `make sandbox terraform-plan` locally on the branch. The only relevant changes should be to Postgres version change and Airbyte changes for postgres as per below output..
-  Run command `make production terraform-plan CONFIRM_PRODUCTION=YES` locally on the branch. The only relevant changes should be to Postgres version change and Airbyte changes for postgres as per below output..

Airbyte expected changes (for Sandbox and Production only)
```
  # module.postgres.azurerm_postgresql_flexible_server_configuration.hot_standby_feedback[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "hot_standby_feedback" {
      + id        = (known after apply)
      + name      = "hot_standby_feedback"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "on"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_replication_slots[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_replication_slots" {
      + id        = (known after apply)
      + name      = "max_replication_slots"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_senders[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_senders" {
      + id        = (known after apply)
      + name      = "max_wal_senders"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_size" {
      + id        = (known after apply)
      + name      = "max_wal_size"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "4096"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.min_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "min_wal_size" {
      + id        = (known after apply)
      + name      = "min_wal_size"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "2048"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.sync_replication_slots[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "sync_replication_slots" {
      + id        = (known after apply)
      + name      = "sync_replication_slots"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "on"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.wal_level[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
      + id        = (known after apply)
      + name      = "wal_level"
      + server_id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-att-production-psql"
      + value     = "logical"
    }
```

**Only merge after the manual upgrade has taken place.**

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
