### PR TITLE
Remove headers from mission control logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -87,7 +87,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.mission_control.jobs.adapters = [ :solid_queue ]
     config.mission_control.jobs.http_basic_auth_enabled = false
-    config.mission_control.jobs.filter_arguments = %w[email_address email code token data body hidden_data]
+    config.mission_control.jobs.filter_arguments = %w[email_address email code token data body hidden_data headers]
 
     config.action_controller.perform_caching = true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,6 +84,7 @@ module ApplyForPostgraduateTeacherTraining
     config.action_view.form_with_generates_remote_forms = false
 
     config.active_job.queue_adapter = :solid_queue
+    config.solid_queue.clear_finished_jobs_after = 1.hour
 
     config.mission_control.jobs.adapters = [ :solid_queue ]
     config.mission_control.jobs.http_basic_auth_enabled = false

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -20,6 +20,7 @@ class Clock
 
   # Hourly jobs
 
+  every(1.hour, 'DeleteFinishedJobs', at: '**:01') { DeleteFinishedJobsWorker.perform_later }
   every(1.hour, 'FindACandidate::PoolInviteChaserWorker', at: '**:35', skip_first_run: true) { FindACandidate::PoolInviteChaserWorker.perform_later }
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_later }
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
@@ -41,7 +42,6 @@ class Clock
   every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_later }
   every(1.day, 'DeactivateStaleServiceAPITokensWorker', at: '5:06') { DeactivateStaleServiceAPITokensWorker.perform_later }
   every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_later }
-  every(1.day, 'DeleteFinishedJobs', at: '19:00') { DeleteFinishedJobsWorker.perform_later }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_later }
 
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_later }


### PR DESCRIPTION
## Context

We have moved all of our job queue over to mission control. I want to filter out headers from the vendor API requests. 

## Changes proposed in this pull request

Just adding headers to the list of things to filter out.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
