### PR TITLE
Mirrors our sidekiq configuration

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -130,7 +130,7 @@ module "solid_queue_secondary_worker" {
   kubernetes_config_map_name   = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name       = module.application_configuration.kubernetes_secret_name
   command                      = ["bundle", "exec", "rake", "solid_queue:start"]
-  probe_command                = ["pgrep", "-f", "solid-queue-secondary-worker"]
+  probe_command                = ["pgrep", "-f", "solid-queue-worker"]
   enable_gcp_wif               = true
   enable_prometheus_monitoring = var.enable_prometheus_monitoring
   enable_logit                 = var.enable_logit

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -114,6 +114,29 @@ module "solid_queue_worker" {
   run_as_non_root              = true
 }
 
+module "solid_queue_secondary_worker" {
+  source     = "./vendor/modules/aks//aks/application"
+  depends_on = [module.web_application]
+
+  is_web                       = false
+  namespace                    = var.namespace
+  environment                  = local.app_name_suffix
+  service_name                 = var.service_name
+  name                         = "solid-queue-secondary-worker"
+  docker_image                 = var.docker_image
+  replicas                     = var.solid_queue_secondary_worker_replicas
+  max_memory                   = var.solid_queue_secondary_worker_memory_max
+  cluster_configuration_map    = module.cluster_data.configuration_map
+  kubernetes_config_map_name   = module.application_configuration.kubernetes_config_map_name
+  kubernetes_secret_name       = module.application_configuration.kubernetes_secret_name
+  command                      = ["bundle", "exec", "rake", "solid_queue:start"]
+  probe_command                = ["pgrep", "-f", "solid-queue-secondary-worker"]
+  enable_gcp_wif               = true
+  enable_prometheus_monitoring = var.enable_prometheus_monitoring
+  enable_logit                 = var.enable_logit
+  run_as_non_root              = true
+}
+
 module "clock_worker" {
   source     = "./vendor/modules/aks//aks/application"
   depends_on = [module.web_application]

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -110,6 +110,16 @@ variable "solid_queue_worker_replicas" {
   default = 1
 }
 
+variable "solid_queue_secondary_worker_memory_max" {
+  type = string
+  default = "2Gi"
+}
+
+variable "solid_queue_secondary_worker_replicas" {
+  type = number
+  default = 1
+}
+
 variable "enable_logit" { default = false }
 
 locals {

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -11,6 +11,7 @@
   "worker_memory_max": "2Gi",
   "secondary_worker_memory_max": "2Gi",
   "solid_queue_worker_memory_max": "3Gi",
+  "solid_queue_secondary_worker_memory_max": "3Gi",
   "clock_worker_memory_max": "1Gi",
   "webapp_replicas": 4,
   "worker_replicas": 2,


### PR DESCRIPTION
## Context

We had two worker pods in our sidekiq configuration. This adds a second solid queue worker. We are currently experiencing a pretty big backlog in the low_priority queue and I think this will add enough CPU to handle it. 

## Changes proposed in this pull request



## Guidance to review

Read the config carefully. 


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
