### PR TITLE
Resolve issue with editable english proficiencies

### DIFF
--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -1,36 +1,42 @@
 module CandidateInterface
   module EnglishForeignLanguage
     module EflReviewHelper
-      def do_you_have_a_qualification_row(value:, return_to_application_review: false)
+      def do_you_have_a_qualification_row(value:, return_to_application_review: false, editable: true)
         {
           key: 'Have you done an English as a foreign language assessment?',
           value:,
-          action: {
-            href: candidate_interface_english_foreign_language_edit_start_path(return_to_params(return_to_application_review)),
-            visually_hidden_text: 'whether or not you have a qualification',
-          },
           html_attributes: {
             data: {
               qa: 'english-as-a-foreign-language',
             },
           },
-        }
+        }.tap do |row|
+          if editable
+            row[:action] = {
+              href: candidate_interface_english_foreign_language_edit_start_path(return_to_params(return_to_application_review)),
+              visually_hidden_text: 'whether or not you have a qualification',
+            }
+          end
+        end
       end
 
-      def type_of_qualification_row(name:, return_to_application_review: false)
+      def type_of_qualification_row(name:, return_to_application_review: false, editable: true)
         {
           key: 'Type of assessment',
           value: name,
-          action: {
-            href: candidate_interface_english_foreign_language_type_path(return_to_params(return_to_application_review)),
-            visually_hidden_text: 'type of assessment',
-          },
           html_attributes: {
             data: {
               qa: 'english-as-a-foreign-language-type',
             },
           },
-        }
+        }.tap do |row|
+          if editable
+            row[:action] = {
+              href: candidate_interface_english_foreign_language_type_path(return_to_params(return_to_application_review)),
+              visually_hidden_text: 'type of assessment',
+            }
+          end
+        end
       end
 
       def return_to_params(return_to_application_review)

--- a/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/ielts_review_component.rb
@@ -3,42 +3,66 @@ module CandidateInterface
     class IeltsReviewComponent < ApplicationComponent
       include EflReviewHelper
 
-      attr_reader :ielts_qualification, :return_to_application_review
+      attr_reader :ielts_qualification, :return_to_application_review, :editable
 
-      def initialize(ielts_qualification, return_to_application_review: false)
+      def initialize(ielts_qualification, return_to_application_review: false, editable: true)
         @ielts_qualification = ielts_qualification
         @return_to_application_review = return_to_application_review
+        @editable = editable
       end
 
       def ielts_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:),
-          type_of_qualification_row(name: 'IELTS', return_to_application_review:),
-          {
-            key: 'Test report form (TRF) number',
-            value: ielts_qualification.trf_number,
-            action: {
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:, editable:),
+          type_of_qualification_row(name: 'IELTS', return_to_application_review:, editable:),
+          trf_number_row,
+          band_score_row,
+          year_completed_row,
+        ]
+      end
+
+    private
+
+      def trf_number_row
+        {
+          key: 'Test report form (TRF) number',
+          value: ielts_qualification.trf_number,
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'TRF number',
-            },
-          },
-          {
-            key: 'Overall band score',
-            value: ielts_qualification.band_score,
-            action: {
+            }
+          end
+        end
+      end
+
+      def band_score_row
+        {
+          key: 'Overall band score',
+          value: ielts_qualification.band_score,
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'overall band score',
-            },
-          },
-          {
-            key: 'Year completed',
-            value: ielts_qualification.award_year,
-            action: {
+            }
+          end
+        end
+      end
+
+      def year_completed_row
+        {
+          key: 'Year completed',
+          value: ielts_qualification.award_year,
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_ielts_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'year completed',
-            },
-          },
-        ]
+            }
+          end
+        end
       end
     end
   end

--- a/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
@@ -3,16 +3,17 @@ module CandidateInterface
     class NoEflQualificationReviewComponent < ApplicationComponent
       include EflReviewHelper
 
-      attr_reader :english_proficiency, :return_to_application_review
+      attr_reader :english_proficiency, :return_to_application_review, :editable
 
-      def initialize(english_proficiency, return_to_application_review: false)
+      def initialize(english_proficiency, return_to_application_review: false, editable: true)
         @english_proficiency = english_proficiency
         @return_to_application_review = return_to_application_review
+        @editable = editable
       end
 
       def no_qualification_rows
         [
-          do_you_have_a_qualification_row(value: summary, return_to_application_review:),
+          do_you_have_a_qualification_row(value: summary, return_to_application_review:, editable:),
         ]
       end
 

