### PR TITLE
Add start date to offer review component

### DIFF
--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     def start_date_row
       {
         key: 'Date course starts',
-        value: @course_choice.current_course.start_date.to_fs(:month_and_year)
+        value: @course_choice.current_course.start_date.to_fs(:month_and_year),
       }
     end
 

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -10,6 +10,7 @@ module CandidateInterface
       [
         provider_row,
         course_row,
+        start_date_row,
         (salary_row if @course_choice.current_course.salary_details),
         (fee_row if @course_choice.current_course.fee?),
         (location_row unless @course_choice.school_placement_auto_selected?),
@@ -34,6 +35,13 @@ module CandidateInterface
       {
         key: 'Course',
         value: course_row_value,
+      }
+    end
+
+    def start_date_row
+      {
+        key: 'Date course starts',
+        value: @course_choice.current_course.start_date.to_fs(:month_and_year)
       }
     end
 

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
     expect(result).not_to include('References')
   end
 
+  it 'renders component with the correct values for the course start date' do
+    result = render_inline(described_class.new(course_choice: application_choice))
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Date course starts')
+    expect(result.css('.govuk-summary-list__value').text).to include(course_option.course.start_date.to_fs(:month_and_year))
+  end
+
   context 'when reference condition' do
     let(:conditions) do
       [


### PR DESCRIPTION
## Context

- Add start date to the`CandidateInterface::OfferReviewComponent`

## Changes proposed in this pull request

- Add start date to the`CandidateInterface::OfferReviewComponent`

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/DAZEh9Hk/2004-bug-missing-course-start-date-from-candidate-offer-view

## Screenshot

<img width="1164" height="1371" alt="screencapture-localhost-3000-candidate-application-choice-157-offer-2026-07-22-11_25_18" src="https://github.com/user-attachments/assets/a12f8569-30ac-4e9f-93ce-0545b47ef57d" />

