### PR TITLE
Update provider interface qualification cards component

### DIFF
--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -44,6 +44,10 @@
                 <dt class="app-qualification__key">Comparability</dt>
                 <dd class="app-qualification__value"><%= enic_statement(qualification) %></dd>
               <% end %>
+              <% if qualification.not_completed_explanation.present? %>
+                <dt class="app-qualification__key">Other evidence I have the skills required</dt>
+                <dd class="app-qualification__value"><%= qualification.not_completed_explanation %></dd>
+              <% end %>
             </dl>
           <%# UK or UK Other qualification %>
           <% else %>

--- a/spec/components/utility/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/utility/gcse_qualification_cards_component_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
               subject: 'maths',
               grade: 'C',
               award_year: 2006,
-              non_uk_qualification_type: 'Diploma',
-              institution_country: 'FR',
+              non_uk_qualification_type: 'KCSE (Kenya Certificate of Secondary Education)',
+              institution_country: 'KE',
             ),
           ],
         )
@@ -91,10 +91,28 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
         result = render_inline(described_class.new(application_form))
 
         expect(result.text).to include 'GCSEs or equivalent'
-        expect(result.text).to include 'Maths Diploma'
-        expect(result.text).to include '2006, France'
+        expect(result.text).to include 'KCSE (Kenya Certificate of Secondary Education)'
+        expect(result.text).to include '2006, Kenya'
         expect(result.text).to include 'C'
         expect(result.text).to include 'UK ENIC or NARIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
+        expect(result.text).not_to include 'Other evidence I have the skills required'
+      end
+
+      context 'when the candidate has provided evidence for a lower grade' do
+        before do
+          application_form.maths_gcse.update(grade: 'E',
+                                             enic_reason: nil,
+                                             enic_reference: nil,
+                                             not_completed_explanation: 'I will provide further documentation via email')
+        end
+
+        it 'displays the other evidence line' do
+          result = render_inline(described_class.new(application_form))
+
+          expect(result.text).to include 'GCSEs or equivalent'
+          expect(result.text).to include 'Other evidence I have the skills required'
+          expect(result.text).to include 'I will provide further documentation via email'
+        end
       end
 
       context 'when the UK ENIC reference is not provided' do


### PR DESCRIPTION
## Context

Update provider interface qualification cards component to display the `not_completed_explanation` is one has been provided.

## Changes proposed in this pull request

- Add a conditional line to the component and update the spec.

## Guidance to review

- Log in as Susan Upport: https://apply-review-12128.test.teacherservices.cloud/support/users/provider/2
- Visit https://apply-review-12128.test.teacherservices.cloud/provider/applications/158
- Inspect GCSEs from the provider viewpoint

<img width="998" height="432" alt="Screenshot 2026-07-22 at 15 40 00" src="https://github.com/user-attachments/assets/25154740-aeb0-417b-b5c3-8095d28e1436" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