--- a/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component.rb
@@ -3,34 +3,51 @@ module CandidateInterface
     class OtherEflQualificationReviewComponent < ApplicationComponent
       include EflReviewHelper
 
-      attr_reader :other_qualification, :return_to_application_review
+      attr_reader :other_qualification, :return_to_application_review, :editable
 
-      def initialize(other_qualification, return_to_application_review: false)
+      def initialize(other_qualification, return_to_application_review: false, editable: true)
         @other_qualification = other_qualification
         @return_to_application_review = return_to_application_review
+        @editable = editable
       end
 
       def ielts_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:),
-          type_of_qualification_row(name: other_qualification.name, return_to_application_review:),
-          {
-            key: 'Score or grade',
-            value: other_qualification.grade,
-            action: {
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:, editable:),
+          type_of_qualification_row(name: other_qualification.name, return_to_application_review:, editable:),
+          score_row,
+          year_completed_row,
+        ]
+      end
+
+    private
+
+      def score_row
+        {
+          key: 'Score or grade',
+          value: other_qualification.grade,
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_other_efl_qualification_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'score or grade',
-            },
-          },
-          {
-            key: 'Year completed',
-            value: other_qualification.award_year,
-            action: {
+            }
+          end
+        end
+      end
+
+      def year_completed_row
+        {
+          key: 'Year completed',
+          value: other_qualification.award_year,
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_other_efl_qualification_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'year completed',
-            },
-          },
-        ]
+            }
+          end
+        end
       end
     end
   end

--- a/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
@@ -3,57 +3,81 @@ module CandidateInterface
     class ToeflReviewComponent < ApplicationComponent
       include EflReviewHelper
 
-      attr_reader :toefl_qualification, :return_to_application_review
+      attr_reader :toefl_qualification, :return_to_application_review, :editable
 
-      def initialize(toefl_qualification, return_to_application_review: false)
+      def initialize(toefl_qualification, return_to_application_review: false, editable: true)
         @toefl_qualification = toefl_qualification
         @return_to_application_review = return_to_application_review
+        @editable = editable
       end
 
       def toefl_rows
         [
-          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:),
-          type_of_qualification_row(name: 'TOEFL', return_to_application_review:),
-          {
-            key: 'TOEFL registration number',
-            value: toefl_qualification.registration_number,
-            action: {
+          do_you_have_a_qualification_row(value: 'Yes', return_to_application_review:, editable:),
+          type_of_qualification_row(name: 'TOEFL', return_to_application_review:, editable:),
+          registration_number_row,
+          year_completed_row,
+          total_score_row,
+        ]
+      end
+
+    private
+
+      def registration_number_row
+        {
+          key: 'TOEFL registration number',
+          value: toefl_qualification.registration_number,
+          html: {
+            data: {
+              qa: 'english-as-a-foreign-language-registration-number',
+            },
+          },
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'registration number',
-            },
-            html: {
-              data: {
-                qa: 'english-as-a-foreign-language-registration-number',
-              },
+            }
+          end
+        end
+      end
+
+      def year_completed_row
+        {
+          key: 'Year completed',
+          value: toefl_qualification.award_year,
+          html_attributes: {
+            data: {
+              qa: 'english-as-a-foreign-language-year-completed',
             },
           },
-          {
-            key: 'Year completed',
-            value: toefl_qualification.award_year,
-            action: {
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'year completed',
-            },
-            html_attributes: {
-              data: {
-                qa: 'english-as-a-foreign-language-year-completed',
-              },
+            }
+          end
+        end
+      end
+
+      def total_score_row
+        {
+          key: 'Total score',
+          value: toefl_qualification.total_score,
+          html_attributes: {
+            data: {
+              qa: 'english-as-a-foreign-language-total-score',
             },
           },
-          {
-            key: 'Total score',
-            value: toefl_qualification.total_score,
-            action: {
+        }.tap do |row|
+          if editable
+            row[:action] = {
               href: candidate_interface_edit_toefl_path(return_to_params(return_to_application_review)),
               visually_hidden_text: 'total score',
-            },
-            html_attributes: {
-              data: {
-                qa: 'english-as-a-foreign-language-total-score',
-              },
-            },
-          },
-        ]
+            }
+          end
+        end
       end
     end
   end

--- a/app/services/candidate_interface/choose_efl_review_component.rb
+++ b/app/services/candidate_interface/choose_efl_review_component.rb
@@ -1,14 +1,15 @@
 module CandidateInterface
   class ChooseEflReviewComponent
-    def self.call(english_proficiency, return_to_application_review: false)
-      new(english_proficiency, return_to_application_review:).call
+    def self.call(english_proficiency, return_to_application_review: false, editable: true)
+      new(english_proficiency, return_to_application_review:, editable:).call
     end
 
     attr_reader :english_proficiency
 
-    def initialize(english_proficiency, return_to_application_review: false)
+    def initialize(english_proficiency, return_to_application_review: false, editable: true)
       @english_proficiency = english_proficiency
       @return_to_application_review = return_to_application_review
+      @editable = editable
     end
 
     def call
@@ -30,7 +31,7 @@ module CandidateInterface
   private
 
     def component_params
-      { return_to_application_review: @return_to_application_review }
+      { return_to_application_review: @return_to_application_review, editable: @editable }
     end
   end
 end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -65,7 +65,7 @@
           CandidateInterface::EnglishProficiencies::ReviewComponent.new(@application_form.english_proficiency, heading_level: 4, actions: false),
         ) %>
       <% else %>
-        <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency, return_to_application_review: true)) %>
+        <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency, return_to_application_review: true, editable:)) %>
       <% end %>
     <% else %>
       <%= render(CandidateInterface::IncompleteSectionComponent.new(section: 'efl', section_path: candidate_interface_english_foreign_language_start_path, error: missing_error)) %>

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -74,4 +74,22 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
       },
     )
   end
