### PR TITLE
New content for remove access emails

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -198,6 +198,7 @@ class ProviderMailer < ApplicationMailer
     @provider_user = provider_user
     @provider = provider
     @permissions_removed_by = permissions_removed_by
+    @hide_get_help = true
 
     if @permissions_removed_by
       provider_notify_email(to: @provider_user.email_address,

--- a/app/views/provider_mailer/permissions_removed.text.erb
+++ b/app/views/provider_mailer/permissions_removed.text.erb
@@ -1,7 +1,27 @@
 Dear <%= @provider_user.full_name %>
 
 <% if @permissions_removed_by %>
-  <%= @permissions_removed_by.full_name %> has removed you from <%= @provider.name %>. You can no longer manage their teacher training applications.
+  <%= @permissions_removed_by.full_name %> has removed your access to Manage.
+
+  You are no longer able to manage teacher training applications for <%= @provider.name %>.
+
+  # If you want to use Manage again
+
+  You will need to contact the person who removed your access.
 <% else %>
-  You have been removed from <%= @provider.name %>. You can no longer manage their teacher training applications.
+  Your access to your Manage account has been removed. This is because your account had not been signed in for 12 months.
+
+  You are no longer able to manage teacher training applications for <%= @provider.name %>.
+
+  # If you want to use Manage again
+
+  You will need to contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to get your access back.
 <% end %>
+
+# Contact us
+
+If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Regards,
+
+Becoming a Teacher team

--- a/app/views/provider_mailer/permissions_removed.text.erb
+++ b/app/views/provider_mailer/permissions_removed.text.erb
@@ -9,7 +9,7 @@ Dear <%= @provider_user.full_name %>
 
   You will need to contact the person who removed your access.
 <% else %>
-  Your access to your Manage account has been removed. This is because your account had not been signed in for 12 months.
+  Your access to your Manage account has been removed. This is because your account had not been signed in to for 12 months.
 
   You are no longer able to manage teacher training applications for <%= @provider.name %>.
 

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -46,9 +46,9 @@ en:
     permissions_updated_by_support:
       subject: "Your permissions have been updated for %{organisation}"
     permissions_removed:
-      subject: "%{permissions_removed_by_user} has removed you from %{organisation}"
+      subject: "%{permissions_removed_by_user} has removed your access to Manage"
     permissions_removed_by_support:
-      subject: "You have been removed from %{organisation}"
+      subject: "Your access to your Manage account has been removed"
     apply_service_is_now_open:
       subject: "Candidates can now apply"
     find_service_is_now_open:

--- a/spec/mailers/provider_mailer/provider_mailer_permissions_removed_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_permissions_removed_spec.rb
@@ -12,10 +12,16 @@ RSpec.describe ProviderMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Jane Doe has removed you from Hogwarts University - manage teacher training applications',
+      'Jane Doe has removed your access to Manage - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
-      'heading' => 'Jane Doe has removed you from Hogwarts University. You can no longer manage their teacher training applications.',
-      'footer' => 'Get help, report a problem or give feedback',
+      'removed_access' => 'Jane Doe has removed your access to Manage.',
+      'no_longer_able' => 'You are no longer able to manage teacher training applications for Hogwarts University.',
+      'manage_again' => 'If you want to use Manage again',
+      'contact_person' => 'You will need to contact the person who removed your access.',
+      'contact_us' => 'Contact us',
+      'any_questions' => 'If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).',
+      'regard' => 'Regards,',
+      'becoming_a_teacher_team' => 'Becoming a Teacher team',
     )
   end
 
@@ -26,10 +32,17 @@ RSpec.describe ProviderMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'You have been removed from Hogwarts University - manage teacher training applications',
+      'Your access to your Manage account has been removed - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
-      'heading' => 'You have been removed from Hogwarts University. You can no longer manage their teacher training applications.',
-      'footer' => 'Get help, report a problem or give feedback',
+      'access_removed' => 'Your access to your Manage account has been removed.',
+      'not_signed_in' => 'This is because your account had not been signed in for 12 months.',
+      'no_longer_able' => 'You are no longer able to manage teacher training applications for Hogwarts University.',
+      'manage_again' => 'If you want to use Manage again',
+      'access_back' => 'You will need to contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to get your access back.',
+      'contact_us' => 'Contact us',
+      'any_questions' => 'If you have any questions, please contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).',
+      'regard' => 'Regards,',
+      'becoming_a_teacher_team' => 'Becoming a Teacher team',
     )
   end
 end

--- a/spec/mailers/provider_mailer/provider_mailer_permissions_removed_spec.rb
+++ b/spec/mailers/provider_mailer/provider_mailer_permissions_removed_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ProviderMailer do
       'Your access to your Manage account has been removed - manage teacher training applications',
       'salutation' => 'Dear Princess Fiona',
       'access_removed' => 'Your access to your Manage account has been removed.',
-      'not_signed_in' => 'This is because your account had not been signed in for 12 months.',
+      'not_signed_in' => 'This is because your account had not been signed in to for 12 months.',
       'no_longer_able' => 'You are no longer able to manage teacher training applications for Hogwarts University.',
       'manage_again' => 'If you want to use Manage again',
       'access_back' => 'You will need to contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to get your access back.',

--- a/spec/system/support_interface/removing_a_provider_user_spec.rb
+++ b/spec/system/support_interface/removing_a_provider_user_spec.rb
@@ -68,6 +68,6 @@ RSpec.describe 'Managing provider users v2' do
 
   def and_the_user_receive_an_email_about_being_removed_from_the_provider
     open_email(@provider_user.email_address)
-    expect(current_email.subject).to include("You have been removed from #{@provider_one.name}")
+    expect(current_email.subject).to include('Your access to your Manage account has been removed')
   end
 end


### PR DESCRIPTION
## Context

- New content for access removed emails

## Changes proposed in this pull request

- New content for `ProviderMailer` `permissions_removed` mailer

## Guidance to review

_Support user removed access_

- Visit https://apply-review-12127.test.teacherservices.cloud/rails/mailers/provider/organisation_permissions_mailer/permissions_removed_by_support
- Check content

_Provider user removed access_

- Visit https://apply-review-12127.test.teacherservices.cloud/rails/mailers/provider/organisation_permissions_mailer/permissions_removed
- Check content

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/kcAHf70f/1982-review-account-deletion-email

## Screenshots

_Support user removed access_

<img width="570" height="670" alt="Screenshot 2026-07-22 at 15 31 50" src="https://github.com/user-attachments/assets/3e0b65ff-5cf6-4122-b7bf-1cf51134fad7" />

_Provider removed access_

<img width="570" height="595" alt="Screenshot 2026-07-22 at 15 32 46" src="https://github.com/user-attachments/assets/420681d1-a727-4260-a78c-1e7fbd0603ef" />

