### PR TITLE
Revert "Lb/migrate remaining workers to solid queue (#12063)"

### DIFF
--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -11,7 +11,7 @@ module Integrations
       return render_unprocessable_entity if params['status'].nil?
       return render json: nil, status: :ok if params['reference'].nil?
 
-      ProcessNotifyCallbackWorker.perform_later(reference_status_parameters)
+      ProcessNotifyCallbackWorker.perform_async(reference_status_parameters)
 
       render json: nil, status: :ok
     end

--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -7,19 +7,19 @@ module SupportInterface
     def run
       case params.fetch(:task)
       when 'generate_test_applications'
-        GenerateTestApplications.perform_later
+        GenerateTestApplications.perform_async
         flash[:success] = 'Scheduled job to generate test applications - this might take a while!'
         redirect_to support_interface_tasks_path
       when 'generate_next_cycle_test_applications'
-        GenerateTestApplications.perform_later(true)
+        GenerateTestApplications.perform_async(true)
         flash[:success] = 'Scheduled job to generate next cycle test applications - this might take a while!'
         redirect_to support_interface_tasks_path
       when 'run_end_of_cycle_jobs'
-        EndOfCycle::RunEndOfCycleJobsWorker.perform_later
+        EndOfCycle::RunEndOfCycleJobsWorker.perform_async
         flash[:success] = 'End of cycle jobs are running - this might take awhile!'
         redirect_to support_interface_tasks_path
       when 'delete_test_applications'
-        DeleteTestApplications.perform_later
+        DeleteTestApplications.perform_async
         flash[:success] = 'Scheduled job to delete test applications'
         redirect_to support_interface_tasks_path
       else

--- a/app/forms/support_interface/candidates/bulk_unsubscribe_form.rb
+++ b/app/forms/support_interface/candidates/bulk_unsubscribe_form.rb
@@ -17,7 +17,7 @@ class SupportInterface::Candidates::BulkUnsubscribeForm
                                     .split("\n")
                                     .map(&:strip)
                                     .compact_blank
-    Support::Candidates::BulkUnsubscribeWorker.perform_later(
+    Support::Candidates::BulkUnsubscribeWorker.perform_async(
       audit_user.id,
       audit_comment,
       unsubscribe_email_addresses,

--- a/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
+++ b/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
@@ -30,7 +30,7 @@ module DfE
       end
 
       def retry_worker
-        NonDisclosureTraineeWithdrawalWorker.set(wait: 10.minutes).perform_later(candidate.id)
+        NonDisclosureTraineeWithdrawalWorker.perform_in(10.minutes, candidate.id)
         []
       end
 

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -1,3 +1,4 @@
+require 'redis'
 require './app/workers/vendor_api_request_worker'
 
 class VendorAPIRequestMiddleware
@@ -25,8 +26,12 @@ class VendorAPIRequestMiddleware
     @request = Rack::Request.new(env)
     status, @headers, @response = @app.call(env)
 
-    if trace_request?
-      VendorAPIRequestWorker.perform_later(request_data, response_data, status, Time.zone.now.to_s)
+    begin
+      if trace_request?
+        VendorAPIRequestWorker.perform_async(request_data, response_data, status, Time.zone.now.to_s)
+      end
+    rescue Redis::BaseError => e
+      Rails.logger.warn e.message
     end
 
     [status, @headers, @response]

--- a/app/models/adviser/sign_up_form.rb
+++ b/app/models/adviser/sign_up_form.rb
@@ -12,7 +12,7 @@ class Adviser::SignUpForm
     return false if invalid?
 
     sign_up_request = Adviser::SignUpRequest.find_or_create_by(application_form: application_form, teaching_subject: preferred_teaching_subject)
-    AdviserSignUpWorker.perform_later(sign_up_request.id)
+    AdviserSignUpWorker.perform_async(sign_up_request.id)
 
     application_form.adviser_status_waiting_to_be_assigned!
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -818,8 +818,8 @@ private
         region_code: find_international_region_from_country,
       )
     else
-      GeocodeApplicationAddressWorker.set(wait: 5.seconds).perform_later(id)
-      LookupAreaByPostcodeWorker.set(wait: 10.seconds).perform_later(id)
+      GeocodeApplicationAddressWorker.perform_in(5.seconds, id)
+      LookupAreaByPostcodeWorker.perform_in(10.seconds, id)
     end
   end
 

--- a/app/models/concerns/adviser_eligibility.rb
+++ b/app/models/concerns/adviser_eligibility.rb
@@ -52,7 +52,7 @@ private
 
   def refresh_adviser_status
     Rails.cache.fetch("adviser_status_check_#{id}", expires_in: ADVISER_STATUS_CHECK_INTERVAL) do
-      Adviser::RefreshAdviserStatusWorker.perform_later(id)
+      Adviser::RefreshAdviserStatusWorker.perform_async(id)
       true
     end
   end

--- a/app/models/previous_teacher_training.rb
+++ b/app/models/previous_teacher_training.rb
@@ -59,7 +59,7 @@ class PreviousTeacherTraining < ApplicationRecord
       application_form.touch
 
       if FeatureFlag.active?(:import_non_disclosure_trainee_withdrawals)
-        NonDisclosureTraineeWithdrawalWorker.perform_later(application_form.candidate_id)
+        NonDisclosureTraineeWithdrawalWorker.perform_async(application_form.candidate_id)
       end
     end
   end

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -21,7 +21,7 @@ module Publications
       return if Publications::NationalRecruitmentPerformanceReport.exists?(cycle_week:, recruitment_cycle_year:)
 
       Publications::NationalRecruitmentPerformanceReportWorker
-        .perform_later(cycle_week, recruitment_cycle_year)
+        .perform_async(cycle_week, recruitment_cycle_year)
     end
 
     def schedule_regional_report
@@ -33,7 +33,7 @@ module Publications
         )
 
         Publications::RegionalRecruitmentPerformanceReportWorker
-          .perform_later(cycle_week, region, recruitment_cycle_year)
+          .perform_async(cycle_week, region, recruitment_cycle_year)
       end
     end
 
@@ -47,7 +47,7 @@ module Publications
         ).count == Publications::ProviderEdiReport.categories.count
 
         Publications::RegionalEdiReportWorker
-          .perform_later(cycle_week, region, recruitment_cycle_year)
+          .perform_async(cycle_week, region, recruitment_cycle_year)
       end
     end
 
@@ -56,7 +56,7 @@ module Publications
         .call(cycle_week:, recruitment_cycle_year:)
         .find_each do |provider|
         Publications::ProviderEdiReportWorker