+
+  context 'when editable is false' do
+    it 'does not render any actions' do
+      ielts_qualification = build(
+        :ielts_qualification,
+        trf_number: '111111',
+        award_year: '2001',
+        band_score: '8',
+      )
+      render_inline(described_class.new(ielts_qualification, editable: false))
+
+      expect(rendered_content).to have_no_link('Change whether or not you have a qualification')
+      expect(rendered_content).to have_no_link('Change type of assessment')
+      expect(rendered_content).to have_no_link('Change TRF number')
+      expect(rendered_content).to have_no_link('Change year completed')
+      expect(rendered_content).to have_no_link('Change overall band score')
+    end
+  end
 end

--- a/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )
   end
+
+  context 'when editable is false' do
+    it 'does not render any actions' do
+      english_proficiency = build(
+        :english_proficiency,
+        :no_qualification,
+        no_qualification_details: 'I’m working on it.',
+      )
+
+      render_inline(described_class.new(english_proficiency, editable: false))
+
+      expect(rendered_content).to have_no_link('Change whether or not you have a qualification')
+    end
+  end
 end

--- a/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
@@ -33,4 +33,21 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )
   end
+
+  context 'when editable is false' do
+    it 'does not render any actions' do
+      other_qualification = build(
+        :other_efl_qualification,
+        name: 'Some English Test',
+        grade: '8',
+        award_year: '2001',
+      )
+      render_inline(described_class.new(other_qualification, editable: false))
+
+      expect(rendered_content).to have_no_link('Change whether or not you have a qualification')
+      expect(rendered_content).to have_no_link('Change type of assessment')
+      expect(rendered_content).to have_no_link('Change score or grade')
+      expect(rendered_content).to have_no_link('Change year completed')
+    end
+  end
 end

--- a/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
@@ -34,4 +34,22 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent,
       Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
     )
   end
+
+  context 'when editable is false' do
+    it 'does not render any actions' do
+      toefl_qualification = build(
+        :toefl_qualification,
+        registration_number: '222222 22222',
+        award_year: '2001',
+        total_score: '80',
+      )
+      render_inline(described_class.new(toefl_qualification, editable: false))
+
+      expect(rendered_content).to have_no_link('Change whether or not you have a qualification')
+      expect(rendered_content).to have_no_link('Change type of assessment')
+      expect(rendered_content).to have_no_link('Change registration number')
+      expect(rendered_content).to have_no_link('Change year completed')
+      expect(rendered_content).to have_no_link('Change total score')
+    end
+  end
 end


### PR DESCRIPTION
## Context

- Add an `editable` argument to English Proficiency components to conditionally show the change links.

## Changes proposed in this pull request

- Add an `editable` argument to each English Proficiency component, conditionally creating change actions.

## Guidance to review

- Visit https://apply-review-12121.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-12121.test.teacherservices.cloud/support/applications/71
- Click on 'Sign in as this candidate'
- Click on 'View application'
- Scroll down until you see `English as a foreign language assessment`
- You will see that the change links no longer appear

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/fdpNOE3e/2006-minor-bug-english-as-foreign-language-editable-from-application-review-pages

## Screenshots

<img width="982" height="659" alt="Screenshot 2026-07-21 at 15 35 58" src="https://github.com/user-attachments/assets/ee20ca98-2e5a-44a2-aff5-6fe5a6d3ba14" />
