### PR TITLE
Inactive prompt date tweak

### DIFF
--- a/app/workers/prompt_inactive_provider_users_worker.rb
+++ b/app/workers/prompt_inactive_provider_users_worker.rb
@@ -33,7 +33,7 @@ private
 
   def almost_inactive_date
     # 11 months and 2 weeks ago
-    @prompt_date ||= INACTIVE_MONTHS_AGO.months.ago - PROMPT_WEEKS_BEFORE.weeks
+    @prompt_date ||= (INACTIVE_MONTHS_AGO.months - PROMPT_WEEKS_BEFORE.weeks).ago
   end
 
   def inactive_date

--- a/config/locales/support_interface/docs/mailer_previews.yml
+++ b/config/locales/support_interface/docs/mailer_previews.yml
@@ -15,7 +15,7 @@ en:
             permissions_granted: Sent when someone receives permissions to manage applications for an organisation.
             permissions_granted_by_support: Sent when the support team give someone permissions to manage applications for an organisation.
             inactive_user_prompt: Sent when permissions are due to be removed in two weeks time.
-            inactive_user_prompt_multiple_providers: As above with multiple providers
+            inactive_user_prompt_multiple_providers: Sent when permissions are due to be removed in two weeks time - with multiple providers.
             permissions_removed: Sent when someone has their permissions removed and can no longer manage applications for an organisation.
             permissions_removed_by_support: Sent when someone has their permissions removed by the support team and can no longer manage applications for an organisation.
             permissions_updated: Sent when any user permissions are changed.

--- a/spec/workers/prompt_inactive_provider_users_worker_spec.rb
+++ b/spec/workers/prompt_inactive_provider_users_worker_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe PromptInactiveProviderUsersWorker do
 
   describe '#perform' do
     it 'prompts soon-to-be inactive provider users' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
-        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
-        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 1.day)
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: Time.zone.parse('2025-08-05 12:00:00'))
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: Time.zone.parse('2025-08-04 12:00:00'))
 
         described_class.new.perform
 
@@ -26,9 +26,9 @@ RSpec.describe PromptInactiveProviderUsersWorker do
     end
 
     it 'prompts users who have never signed in but were created almost a year ago' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
-        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks)
-        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 12.months.ago - 2.weeks - 1.day)
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: Time.zone.parse('2025-08-05 12:00:00'))
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: Time.zone.parse('2025-08-04 12:00:00'))
 
         described_class.new.perform
 
@@ -39,10 +39,10 @@ RSpec.describe PromptInactiveProviderUsersWorker do
       end
     end
 
-    it 'only prompts users on the prompt date and not again at a later date' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
-        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks)
-        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: 12.months.ago - 2.weeks - 3.days)
+    it 'only prompts users on their prompt date and not after it has passed' do
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
+        should_prompt = create(:provider_user, :with_provider, last_signed_in_at: Time.zone.parse('2025-08-05 12:00:00'))
+        should_not_prompt = create(:provider_user, :with_provider, last_signed_in_at: Time.zone.parse('2025-08-02 12:00:00'))
 
         described_class.new.perform
 
@@ -54,7 +54,7 @@ RSpec.describe PromptInactiveProviderUsersWorker do
     end
 
     it 'does not prompt a recently added but never signed in user' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
         create(:provider_user, :with_provider, last_signed_in_at: nil, created_at: 2.months.ago)
 
         described_class.new.perform
@@ -64,7 +64,7 @@ RSpec.describe PromptInactiveProviderUsersWorker do
     end
 
     it 'does not prompt an active user' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
         create(:provider_user, :with_provider, last_signed_in_at: 1.week.ago)
 
         described_class.new.perform
@@ -74,11 +74,11 @@ RSpec.describe PromptInactiveProviderUsersWorker do
     end
 
     it 'prompts users regardless of the time they signed in 11 months and 2 weeks ago' do
-      travel_to Time.zone.parse('2026-01-01 12:00:00') do
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
         should_prompt = create(
           :provider_user,
           :with_provider,
-          last_signed_in_at: Time.zone.parse('2024-12-18 15:59:59'),
+          last_signed_in_at: Time.zone.parse('2025-08-05 15:59:59'),
         )
 
         described_class.new.perform
@@ -88,12 +88,12 @@ RSpec.describe PromptInactiveProviderUsersWorker do
     end
 
     it 'batches users in groups of 100' do
-      travel_to Time.zone.parse('2026-1-1 12:00:00') do
+      travel_to Time.zone.parse('2026-07-22 12:00:00') do
         create_list(
           :provider_user,
           101,
           :with_provider,
-          last_signed_in_at: 12.months.ago - 2.weeks,
+          last_signed_in_at: Time.zone.parse('2025-08-05 12:00:00'),
         )
 
         described_class.new.perform


### PR DESCRIPTION
## Context

A tweak to #12093 to correctly work out the prompt date. The previous implementation set a prompt date based on last activity 12 months, 2 weeks ago when the intention was to grab a date 11 months, 2 weeks ago. As a result, five provider users whose permissions have already been removed received the prompt.

## Changes proposed in this pull request

- Change the calculation to work out the 11 months, 2 weeks in parentheses and _then_ work out the date from the date the job runs
- Improve spec to use dates rather than relative time periods

## Guidance to review

- Double check the date logic and spec
- We want to prompt someone who last signed in two weeks from now a year ago to get ahead of their reaching 12 months inactive:
```
Apply/Manage (development)> 12.months.ago - 2.weeks # previous implementation
=> 2025-07-08 10:43:48.886171000 BST +01:00
Apply/Manage (development)> (12.months - 2.weeks).ago # proposed implementation
=> 2025-08-05 10:44:05.853364000 BST +01:00
```

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