-          .perform_later(
+          .perform_async(
             provider.id,
             cycle_week,
             recruitment_cycle_year,
@@ -69,7 +69,7 @@ module Publications
         .call(cycle_week:, recruitment_cycle_year:)
         .find_each do |provider|
         Publications::ProviderRecruitmentPerformanceReportWorker
-          .perform_later(
+          .perform_async(
             provider.id,
             cycle_week,
             recruitment_cycle_year,

--- a/app/models/support_interface/notify_send_request.rb
+++ b/app/models/support_interface/notify_send_request.rb
@@ -8,7 +8,7 @@ module SupportInterface
     has_one_attached :file
 
     def send_emails
-      Support::SendNotifyTemplateWithAttachmentWorker.perform_later(id)
+      Support::SendNotifyTemplateWithAttachmentWorker.perform_async(id)
     end
   end
 end

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         CandidateMailer.application_choice_submitted(application_choice).deliver_later
 
         if FeatureFlag.active?(:import_non_disclosure_trainee_withdrawals)
-          NonDisclosureTraineeWithdrawalWorker.perform_later(application_form.candidate_id)
+          NonDisclosureTraineeWithdrawalWorker.perform_async(application_form.candidate_id)
         end
 
         LocationPreferences.add_dynamic_location(

--- a/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
+++ b/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
@@ -8,7 +8,7 @@ module DataMigrations
 
       choices_without_work_histories.each_slice(5000).with_index do |ids, index|
         next_batch_time = time_now + index.minutes
-        MigrateApplicationChoicesWorker.set(wait_until: next_batch_time).perform_later(ids)
+        MigrateApplicationChoicesWorker.perform_at(next_batch_time, ids)
       end
     end
 

--- a/app/services/data_migrations/delete_all_old_audits.rb
+++ b/app/services/data_migrations/delete_all_old_audits.rb
@@ -4,7 +4,7 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      DeleteAllOldAuditsInBatches.perform_later
+      DeleteAllOldAuditsInBatches.perform_async
     end
   end
 end

--- a/app/services/data_migrations/delete_work_history_audits.rb
+++ b/app/services/data_migrations/delete_work_history_audits.rb
@@ -6,7 +6,7 @@ module DataMigrations
 
     def change
       relation.in_batches(of: BATCH_SIZE) do |batch|
-        DeleteAuditsWorker.perform_later(batch.ids)
+        DeleteAuditsWorker.perform_async(batch.ids)
       end
     end
 

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -12,7 +12,7 @@ class DeclineOffer
     )
 
     if @application_choice.application_form.ended_without_success?
-      CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker.perform_later(@application_choice.id)
+      CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker.perform_async(@application_choice.id)
     end
 
     NotificationsList.for(@application_choice, event: :declined, include_ratifying_provider: true).each do |provider_user|

--- a/app/services/decline_or_withdraw_application.rb
+++ b/app/services/decline_or_withdraw_application.rb
@@ -16,7 +16,7 @@ class DeclineOrWithdrawApplication
       cancel_upcoming_interviews!
     end
 
-    CandidateMailers::SendWithdrawnOnRequestEmailWorker.perform_later(application_choice.id)
+    CandidateMailers::SendWithdrawnOnRequestEmailWorker.perform_async(application_choice.id)
 
     true
   end

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -36,7 +36,7 @@ class GenerateTestApplicationsForProvider
 
       raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
 
-      GenerateTestApplicationsForCourses.perform_later(
+      GenerateTestApplicationsForCourses.perform_async(
         course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle, received_state_only
       )
     end

--- a/app/services/provider_interface/change_choices_to_main_site.rb
+++ b/app/services/provider_interface/change_choices_to_main_site.rb
@@ -38,7 +38,7 @@ module ProviderInterface
 
           batch_size = 100
           choices.in_batches(of: batch_size) do |batch|
-            Provider::ChangeChoicesToMainSiteWorker.perform_later(batch.ids)
+            Provider::ChangeChoicesToMainSiteWorker.perform_async(batch.ids)
             jobs_counter += 1
           end
         end

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -33,7 +33,7 @@ class RejectApplication
 
       CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
 
-      CandidateMailers::SendRejectionEmailWorker.perform_later(@application_choice.id)
+      CandidateMailers::SendRejectionEmailWorker.perform_async(@application_choice.id)
     end
 
     true

--- a/app/services/teacher_training_public_api/sync_2026_course_uuids_in_sandbox.rb
+++ b/app/services/teacher_training_public_api/sync_2026_course_uuids_in_sandbox.rb
@@ -1,0 +1,50 @@
+module TeacherTrainingPublicAPI
+  class Sync2026CourseUuidsInSandbox
+    # This is a temporary job to fix a specific problem in sandbox. We can delete it after it is run.
+    # It will enable the normal syncs to run again, so only updates the UUID, no other course data.
+
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :low_priority
+
+    def perform
+      return if HostingEnvironment.production?
+
+      # In sandbox there are 420 providers with 2026 courses
+      provider_codes = ::Provider
+                         .joins(:courses)
+                         .where('courses.recruitment_cycle_year': 2026)
+                         .pluck(:code)
+
+      provider_codes.each do |provider_code|
+        Sync2026CourseUuidsInSandboxSecondaryWorker.perform_async(provider_code)
+      end
+    end
+  end
+
+  class Sync2026CourseUuidsInSandboxSecondaryWorker
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :low_priority
+
+    def perform(provider_code)
+      return if HostingEnvironment.production?
+
+      provider = ::Provider.find_by(code: provider_code)
+
+      provider_courses_from_api = TeacherTrainingPublicAPI::Course.where(
+        year: 2026,
+        provider_code: provider_code,
+      ).paginate(per_page: 500)
+
+      provider_courses_from_api.each do |course_from_api|
+        course = provider.courses.find_by(code: course_from_api.code, recruitment_cycle_year: 2026)
+        next if course.blank?
+
+        next if course.uuid == course_from_api.uuid
+
+        course.update!(uuid: course_from_api.uuid)
+      end
+    end
+  end
+end

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -1,9 +1,10 @@
 module TeacherTrainingPublicAPI
-  class SyncCourses < ApplicationJob
-    retry_on StandardError, attempts: 3
-    queue_as :low_priority
-
+  class SyncCourses
     attr_reader :provider, :run_in_background, :incremental_sync, :recruitment_cycle_year
+
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :low_priority
 
     API_COURSE_DRAFT_STATES = %w[rolled_over draft].freeze
 
@@ -46,7 +47,7 @@ module TeacherTrainingPublicAPI
 
         course.save!
         if notify_candidates == true
-          CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker.perform_later(course.id)
+          CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker.perform_async(course.id)
         end
 
         course
@@ -75,7 +76,7 @@ module TeacherTrainingPublicAPI
       ]
 
       if run_in_background
-        TeacherTrainingPublicAPI::SyncSites.perform_later(*job_args)
+        TeacherTrainingPublicAPI::SyncSites.perform_async(*job_args)
       else
         TeacherTrainingPublicAPI::SyncSites.new.perform(*job_args)
       end

--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -15,7 +15,7 @@ module TeacherTrainingPublicAPI
 
     def sync_courses(run_in_background, provider)
       if run_in_background
-        TeacherTrainingPublicAPI::SyncCourses.set(wait: @delay_by).perform_later(provider.id, @recruitment_cycle_year, @incremental_sync)
+        TeacherTrainingPublicAPI::SyncCourses.perform_in(@delay_by, provider.id, @recruitment_cycle_year, @incremental_sync)
       else
         TeacherTrainingPublicAPI::SyncCourses.new.perform(provider.id, @recruitment_cycle_year, @incremental_sync, run_in_background: false)
       end

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -9,11 +9,12 @@ module TeacherTrainingPublicAPI
   #
   # There is no specification for what to do with orphaned sites that are not associated with a CourseOption
   #
-  class SyncSites < ApplicationJob
-    retry_on StandardError, attempts: 3
-    queue_as :low_priority
-
+  class SyncSites
     attr_reader :provider, :course
+
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :low_priority
 
     def perform(provider_id, recruitment_cycle_year, course_id, course_status_from_api, incremental_sync = true)
       @provider = ::Provider.find(provider_id)

--- a/app/services/teacher_training_public_api/sync_subjects.rb
+++ b/app/services/teacher_training_public_api/sync_subjects.rb
@@ -1,8 +1,8 @@
 module TeacherTrainingPublicAPI
-  class SyncSubjects < ApplicationJob
-    retry_on StandardError, attempts: 3
+  class SyncSubjects
+    include Sidekiq::Worker
 
-    queue_as :low_priority
+    sidekiq_options retry: 3, queue: :low_priority
 
     def perform
       TeacherTrainingPublicAPI::Subject.paginate(per_page: 500).each do |api_subject|

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -34,7 +34,7 @@ class WithdrawApplication
     ).call!
 
     if application_choice.application_form.ended_without_success?
-      CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker.perform_later(application_choice.application_form_id)
+      CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker.perform_async(application_choice.application_form_id)
     end
 
     send_email_notification_to_provider_users

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -27,7 +27,7 @@ class WithdrawOffer
         )
       end
 
-      CandidateMailers::SendWithdrawnOfferEmailWorker.perform_later(@application_choice.id)
+      CandidateMailers::SendWithdrawnOfferEmailWorker.perform_async(@application_choice.id)
 
       true
     end

--- a/app/workers/adviser/fetch_teaching_subjects_worker.rb
+++ b/app/workers/adviser/fetch_teaching_subjects_worker.rb
@@ -1,4 +1,6 @@
 class Adviser::FetchTeachingSubjectsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/adviser/refresh_adviser_status_worker.rb
+++ b/app/workers/adviser/refresh_adviser_status_worker.rb
@@ -1,4 +1,6 @@
-class Adviser::RefreshAdviserStatusWorker < ApplicationJob
+class Adviser::RefreshAdviserStatusWorker
+  include Sidekiq::Worker
+
   def perform(application_form_id)
     return unless FeatureFlag.active?(:adviser_sign_up)
 

--- a/app/workers/adviser_sign_up_worker.rb
+++ b/app/workers/adviser_sign_up_worker.rb
@@ -1,4 +1,6 @@
-class AdviserSignUpWorker < ApplicationJob
+class AdviserSignUpWorker
+  include Sidekiq::Worker
+
   attr_reader :application_form, :candidate_matchback, :preferred_teaching_subject_id
 
   MATCHBACK_ATTRIBUTES = %i[

--- a/app/workers/cancel_previous_cycle_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_previous_cycle_unsubmitted_applications_worker.rb
@@ -1,4 +1,6 @@
-class CancelPreviousCycleUnsubmittedApplicationsWorker < ApplicationJob
+class CancelPreviousCycleUnsubmittedApplicationsWorker
+  include Sidekiq::Worker
+
   def perform
     unsubmitted_applications_from_earlier_cycle.each do |application_form|
       CandidateInterface::CancelUnsubmittedApplicationAtEndOfCycle.new(application_form).call

--- a/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
+++ b/app/workers/candidate/delete_draft_candidate_preferences_worker.rb
@@ -1,4 +1,6 @@
 class Candidate::DeleteDraftCandidatePreferencesWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
+++ b/app/workers/candidate/delete_draft_withdrawal_reason_records_worker.rb
@@ -1,4 +1,6 @@
 class Candidate::DeleteDraftWithdrawalReasonRecordsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/candidate/english_proficiency_data_conversion_worker.rb
+++ b/app/workers/candidate/english_proficiency_data_conversion_worker.rb
@@ -1,4 +1,6 @@
 class Candidate::EnglishProficiencyDataConversionWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/candidate/pool_eligible_application_form_worker.rb
+++ b/app/workers/candidate/pool_eligible_application_form_worker.rb
@@ -1,5 +1,7 @@
-class Candidate::PoolEligibleApplicationFormWorker < ApplicationJob
-  queue_as :low_priority
+class Candidate::PoolEligibleApplicationFormWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform
     application_forms = Pool::Candidates.new.application_forms_in_the_pool.select(:id)

--- a/app/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_change_worker.rb
+++ b/app/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_change_worker.rb
@@ -1,5 +1,7 @@
 module CandidateMailers
-  class EnqueueVisaSponsorshipDeadlineChangeWorker < ApplicationJob
+  class EnqueueVisaSponsorshipDeadlineChangeWorker
+    include Sidekiq::Worker
+
     def perform(course_id)
       course = Course.open.find_by(id: course_id)
       return if course.nil?
@@ -17,7 +19,8 @@ module CandidateMailers
         batch_size: 120,
         stagger_over:,
       ).each do |batch_time, records|
-        SendVisaSponsorshipDeadlineChangeWorker.set(wait_until: batch_time).perform_later(
+        SendVisaSponsorshipDeadlineChangeWorker.perform_at(
+          batch_time,
           records.pluck(:id),
         )
       end

--- a/app/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_reminder_worker.rb
+++ b/app/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_reminder_worker.rb
@@ -1,5 +1,7 @@
 module CandidateMailers
   class EnqueueVisaSponsorshipDeadlineReminderWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     def perform
       relation = ApplicationChoicesVisaSponsorshipDeadlineReminder.call
 

--- a/app/workers/candidate_mailers/send_declined_last_application_choice_email_worker.rb
+++ b/app/workers/candidate_mailers/send_declined_last_application_choice_email_worker.rb
@@ -1,4 +1,6 @@
-class CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker < ApplicationJob
+class CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker
+  include Sidekiq::Worker
+
   def perform(application_choice_id)
     application_choice = ApplicationChoice.find(application_choice_id)
 

--- a/app/workers/candidate_mailers/send_rejection_email_worker.rb
+++ b/app/workers/candidate_mailers/send_rejection_email_worker.rb
@@ -1,4 +1,6 @@
-class CandidateMailers::SendRejectionEmailWorker < ApplicationJob
+class CandidateMailers::SendRejectionEmailWorker
+  include Sidekiq::Worker
+
   def perform(application_choice_id)
     application_choice = ApplicationChoice.find(application_choice_id)
 

--- a/app/workers/candidate_mailers/send_visa_sponsorship_deadline_change_worker.rb
+++ b/app/workers/candidate_mailers/send_visa_sponsorship_deadline_change_worker.rb
@@ -1,6 +1,8 @@
 module CandidateMailers
-  class SendVisaSponsorshipDeadlineChangeWorker < ApplicationJob
-    queue_as :mailers
+  class SendVisaSponsorshipDeadlineChangeWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :mailers
 
     def perform(application_choice_ids)
       ApplicationChoice.where(id: application_choice_ids).each do |choice|

--- a/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
+++ b/app/workers/candidate_mailers/send_visa_sponsorship_deadline_reminder_worker.rb
@@ -1,5 +1,7 @@
 module CandidateMailers
   class SendVisaSponsorshipDeadlineReminderWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     def perform(application_choice_ids)
       ApplicationChoice.where(id: application_choice_ids).each do |choice|
         application_form = choice.application_form

--- a/app/workers/candidate_mailers/send_withdrawn_last_application_choice_email_worker.rb
+++ b/app/workers/candidate_mailers/send_withdrawn_last_application_choice_email_worker.rb
@@ -1,4 +1,6 @@
-class CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker < ApplicationJob
+class CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker
+  include Sidekiq::Worker
+
   def perform(application_form_id)
     application_form = ApplicationForm.find(application_form_id)
 

--- a/app/workers/candidate_mailers/send_withdrawn_offer_email_worker.rb
+++ b/app/workers/candidate_mailers/send_withdrawn_offer_email_worker.rb
@@ -1,4 +1,6 @@
-class CandidateMailers::SendWithdrawnOfferEmailWorker < ApplicationJob
+class CandidateMailers::SendWithdrawnOfferEmailWorker
+  include Sidekiq::Worker
+
   def perform(application_choice_id)
     application_choice = ApplicationChoice.find(application_choice_id)
 

--- a/app/workers/candidate_mailers/send_withdrawn_on_request_email_worker.rb
+++ b/app/workers/candidate_mailers/send_withdrawn_on_request_email_worker.rb
@@ -1,4 +1,6 @@
-class CandidateMailers::SendWithdrawnOnRequestEmailWorker < ApplicationJob
+class CandidateMailers::SendWithdrawnOnRequestEmailWorker
+  include Sidekiq::Worker
+
   def perform(application_choice_id)
     application_choice = ApplicationChoice.find(application_choice_id)
 

--- a/app/workers/chase_references.rb
+++ b/app/workers/chase_references.rb
@@ -1,4 +1,6 @@
 class ChaseReferences < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   REFEREE_CHASERS = [
     {
       after: 7.days,

--- a/app/workers/chasers/candidate/offer_worker.rb
+++ b/app/workers/chasers/candidate/offer_worker.rb
@@ -1,6 +1,8 @@
 module Chasers
   module Candidate
     class OfferWorker < ApplicationJob
+      self.queue_adapter = :solid_queue
+
       def perform
         Chasers::Candidate.chaser_to_date_range.each do |chaser_type, date_range|
           mailer = chaser_type

--- a/app/workers/clean_up_course_options_with_no_study_mode.rb
+++ b/app/workers/clean_up_course_options_with_no_study_mode.rb
@@ -1,4 +1,6 @@
-class CleanUpCourseOptionsWithNoStudyMode < ApplicationJob
+class CleanUpCourseOptionsWithNoStudyMode
+  include Sidekiq::Worker
+
   def perform
     CourseOption.where('study_mode IN (\'0\',\'1\')').find_each do |nil_co|
       intended_study_mode = case nil_co.study_mode_before_type_cast

--- a/app/workers/data_exporter.rb
+++ b/app/workers/data_exporter.rb
@@ -1,8 +1,10 @@
 class DataExporter < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform(importer_class, data_export_type, export_options = {})
     RequestLocals.store[:debugging_info] = { data_export_type:, importer_class: }
 
-    Rails.logger.info 'SolidQueue running. Loading data export record'
+    Rails.logger.info 'Sidekiq running. Loading data export record'
     data_export = DataExport.find(data_export_type)
 
     Rails.logger.info 'Started CSV generation'
@@ -26,7 +28,7 @@ class DataExporter < ApplicationJob
       completed_at: Time.current,
     )
 
-    Rails.logger.info 'Finished writing CSV. SolidQueue done'
+    Rails.logger.info 'Finished writing CSV. Sidekiq done'
   end
 
 private

--- a/app/workers/deactivate_stale_service_api_tokens_worker.rb
+++ b/app/workers/deactivate_stale_service_api_tokens_worker.rb
@@ -1,4 +1,6 @@
 class DeactivateStaleServiceAPITokensWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   INACTIVE_MONTHS_AGO = 3

--- a/app/workers/delete_all_drafts_worker.rb
+++ b/app/workers/delete_all_drafts_worker.rb
@@ -1,4 +1,6 @@
 class DeleteAllDraftsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/delete_all_old_audits_in_batches.rb
+++ b/app/workers/delete_all_old_audits_in_batches.rb
@@ -1,5 +1,7 @@
-class DeleteAllOldAuditsInBatches < ApplicationJob
-  queue_as :low_priority
+class DeleteAllOldAuditsInBatches
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform
     before = Time.zone.local(2022, 10, 4)

--- a/app/workers/delete_audits_worker.rb
+++ b/app/workers/delete_audits_worker.rb
@@ -1,5 +1,7 @@
-class DeleteAuditsWorker < ApplicationJob
-  queue_as :low_priority
+class DeleteAuditsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform(audit_ids)
     Audited::Audit.where(id: audit_ids).delete_all

--- a/app/workers/delete_expired_sessions_worker.rb
+++ b/app/workers/delete_expired_sessions_worker.rb
@@ -1,4 +1,6 @@
 class DeleteExpiredSessionsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/delete_finished_jobs_worker.rb
+++ b/app/workers/delete_finished_jobs_worker.rb
@@ -1,4 +1,6 @@
 class DeleteFinishedJobsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/delete_test_applications.rb
+++ b/app/workers/delete_test_applications.rb
@@ -1,4 +1,6 @@
-class DeleteTestApplications < ApplicationJob
+class DeleteTestApplications
+  include Sidekiq::Worker
+
   def perform(*)
     raise 'You can only delete test applications in a test environment' unless DeleteTestApplications.can_run_in_this_environment?
 

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -1,5 +1,7 @@
 # Detect state that *should* be impossible in the system and report them to Sentry
 class DetectInvariantsDailyCheck < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform
     detect_if_the_monthly_statistics_has_not_run
   end

--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -1,4 +1,6 @@
 class DetectInvariantsHourlyCheck < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform
     detect_course_sync_not_succeeded_for_an_hour unless HostingEnvironment.review?
     detect_unauthorised_application_form_edits

--- a/app/workers/end_of_cycle/cancel_reference_requests_worker.rb
+++ b/app/workers/end_of_cycle/cancel_reference_requests_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class CancelReferenceRequestsWorker < ApplicationJob
+  class CancelReferenceRequestsWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 200
 
     def perform
       return unless run?
 
       BatchDelivery.new(relation:, stagger_over: 2.hours, batch_size: BATCH_SIZE).each do |batch_time, references|
-        CancelReferenceRequestsSecondaryWorker.set(wait_until: batch_time).perform_later(references.pluck(:id))
+        CancelReferenceRequestsSecondaryWorker.perform_at(batch_time, references.pluck(:id))
       end
     end
 
@@ -47,7 +49,9 @@ module EndOfCycle
     end
   end
 
-  class CancelReferenceRequestsSecondaryWorker < ApplicationJob
+  class CancelReferenceRequestsSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(reference_ids)
       ApplicationReference.feedback_requested.where(id: reference_ids).find_each do |reference|
         CancelReferee.new.call(reference:)

--- a/app/workers/end_of_cycle/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/end_of_cycle/cancel_unsubmitted_applications_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class CancelUnsubmittedApplicationsWorker < ApplicationJob
+  class CancelUnsubmittedApplicationsWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 200
 
     def perform(force = false)
       return unless EndOfCycle::JobTimetabler.new.run_cancel_unsubmitted_applications? || force
 
       BatchDelivery.new(relation:, stagger_over: 2.hours, batch_size: BATCH_SIZE).each do |batch_time, applications|
-        CancelUnsubmittedApplicationsSecondaryWorker.set(wait_until: batch_time).perform_later(applications.pluck(:id))
+        CancelUnsubmittedApplicationsSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end
 
@@ -18,7 +20,9 @@ module EndOfCycle
     end
   end
 
-  class CancelUnsubmittedApplicationsSecondaryWorker < ApplicationJob
+  class CancelUnsubmittedApplicationsSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       application_forms = ApplicationForm.where(id: application_form_ids).includes(:application_choices)
       application_forms.find_each do |application_form|

--- a/app/workers/end_of_cycle/close_courses_on_invites.rb
+++ b/app/workers/end_of_cycle/close_courses_on_invites.rb
@@ -1,6 +1,6 @@
 module EndOfCycle
-  class CloseCoursesOnInvites < ApplicationJob
-    # Updated by Junie
+  class CloseCoursesOnInvites
+    include Sidekiq::Worker
 
     def perform(force = false)
       return unless EndOfCycle::JobTimetabler.new.run_cancel_unsubmitted_applications? || force

--- a/app/workers/end_of_cycle/decline_by_default_worker.rb
+++ b/app/workers/end_of_cycle/decline_by_default_worker.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
-  class DeclineByDefaultWorker < ApplicationJob
+  class DeclineByDefaultWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
     STAGGER_OVER = 1.minute
 
@@ -7,7 +9,7 @@ module EndOfCycle
       return unless run_decline_by_default? || force
 
       BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
-        DeclineByDefaultSecondaryWorker.set(wait_until: batch_time).perform_later(applications.pluck(:id))
+        DeclineByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end
 
@@ -35,7 +37,9 @@ module EndOfCycle
     end
   end
 
-  class DeclineByDefaultSecondaryWorker < ApplicationJob
+  class DeclineByDefaultSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       application_forms = ApplicationForm.where(id: application_form_ids).includes(:application_choices)
       application_forms.find_each do |application_form|

--- a/app/workers/end_of_cycle/next_year_incremental_sync.rb
+++ b/app/workers/end_of_cycle/next_year_incremental_sync.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
   class NextYearIncrementalSync < SyncNextYearsCoursesAndProviders
+    self.queue_adapter = :solid_queue
+
     def perform
       return unless sync_next_year?
 

--- a/app/workers/end_of_cycle/reject_by_default_worker.rb
+++ b/app/workers/end_of_cycle/reject_by_default_worker.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
-  class RejectByDefaultWorker < ApplicationJob
+  class RejectByDefaultWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
     STAGGER_OVER = 1.hour
 
@@ -7,7 +9,7 @@ module EndOfCycle
       return unless run_reject_by_default? || force
 
       BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
-        RejectByDefaultSecondaryWorker.set(wait_until: batch_time).perform_later(applications.pluck(:id))
+        RejectByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end
 
@@ -36,7 +38,9 @@ module EndOfCycle
     end
   end
 
-  class RejectByDefaultSecondaryWorker < ApplicationJob
+  class RejectByDefaultSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       application_forms = ApplicationForm.where(id: application_form_ids).includes(:application_choices)
       application_forms.find_each do |application_form|

--- a/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
+++ b/app/workers/end_of_cycle/run_end_of_cycle_jobs_worker.rb
@@ -1,26 +1,28 @@
 module EndOfCycle
-  class RunEndOfCycleJobsWorker < ApplicationJob
+  class RunEndOfCycleJobsWorker
+    include Sidekiq::Worker
+
     def perform
       if current_timetable.after_apply_deadline?
-        EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_later(true)
-        EndOfCycle::CloseCoursesOnInvites.perform_later(true)
+        EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_async(true)
+        EndOfCycle::CloseCoursesOnInvites.perform_async(true)
       end
 
       if current_timetable.after_reject_by_default?
-        EndOfCycle::RejectByDefaultWorker.perform_later(true)
+        EndOfCycle::RejectByDefaultWorker.perform_async(true)
       end
 
       if current_timetable.after_decline_by_default?
-        EndOfCycle::DeclineByDefaultWorker.perform_later(true)
-        EndOfCycle::CancelReferenceRequestsWorker.perform_later
+        EndOfCycle::DeclineByDefaultWorker.perform_async(true)
+        EndOfCycle::CancelReferenceRequestsWorker.perform_async
       end
 
       if Time.zone.now.after?(previous_timetable.winter_reject_by_default_at)
-        EndOfCycle::WinterRejectByDefaultWorker.perform_later(true)
+        EndOfCycle::WinterRejectByDefaultWorker.perform_async(true)
       end
 
       if Time.zone.now.after?(previous_timetable.winter_decline_by_default_at)
-        EndOfCycle::WinterDeclineByDefaultWorker.perform_later(true)
+        EndOfCycle::WinterDeclineByDefaultWorker.perform_async(true)
       end
     end
 

--- a/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendApplicationDeadlineHasPassedEmailToCandidatesWorker < ApplicationJob
+  class SendApplicationDeadlineHasPassedEmailToCandidatesWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless EndOfCycle::CandidateEmailTimetabler.new.send_application_deadline_has_passed_email?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker.set(wait_until: batch_time).perform_later(application_forms.pluck(:id))
+        SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -19,7 +21,9 @@ module EndOfCycle
     end
   end
 
-  class SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker < ApplicationJob
+  class SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       ApplicationForm.where(id: application_form_ids).find_each do |application_form|
         CandidateMailer.application_deadline_has_passed(application_form).deliver_later

--- a/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendDeclineByDefaultExplainerEmailToCandidatesWorker < ApplicationJob
+  class SendDeclineByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless CandidateEmailTimetabler.new.send_decline_by_default_explainer?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker.set(wait_until: batch_time).perform_later(application_forms.pluck(:id))
+        SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -19,7 +21,9 @@ module EndOfCycle
     end
   end
 
-  class SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker < ApplicationJob
+  class SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
         CandidateMailer.decline_by_default_explainer(application_form).deliver_later

--- a/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendRejectByDefaultExplainerEmailToCandidatesWorker < ApplicationJob
+  class SendRejectByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless CandidateEmailTimetabler.new.send_reject_by_default_explainer?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendRejectByDefaultExplainerEmailToCandidatesBatchWorker.set(wait_until: batch_time).perform_later(application_forms.pluck(:id))
+        SendRejectByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -19,7 +21,9 @@ module EndOfCycle
     end
   end
 
-  class SendRejectByDefaultExplainerEmailToCandidatesBatchWorker < ApplicationJob
+  class SendRejectByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
         if application_form.application_choices.pluck(:status).include?('offer')

--- a/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendRejectByDefaultReminderToProvidersWorker < ApplicationJob
+  class SendRejectByDefaultReminderToProvidersWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless send_email?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, providers|
-        SendRejectByDefaultReminderToProvidersBatchWorker.set(wait_until: batch_time).perform_later(providers.pluck(:id))
+        SendRejectByDefaultReminderToProvidersBatchWorker.perform_at(batch_time, providers.pluck(:id))
       end
     end
 
@@ -24,7 +26,9 @@ module EndOfCycle
     end
   end
 
-  class SendRejectByDefaultReminderToProvidersBatchWorker < ApplicationJob
+  class SendRejectByDefaultReminderToProvidersBatchWorker
+    include Sidekiq::Worker
+
     def perform(provider_ids)
       Provider.where(id: provider_ids).includes(:provider_users).find_each do |provider|
         SendRejectByDefaultReminderToProvidersService.new(provider).call

--- a/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker < ApplicationJob
+  class SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless send_emails?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker.set(wait_until: batch_time).perform_later(application_forms.pluck(:id))
+        SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -31,7 +33,9 @@ module EndOfCycle
     end
   end
 
-  class SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker < ApplicationJob
+  class SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
         CandidateMailer.winter_decline_by_default_explainer(application_form).deliver_later

--- a/app/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker.rb
@@ -1,14 +1,14 @@
 module EndOfCycle
-  class SendWinterRejectByDefaultExplainerEmailToCandidatesWorker < ApplicationJob
+  class SendWinterRejectByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless send_emails?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
-        SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker
-          .set(wait_until: batch_time)
-          .perform_later(application_forms.pluck(:id))
+        SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
       end
     end
 
@@ -33,7 +33,9 @@ module EndOfCycle
     end
   end
 
-  class SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker < ApplicationJob
+  class SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
         if application_form.application_choices.pluck(:status).include?('offer')

--- a/app/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker.rb
+++ b/app/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker.rb
@@ -1,12 +1,14 @@
 module EndOfCycle
-  class SendWinterRejectByDefaultReminderToProvidersWorker < ApplicationJob
+  class SendWinterRejectByDefaultReminderToProvidersWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
 
     def perform
       return unless send_email?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, providers|
-        SendWinterRejectByDefaultReminderToProvidersBatchWorker.set(wait_until: batch_time).perform_later(providers.pluck(:id))
+        SendWinterRejectByDefaultReminderToProvidersBatchWorker.perform_at(batch_time, providers.pluck(:id))
       end
     end
 
@@ -24,7 +26,9 @@ module EndOfCycle
     end
   end
 
-  class SendWinterRejectByDefaultReminderToProvidersBatchWorker < ApplicationJob
+  class SendWinterRejectByDefaultReminderToProvidersBatchWorker
+    include Sidekiq::Worker
+
     def perform(provider_ids)
       Provider.where(id: provider_ids).includes(:provider_users).find_each do |provider|
         SendWinterRejectByDefaultReminderToProvidersService.new(provider).call

--- a/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
+++ b/app/workers/end_of_cycle/sync_next_years_courses_and_providers.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
   class SyncNextYearsCoursesAndProviders < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     def first_full_sync_after
       start_syncing_after = 2.weeks.before(current_timetable.apply_deadline_at).change(hour: 0o0, min: 4)
       start_syncing_after = start_syncing_after.next_occurring(:friday) unless start_syncing_after.friday?

--- a/app/workers/end_of_cycle/winter_decline_by_default_worker.rb
+++ b/app/workers/end_of_cycle/winter_decline_by_default_worker.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
-  class WinterDeclineByDefaultWorker < ApplicationJob
+  class WinterDeclineByDefaultWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
     STAGGER_OVER = 1.minute
 
@@ -7,7 +9,7 @@ module EndOfCycle
       return unless run_winter_decline_by_default? || force
 
       BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
-        WinterDeclineByDefaultSecondaryWorker.set(wait_until: batch_time).perform_later(applications.pluck(:id))
+        WinterDeclineByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end
 
@@ -25,7 +27,9 @@ module EndOfCycle
     end
   end
 
-  class WinterDeclineByDefaultSecondaryWorker < ApplicationJob
+  class WinterDeclineByDefaultSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       application_forms = ApplicationForm.where(id: application_form_ids).includes(:application_choices)
       application_forms.find_each do |application_form|

--- a/app/workers/end_of_cycle/winter_reject_by_default_worker.rb
+++ b/app/workers/end_of_cycle/winter_reject_by_default_worker.rb
@@ -1,5 +1,7 @@
 module EndOfCycle
-  class WinterRejectByDefaultWorker < ApplicationJob
+  class WinterRejectByDefaultWorker
+    include Sidekiq::Worker
+
     BATCH_SIZE = 120
     STAGGER_OVER = 1.hour
 
@@ -7,7 +9,7 @@ module EndOfCycle
       return unless run_winter_reject_by_default? || force
 
       BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
-        WinterRejectByDefaultSecondaryWorker.set(wait_until: batch_time).perform_later(applications.pluck(:id))
+        WinterRejectByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end
 
@@ -25,7 +27,9 @@ module EndOfCycle
     end
   end
 
-  class WinterRejectByDefaultSecondaryWorker < ApplicationJob
+  class WinterRejectByDefaultSecondaryWorker
+    include Sidekiq::Worker
+
     def perform(application_form_ids)
       application_forms = ApplicationForm.where(id: application_form_ids).includes(:application_choices)
       application_forms.find_each do |application_form|

--- a/app/workers/find_a_candidate/pool_invite_chaser_worker.rb
+++ b/app/workers/find_a_candidate/pool_invite_chaser_worker.rb
@@ -1,5 +1,7 @@
 module FindACandidate
   class PoolInviteChaserWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     def perform
       invites = Pool::Invite.current_cycle.published.not_responded
         .where.missing(:chasers_sent)

--- a/app/workers/find_a_candidate/populate_pool_worker.rb
+++ b/app/workers/find_a_candidate/populate_pool_worker.rb
@@ -1,4 +1,6 @@
 class FindACandidate::PopulatePoolWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform
     if CandidatePoolApplication.closed?
       CandidatePoolApplication.delete_all

--- a/app/workers/find_a_candidate/send_chaser_worker.rb
+++ b/app/workers/find_a_candidate/send_chaser_worker.rb
@@ -1,5 +1,7 @@
 module FindACandidate
   class SendChaserWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     def perform(invite_ids)
       ActiveRecord::Base.transaction do
         invites = Pool::Invite.current_cycle.published.not_responded

--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -1,4 +1,6 @@
 class GenerateMonthlyStatistics < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   retry_on StandardError, attempts: 3
 
   def perform(force = false, generation_date = nil, publication_date = nil)

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -1,4 +1,6 @@
-class GenerateTestApplications < ApplicationJob
+class GenerateTestApplications
+  include Sidekiq::Worker
+
   def perform(next_cycle_applications = false)
     raise 'You cannot generate test data in production' if HostingEnvironment.production?
 

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -1,4 +1,6 @@
-class GenerateTestApplicationsForCourses < ApplicationJob
+class GenerateTestApplicationsForCourses
+  include Sidekiq::Worker
+
   def perform(course_ids, courses_per_application, previous_cycle, incomplete_references = false, next_cycle = false, received_state_only = false)
     generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle, received_state_only)
   end

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -1,7 +1,7 @@
-class GeocodeApplicationAddressWorker < ApplicationJob
-  queue_as :low_priority
+class GeocodeApplicationAddressWorker
+  include Sidekiq::Worker
 
-  retry_on StandardError, attempts: 5
+  sidekiq_options queue: :low_priority, retry: 5
 
   def perform(application_form_id)
     return unless Geocoder.config.api_key

--- a/app/workers/lookup_area_by_postcode_worker.rb
+++ b/app/workers/lookup_area_by_postcode_worker.rb
@@ -1,7 +1,7 @@
-class LookupAreaByPostcodeWorker < ApplicationJob
-  queue_as :low_priority
+class LookupAreaByPostcodeWorker
+  include Sidekiq::Worker
 
-  retry_on StandardError, attempts: 5
+  sidekiq_options queue: :low_priority, retry: 5
 
   attr_reader :application_form
 

--- a/app/workers/migrate_application_choices_worker.rb
+++ b/app/workers/migrate_application_choices_worker.rb
@@ -1,5 +1,7 @@
-class MigrateApplicationChoicesWorker < ApplicationJob
-  queue_as :low_priority
+class MigrateApplicationChoicesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform(choice_ids)
     return if HostingEnvironment.production?

--- a/app/workers/non_disclosure_trainee_withdrawal_worker.rb
+++ b/app/workers/non_disclosure_trainee_withdrawal_worker.rb
@@ -1,7 +1,7 @@
-class NonDisclosureTraineeWithdrawalWorker < ApplicationJob
-  queue_as :default
+class NonDisclosureTraineeWithdrawalWorker
+  include Sidekiq::Worker
 
-  retry_on StandardError, attempts: 3
+  sidekiq_options retry: 3, queue: :default
 
   def perform(candidate_id)
     return unless HostingEnvironment.production? || HostingEnvironment.qa? || HostingEnvironment.test_environment?

--- a/app/workers/nudge_candidates_worker.rb
+++ b/app/workers/nudge_candidates_worker.rb
@@ -1,5 +1,7 @@
 # This worker will be scheduled to run daily
-class NudgeCandidatesWorker < ApplicationJob
+class NudgeCandidatesWorker
+  include Sidekiq::Worker
+
   Nudge = Struct.new(:query_class, :mailer_action)
   NUDGES = [
     Nudge.new(

--- a/app/workers/process_notify_callback_worker.rb
+++ b/app/workers/process_notify_callback_worker.rb
@@ -1,5 +1,7 @@
-class ProcessNotifyCallbackWorker < ApplicationJob
-  queue_as :low_priority
+class ProcessNotifyCallbackWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform(params)
     ProcessNotifyCallback.new(

--- a/app/workers/process_stale_applications_worker.rb
+++ b/app/workers/process_stale_applications_worker.rb
@@ -1,4 +1,6 @@
 class ProcessStaleApplicationsWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform
     ProcessStaleApplications.new.call
   end

--- a/app/workers/provider/change_choices_to_main_site_worker.rb
+++ b/app/workers/provider/change_choices_to_main_site_worker.rb
@@ -1,5 +1,7 @@
-class Provider::ChangeChoicesToMainSiteWorker < ApplicationJob
-  queue_as :low_priority
+class Provider::ChangeChoicesToMainSiteWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform(choice_ids)
     choices = ApplicationChoice.where(id: choice_ids)

--- a/app/workers/provider/delete_draft_pool_invites_worker.rb
+++ b/app/workers/provider/delete_draft_pool_invites_worker.rb
@@ -1,4 +1,6 @@
 class Provider::DeleteDraftPoolInvitesWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/publications/national_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/national_recruitment_performance_report_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class NationalRecruitmentPerformanceReportWorker < ApplicationJob
-    queue_as :default
+  class NationalRecruitmentPerformanceReportWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform(cycle_week, recruitment_cycle_year)
       Publications::NationalRecruitmentPerformanceReportGenerator.new(

--- a/app/workers/publications/provider_edi_report_worker.rb
+++ b/app/workers/publications/provider_edi_report_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class ProviderEdiReportWorker < ApplicationJob
-    queue_as :default
+  class ProviderEdiReportWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform(provider_id, cycle_week, recruitment_cycle_year)
       ProviderEdiReportGenerator.new(

--- a/app/workers/publications/provider_recruitment_performance_reminder_worker.rb
+++ b/app/workers/publications/provider_recruitment_performance_reminder_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class ProviderRecruitmentPerformanceReminderWorker < ApplicationJob
-    queue_as :default
+  class ProviderRecruitmentPerformanceReminderWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform
       cycle_week = RecruitmentCycleTimetable.current_cycle_week.pred

--- a/app/workers/publications/provider_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/provider_recruitment_performance_report_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class ProviderRecruitmentPerformanceReportWorker < ApplicationJob
-    queue_as :default
+  class ProviderRecruitmentPerformanceReportWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform(provider_id, cycle_week, recruitment_cycle_year)
       ProviderRecruitmentPerformanceReportGenerator.new(

--- a/app/workers/publications/regional_edi_report_worker.rb
+++ b/app/workers/publications/regional_edi_report_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class RegionalEdiReportWorker < ApplicationJob
-    queue_as :default
+  class RegionalEdiReportWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform(cycle_week, region, recruitment_cycle_year)
       Publications::RegionalEdiReportGenerator.new(

--- a/app/workers/publications/regional_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/regional_recruitment_performance_report_worker.rb
@@ -1,8 +1,8 @@
 module Publications
-  class RegionalRecruitmentPerformanceReportWorker < ApplicationJob
-    queue_as :default
+  class RegionalRecruitmentPerformanceReportWorker
+    include Sidekiq::Worker
 
-    retry_on StandardError, attempts: 3
+    sidekiq_options retry: 3, queue: :default
 
     def perform(cycle_week, region, recruitment_cycle_year)
       Publications::RegionalRecruitmentPerformanceReportGenerator.new(

--- a/app/workers/remove_inactive_provider_users_worker.rb
+++ b/app/workers/remove_inactive_provider_users_worker.rb
@@ -1,4 +1,6 @@
 class RemoveInactiveProviderUsersWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   INACTIVE_MONTHS_AGO = 12

--- a/app/workers/remove_inactive_support_users_worker.rb
+++ b/app/workers/remove_inactive_support_users_worker.rb
@@ -1,4 +1,6 @@
 class RemoveInactiveSupportUsersWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/revert_application_choices_updated_at_worker.rb
+++ b/app/workers/revert_application_choices_updated_at_worker.rb
@@ -1,5 +1,7 @@
-class RevertApplicationChoicesUpdatedAtWorker < ApplicationJob
-  queue_as :low_priority
+class RevertApplicationChoicesUpdatedAtWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
 
   def perform(choice_ids)
     choices_to_update = {}

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
@@ -1,4 +1,6 @@
-class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker < ApplicationJob
+class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker
+  include Sidekiq::Worker
+
   def perform(application_ids)
     ApplicationForm.where(id: application_ids).each do |application_form|
       SendApplyToAnotherCourseWhenInactiveEmailToCandidate.call(application_form)

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
@@ -1,4 +1,6 @@
-class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker < ApplicationJob
+class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker
+  include Sidekiq::Worker
+
   STAGGER_OVER = 20.minutes
   BATCH_SIZE = 150
 
@@ -6,9 +8,10 @@ class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker < ApplicationJ
     return if RecruitmentCycleTimetable.current_timetable.after_apply_deadline?
 
     GroupedRelationBatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, records|
-      SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker
-        .set(wait_until: batch_time)
-        .perform_later(records.pluck(:id))
+      SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker.perform_at(
+        batch_time,
+        records.pluck(:id),
+      )
     end
   end
 end

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
@@ -1,4 +1,6 @@
-class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker < ApplicationJob
+class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker
+  include Sidekiq::Worker
+
   def perform(application_ids)
     ApplicationForm.where(id: application_ids).each do |application_form|
       SendApplyToMultipleCoursesWhenInactiveEmailToCandidate.call(application_form)

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
@@ -1,12 +1,15 @@
-class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker < ApplicationJob
+class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker
+  include Sidekiq::Worker
+
   STAGGER_OVER = 20.minutes
   BATCH_SIZE = 150
 
   def perform
     GroupedRelationBatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call(single: false), stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, records|
-      SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker
-        .set(wait_until: batch_time)
-        .perform_later(records.pluck(:id))
+      SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker.perform_at(
+        batch_time,
+        records.pluck(:id),
+      )
     end
   end
 end

--- a/app/workers/send_deferred_offer_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_deferred_offer_reminder_email_to_candidates_worker.rb
@@ -1,4 +1,6 @@
-class SendDeferredOfferReminderEmailToCandidatesWorker < ApplicationJob
+class SendDeferredOfferReminderEmailToCandidatesWorker
+  include Sidekiq::Worker
+
   def perform
     GetDeferredApplicationChoicesForCurrentCycle.call.each do |application_choice|
       SendDeferredOfferReminderEmailToCandidate.call(application_choice:)

--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker.rb
@@ -1,4 +1,6 @@
-class SendEocDeadlineReminderEmailToCandidatesBatchWorker < ApplicationJob
+class SendEocDeadlineReminderEmailToCandidatesBatchWorker
+  include Sidekiq::Worker
+
   def perform(application_ids, chaser_type)
     ApplicationForm.where(id: application_ids).each do |application_form|
       SendEocDeadlineReminderEmailToCandidate.new(application_form:, chaser_type:).call

--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -1,4 +1,6 @@
-class SendEocDeadlineReminderEmailToCandidatesWorker < ApplicationJob
+class SendEocDeadlineReminderEmailToCandidatesWorker
+  include Sidekiq::Worker
+
   BATCH_SIZE = 120
 
   def perform
@@ -8,9 +10,11 @@ class SendEocDeadlineReminderEmailToCandidatesWorker < ApplicationJob
       relation: GetApplicationsToSendDeadlineRemindersTo.call,
       batch_size: BATCH_SIZE,
     ).each do |batch_time, records|
-      SendEocDeadlineReminderEmailToCandidatesBatchWorker
-      .set(wait_until: batch_time)
-      .perform_later(records.pluck(:id), chaser_type)
+      SendEocDeadlineReminderEmailToCandidatesBatchWorker.perform_at(
+        batch_time,
+        records.pluck(:id),
+        chaser_type,
+      )
     end
   end
 

--- a/app/workers/send_find_has_opened_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_find_has_opened_email_to_candidates_batch_worker.rb
@@ -1,4 +1,6 @@
 class SendFindHasOpenedEmailToCandidatesBatchWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform(candidate_ids)
     Candidate.includes(:application_forms).where(id: candidate_ids).find_each do |candidate|
       SendFindHasOpenedEmailToCandidate.call(

--- a/app/workers/send_find_has_opened_email_to_candidates_worker.rb
+++ b/app/workers/send_find_has_opened_email_to_candidates_worker.rb
@@ -1,4 +1,6 @@
 class SendFindHasOpenedEmailToCandidatesWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   BATCH_SIZE = 120
 
   def perform

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_batch_worker.rb
@@ -1,4 +1,6 @@
 class SendNewCycleHasStartedEmailToCandidatesBatchWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform(candidate_ids)
     Candidate.includes(:application_forms).where(id: candidate_ids).each do |candidate|
       SendNewCycleHasStartedEmailToCandidate.call(

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -1,4 +1,6 @@
 class SendNewCycleHasStartedEmailToCandidatesWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   BATCH_SIZE = 120
 
   def perform

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -1,4 +1,6 @@
 class StartOfCycleNotificationWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform(service = 'find')
     return unless service_opens_today?(service, RecruitmentCycleTimetable.current_year)
     return unless hours_remaining.positive?

--- a/app/workers/support/candidates/bulk_unsubscribe_worker.rb
+++ b/app/workers/support/candidates/bulk_unsubscribe_worker.rb
@@ -1,4 +1,6 @@
-class Support::Candidates::BulkUnsubscribeWorker < ApplicationJob
+class Support::Candidates::BulkUnsubscribeWorker
+  include Sidekiq::Worker
+
   def perform(audit_user_id, audit_comment, email_addresses = [])
     SupportInterface::Candidates::BulkUnsubscribe.bulk_unsubscribe(
       audit_user_id,

--- a/app/workers/support/send_notify_template_with_attachment_batch_worker.rb
+++ b/app/workers/support/send_notify_template_with_attachment_batch_worker.rb
@@ -1,4 +1,6 @@
-class Support::SendNotifyTemplateWithAttachmentBatchWorker < ApplicationJob
+class Support::SendNotifyTemplateWithAttachmentBatchWorker
+  include Sidekiq::Worker
+
   def perform(email_addresses, notify_request_id)
     request = SupportInterface::NotifySendRequest.find(notify_request_id)
     request.file.open do |file|

--- a/app/workers/support/send_notify_template_with_attachment_worker.rb
+++ b/app/workers/support/send_notify_template_with_attachment_worker.rb
@@ -1,9 +1,12 @@
-class Support::SendNotifyTemplateWithAttachmentWorker < ApplicationJob
+class Support::SendNotifyTemplateWithAttachmentWorker
+  include Sidekiq::Worker
+
   def perform(notify_request_id)
     request = SupportInterface::NotifySendRequest.find(notify_request_id)
     relation = request.email_addresses
     ArrayBatchDelivery.new(relation:, stagger_over: stagger_over(relation)).each do |batch_time, batch_email_addresses|
-      Support::SendNotifyTemplateWithAttachmentBatchWorker.set(wait_until: batch_time).perform_later(
+      Support::SendNotifyTemplateWithAttachmentBatchWorker.perform_at(
+        batch_time,
         batch_email_addresses,
         request.id,
       )

--- a/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
+++ b/app/workers/teacher_training_public_api/sync_all_providers_and_courses_worker.rb
@@ -1,5 +1,7 @@
 module TeacherTrainingPublicAPI
   class SyncAllProvidersAndCoursesWorker < ApplicationJob
+    self.queue_adapter = :solid_queue
+
     queue_as :low_priority
 
     retry_on StandardError, attempts: 3

--- a/app/workers/update_duplicate_matches_worker.rb
+++ b/app/workers/update_duplicate_matches_worker.rb
@@ -1,4 +1,6 @@
 class UpdateDuplicateMatchesWorker < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   queue_as :low_priority
 
   def perform

--- a/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
+++ b/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
@@ -1,4 +1,6 @@
 class UpdateOutOfDateProviderIdsOnApplicationChoices < ApplicationJob
+  self.queue_adapter = :solid_queue
+
   def perform
     return unless out_of_date_application_choices.any?
 

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -1,13 +1,10 @@
-require './app/jobs/application_job'
-
-class VendorAPIRequestWorker < ApplicationJob
+class VendorAPIRequestWorker
   AuthorizationStruct = Struct.new(:authorization)
 
+  include Sidekiq::Worker
   include ActionController::HttpAuthentication::Token
 
-  queue_as :low_priority
-
-  retry_on StandardError, attempts: 3
+  sidekiq_options retry: 3, queue: :low_priority
 
   def perform(request_data, response_data, status_code, created_at)
     request_headers = request_data.fetch('headers', {})

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,7 +83,7 @@ module ApplyForPostgraduateTeacherTraining
     config.i18n.raise_on_missing_translations = true
     config.action_view.form_with_generates_remote_forms = false
 
-    config.active_job.queue_adapter = :solid_queue
+    config.active_job.queue_adapter = :sidekiq
 
     config.mission_control.jobs.adapters = [ :solid_queue ]
     config.mission_control.jobs.http_basic_auth_enabled = false

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -47,37 +47,37 @@ class Clock
 
   every(1.day, 'Generate monthly statistics report and exports', at: '05:00') { GenerateMonthlyStatistics.perform_later }
 
-  every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.perform_later }
+  every(1.day, 'SendEocDeadlineReminderEmailToCandidatesWorker', at: '12:00') { SendEocDeadlineReminderEmailToCandidatesWorker.perform_async }
   every(1.day, 'SendVisaSponsorshipDeadlineReminder', at: '12:00') { CandidateMailers::EnqueueVisaSponsorshipDeadlineReminderWorker.perform_later }
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.perform_later }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '10:00') { SendNewCycleHasStartedEmailToCandidatesWorker.perform_later }
-  every(1.day, 'EndOfCycle::SendRejectByDefaultReminderToProvidersWorker') { EndOfCycle::SendRejectByDefaultReminderToProvidersWorker.perform_now }
-  every(1.day, 'EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker', at: '09:00') { EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker.perform_now }
-  every(1.day, 'EndOfCycle:SendRejectByDefaultExplainerToCandidatesWorker', at: '09:01') { EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker.perform_now }
-  every(1.day, 'Candidate::PoolEligibleApplicationFormWorker', at: '09:02') { Candidate::PoolEligibleApplicationFormWorker.perform_later }
-  every(1.day, 'EndOfCycle:SendDeclineByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker.perform_now }
+  every(1.day, 'EndOfCycle::SendRejectByDefaultReminderToProvidersWorker') { EndOfCycle::SendRejectByDefaultReminderToProvidersWorker.new.perform }
+  every(1.day, 'EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker', at: '09:00') { EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker.new.perform }
+  every(1.day, 'EndOfCycle:SendRejectByDefaultExplainerToCandidatesWorker', at: '09:01') { EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
+  every(1.day, 'Candidate::PoolEligibleApplicationFormWorker', at: '09:02') { Candidate::PoolEligibleApplicationFormWorker.new.perform }
+  every(1.day, 'EndOfCycle:SendDeclineByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker.new.perform }
 
   # End of cycle january start dates/winter end dates jobs
-  every(1.day, 'EndOfCycle:SendWinterRejectByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWorker.perform_now }
-  every(1.day, 'EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker', at: '09:04') { EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker.perform_now }
-  every(1.day, 'EndOfCycle:WinterDeclineByDefaultWorker', at: '09:05') { EndOfCycle::WinterDeclineByDefaultWorker.perform_now }
-  every(1.day, 'EndOfCycle::WinterRejectByDefaultWorker', at: '09:06') { EndOfCycle::WinterRejectByDefaultWorker.perform_now }
-  every(1.day, 'EndOfCycle::CancelReferenceRequestsWorker', at: '09:07') { EndOfCycle::CancelReferenceRequestsWorker.perform_now }
-  every(1.day, 'EndOfCycle:SendWinterDeclineByDefaultExplainerToCandidatesWorker', at: '09:08') { EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker.perform_now }
+  every(1.day, 'EndOfCycle:SendWinterRejectByDefaultExplainerToCandidatesWorker', at: '09:03') { EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
+  every(1.day, 'EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker', at: '09:04') { EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker.new.perform }
+  every(1.day, 'EndOfCycle:WinterDeclineByDefaultWorker', at: '09:05') { EndOfCycle::WinterDeclineByDefaultWorker.new.perform }
+  every(1.day, 'EndOfCycle::WinterRejectByDefaultWorker', at: '09:06') { EndOfCycle::WinterRejectByDefaultWorker.new.perform }
+  every(1.day, 'EndOfCycle::CancelReferenceRequestsWorker', at: '09:07') { EndOfCycle::CancelReferenceRequestsWorker.new.perform }
+  every(1.day, 'EndOfCycle:SendWinterDeclineByDefaultExplainerToCandidatesWorker', at: '09:08') { EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesWorker.new.perform }
 
-  every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_later }
-  every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_later }
-  every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_later }
+  every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
+  every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }
+  every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }
 
   # End of cycle application choice status jobs
   # Changes unsubmitted application choices to 'application_not_sent'
-  every(1.day, 'EndOfCycle::CancelUnsubmittedApplicationsWorker', at: '18:01') { EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_later }
-  every(1.day, 'EndOfCycle::CloseCoursesOnInvites', at: '18:01') { EndOfCycle::CloseCoursesOnInvites.perform_later }
+  every(1.day, 'EndOfCycle::CancelUnsubmittedApplicationsWorker', at: '18:01') { EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_async }
+  every(1.day, 'EndOfCycle::CloseCoursesOnInvites', at: '18:01') { EndOfCycle::CloseCoursesOnInvites.perform_async }
   # Reject any application choices that are still awaiting provider decision (interviewing, inactive, and awaiting decision)
-  every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_later }
+  every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
   # Decline any offers that are awaiting candidate decision
-  every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_later }
+  every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
   every(1.day, 'Candidate::EnglishProficiencyDataConversionWorker', at: '23:00') { Candidate::EnglishProficiencyDataConversionWorker.perform_later }
 
   # Weekly jobs
@@ -88,5 +88,5 @@ class Clock
   every(7.days, 'EndOfCycle::NextYearFullSync', at: 'Friday 00:05') { EndOfCycle::NextYearFullSync.perform_later }
 
   every(7.days, 'Schedule Recruitment Performance reports', at: 'Monday 05:30', if: ->(_period) { RecruitmentPerformanceReportTimetable.report_season? }) { Publications::RecruitmentPerformanceReportScheduler.new.call }
-  every(7.days, 'ProviderRecruitmentPerformanceReportReminder', at: 'Monday 12:00') { Publications::ProviderRecruitmentPerformanceReminderWorker.perform_later }
+  every(7.days, 'ProviderRecruitmentPerformanceReportReminder', at: 'Monday 12:00') { Publications::ProviderRecruitmentPerformanceReminderWorker.perform_async }
 end

--- a/lib/tasks/region_code_backfill.rake
+++ b/lib/tasks/region_code_backfill.rake
@@ -11,7 +11,7 @@ task region_code_backfill: :environment do
     .where.not(postcode: nil)
     .find_in_batches(batch_size: RegionCodeBackfill::BATCH_SIZE) do |batch|
       batch.each do |application_form|
-        LookupAreaByPostcodeWorker.set(wait_until: next_batch_time).perform_later(application_form.id)
+        LookupAreaByPostcodeWorker.perform_at(next_batch_time, application_form.id)
       end
       next_batch_time += RegionCodeBackfill::INTERVAL_BETWEEN_BATCHES
     end

--- a/lib/tasks/reset_qa.rake
+++ b/lib/tasks/reset_qa.rake
@@ -36,6 +36,6 @@ end
 task :run_end_of_cycle_jobs, :environment do
   raise 'Not permitted on this environment' unless HostingEnvironment.generate_test_data?
 
-  EndOfCycle::RunEndOfCycleJobsWorker.perform_later
+  EndOfCycle::RunEndOfCycleJobsWorker.perform_async
   puts 'Running all relevant end of cycle jobs based on the current point in the cycle'
 end

--- a/spec/forms/support_interface/candidates/bulk_unsubscribe_form_spec.rb
+++ b/spec/forms/support_interface/candidates/bulk_unsubscribe_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SupportInterface::Candidates::BulkUnsubscribeForm, type: :model d
     end
 
     it 'calls Support::Candidates::BulkUnsubscribeWorker with an array of email addresses' do
-      allow(Support::Candidates::BulkUnsubscribeWorker).to receive(:perform_later)
+      allow(Support::Candidates::BulkUnsubscribeWorker).to receive(:perform_async)
 
       # White space is intentional to test that it is stripped
       form_email_addresses = "
@@ -41,7 +41,7 @@ RSpec.describe SupportInterface::Candidates::BulkUnsubscribeForm, type: :model d
         email_addresses: form_email_addresses,
       )
       form.save
-      expect(Support::Candidates::BulkUnsubscribeWorker).to have_received(:perform_later)
+      expect(Support::Candidates::BulkUnsubscribeWorker).to have_received(:perform_async)
         .with(
           audit_user.id,
           audit_comment,

--- a/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
+++ b/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
@@ -119,13 +119,18 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
         end
       end
 
-      context 'when a Google::Auth::AuthorizationError is returned' do
+      context 'when a Google::Auth::AuthorizationError is returneed' do
         before do
           stub_bigquery_non_disclosure_trainee_withdrawals_request(auth_error: true)
+          allow(NonDisclosureTraineeWithdrawalWorker).to receive(:perform_in)
         end
 
         it 'enqueues the worker for 10 minutes later' do
-          expect { trainee_data }.to enqueue_job(NonDisclosureTraineeWithdrawalWorker).at(10.minutes.from_now).with(candidate.id)
+          trainee_data
+
+          expect(
+            NonDisclosureTraineeWithdrawalWorker,
+          ).to have_received(:perform_in).with(10.minutes, candidate.id)
         end
       end
     end

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
 
   before do
     mock_app
-    allow(VendorAPIRequestWorker).to receive(:perform_later)
+    allow(VendorAPIRequestWorker).to receive(:perform_async)
   end
 
   describe '#call on a non-API path' do
     it 'does not enqueue a background job' do
       get '/api/v2'
 
-      expect(VendorAPIRequestWorker).not_to have_received(:perform_later)
+      expect(VendorAPIRequestWorker).not_to have_received(:perform_async)
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
     it 'enqueues a worker job' do
       get '/api/v1/applications/1', params: { foo: 'bar' }
 
-      expect(VendorAPIRequestWorker).to have_received(:perform_later).with(
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
         hash_including('path' => '/api/v1/applications/1', 'params' => { 'foo' => 'bar' }, 'method' => 'GET'), anything, 401, anything
       )
     end
@@ -44,7 +44,7 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
     it 'enqueues a worker job' do
       get '/api/v1.1/applications/1', params: { foo: 'bar' }
 
-      expect(VendorAPIRequestWorker).to have_received(:perform_later).with(
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
         hash_including('path' => '/api/v1.1/applications/1', 'params' => { 'foo' => 'bar' }, 'method' => 'GET'), anything, 401, anything
       )
     end
@@ -54,9 +54,20 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
     it 'enqueues a worker job including post data' do
       post '/api/v1/applications/1/offer', as: :json, params: { foo: 'bar' }
 
-      expect(VendorAPIRequestWorker).to have_received(:perform_later).with(
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
         hash_including('path' => '/api/v1/applications/1/offer', 'body' => '{"foo":"bar"}', 'method' => 'POST'), anything, 401, anything
       )
+    end
+  end
+
+  describe '#call on an API path when Redis is unavailable' do
+    it 'logs the Redis exception and returns' do
+      allow(Rails.logger).to receive(:warn)
+      allow(VendorAPIRequestWorker).to receive(:perform_async).and_raise(Redis::BaseError.new('Oops no Redis'))
+
+      get '/api/v1/applications/1'
+
+      expect(Rails.logger).to have_received(:warn).with('Oops no Redis')
     end
   end
 end

--- a/spec/models/adviser/sign_up_form_spec.rb
+++ b/spec/models/adviser/sign_up_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Adviser::SignUpForm do
   before do
-    allow(AdviserSignUpWorker).to receive(:perform_later)
+    allow(AdviserSignUpWorker).to receive(:perform_async)
   end
 
   let(:application_form) { create(:completed_application_form, :with_domestic_adviser_qualifications) }
@@ -42,7 +42,7 @@ RSpec.describe Adviser::SignUpForm do
 
     it 'enqueues an AdviserSignUpWorker job' do
       sign_up_form.save
-      expect(AdviserSignUpWorker).to have_received(:perform_later)
+      expect(AdviserSignUpWorker).to have_received(:perform_async)
     end
 
     it 'sets adviser_status to waiting_to_be_assigned' do
@@ -61,7 +61,7 @@ RSpec.describe Adviser::SignUpForm do
       it 'does not enqueue a AdviserSignUpWorker job' do
         sign_up_form.save
 
-        expect(AdviserSignUpWorker).not_to have_received(:perform_later)
+        expect(AdviserSignUpWorker).not_to have_received(:perform_async)
       end
 
       it 'does not change adviser_status' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -356,8 +356,11 @@ RSpec.describe ApplicationForm do
     end
 
     describe 'updating region code' do
+      before do
+        allow(LookupAreaByPostcodeWorker).to receive(:perform_in).and_return(nil)
+      end
+
       it 'sets value to `rest_of_the_world` for international addresses outside EEA' do
-        clear_enqueued_jobs
         application_form = create(:application_form, region_code: :london)
 
         application_form.update!(
@@ -366,13 +369,12 @@ RSpec.describe ApplicationForm do
           international_address: '123 MG Road, Mumbai',
         )
 
-        expect(LookupAreaByPostcodeWorker).not_to have_been_enqueued
+        expect(LookupAreaByPostcodeWorker).not_to have_received(:perform_in)
         expect(application_form.reload.rest_of_the_world?).to be(true)
       end
 
       it 'sets value to `european_economic_area` for international addresses inside EEA' do
         application_form = create(:application_form, region_code: :london)
-        clear_enqueued_jobs
 
         application_form.update!(
           country: 'FR',
@@ -380,7 +382,7 @@ RSpec.describe ApplicationForm do
           international_address: '123 Rue de Rivoli, Paris',
         )
 
-        expect(LookupAreaByPostcodeWorker).not_to have_been_enqueued
+        expect(LookupAreaByPostcodeWorker).not_to have_received(:perform_in)
         expect(application_form.reload.european_economic_area?).to be(true)
       end
 
@@ -392,7 +394,8 @@ RSpec.describe ApplicationForm do
             address_type: :uk,
             postcode: 'SW1P 3BT',
           )
-          expect(LookupAreaByPostcodeWorker).to have_been_enqueued.with(application_form.id)
+
+          expect(LookupAreaByPostcodeWorker).to have_received(:perform_in).with(anything, application_form.id)
         end
 
         it 'queues an LookupAreaByPostcodeWorker job for Cardiff postcode' do
@@ -403,21 +406,23 @@ RSpec.describe ApplicationForm do
             postcode: 'CF40 2QD',
           )
 
-          expect(LookupAreaByPostcodeWorker).to have_been_enqueued.with(application_form.id)
+          expect(LookupAreaByPostcodeWorker).to have_received(:perform_in).with(anything, application_form.id)
         end
       end
     end
 
     describe 'geocoding address' do
       it 'invokes geocoding of UK addresses on create' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_in)
         application_form = create(:application_form, :minimum_info)
 
         application_form.update!(postcode: 'SE10NE')
 
-        expect(GeocodeApplicationAddressWorker).to have_been_enqueued.with(application_form.id)
+        expect(GeocodeApplicationAddressWorker).to have_received(:perform_in).with(anything, application_form.id)
       end
 
       it 'invokes geocoding of UK addresses on update' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_in)
         application_form = create(:application_form, :minimum_info)
 
         address_attributes = %i[address_line1 address_line2 address_line3 address_line4 postcode country]
@@ -427,34 +432,40 @@ RSpec.describe ApplicationForm do
 
         expected_calls_to_worker = address_attributes.size # Each update excluding the initial create
         expect(GeocodeApplicationAddressWorker)
-          .to have_been_enqueued
-          .with(application_form.id)
+          .to have_received(:perform_in)
+          .with(anything, application_form.id)
           .exactly(expected_calls_to_worker).times
       end
 
       it 'does not invoke geocoding for international addresses' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_in)
+
         application_form = create(:application_form, :minimum_info)
 
         application_form.update!(address_type: :international)
 
-        expect(GeocodeApplicationAddressWorker).not_to have_been_enqueued.with(application_form.id)
+        expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_in).with(application_form.id)
       end
 
       it 'does not invoke geocoding if address fields have not been changed' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_in)
+
         application_form = create(:application_form, :minimum_info)
 
         application_form.update!(phone_number: 111111)
 
-        expect(GeocodeApplicationAddressWorker).not_to have_been_enqueued.with(application_form.id)
+        expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_in).with(application_form.id)
       end
 
       it 'clears existing coordinates if address changed to international' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_in)
