### PR TITLE
Check all reference-related conditions for references button

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -26,4 +26,11 @@ class Offer < ApplicationRecord
   def all_conditions_met?
     conditions.all?(&:met?)
   end
+
+  def all_references_conditions_met?
+    [
+      reference_condition,
+      conditions.filter(&:satisfactory_references?),
+    ].flatten.compact_blank.all?(&:met?)
+  end
 end

--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,5 +1,6 @@
 class OfferCondition < ApplicationRecord
-  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check', 'Satisfactory references'].freeze
+  SATISFACTORY_REFERENCES = 'Satisfactory references'.freeze
+  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check', SATISFACTORY_REFERENCES].freeze
 
   belongs_to :offer, touch: true
   has_one :application_choice, through: :offer
@@ -17,6 +18,10 @@ class OfferCondition < ApplicationRecord
 
   def standard_condition?
     STANDARD_CONDITIONS.include?(text)
+  end
+
+  def satisfactory_references?
+    text == SATISFACTORY_REFERENCES
   end
 
   def self.detail(key)

--- a/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
@@ -4,7 +4,7 @@
 
 <%= render CandidateInterface::ReferencesComponent.new(references: @references, reference_condition: @application_choice.offer.reference_condition) %>
 
-<% unless @application_choice.offer.reference_condition&.met? %>
+<% unless @application_choice.offer.all_references_conditions_met? %>
   <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
 <% end %>
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -102,4 +102,39 @@ RSpec.describe Offer do
       expect(offer.all_conditions_met?).to be false
     end
   end
+
+  describe '#all_references_conditions_met?' do
+    it 'returns true if both reference condition and the satisfactory references condition are met' do
+      offer = create(
+        :offer,
+        conditions: [
+          build(:text_condition, status: 'met', description: 'Satisfactory references'),
+          build(:reference_condition, status: 'met'),
+        ],
+      )
+      expect(offer.all_references_conditions_met?).to be true
+    end
+
+    it 'returns false if the satisfactory references condition is not met' do
+      offer = create(
+        :offer,
+        conditions: [
+          build(:text_condition, status: 'pending', description: 'Satisfactory references'),
+          build(:reference_condition, status: 'met'),
+        ],
+      )
+      expect(offer.all_references_conditions_met?).to be false
+    end
+
+    it 'returns false if the references condition is not met' do
+      offer = create(
+        :offer,
+        conditions: [
+          build(:text_condition, status: 'met', description: 'Satisfactory references'),
+          build(:reference_condition, status: 'pending'),
+        ],
+      )
+      expect(offer.all_references_conditions_met?).to be false
+    end
+  end
 end

--- a/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_post_offer_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_reference_with_personal_email_address_post_offer_spec.rb
@@ -79,6 +79,7 @@ private
       :accepted,
       application_form: @application_form,
     )
+    create(:text_condition, description: 'Satisfactory references', status: 'pending', offer: @application_choice.offer)
   end
 
   def and_i_navigate_to_add_another_reference

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'New References', :with_audited do
 
   scenario 'Candidate request their references on the post offer dashboard' do
     given_i_am_signed_in_with_one_login
-    and_i_have_an_accepted_offer
+    and_i_have_an_accepted_offer_with_unmet_reference_conditions
 
     when_i_visit_the_application_dashboard
     then_i_see_the_post_offer_dashboard
@@ -58,7 +58,7 @@ RSpec.describe 'New References', :with_audited do
     then_the_back_link_point_to_the_offer_dashboard_page
   end
 
-  def and_i_have_an_accepted_offer
+  def and_i_have_an_accepted_offer_with_unmet_reference_conditions
     @application_form = create(:completed_application_form, candidate: @current_candidate)
     @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
     @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
@@ -68,6 +68,7 @@ RSpec.describe 'New References', :with_audited do
       :accepted,
       application_form: @application_form,
     )
+    create(:text_condition, description: 'Satisfactory references', status: 'pending', offer: @application_choice.offer)
   end
 
   def when_i_visit_the_application_dashboard


### PR DESCRIPTION
## Context

We received a support request from someone unable to request additional references from their offer page, so I had a look at the conditions around rendering the 'Request more references' button and they are bit too limiting as we now have two possible reference-related conditions -- the mandatory one with description == 'Satisfactory References' condition and the specific `ReferenceCondition`. This was only looking to see if the`ReferenceCondition` was met. 

## Changes proposed in this pull request

Added a method to the offer for checking that all the reference-related conditions are met, not just the one with type == "Reference". 

## Guidance to review

Just some code to read. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