+
         application_form = create(:application_form, :minimum_info, latitude: 1.5, longitude: 0.2)
 
         application_form.update!(address_type: :international)
 
         expect([application_form.latitude, application_form.longitude]).to eq [nil, nil]
-        expect(GeocodeApplicationAddressWorker).not_to have_been_enqueued.with(application_form.id)
+        expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_in)
       end
     end
   end
@@ -1579,7 +1590,7 @@ RSpec.describe ApplicationForm do
     before do
       allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
       Rails.cache.clear
-      clear_enqueued_jobs
+      Sidekiq::Worker.clear_all
     end
 
     subject(:application_form) { build_stubbed(:application_form) }
@@ -1606,7 +1617,7 @@ RSpec.describe ApplicationForm do
       it 'queues the refresh worker' do
         expect {
           application_form.eligible_to_sign_up_for_a_teaching_training_adviser?
-        }.to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.to change(Adviser::RefreshAdviserStatusWorker.jobs, :size).from(0).to(1)
       end
 
       it 'does not queue the refresh worker if it has been refreshed recently' do
@@ -1614,7 +1625,7 @@ RSpec.describe ApplicationForm do
 
         expect {
           application_form.eligible_to_sign_up_for_a_teaching_training_adviser?
-        }.not_to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.not_to change(Adviser::RefreshAdviserStatusWorker.jobs, :size)
       end
     end
   end
@@ -1623,7 +1634,7 @@ RSpec.describe ApplicationForm do
     before do
       allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
       Rails.cache.clear
-      clear_enqueued_jobs
+      Sidekiq::Worker.clear_all
     end
 
     context 'when the application form is assigned to an adviser' do
@@ -1656,7 +1667,7 @@ RSpec.describe ApplicationForm do
       it 'queues the refresh worker' do
         expect {
           application_form.already_assigned_to_an_adviser?
-        }.to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.to change(Adviser::RefreshAdviserStatusWorker.jobs, :size).from(0).to(1)
       end
 
       it 'does not queue the refresh worker if it has been refreshed recently' do
@@ -1664,7 +1675,7 @@ RSpec.describe ApplicationForm do
 
         expect {
           application_form.already_assigned_to_an_adviser?
-        }.not_to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.not_to change(Adviser::RefreshAdviserStatusWorker.jobs, :size)
       end
     end
   end
@@ -1673,7 +1684,7 @@ RSpec.describe ApplicationForm do
     before do
       allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
       Rails.cache.clear
-      clear_enqueued_jobs
+      Sidekiq::Worker.clear_all
     end
 
     context 'when the application form is assigned to an adviser' do
@@ -1706,7 +1717,7 @@ RSpec.describe ApplicationForm do
       it 'queues the refresh worker' do
         expect {
           application_form.waiting_to_be_assigned_to_an_adviser?
-        }.to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.to change(Adviser::RefreshAdviserStatusWorker.jobs, :size).from(0).to(1)
       end
 
       it 'does not queue the refresh worker if it has been refreshed recently' do
@@ -1714,7 +1725,7 @@ RSpec.describe ApplicationForm do
 
         expect {
           application_form.waiting_to_be_assigned_to_an_adviser?
-        }.not_to enqueue_job(Adviser::RefreshAdviserStatusWorker)
+        }.not_to change(Adviser::RefreshAdviserStatusWorker.jobs, :size)
       end
     end
   end

--- a/spec/models/previous_teacher_training_spec.rb
+++ b/spec/models/previous_teacher_training_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe PreviousTeacherTraining do
       end
 
       it 'enqueues a NonDisclosureTraineeWithdrawalWorker' do
-        allow(NonDisclosureTraineeWithdrawalWorker).to receive(:perform_later)
+        allow(NonDisclosureTraineeWithdrawalWorker).to receive(:perform_async)
         previous_teacher_training.make_published
 
         expect(
           NonDisclosureTraineeWithdrawalWorker,
-        ).to have_received(:perform_later).with(application_form.candidate.id)
+        ).to have_received(:perform_async).with(application_form.candidate.id)
       end
 
       context 'when the previous teacher training has a duplicate record' do

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   context 'provider report is generated for appropriate providers' do
     before do
       allow(HostingEnvironment).to receive(:production?).and_return true
-      allow(provider_worker).to receive(:perform_later)
+      allow(provider_worker).to receive(:perform_async)
       application_choice
     end
 
     it 'creates a report for a provider who has applications' do
       described_class.new.call
 
-      expect(provider_worker).to have_received(:perform_later).with(
+      expect(provider_worker).to have_received(:perform_async).with(
         provider.id,
         cycle_week,
         recruitment_cycle_year,
@@ -35,7 +35,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(provider_worker).not_to have_received(:perform_later).with(
+      expect(provider_worker).not_to have_received(:perform_async).with(
         provider.id,
         cycle_week,
         recruitment_cycle_year,
@@ -47,7 +47,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(provider_worker).to have_received(:perform_later).with(
+      expect(provider_worker).to have_received(:perform_async).with(
         provider.id,
         cycle_week,
         recruitment_cycle_year,
@@ -67,7 +67,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       it 'creates a report for a provider who received an application before cycle_week' do
         described_class.new(cycle_week:).call
 
-        expect(provider_worker).to have_received(:perform_later).with(
+        expect(provider_worker).to have_received(:perform_async).with(
           provider.id,
           cycle_week,
           recruitment_cycle_year,
@@ -79,13 +79,13 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   context 'national report is generated' do
     before do
       allow(HostingEnvironment).to receive(:production?).and_return true
-      allow(national_worker).to receive(:perform_later)
+      allow(national_worker).to receive(:perform_async)
     end
 
     it 'creates a National report' do
       described_class.new.call
 
-      expect(national_worker).to have_received(:perform_later).with(
+      expect(national_worker).to have_received(:perform_async).with(
         cycle_week,
         recruitment_cycle_year,
       )
@@ -101,7 +101,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(national_worker).to have_received(:perform_later).with(
+      expect(national_worker).to have_received(:perform_async).with(
         cycle_week,
         recruitment_cycle_year,
       )
@@ -117,7 +117,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(national_worker).not_to have_received(:perform_later).with(
+      expect(national_worker).not_to have_received(:perform_async).with(
         cycle_week,
         recruitment_cycle_year,
       )
@@ -129,7 +129,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       it 'creates a national report for the cycle_week value' do
         described_class.new(cycle_week:).call
 
-        expect(national_worker).to have_received(:perform_later).with(
+        expect(national_worker).to have_received(:perform_async).with(
           cycle_week,
           recruitment_cycle_year,
         )
@@ -140,14 +140,14 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   context 'regional report is generated' do
     before do
       allow(HostingEnvironment).to receive(:production?).and_return true
-      allow(regional_worker).to receive(:perform_later)
+      allow(regional_worker).to receive(:perform_async)
     end
 
     it 'creates a Regional report' do
       described_class.new.call
 
       Publications::RegionalRecruitmentPerformanceReport.regions.each_value do |region|
-        expect(regional_worker).to have_received(:perform_later).with(
+        expect(regional_worker).to have_received(:perform_async).with(
           cycle_week,
           region,
           recruitment_cycle_year,
@@ -166,7 +166,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(regional_worker).to have_received(:perform_later).with(
+      expect(regional_worker).to have_received(:perform_async).with(
         cycle_week,
         'West Midlands (England)',
         recruitment_cycle_year,
@@ -184,7 +184,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(regional_worker).not_to have_received(:perform_later).with(
+      expect(regional_worker).not_to have_received(:perform_async).with(
         cycle_week,
         'West Midlands (England)',
         recruitment_cycle_year,
@@ -198,7 +198,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         described_class.new(cycle_week:).call
 
         Publications::RegionalRecruitmentPerformanceReport.regions.each_value do |region|
-          expect(regional_worker).to have_received(:perform_later).with(
+          expect(regional_worker).to have_received(:perform_async).with(
             cycle_week,
             region,
             recruitment_cycle_year,
@@ -211,14 +211,14 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   context 'regional edi report is generated' do
     before do
       allow(HostingEnvironment).to receive(:production?).and_return true
-      allow(regional_edi_worker).to receive(:perform_later)
+      allow(regional_edi_worker).to receive(:perform_async)
     end
 
     it 'creates a Regional edi report' do
       described_class.new.call
 
       Publications::RegionalEdiReport.regions.each_value do |region|
-        expect(regional_edi_worker).to have_received(:perform_later).with(
+        expect(regional_edi_worker).to have_received(:perform_async).with(
           cycle_week,
           region,
           recruitment_cycle_year,
@@ -233,7 +233,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         create(:regional_edi_report, recruitment_cycle_year: previous_year, region: :london)
         described_class.new(cycle_week:).call
 
-        expect(regional_edi_worker).to have_received(:perform_later).with(
+        expect(regional_edi_worker).to have_received(:perform_async).with(
           cycle_week,
           'London',
           recruitment_cycle_year,
@@ -245,7 +245,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         allow(Publications::ProviderEdiReport).to receive(:categories).and_return({ 'sex' => 'Sex' })
         described_class.new(cycle_week:).call
 
-        expect(regional_edi_worker).not_to have_received(:perform_later).with(
+        expect(regional_edi_worker).not_to have_received(:perform_async).with(
           cycle_week,
           'London',
           recruitment_cycle_year,
@@ -256,7 +256,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         described_class.new(cycle_week:).call
 
         Publications::RegionalEdiReport.regions.each_value do |region|
-          expect(regional_edi_worker).to have_received(:perform_later).with(
+          expect(regional_edi_worker).to have_received(:perform_async).with(
             cycle_week,
             region,
             recruitment_cycle_year,
@@ -269,14 +269,14 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   context 'provider edi report is generated' do
     before do
       allow(HostingEnvironment).to receive(:production?).and_return true
-      allow(provider_edi_worker).to receive(:perform_later)
+      allow(provider_edi_worker).to receive(:perform_async)
       application_choice
     end
 
     it 'creates a Provider edi report' do
       described_class.new.call
 
-      expect(provider_edi_worker).to have_received(:perform_later).with(
+      expect(provider_edi_worker).to have_received(:perform_async).with(
         provider.id,
         cycle_week,
         recruitment_cycle_year,
@@ -290,7 +290,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         create(:provider_recruitment_performance_report, provider:, cycle_week:, recruitment_cycle_year: previous_year)
         described_class.new(cycle_week:).call
 
-        expect(provider_edi_worker).to have_received(:perform_later).with(
+        expect(provider_edi_worker).to have_received(:perform_async).with(
           provider.id,
           cycle_week,
           recruitment_cycle_year,
@@ -301,7 +301,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         create(:provider_recruitment_performance_report, provider:, cycle_week:, recruitment_cycle_year: current_year)
         described_class.new(cycle_week:).call
 
-        expect(provider_edi_worker).not_to have_received(:perform_later).with(
+        expect(provider_edi_worker).not_to have_received(:perform_async).with(
           provider.id,
           cycle_week,
           recruitment_cycle_year,
@@ -311,7 +311,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       it 'creates a Provider edi report for the cycle_week value' do
         described_class.new(cycle_week:).call
 
-        expect(provider_edi_worker).to have_received(:perform_later).with(
+        expect(provider_edi_worker).to have_received(:perform_async).with(
           provider.id,
           cycle_week,
           recruitment_cycle_year,
@@ -335,18 +335,18 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
     before do
       allow(HostingEnvironment).to receive(:production?).and_return false
-      allow(national_worker).to receive(:perform_later)
-      allow(regional_worker).to receive(:perform_later)
-      allow(regional_edi_worker).to receive(:perform_later)
-      allow(provider_edi_worker).to receive(:perform_later)
-      allow(provider_worker).to receive(:perform_later)
+      allow(national_worker).to receive(:perform_async)
+      allow(regional_worker).to receive(:perform_async)
+      allow(regional_edi_worker).to receive(:perform_async)
+      allow(provider_edi_worker).to receive(:perform_async)
+      allow(provider_worker).to receive(:perform_async)
     end
 
     it 'does not create any reports' do
       described_class.new(cycle_week:).call
-      expect(national_worker).not_to have_received(:perform_later).with(cycle_week)
+      expect(national_worker).not_to have_received(:perform_async).with(cycle_week)
       Publications::RegionalRecruitmentPerformanceReport.regions.each_value do |region|
-        expect(regional_worker).not_to have_received(:perform_later).with(
+        expect(regional_worker).not_to have_received(:perform_async).with(
           cycle_week,
           region,
           recruitment_cycle_year,
@@ -355,7 +355,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       Publications::RegionalEdiReport.regions.each_value do |region|
         Publications::RegionalEdiReport.categories.each_value do |category|
-          expect(regional_edi_worker).not_to have_received(:perform_later).with(
+          expect(regional_edi_worker).not_to have_received(:perform_async).with(
             cycle_week,
             region,
             category,
@@ -365,7 +365,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
       end
 
       Publications::ProviderEdiReport.categories.each_value do |category|
-        expect(provider_edi_worker).not_to have_received(:perform_later).with(
+        expect(provider_edi_worker).not_to have_received(:perform_async).with(
           provider.id,
           cycle_week,
           category,
@@ -373,7 +373,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
         )
       end
 
-      expect(provider_worker).not_to have_received(:perform_later).with(
+      expect(provider_worker).not_to have_received(:perform_async).with(
         provider.id,
         cycle_week,
         recruitment_cycle_year,

--- a/spec/models/support_interface/notify_send_request_spec.rb
+++ b/spec/models/support_interface/notify_send_request_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe SupportInterface::NotifySendRequest do
     let(:notify_request) { create(:notify_send_request) }
 
     before do
-      allow(Support::SendNotifyTemplateWithAttachmentWorker).to receive(:perform_later)
+      allow(Support::SendNotifyTemplateWithAttachmentWorker).to receive(:perform_async)
 
       send_emails
     end
 
     it 'triggers a Support::SendNotifyTemplateWithAttachmentWorker' do
-      expect(Support::SendNotifyTemplateWithAttachmentWorker).to have_received(:perform_later)
+      expect(Support::SendNotifyTemplateWithAttachmentWorker).to have_received(:perform_async)
         .with(
           notify_request.id,
         ).once

--- a/spec/requests/support_interface/provider_test_data_controller_spec.rb
+++ b/spec/requests/support_interface/provider_test_data_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SupportInterface::ProviderTestDataController do
 
   describe 'POST create' do
     before do
-      allow(GenerateTestApplicationsForCourses).to receive(:perform_later)
+      allow(GenerateTestApplicationsForCourses).to receive(:perform_async)
       post support_interface_provider_test_data_path(provider)
     end
 
@@ -32,7 +32,7 @@ RSpec.describe SupportInterface::ProviderTestDataController do
 
       it 'enqueues a generation test data job' do
         expect(GenerateTestApplicationsForCourses)
-          .to have_received(:perform_later)
+          .to have_received(:perform_async)
           .exactly(100).times
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe SupportInterface::ProviderTestDataController do
       end
 
       it 'does not enqueue a generation test data job' do
-        expect(GenerateTestApplicationsForCourses).not_to have_received(:perform_later)
+        expect(GenerateTestApplicationsForCourses).not_to have_received(:perform_async)
       end
     end
   end

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -148,12 +148,12 @@ module CandidateInterface
         it 'enqueues a NonDisclosureTraineeWithdrawalWorker' do
           Feature.find_or_create_by(name: 'import_non_disclosure_trainee_withdrawals', active: true)
 
-          allow(NonDisclosureTraineeWithdrawalWorker).to receive(:perform_later)
+          allow(NonDisclosureTraineeWithdrawalWorker).to receive(:perform_async)
           submit_application
 
           expect(
             NonDisclosureTraineeWithdrawalWorker,
-          ).to have_received(:perform_later).with(application_form.candidate.id)
+          ).to have_received(:perform_async).with(application_form.candidate.id)
 
           FeatureFlag.deactivate(:import_non_disclosure_trainee_withdrawals)
         end

--- a/spec/services/data_migrations/backfill_application_choices_with_work_experiences_spec.rb
+++ b/spec/services/data_migrations/backfill_application_choices_with_work_experiences_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe DataMigrations::BackfillApplicationChoicesWithWorkExperiences do
       application_form = create(:application_form)
       create(:application_choice, :awaiting_provider_decision, application_form:)
 
-      expect { described_class.new.change }
-        .to enqueue_job(MigrateApplicationChoicesWorker)
+      expect { described_class.new.change }.to change(
+        MigrateApplicationChoicesWorker.jobs, :size
+      ).by(1)
     end
   end
 

--- a/spec/services/data_migrations/delete_all_old_audits_spec.rb
+++ b/spec/services/data_migrations/delete_all_old_audits_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe DataMigrations::DeleteAllOldAudits do
   describe '#change' do
     it 'enqueues the DeleteAllAuditsInBatches worker' do
-      expect { described_class.new.change }.to enqueue_job(DeleteAllOldAuditsInBatches)
+      expect { described_class.new.change }.to change(
+        DeleteAllOldAuditsInBatches.jobs, :size
+      ).by(1)
     end
   end
 end

--- a/spec/services/data_migrations/delete_work_history_audits_spec.rb
+++ b/spec/services/data_migrations/delete_work_history_audits_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::DeleteWorkHistoryAudits do
   describe '#change' do
-    it 'enqueues jobs to DeleteAuditsWorker' do
+    it 'enques jobs to DeleteAuditsWorker' do
       create(
         :application_work_history_break_audit,
         user_type: nil,
@@ -12,7 +12,9 @@ RSpec.describe DataMigrations::DeleteWorkHistoryAudits do
         username: '(Automated process)',
       )
 
-      expect { described_class.new.change }.to enqueue_job(DeleteAuditsWorker)
+      expect { described_class.new.change }.to change(
+        DeleteAuditsWorker.jobs, :size
+      ).by(1)
     end
   end
 

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -55,22 +55,22 @@ RSpec.describe DeclineOffer do
   end
 
   it 'sends a notification email to the candidate if the application is the last one' do
-    allow(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to receive(:perform_later).and_return(true)
+    allow(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to receive(:perform_async).and_return(true)
     application_choice = create(:application_choice, status: :offer)
 
     described_class.new(application_choice:).save!
 
-    expect(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to have_received(:perform_later).with(application_choice.id)
+    expect(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to have_received(:perform_async).with(application_choice.id)
   end
 
   it 'does not send a notification email to the candidate if the application is not the last one' do
-    allow(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to receive(:perform_later).and_return(true)
+    allow(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).to receive(:perform_async).and_return(true)
     application_form = create(:completed_application_form)
     application_choice = create(:application_choice, status: :offer, application_form:)
     _other_application_choice = create(:application_choice, status: :offer, application_form:)
 
     described_class.new(application_choice:).save!
 
-    expect(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).not_to have_received(:perform_later)
+    expect(CandidateMailers::SendDeclinedLastApplicationChoiceEmailWorker).not_to have_received(:perform_async)
   end
 end

--- a/spec/services/decline_or_withdraw_application_spec.rb
+++ b/spec/services/decline_or_withdraw_application_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe DeclineOrWithdrawApplication do
 
     context 'when an application is withdrawn' do
       it 'an email is send to the candidate' do
-        allow(CandidateMailers::SendWithdrawnOnRequestEmailWorker).to receive(:perform_later).and_return(true)
+        allow(CandidateMailers::SendWithdrawnOnRequestEmailWorker).to receive(:perform_async).and_return(true)
 
         described_class.new(application_choice:, actor: user).save!
 
-        expect(CandidateMailers::SendWithdrawnOnRequestEmailWorker).to have_received(:perform_later).with(application_choice.id)
+        expect(CandidateMailers::SendWithdrawnOnRequestEmailWorker).to have_received(:perform_async).with(application_choice.id)
       end
 
       it 'the CancelUpcomingInterviewsService is called' do

--- a/spec/services/provider_interface/change_choices_to_main_site_spec.rb
+++ b/spec/services/provider_interface/change_choices_to_main_site_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe ProviderInterface::ChangeChoicesToMainSite do
           school_placement_auto_selected: true,
         )
 
-        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_later)
+        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_async)
 
         described_class.call(provider_ids: [provider.id])
 
-        expect(Provider::ChangeChoicesToMainSiteWorker).to have_received(:perform_later).with(
+        expect(Provider::ChangeChoicesToMainSiteWorker).to have_received(:perform_async).with(
           [choice.id],
         )
       end
@@ -40,10 +40,10 @@ RSpec.describe ProviderInterface::ChangeChoicesToMainSite do
           current_course_option: old_course_option,
         )
 
-        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_later)
+        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_async)
 
         described_class.call(provider_ids: [provider.id])
-        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_later)
+        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_async)
       end
     end
 
@@ -59,10 +59,10 @@ RSpec.describe ProviderInterface::ChangeChoicesToMainSite do
           original_course_option: old_course_option,
         )
 
-        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_later)
+        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_async)
 
         described_class.call(provider_ids: [provider.id])
-        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_later)
+        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_async)
       end
     end
 
@@ -80,10 +80,10 @@ RSpec.describe ProviderInterface::ChangeChoicesToMainSite do
           original_course_option: old_course_option,
         )
 
-        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_later)
+        allow(Provider::ChangeChoicesToMainSiteWorker).to receive(:perform_async)
 
         described_class.call(provider_ids: 'wrong')
-        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_later)
+        expect(Provider::ChangeChoicesToMainSiteWorker).not_to have_received(:perform_async)
       end
     end
   end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -65,11 +65,11 @@ RSpec.describe RejectApplication do
     end
 
     it 'emails the candidate' do
-      allow(CandidateMailers::SendRejectionEmailWorker).to receive(:perform_later).and_return(true)
+      allow(CandidateMailers::SendRejectionEmailWorker).to receive(:perform_async).and_return(true)
 
       service.save
 
-      expect(CandidateMailers::SendRejectionEmailWorker).to have_received(:perform_later).with(application_choice.id)
+      expect(CandidateMailers::SendRejectionEmailWorker).to have_received(:perform_async).with(application_choice.id)
     end
 
     it 'returns true if the call was successful' do

--- a/spec/services/teacher_training_public_api/sync2026_course_uuids_in_sandbox_secondary_worker_spec.rb
+++ b/spec/services/teacher_training_public_api/sync2026_course_uuids_in_sandbox_secondary_worker_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker, :sidekiq do
+  include TeacherTrainingPublicAPIHelper
+
+  context 'not production' do
+    before do
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    context 'api course exists and the UUID is the same as publish sandbox' do
+      let(:api_uuid) { SecureRandom.uuid }
+      let(:course) { create(:course, recruitment_cycle_year: 2026, uuid: api_uuid) }
+      let(:provider) { course.provider }
+
+      before do
+        stub_teacher_training_api_courses(
+          provider_code: provider.code,
+          specified_attributes: [{ uuid: api_uuid, code: course.code, recruitment_cycle_year: 2026 }],
+          recruitment_cycle_year: 2026,
+        )
+      end
+
+      it 'does not update course' do
+        original_uuid = course.uuid
+        described_class.new.perform(provider.code)
+        expect(course.reload.uuid).to eq original_uuid
+      end
+    end
+
+    context 'api course exists and the UUID is different in publish sandbox' do
+      let(:api_uuid) { SecureRandom.uuid }
+      let(:course) { create(:course, recruitment_cycle_year: 2026, uuid: SecureRandom.uuid) }
+      let!(:provider) { course.provider }
+
+      before do
+        stub_teacher_training_api_courses(
+          provider_code: provider.code,
+          specified_attributes: [{ uuid: api_uuid, code: course.code, recruitment_cycle_year: 2026 }],
+          recruitment_cycle_year: 2026,
+        )
+      end
+
+      it 'updates course to match publish sandbox' do
+        provider_code = course.provider.code
+        described_class.new.perform(provider_code)
+
+        expect(course.reload.uuid).to eq api_uuid
+      end
+    end
+  end
+end

--- a/spec/services/teacher_training_public_api/sync2026_course_uuids_in_sandbox_spec.rb
+++ b/spec/services/teacher_training_public_api/sync2026_course_uuids_in_sandbox_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandbox, :sidekiq do
+  include TeacherTrainingPublicAPIHelper
+
+  context 'not production' do
+    before do
+      allow(HostingEnvironment).to receive(:production?).and_return false
+      allow(TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker).to receive(:perform_async)
+    end
+
+    context 'provider has 2026 courses' do
+      let(:course) { create(:course, recruitment_cycle_year: 2026) }
+
+      it 'calls the secondary worker' do
+        provider = course.provider
+        described_class.new.perform
+
+        expect(TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker)
+          .to have_received(:perform_async)
+                .with(provider.code)
+      end
+    end
+
+    context 'provider does not have 2026 courses' do
+      let(:course) { create(:course, recruitment_cycle_year: 2025) }
+
+      it 'does not call the secondary worker' do
+        provider = course.provider
+        described_class.new.perform
+
+        expect(TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker)
+          .not_to have_received(:perform_async)
+                .with(provider.code)
+      end
+    end
+  end
+
+  context 'production' do
+    before do
+      allow(HostingEnvironment).to receive(:production?).and_return true
+      allow(TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker).to receive(:perform_async)
+    end
+
+    context 'provider has 2026 courses' do
+      let(:course) { create(:course, recruitment_cycle_year: 2026) }
+
+      it 'does not call secondary worker' do
+        provider = course.provider
+        described_class.new.perform
+
+        expect(TeacherTrainingPublicAPI::Sync2026CourseUuidsInSandboxSecondaryWorker)
+          .not_to have_received(:perform_async)
+                    .with(provider.code)
+      end
+    end
+  end
+end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
     before do
       stub_teacher_training_api_courses(provider_code: provider.code, specified_attributes: stubbed_attributes)
-      allow(TeacherTrainingPublicAPI::SyncSites).to receive(:perform_later).and_return(true)
+      allow(TeacherTrainingPublicAPI::SyncSites).to receive(:perform_async).and_return(true)
     end
 
     context 'when the API course does not have a application_open_from date' do
@@ -41,13 +41,13 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'does not add visa_sponsorship_application_deadline_at value to course' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
         perform_job
 
         expect(provider.courses.where.not(visa_sponsorship_application_deadline_at: nil).count).to eq 0
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).not_to(
-          have_received(:perform_later),
+          have_received(:perform_async),
         )
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'saves the visa_sponsorship_application_deadline_at value to course' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
         perform_job
 
@@ -66,7 +66,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
           .to be_within(1.second)
                 .of(stubbed_sponsorship_application_deadline_at)
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).not_to(
-          have_received(:perform_later),
+          have_received(:perform_async),
         )
       end
     end
@@ -147,14 +147,14 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'updates the course to open including the invite' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
 
         expect { perform_job }.not_to change(Course, :count)
         expect(course.reload.open?).to be(true)
         expect(invite.reload.course_open).to be(true)
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          have_received(:perform_later).with(course.id),
+          have_received(:perform_async).with(course.id),
         )
       end
     end
@@ -183,12 +183,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'sends emails to candidates that applied for this course' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
         perform_job
 
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          have_received(:perform_later).with(course.id),
+          have_received(:perform_async).with(course.id),
         )
       end
     end
@@ -217,12 +217,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'does not send emails to candidates that applied for this course' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
         perform_job
 
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).not_to(
-          have_received(:perform_later).with(course.id),
+          have_received(:perform_async).with(course.id),
         )
       end
     end
@@ -251,12 +251,12 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
 
       it 'does not send emails to candidates that applied for this course' do
         allow(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
-          receive(:perform_later),
+          receive(:perform_async),
         )
         perform_job
 
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).not_to(
-          have_received(:perform_later).with(course.id),
+          have_received(:perform_async).with(course.id),
         )
       end
     end

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TeacherTrainingPublicAPI::SyncProvider do
+RSpec.describe TeacherTrainingPublicAPI::SyncProvider, :sidekiq do
   include TeacherTrainingPublicAPIHelper
 
   let(:delay_by) { nil }
@@ -8,11 +8,14 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider do
   describe '.call' do
     let(:incremental_sync) { true }
 
+    before do
+      allow(TeacherTrainingPublicAPI::SyncCourses).to receive(:perform_in).and_return(true)
+    end
+
     context 'ingesting a brand new provider' do
-      let(:provider_from_api) { fake_api_provider({ code: 'ABC', latitude: nil, longitude: nil }) }
+      let(:provider_from_api) { fake_api_provider({ code: 'ABC' }) }
 
       before do
-        clear_enqueued_jobs
         described_class.new(
           provider_from_api:,
           recruitment_cycle_year: stubbed_recruitment_cycle_year,
@@ -22,21 +25,26 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider do
       end
 
       it 'creates the provider' do
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_been_enqueued
         provider = Provider.find_by(code: 'ABC')
         expect(provider).to be_present
       end
 
-      it 'handles missing latitude and longitude values' do
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_been_enqueued
-        provider = Provider.find_by(code: 'ABC')
-        expect(provider.latitude).to be_blank
+      it 'syncs the provider courses' do
+        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_in).exactly(1).time
+      end
+
+      context 'when latitude and longitude values are missing' do
+        let(:provider_from_api) { fake_api_provider({ code: 'ABC', latitude: nil, longitude: nil }) }
+
+        it 'handles missing latitude and longitude values' do
+          provider = Provider.find_by(code: 'ABC')
+          expect(provider.latitude).to be_blank
+        end
       end
     end
 
     context 'ingesting an existing provider' do
       before do
-        clear_enqueued_jobs
         described_class.new(
           provider_from_api:,
           recruitment_cycle_year: stubbed_recruitment_cycle_year,
@@ -51,24 +59,32 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider do
       let(:provider_from_api) { fake_api_provider(id: existing_provider.id, code: existing_provider.code, name: 'ABC College', region_code: 'north_west') }
 
       it 'correctly updates the provider' do
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_been_enqueued
         expect(existing_provider.reload.name).to eq('ABC College')
       end
 
       it 'correctly updates the Provider#region_code' do
-        expect(TeacherTrainingPublicAPI::SyncCourses).to have_been_enqueued.with(
+        expect(existing_provider.reload.region_code).to eq('north_west')
+      end
+
+      it 'calls the Sync Courses job with the correct parameters' do
+        expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_in).with(
+          nil,
           provider_from_api.id,
           stubbed_recruitment_cycle_year,
           true,
-        )
-        expect(existing_provider.reload.region_code).to eq('north_west')
+        ).exactly(1).time
       end
 
       context 'when delay set for running background job' do
         let(:delay_by) { 2.minutes }
 
         it 'calls the Sync Courses job with the correct delay time' do
-          expect(TeacherTrainingPublicAPI::SyncCourses).to have_been_enqueued.at(delay_by.from_now)
+          expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_in).with(
+            delay_by,
+            provider_from_api.id,
+            stubbed_recruitment_cycle_year,
+            true,
+          ).exactly(1).time
         end
       end
     end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -31,24 +31,24 @@ RSpec.describe WithdrawApplication do
     end
 
     it 'sends a notification email to the candidate if the application is the last one' do
-      allow(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to receive(:perform_later).and_return(true)
+      allow(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to receive(:perform_async).and_return(true)
       application_form = create(:completed_application_form)
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
 
       described_class.new(application_choice:).save!
 
-      expect(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to have_received(:perform_later).with(application_form.id)
+      expect(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to have_received(:perform_async).with(application_form.id)
     end
 
     it 'does not send a notification email to the candidate if the application is not the last one' do
-      allow(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to receive(:perform_later).and_return(true)
+      allow(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).to receive(:perform_async).and_return(true)
       application_form = create(:completed_application_form)
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
       _other_application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
 
       described_class.new(application_choice:).save!
 
-      expect(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).not_to have_received(:perform_later)
+      expect(CandidateMailers::SendWithdrawnLastApplicationChoiceEmailWorker).not_to have_received(:perform_async)
     end
   end
 

--- a/spec/services/withdraw_offer_spec.rb
+++ b/spec/services/withdraw_offer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe WithdrawOffer do
     end
 
     it 'sends an email to the candidate' do
-      allow(CandidateMailers::SendWithdrawnOfferEmailWorker).to receive(:perform_later).and_return(true)
+      allow(CandidateMailers::SendWithdrawnOfferEmailWorker).to receive(:perform_async).and_return(true)
       application_choice = create(:application_choice, status: :offer)
       withdrawal_reason = 'We messed up big time'
 
@@ -55,7 +55,7 @@ RSpec.describe WithdrawOffer do
         offer_withdrawal_reason: withdrawal_reason,
       ).save
 
-      expect(CandidateMailers::SendWithdrawnOfferEmailWorker).to have_received(:perform_later).with(application_choice.id)
+      expect(CandidateMailers::SendWithdrawnOfferEmailWorker).to have_received(:perform_async).with(application_choice.id)
     end
   end
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def and_adviser_sign_up_jobs_can_be_enqueued
-    allow(AdviserSignUpWorker).to receive(:perform_later)
+    allow(AdviserSignUpWorker).to receive(:perform_async)
   end
 
   def and_i_have_an_eligible_application
@@ -117,7 +117,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def and_an_adviser_sign_up_job_is_enqueued
-    expect(AdviserSignUpWorker).to have_received(:perform_later).once
+    expect(AdviserSignUpWorker).to have_received(:perform_async).once
     expect(Adviser::SignUpRequest.last).to have_attributes(application_form: @application_form)
   end
 

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_with_subject_match_changes_preferred_teaching_subject_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_with_subject_match_changes_preferred_teaching_subject_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate with a degree subject match changes their preferred te
   end
 
   def and_adviser_sign_up_jobs_can_be_enqueued
-    allow(AdviserSignUpWorker).to receive(:perform_later)
+    allow(AdviserSignUpWorker).to receive(:perform_async)
   end
 
   def when_i_visit_my_details_page

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_with_subject_match_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_with_subject_match_selects_yes_on_adviser_interruption_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate with a degree subject that matches an adviser teaching
   end
 
   def and_adviser_sign_up_jobs_can_be_enqueued
-    allow(AdviserSignUpWorker).to receive(:perform_later)
+    allow(AdviserSignUpWorker).to receive(:perform_async)
   end
 
   def when_i_visit_my_details_page

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_without_subject_match_selects_yes_on_adviser_interruption_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_without_subject_match_selects_yes_on_adviser_interruption_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Candidate selects yes on adviser interruption' do
   end
 
   def and_adviser_sign_up_jobs_can_be_enqueued
-    allow(AdviserSignUpWorker).to receive(:perform_later)
+    allow(AdviserSignUpWorker).to receive(:perform_async)
   end
 
   def when_i_visit_my_details_page

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -74,7 +74,7 @@ private
 
   def and_the_apply_deadline_has_passed
     advance_time_to(cancel_application_deadline + 1.second)
-    EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_now
+    EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_sync
   end
 
   def when_i_sign_in
@@ -120,13 +120,13 @@ private
 
   def when_the_reject_by_default_deadline_has_passed
     advance_time_to(reject_by_default_run_date)
-    EndOfCycle::RejectByDefaultWorker.perform_now
+    EndOfCycle::RejectByDefaultWorker.perform_sync
   end
   alias_method :and_the_reject_by_default_deadline_has_passed, :when_the_reject_by_default_deadline_has_passed
 
   def when_the_decline_by_default_date_has_passed
     advance_time_to(decline_by_default_run_date)
-    EndOfCycle::DeclineByDefaultWorker.perform_now
+    EndOfCycle::DeclineByDefaultWorker.perform_sync
   end
   alias_method :and_the_decline_by_default_date_has_passed, :when_the_decline_by_default_date_has_passed
 

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -76,7 +76,7 @@ private
 
   def and_the_apply_deadline_has_passed
     advance_time_to(cancel_application_deadline + 1.second)
-    EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_now
+    EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_sync
   end
 
   def when_i_sign_in
@@ -124,7 +124,7 @@ private
 
   def when_the_reject_by_default_deadline_has_passed
     advance_time_to(reject_by_default_run_date)
-    EndOfCycle::RejectByDefaultWorker.perform_now
+    EndOfCycle::RejectByDefaultWorker.perform_sync
   end
 
   def then_i_see_the_recruitment_deadline_page

--- a/spec/system/support_interface/data_directory_spec.rb
+++ b/spec/system/support_interface/data_directory_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe 'Data export' do
   end
 
   def when_i_click_the_generate_new_export_button
-    allow(DataExporter).to receive(:perform_later).and_return true
     click_link_or_button 'Generate new export'
   end
 

--- a/spec/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_change_worker_spec.rb
+++ b/spec/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_change_worker_spec.rb
@@ -9,8 +9,10 @@ module CandidateMailers
         allow(UnsubmittedApplicationChoicesForCourse).to(
           receive(:call).with(course.id).and_return(ApplicationChoice.all),
         )
+        allow(SendVisaSponsorshipDeadlineChangeWorker).to receive(:perform_at)
 
-        expect { described_class.new.perform(course.id) }.to enqueue_job(SendVisaSponsorshipDeadlineChangeWorker)
+        described_class.new.perform(course.id)
+        expect(SendVisaSponsorshipDeadlineChangeWorker).to have_received(:perform_at)
       end
 
       context 'when course is closed' do
@@ -20,8 +22,10 @@ module CandidateMailers
           allow(UnsubmittedApplicationChoicesForCourse).to(
             receive(:call).with(course.id).and_return(ApplicationChoice.all),
           )
+          allow(SendVisaSponsorshipDeadlineChangeWorker).to receive(:perform_at)
 
-          expect { described_class.new.perform(course.id) }.not_to enqueue_job(SendVisaSponsorshipDeadlineChangeWorker)
+          described_class.new.perform(course.id)
+          expect(SendVisaSponsorshipDeadlineChangeWorker).not_to have_received(:perform_at)
         end
       end
     end

--- a/spec/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_reminder_worker_spec.rb
+++ b/spec/workers/candidate_mailers/enqueue_visa_sponsorship_deadline_reminder_worker_spec.rb
@@ -8,7 +8,13 @@ module CandidateMailers
         allow(ApplicationChoicesVisaSponsorshipDeadlineReminder).to(
           receive(:call).and_return(ApplicationChoice.all),
         )
-        expect { described_class.perform_now }.to enqueue_job(SendVisaSponsorshipDeadlineReminderWorker).with(ApplicationChoice.all.pluck(:id))
+        worker = instance_double(ActiveJob::ConfiguredJob)
+        allow(SendVisaSponsorshipDeadlineReminderWorker).to receive(:set).and_return(worker)
+        allow(worker).to receive(:perform_later)
+
+        described_class.new.perform
+        expect(SendVisaSponsorshipDeadlineReminderWorker).to have_received(:set)
+        expect(worker).to have_received(:perform_later).with(ApplicationChoice.all.pluck(:id))
       end
     end
   end

--- a/spec/workers/delete_all_old_audits_in_batches_spec.rb
+++ b/spec/workers/delete_all_old_audits_in_batches_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DeleteAllOldAuditsInBatches do
       destroyable_audit_5 = create(:audit, created_at: Time.zone.local(2022, 10, 3, 23, 59, 59)) # 1 second before the timestamp
       safe_audit = create(:audit, created_at: Time.zone.local(2022, 10, 4, 0, 0, 1)) # 1 second after the timestamp
 
-      described_class.perform_now
+      described_class.perform_sync
 
       expect(Audited::Audit.all).to include(safe_audit)
       expect(Audited::Audit.all).not_to include(

--- a/spec/workers/end_of_cycle/cancel_reference_requests_worker_spec.rb
+++ b/spec/workers/end_of_cycle/cancel_reference_requests_worker_spec.rb
@@ -37,30 +37,39 @@ RSpec.describe EndOfCycle::CancelReferenceRequestsWorker do
   end
 
   describe '#perform' do
-    context 'after the decline by default date, and the course starts in September' do
-      it 'enqueues secondary worker for references with requested feedback, with a September course', time: decline_by_default_run_date(current_year) do
-        expect { described_class.new.perform }.to enqueue_job(EndOfCycle::CancelReferenceRequestsSecondaryWorker).with([september_reference.id])
+    context 'after the decline by default date, and the course starts in september' do
+      it 'enqueues secondary worker for references with requested feedback, with a september course', time: decline_by_default_run_date(current_year) do
+        allow(EndOfCycle::CancelReferenceRequestsSecondaryWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::CancelReferenceRequestsSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), contain_exactly(september_reference.id))
       end
     end
 
-    context 'after the decline by default date, and the application has courses ending in September and January' do
-      it 'does not enqueue a secondary worker for references with requested feedback, with a September course' do
+    context 'after the decline by default date, and the application has courses ending in september and january' do
+      it 'does not enqueue a secondary worker for references with requested feedback, with a september course' do
         create(
           :application_choice,
           application_form: september_application_choice.application_form,
           current_recruitment_cycle_year: year,
           course_option: build(:course_option, course: january_course),
         )
-        expect { described_class.perform_now }.not_to enqueue_job(EndOfCycle::CancelReferenceRequestsSecondaryWorker)
+        allow(EndOfCycle::CancelReferenceRequestsSecondaryWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::CancelReferenceRequestsSecondaryWorker)
+          .not_to have_received(:perform_at).with(kind_of(Time), contain_exactly(september_reference.id))
       end
     end
 
-    context 'after the winter decline by default date, and the course starting after September' do
+    context 'after the winter decline by default date, and the course starting after september' do
       let(:instance) { described_class.new }
 
-      it 'enqueues secondary worker for references with requested feedback, with a January course' do
+      it 'enqueues secondary worker for references with requested feedback, with a january course' do
         allow(instance).to receive(:run_winter_cancel_reference_requests?).and_return(true)
-        expect { instance.perform }.to enqueue_job(EndOfCycle::CancelReferenceRequestsSecondaryWorker).with([january_reference.id])
+        allow(EndOfCycle::CancelReferenceRequestsSecondaryWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::CancelReferenceRequestsSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), contain_exactly(january_reference.id))
       end
     end
   end

--- a/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/end_of_cycle/cancel_unsubmitted_applications_worker_spec.rb
@@ -60,9 +60,17 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
     context 'when force is true', time: mid_cycle do
       it 'allows job to be run' do
         create_test_applications
-        expect { described_class.new.perform(true) }
-          .to enqueue_job(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
-                .with(contain_exactly(unsubmitted_application_from_this_year.id, hidden_application_from_this_year.id))
+        allow(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).to receive(:perform_at)
+        described_class.new.perform(true)
+        expect(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
+          .to have_received(:perform_at)
+                .with(
+                  kind_of(Time),
+                  contain_exactly(
+                    unsubmitted_application_from_this_year.id,
+                    hidden_application_from_this_year.id,
+                  ),
+                )
       end
     end
 
@@ -72,9 +80,17 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
           it 'cancels applications' do
             create_test_applications
 
-            expect { described_class.new.perform }
-              .to enqueue_job(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
-                    .with(contain_exactly(unsubmitted_application_from_this_year.id, hidden_application_from_this_year.id))
+            allow(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
+              .to have_received(:perform_at)
+                    .with(
+                      kind_of(Time),
+                      contain_exactly(
+                        unsubmitted_application_from_this_year.id,
+                        hidden_application_from_this_year.id,
+                      ),
+                    )
           end
         end
 
@@ -82,7 +98,9 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
           it 'does not cancel any applications' do
             create_test_applications
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
+            allow(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -90,7 +108,9 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
           it 'does not run once in the middle of a cycle' do
             create_test_applications
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
+            allow(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -98,7 +118,9 @@ RSpec.describe EndOfCycle::CancelUnsubmittedApplicationsWorker do
           it 'does not run once the new cycle starts' do
             create_test_applications
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker)
+            allow(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::CancelUnsubmittedApplicationsSecondaryWorker).not_to have_received(:perform_at)
           end
         end
       end

--- a/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
         allow(instance).to receive_messages(winter_decline_by_default_set?: false)
         declineable = create(:application_choice, :offer)
 
-        expect { instance.perform(true) }
-          .to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
-                .with([declineable.application_form.id])
+        allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform(true)
+        expect(EndOfCycle::DeclineByDefaultSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [declineable.application_form.id])
       end
     end
 
@@ -22,9 +23,10 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
             allow(instance).to receive_messages(winter_decline_by_default_set?: false)
             declineable = create(:application_choice, :offer)
 
-            expect { instance.perform }
-              .to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
-                    .with([declineable.application_form.id])
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker)
+              .to have_received(:perform_at).with(kind_of(Time), contain_exactly(declineable.application_form.id))
           end
         end
 
@@ -32,7 +34,9 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
           it 'does not enqueues secondary worker' do
             create(:application_choice, :offer)
 
-            expect { instance.perform }.not_to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -40,7 +44,9 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
           it 'does not enqueues secondary worker' do
             create(:application_choice, :offer)
 
-            expect { instance.perform }.not_to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -48,7 +54,9 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
           it 'does not enqueues secondary worker' do
             create(:application_choice, :offer)
 
-            expect { instance.perform }.not_to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -67,7 +75,10 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
               course_option: create(:course_option, course: january_course),
             )
 
-            expect { instance.perform }.to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker).with([declineable.application_form.id])
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker)
+              .to have_received(:perform_at).with(kind_of(Time), contain_exactly(declineable.application_form.id))
           end
         end
 
@@ -86,7 +97,9 @@ RSpec.describe EndOfCycle::DeclineByDefaultWorker do
               course_option: create(:course_option, course: january_course),
             )
 
-            expect { instance.perform }.not_to enqueue_job(EndOfCycle::DeclineByDefaultSecondaryWorker)
+            allow(EndOfCycle::DeclineByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::DeclineByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
       end

--- a/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
       it 'enqueues the secondary worker', time: mid_cycle do
         rejectable = create(:application_choice, :inactive)
 
-        expect { described_class.new.perform(true) }.to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker).with(contain_exactly(rejectable.application_form.id))
+        allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+        described_class.new.perform(true)
+        expect(EndOfCycle::RejectByDefaultSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejectable.application_form.id])
       end
     end
 
@@ -24,14 +27,18 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
             # It will not include the offered application choice
             create(:application_choice, :offer)
 
-            expect { instance.perform }.to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
-              .with(
-                contain_exactly(
-                  inactive_choice.application_form.id,
-                  interviewing_choice.application_form.id,
-                  awaiting_decision_choice.application_form.id,
-                ),
-              )
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker)
+              .to have_received(:perform_at)
+                    .with(
+                      kind_of(Time),
+                      contain_exactly(
+                        inactive_choice.application_form.id,
+                        interviewing_choice.application_form.id,
+                        awaiting_decision_choice.application_form.id,
+                      ),
+                    )
           end
         end
 
@@ -39,7 +46,9 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
           it 'does not enqueue the secondary worker' do
             create(:application_choice, :inactive)
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -47,7 +56,9 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
           it 'does not enqueue the secondary worker' do
             create(:application_choice, :inactive)
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -55,7 +66,9 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
           it 'does not enqueue the secondary worker' do
             create(:application_choice, :inactive)
 
-            expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            described_class.new.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
 
@@ -78,14 +91,18 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
             # It will not include the offered application choice
             create(:application_choice, :offer)
 
-            expect { instance.perform }.to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
-              .with(
-                contain_exactly(
-                  inactive_choice.application_form.id,
-                  interviewing_choice.application_form.id,
-                  awaiting_decision_choice.application_form.id,
-                ),
-              )
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker)
+              .to have_received(:perform_at)
+                    .with(
+                      kind_of(Time),
+                      contain_exactly(
+                        inactive_choice.application_form.id,
+                        interviewing_choice.application_form.id,
+                        awaiting_decision_choice.application_form.id,
+                      ),
+                    )
           end
         end
 
@@ -101,7 +118,9 @@ RSpec.describe EndOfCycle::RejectByDefaultWorker do
               course_option: create(:course_option, course: january_course),
             )
 
-            expect { instance.perform }.not_to enqueue_job(EndOfCycle::RejectByDefaultSecondaryWorker)
+            allow(EndOfCycle::RejectByDefaultSecondaryWorker).to receive(:perform_at)
+            instance.perform
+            expect(EndOfCycle::RejectByDefaultSecondaryWorker).not_to have_received(:perform_at)
           end
         end
       end

--- a/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
+++ b/spec/workers/end_of_cycle/run_end_of_cycle_jobs_worker_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
   before do
-    allow(EndOfCycle::CancelUnsubmittedApplicationsWorker).to receive(:perform_later).with(true)
-    allow(EndOfCycle::CloseCoursesOnInvites).to receive(:perform_later).with(true)
-    allow(EndOfCycle::RejectByDefaultWorker).to receive(:perform_later).with(true)
-    allow(EndOfCycle::CancelReferenceRequestsWorker).to receive(:perform_later)
-    allow(EndOfCycle::DeclineByDefaultWorker).to receive(:perform_later).with(true)
-    allow(EndOfCycle::WinterRejectByDefaultWorker).to receive(:perform_later).with(true)
-    allow(EndOfCycle::WinterDeclineByDefaultWorker).to receive(:perform_later).with(true)
+    allow(EndOfCycle::CancelUnsubmittedApplicationsWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::CloseCoursesOnInvites).to receive(:perform_async).with(true)
+    allow(EndOfCycle::RejectByDefaultWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::CancelReferenceRequestsWorker).to receive(:perform_async)
+    allow(EndOfCycle::DeclineByDefaultWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::WinterRejectByDefaultWorker).to receive(:perform_async).with(true)
+    allow(EndOfCycle::WinterDeclineByDefaultWorker).to receive(:perform_async).with(true)
   end
 
   describe '#perform' do
@@ -17,13 +17,13 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         date = current_timetable.apply_opens_at + 2.months
         travel_temporarily_to(date) do
           described_class.new.perform
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_later)
-          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_async)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -34,15 +34,15 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         travel_temporarily_to(date) do
           described_class.new.perform
           # The winter jobs from the previous year will run
-          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_later)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_later)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # These jobs run on the apply deadline
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_later).with(true)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
           # Not these
-          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -53,16 +53,16 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         travel_temporarily_to(date) do
           described_class.new.perform
           # The winter jobs from the previous year will run
-          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_later)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_later)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # These jobs run on the apply deadline
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_later).with(true)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
           # And the reject by default worker
-          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_later).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_async).with(true)
           # Not these
-          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_later)
-          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -73,16 +73,16 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         travel_temporarily_to(date) do
           described_class.new.perform
           # The winter jobs from the previous year will run
-          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_later)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_later)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # Apply deadline jobs
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_later).with(true)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).to have_received(:perform_async).with(true)
           # And the reject by default worker
-          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_later).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).to have_received(:perform_async).with(true)
           # And the decline by default worker related jobs
-          expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_later)
+          expect(EndOfCycle::DeclineByDefaultWorker).to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).to have_received(:perform_async)
         end
       end
     end
@@ -93,15 +93,15 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         travel_temporarily_to(date) do
           described_class.new.perform
           # The winter reject by default worker will run
-          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_later)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
           # But not the winter decline by default worker
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).not_to have_received(:perform_async)
           # Or anything else
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
         end
       end
     end
@@ -112,14 +112,14 @@ RSpec.describe EndOfCycle::RunEndOfCycleJobsWorker do
         travel_temporarily_to(date) do
           described_class.new.perform
           # Both winter jobs run
-          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_later)
-          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_later)
+          expect(EndOfCycle::WinterRejectByDefaultWorker).to have_received(:perform_async)
+          expect(EndOfCycle::WinterDeclineByDefaultWorker).to have_received(:perform_async)
           # But nothing else
-          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_later).with(true)
-          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_later)
+          expect(EndOfCycle::CancelUnsubmittedApplicationsWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CloseCoursesOnInvites).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::RejectByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::DeclineByDefaultWorker).not_to have_received(:perform_async).with(true)
+          expect(EndOfCycle::CancelReferenceRequestsWorker).not_to have_received(:perform_async)
         end
       end
     end

--- a/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWork
       it 'does not enqueue the batch worker' do
         create(:application_form, :unsubmitted)
 
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
@@ -14,7 +16,9 @@ RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWork
       it 'does not enqueue the batch worker' do
         create(:application_form, :unsubmitted)
 
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
@@ -33,7 +37,11 @@ RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWork
         account_locked_candidate = create(:candidate, account_locked: true)
         create(:application_form, :unsubmitted, candidate: account_locked_candidate)
 
-        expect { described_class.new.perform }.to enqueue_job(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).with(contain_exactly(unsubmitted_application_form.id))
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [unsubmitted_application_form.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_decline_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -5,14 +5,18 @@ RSpec.describe EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker 
     context 'before the date for sending the explainer email', time: decline_by_default_explainer_date - 1.day do
       it 'does not enqueue the batch worker' do
         create(:application_choice, :declined_by_default)
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
     context 'after the date for sending the explainer email', time: decline_by_default_explainer_date + 1.day do
       it 'does not enqueue the batch worker' do
         create(:application_choice, :declined_by_default)
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
@@ -29,7 +33,11 @@ RSpec.describe EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesWorker 
         create(:application_choice, :interviewing)
         create(:application_choice, :awaiting_provider_decision)
 
-        expect { described_class.new.perform }.to enqueue_job(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).with(contain_exactly(rejected_with_offer.id, rejected_without_offer.id))
+        allow(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -5,14 +5,18 @@ RSpec.describe EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker d
     context 'before the date for sending the explainer email', time: reject_by_default_explainer_date - 1.day do
       it 'does not enqueue the batch worker' do
         create(:application_choice, :rejected_by_default)
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
     context 'after the date for sending the explainer email', time: reject_by_default_explainer_date + 1.day do
       it 'does not enqueue the batch worker' do
         create(:application_choice, :rejected_by_default)
-        expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
@@ -29,7 +33,11 @@ RSpec.describe EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker d
         create(:application_choice, :interviewing)
         create(:application_choice, :awaiting_provider_decision)
 
-        expect { described_class.new.perform }.to enqueue_job(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).with(contain_exactly(rejected_with_offer.id, rejected_without_offer.id))
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe EndOfCycle::SendRejectByDefaultReminderToProvidersWorker do
           application_choices = create(:application_choice, :awaiting_provider_decision)
           create(:provider_permissions, provider: application_choices.provider)
 
-          expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker)
+          allow(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          described_class.new.perform
+          expect(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).not_to have_received(:perform_at)
         end
       end
     end
@@ -19,7 +21,9 @@ RSpec.describe EndOfCycle::SendRejectByDefaultReminderToProvidersWorker do
           application_choices = create(:application_choice, :awaiting_provider_decision)
           create(:provider_permissions, provider: application_choices.provider)
 
-          expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker)
+          allow(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          described_class.new.perform
+          expect(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).not_to have_received(:perform_at)
         end
       end
     end
@@ -37,13 +41,15 @@ RSpec.describe EndOfCycle::SendRejectByDefaultReminderToProvidersWorker do
           create(:application_choice, :rejected)
           create(:application_choice, :unsubmitted)
 
-          expect { instance.perform }.to enqueue_job(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).with(
-            contain_exactly(
+          allow(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          instance.perform
+
+          expect(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker)
+            .to have_received(:perform_at).with(kind_of(Time), [
               inactive_application.provider.id,
               interview_application.provider.id,
               awaiting_application.provider.id,
-            ),
-          )
+            ])
         end
       end
     end
@@ -67,11 +73,13 @@ RSpec.describe EndOfCycle::SendRejectByDefaultReminderToProvidersWorker do
           create(:application_choice, :rejected)
           create(:application_choice, :unsubmitted)
 
-          expect { described_class.new.perform }.to enqueue_job(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).with(
-            contain_exactly(
+          allow(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          described_class.new.perform
+
+          expect(EndOfCycle::SendRejectByDefaultReminderToProvidersBatchWorker)
+            .to have_received(:perform_at).with(kind_of(Time), [
               september_course.provider.id,
-            ),
-          )
+            ])
         end
       end
     end

--- a/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_decline_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesW
           current_recruitment_cycle_year: previous_year,
           application_form: create(:application_form, recruitment_cycle_year: previous_year),
         )
-        expect { instance.perform }.not_to enqueue_job(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+        allow(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
@@ -41,7 +43,11 @@ RSpec.describe EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesW
         create(:application_choice, :awaiting_provider_decision, application_form: build(:application_form, recruitment_cycle_year: previous_year))
         create(:application_choice, :declined_by_default)
 
-        expect { instance.perform }.to enqueue_job(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).with(contain_exactly(declined_by_default_application.id))
+        allow(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        instance.perform
+
+        expect(EndOfCycle::SendWinterDeclineByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [declined_by_default_application.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_reject_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWorker do
+  let(:instance) { described_class.new }
   let(:previous_year) { RecruitmentCycleTimetable.previous_year }
 
   describe '#perform' do
@@ -12,15 +13,13 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWo
           current_recruitment_cycle_year: previous_year,
           application_form: create(:application_form, recruitment_cycle_year: previous_year),
         )
-        allow(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:set)
-        described_class.perform_now
-        expect(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:set)
+        allow(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
       end
     end
 
     context 'the date for sending the explainer email' do
-      let(:instance) { described_class.new }
-
       before do
         allow(instance).to receive(:send_emails?).and_return(true)
       end
@@ -80,14 +79,11 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesWo
         create(:application_choice, :awaiting_provider_decision, application_form: build(:application_form, recruitment_cycle_year: previous_year))
         create(:application_choice, :rejected_by_default)
 
-        worker = instance_double(ActiveJob::ConfiguredJob)
-        allow(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:set).and_return(worker)
-        allow(worker).to receive(:perform_later)
-
+        allow(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
         instance.perform
 
-        expect(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker).to have_received(:set)
-        expect(worker).to have_received(:perform_later).with([rejected_with_offer.id, rejected_without_offer.id, duplication_january_course_form.id])
+        expect(EndOfCycle::SendWinterRejectByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id, duplication_january_course_form.id])
       end
     end
   end

--- a/spec/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_winter_reject_by_default_reminder_to_providers_worker_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
           )
           create(:provider_permissions, provider: application_choice.provider)
 
-          expect { described_class.new.perform }.not_to enqueue_job(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker)
+          allow(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          described_class.new.perform
+          expect(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker).not_to have_received(:perform_at)
         end
       end
     end
@@ -77,11 +79,13 @@ RSpec.describe EndOfCycle::SendWinterRejectByDefaultReminderToProvidersWorker do
           create(:application_choice, :rejected, current_recruitment_cycle_year: previous_year)
           create(:application_choice, :unsubmitted, current_recruitment_cycle_year: previous_year)
 
-          expect { instance.perform }.to enqueue_job(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker).with(
-            contain_exactly(
+          allow(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker).to receive(:perform_at)
+          instance.perform
+
+          expect(EndOfCycle::SendWinterRejectByDefaultReminderToProvidersBatchWorker)
+            .to have_received(:perform_at).with(kind_of(Time), [
               january_course.provider.id, duplication_january_course.provider.id
-            ),
-          )
+            ])
         end
       end
     end

--- a/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/winter_decline_by_default_worker_spec.rb
@@ -42,21 +42,30 @@ RSpec.describe EndOfCycle::WinterDeclineByDefaultWorker do
   describe '#perform' do
     context 'where force is true' do
       it 'enqueues secondary worker for offered application choices', time: mid_cycle do
-        expect { instance.perform(true) }.to enqueue_job(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).with(contain_exactly(declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id))
+        allow(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform(true)
+        expect(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id])
       end
     end
 
     context 'after winter decline by default date' do
       it 'enqueues secondary worker for offered application choices' do
         allow(instance).to receive_messages(run_winter_decline_by_default?: true)
-        expect { instance.perform }.to enqueue_job(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).with(contain_exactly(declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id))
+        allow(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [declineable_last_cycle.application_form.id, declineable_this_cycle.application_form.id])
       end
     end
 
     context 'before winter decline by default date' do
       it 'enqueues secondary worker for offered application choices' do
         allow(instance).to receive_messages(run_winter_decline_by_default?: false)
-        expect { instance.perform }.not_to enqueue_job(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
+        allow(EndOfCycle::WinterDeclineByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::WinterDeclineByDefaultSecondaryWorker)
+          .not_to have_received(:perform_at)
       end
     end
   end

--- a/spec/workers/end_of_cycle/winter_reject_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/winter_reject_by_default_worker_spec.rb
@@ -63,35 +63,48 @@ RSpec.describe EndOfCycle::WinterRejectByDefaultWorker do
   describe '#perform' do
     context 'where force is true' do
       it 'enqueues the secondary worker', time: mid_cycle do
-        expect { instance.perform(force: true) }.to enqueue_job(EndOfCycle::WinterRejectByDefaultSecondaryWorker).with(
-          contain_exactly(
-            inactive_choice.application_form.id,
-            interviewing_choice.application_form.id,
-            awaiting_decision_choice.application_form.id,
-            inactive_choice_this_cycle.application_form.id,
-          ),
-        )
+        allow(EndOfCycle::WinterRejectByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform(force: true)
+        expect(EndOfCycle::WinterRejectByDefaultSecondaryWorker)
+          .to have_received(:perform_at)
+                .with(
+                  kind_of(Time),
+                  contain_exactly(
+                    inactive_choice.application_form.id,
+                    interviewing_choice.application_form.id,
+                    awaiting_decision_choice.application_form.id,
+                    inactive_choice_this_cycle.application_form.id,
+                  ),
+                )
       end
     end
 
     context 'after winter reject by default dates' do
       it 'enqueues the secondary worker' do
         allow(instance).to receive_messages(run_winter_reject_by_default?: true)
-        expect { instance.perform }.to enqueue_job(EndOfCycle::WinterRejectByDefaultSecondaryWorker).with(
-          contain_exactly(
-            inactive_choice.application_form.id,
-            interviewing_choice.application_form.id,
-            awaiting_decision_choice.application_form.id,
-            inactive_choice_this_cycle.application_form.id,
-          ),
-        )
+        allow(EndOfCycle::WinterRejectByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::WinterRejectByDefaultSecondaryWorker)
+          .to have_received(:perform_at)
+                .with(
+                  kind_of(Time),
+                  contain_exactly(
+                    inactive_choice.application_form.id,
+                    interviewing_choice.application_form.id,
+                    awaiting_decision_choice.application_form.id,
+                    inactive_choice_this_cycle.application_form.id,
+                  ),
+                )
       end
     end
 
     context 'before winter reject by default dates' do
       it 'enqueues the secondary worker' do
         allow(instance).to receive_messages(run_winter_reject_by_default?: false)
-        expect { instance.perform }.not_to enqueue_job(EndOfCycle::WinterRejectByDefaultSecondaryWorker)
+        allow(EndOfCycle::WinterRejectByDefaultSecondaryWorker).to receive(:perform_at)
+        instance.perform
+        expect(EndOfCycle::WinterRejectByDefaultSecondaryWorker)
+          .not_to have_received(:perform_at)
       end
     end
   end

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
+RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
     it 'returns an application on the reminder date' do
       travel_temporarily_to(first_reminder_date) do
@@ -13,7 +13,11 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
           recruitment_cycle_year: current_year,
         )
 
-        expect { described_class.perform_now }.to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).to be_present
       end
     end
 
@@ -22,7 +26,11 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
         unsubscribed_candidate = create(:candidate, account_locked: true)
         create(:application_form, candidate: unsubscribed_candidate)
 
-        expect { described_class.new.perform }.not_to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(unsubscribed_candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
 
@@ -31,7 +39,11 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
         unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
         create(:application_form, candidate: unsubscribed_candidate)
 
-        expect { described_class.new.perform }.not_to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(unsubscribed_candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
 
@@ -40,7 +52,11 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
         unsubscribed_candidate = create(:candidate, submission_blocked: true)
         create(:application_form, candidate: unsubscribed_candidate)
 
-        expect { described_class.new.perform }.not_to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(unsubscribed_candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
 
@@ -56,7 +72,11 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
           recruitment_cycle_year: current_year,
         )
 
-        expect { described_class.new.perform }.to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).to be_present
       end
     end
 
@@ -71,33 +91,55 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker do
           recruitment_cycle_year: current_year,
         )
 
-        expect { described_class.new.perform }.not_to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
 
     it 'does not return an application when the deadline has passed' do
       travel_temporarily_to(current_timetable.apply_deadline_at + 1.day) do
+        candidate = create(:candidate)
+
         create(
           :application_form,
+          candidate:,
           application_choices: [create(:application_choice, :application_not_sent)],
           recruitment_cycle_year: current_year,
         )
 
-        expect { described_class.new.perform }.not_to enqueue_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
 
     it 'does not return an application form from the previous cycle' do
       travel_temporarily_to(first_reminder_date) do
+        candidate = create(:candidate)
+
         create(
           :application_form,
-          application_choices: [build(:application_choice, :application_not_sent)],
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
           recruitment_cycle_year: previous_year,
         )
 
-        expect { described_class.new.perform }.not_to have_enqueued_job(SendEocDeadlineReminderEmailToCandidatesBatchWorker)
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).not_to be_present
       end
     end
+  end
+
+  def email_for_candidate(candidate)
+    ActionMailer::Base.deliveries.find { |e| e.header['to'].value == candidate.email_address }
   end
 
   def first_reminder_date

--- a/spec/workers/support/send_notify_template_with_attachment_worker_spec.rb
+++ b/spec/workers/support/send_notify_template_with_attachment_worker_spec.rb
@@ -1,16 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe Support::SendNotifyTemplateWithAttachmentWorker do
+RSpec.describe Support::SendNotifyTemplateWithAttachmentWorker, :sidekiq do
   let(:notify_request) do
     create(:notify_send_request, email_addresses:)
+  end
+
+  before do
+    allow(Support::SendNotifyTemplateWithAttachmentBatchWorker).to receive(:perform_at)
+
+    described_class.new.perform(notify_request.id)
   end
 
   describe '#perform' do
     let(:email_addresses) { %w[user_1@exmaple.com user_2@example.com user_3@example.com] }
 
     it 'enqueues a Support::SendNotifyTemplateWithAttachmentBatchWorker' do
-      expect { described_class.new.perform(notify_request.id) }.to enqueue_job(Support::SendNotifyTemplateWithAttachmentBatchWorker)
+      expect(Support::SendNotifyTemplateWithAttachmentBatchWorker).to have_received(:perform_at)
          .with(
+           Time.zone.now,
            %w[user_1@exmaple.com user_2@example.com user_3@example.com],
            notify_request.id,
          ).once
@@ -20,7 +27,7 @@ RSpec.describe Support::SendNotifyTemplateWithAttachmentWorker do
       let(:email_addresses) { 200.times.map { |n| "user_#{n}@example.com" } }
 
       it 'enqueues a batch of Support::SendNotifyTemplateWithAttachmentBatchWorkers' do
-        expect { described_class.new.perform(notify_request.id) }.to enqueue_job(Support::SendNotifyTemplateWithAttachmentBatchWorker).twice
+        expect(Support::SendNotifyTemplateWithAttachmentBatchWorker).to have_received(:perform_at).twice
       end
     end
   end


### PR DESCRIPTION
This reverts commit 8fd8f3523b954c3390924d92aded001098b59598.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
