### PR TITLE
Updates to ApplicationForm carry over script

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -25,6 +25,10 @@ class DuplicateApplication
         )
       end
 
+      new_application_form.update(
+        contact_details_completed: false,
+      )
+
       if !new_application_form.british_or_irish?
         new_application_form.update(
           personal_details_completed: false,

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -6,7 +6,7 @@ class DuplicateApplication
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
-  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details efl_completed efl_completed_at feedback_form_complete equality_and_diversity_completed equality_and_diversity_completed_at adviser_interruption_response].freeze
+  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete efl_completed efl_completed_at feedback_form_complete equality_and_diversity_completed equality_and_diversity_completed_at adviser_interruption_response].freeze
   IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
 
   def duplicate
@@ -134,7 +134,12 @@ class DuplicateApplication
 
       original_previous_teacher_trainings = original_application_form.published_previous_teacher_trainings
 
-      if original_previous_teacher_trainings.blank?
+      if original_previous_teacher_trainings.blank? || multiple_previous_teacher_trainings_2025?
+        new_application_form.update!(previous_teacher_training_completed: false)
+      elsif single_previous_teacher_training_2025?
+        new_application_form.published_previous_teacher_trainings.create!(
+          original_previous_teacher_trainings.first.attributes.except(*IGNORED_ATTRIBUTES),
+        )
         new_application_form.update!(previous_teacher_training_completed: false)
       else
         new_application_form.published_previous_teacher_trainings.create!(
@@ -145,7 +150,7 @@ class DuplicateApplication
         new_application_form.update!(previous_teacher_training_completed: true)
       end
 
-      if new_application_form.recruitment_cycle_year <= 2024
+      if original_application_form.recruitment_cycle_year <= 2024
         new_application_form.update!(equality_and_diversity: nil)
       end
 

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -41,6 +41,13 @@ class DuplicateApplication
         new_application_form.application_qualifications.create!(
           w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
         )
+
+        next unless w.non_uk_qualification_type.present? && unstructured_qualification_from_a_structured_qualification_country?(w)
+                      && %w[english maths science].include?(w.subject)
+
+        new_application_form.update(
+          "#{w.subject}_gcse_completed": false,
+        )
       end
 
       if new_application_form.incomplete_degree_information?
@@ -139,6 +146,31 @@ class DuplicateApplication
   end
 
 private
+
+  def multiple_previous_teacher_trainings_2025?
+    original_application_form.recruitment_cycle_year == 2025 && original_application_form.published_previous_teacher_trainings.many?
+  end
+
+  def single_previous_teacher_training_2025?
+    original_application_form.recruitment_cycle_year == 2025 && original_application_form.published_previous_teacher_trainings.one?
+  end
+
+  def visa_carry_over_condition_not_met_for_2027(new_application_form, original_application_form)
+    new_application_form.recruitment_cycle_year == 2027
+        && original_application_form.temporary_immigration_status?
+  end
+
+  def subsequent_years_visa_carry_over_condition_not_met(new_application_form, original_application_form)
+    new_application_form.recruitment_cycle_year > 2027 &&
+      original_application_form.visa_expired_at.present? && original_application_form.visa_expired_at <= Time.zone.today
+  end
+
+  def unstructured_qualification_from_a_structured_qualification_country?(qualification)
+    InternationalQualifications::StructuredGcseOptionFinder
+      .new(qualification.institution_country, qualification.subject)
+      .international_qualifications
+      .none? { |qual| qual.name == qualification.non_uk_qualification_type }
+  end
 
   def infer_currently_working(application_experience)
     return application_experience.currently_working unless application_experience.currently_working.nil?

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -29,6 +29,16 @@ class DuplicateApplication
         new_application_form.update(
           personal_details_completed: false,
         )
+
+        if visa_carry_over_condition_not_met_for_2027(new_application_form, original_application_form)
+          || subsequent_years_visa_carry_over_condition_not_met(new_application_form, original_application_form)
+          new_application_form.update(
+            immigration_status: nil,
+            visa_expired_at: nil,
+            right_to_work_or_study: nil,
+            right_to_work_or_study_details: nil,
+          )
+        end
       end
 
       original_application_form.application_volunteering_experiences.each do |w|

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -6,7 +6,7 @@ class DuplicateApplication
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
-  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details efl_completed efl_completed_at feedback_form_complete equality_and_diversity equality_and_diversity_completed adviser_interruption_response].freeze
+  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details efl_completed efl_completed_at feedback_form_complete equality_and_diversity_completed equality_and_diversity_completed_at adviser_interruption_response].freeze
   IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
 
   def duplicate
@@ -143,6 +143,10 @@ class DuplicateApplication
           end,
         )
         new_application_form.update!(previous_teacher_training_completed: true)
+      end
+
+      if new_application_form.recruitment_cycle_year <= 2024
+        new_application_form.update!(equality_and_diversity: nil)
       end
 
       if original_application_form.never_asked?

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -6,7 +6,7 @@ class DuplicateApplication
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
-  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete equality_and_diversity equality_and_diversity_completed adviser_interruption_response].freeze
+  IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details efl_completed efl_completed_at feedback_form_complete equality_and_diversity equality_and_diversity_completed adviser_interruption_response].freeze
   IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
 
   def duplicate
@@ -24,10 +24,6 @@ class DuplicateApplication
           w.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge('currently_working' => infer_currently_working(w)),
         )
       end
-
-      new_application_form.update(
-        contact_details_completed: false,
-      )
 
       if !new_application_form.british_or_irish?
         new_application_form.update(

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -30,8 +30,8 @@ class DuplicateApplication
           personal_details_completed: false,
         )
 
-        if visa_carry_over_condition_not_met_for_2027(new_application_form, original_application_form)
-          || subsequent_years_visa_carry_over_condition_not_met(new_application_form, original_application_form)
+        if temporary_visa_and_recruitment_cycle_into_2027?(new_application_form, original_application_form)
+          || visa_expired?(original_application_form)
           new_application_form.update(
             immigration_status: nil,
             visa_expired_at: nil,
@@ -134,9 +134,9 @@ class DuplicateApplication
 
       original_previous_teacher_trainings = original_application_form.published_previous_teacher_trainings
 
-      if original_previous_teacher_trainings.blank? || multiple_previous_teacher_trainings_2025?
+      if multiple_previous_teacher_trainings_from_2025? || original_previous_teacher_trainings.blank?
         new_application_form.update!(previous_teacher_training_completed: false)
-      elsif single_previous_teacher_training_2025?
+      elsif single_previous_teacher_training_from_2025?
         new_application_form.published_previous_teacher_trainings.create!(
           original_previous_teacher_trainings.first.attributes.except(*IGNORED_ATTRIBUTES),
         )
@@ -166,22 +166,21 @@ class DuplicateApplication
 
 private
 
-  def multiple_previous_teacher_trainings_2025?
+  def multiple_previous_teacher_trainings_from_2025?
     original_application_form.recruitment_cycle_year == 2025 && original_application_form.published_previous_teacher_trainings.many?
   end
 
-  def single_previous_teacher_training_2025?
+  def single_previous_teacher_training_from_2025?
     original_application_form.recruitment_cycle_year == 2025 && original_application_form.published_previous_teacher_trainings.one?
   end
 
-  def visa_carry_over_condition_not_met_for_2027(new_application_form, original_application_form)
+  def temporary_visa_and_recruitment_cycle_into_2027?(new_application_form, original_application_form)
     new_application_form.recruitment_cycle_year == 2027
         && original_application_form.temporary_immigration_status?
   end
 
-  def subsequent_years_visa_carry_over_condition_not_met(new_application_form, original_application_form)
-    new_application_form.recruitment_cycle_year > 2027 &&
-      original_application_form.visa_expired_at.present? && original_application_form.visa_expired_at <= Time.zone.today
+  def visa_expired?(original_application_form)
+    original_application_form.visa_expired_at.present? && original_application_form.visa_expired_at <= Time.zone.today
   end
 
   def unstructured_qualification_from_a_structured_qualification_country?(qualification)

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -30,8 +30,7 @@ class DuplicateApplication
           personal_details_completed: false,
         )
 
-        if temporary_visa_and_recruitment_cycle_into_2027?(new_application_form, original_application_form)
-          || visa_expired?(original_application_form)
+        if original_application_form.temporary_immigration_status? && visa_expired?(original_application_form)
           new_application_form.update(
             immigration_status: nil,
             visa_expired_at: nil,
@@ -52,8 +51,8 @@ class DuplicateApplication
           w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
         )
 
-        next unless w.non_uk_qualification_type.present? && unstructured_qualification_from_a_structured_qualification_country?(w)
-                      && %w[english maths science].include?(w.subject)
+        next unless international_gcse_equivalent_present?(w) && %w[english maths science].include?(w.subject)
+              && unstructured_qualification_from_a_structured_qualification_country?(w)
 
         new_application_form.update(
           "#{w.subject}_gcse_completed": false,
@@ -134,9 +133,7 @@ class DuplicateApplication
 
       original_previous_teacher_trainings = original_application_form.published_previous_teacher_trainings
 
-      if multiple_previous_teacher_trainings_from_2025? || original_previous_teacher_trainings.blank?
-        new_application_form.update!(previous_teacher_training_completed: false)
-      elsif single_previous_teacher_training_from_2025?
+      if single_previous_teacher_training_from_2025?
         new_application_form.published_previous_teacher_trainings.create!(
           original_previous_teacher_trainings.first.attributes.except(*IGNORED_ATTRIBUTES),
         )
@@ -174,13 +171,9 @@ private
     original_application_form.recruitment_cycle_year == 2025 && original_application_form.published_previous_teacher_trainings.one?
   end
 
-  def temporary_visa_and_recruitment_cycle_into_2027?(new_application_form, original_application_form)
-    new_application_form.recruitment_cycle_year == 2027
-        && original_application_form.temporary_immigration_status?
-  end
-
   def visa_expired?(original_application_form)
-    original_application_form.visa_expired_at.present? && original_application_form.visa_expired_at <= Time.zone.today
+    original_application_form.visa_expired_at.nil? || (original_application_form.visa_expired_at.present?
+        && original_application_form.visa_expired_at <= Time.zone.today)
   end
 
   def unstructured_qualification_from_a_structured_qualification_country?(qualification)
@@ -188,6 +181,10 @@ private
       .new(qualification.institution_country, qualification.subject)
       .international_qualifications
       .none? { |qual| qual.name == qualification.non_uk_qualification_type }
+  end
+
+  def international_gcse_equivalent_present?(qualification)
+    qualification.level == 'gcse' && qualification.non_uk_qualification_type.present?
   end
 
   def infer_currently_working(application_experience)

--- a/config/initializers/qualifications/gcses/international/qualifications.rb
+++ b/config/initializers/qualifications/gcses/international/qualifications.rb
@@ -54,6 +54,8 @@ module DfE
           },
           schema: INTERNATIONAL_QUALIFICATIONS_SCHEMA,
         )
+
+        STRUCTURED_QUALIFICATION_COUNTRIES = %w[NG GH SL GM LR KE IN].freeze
       end
     end
   end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe CarryOverApplication do
 
   let(:application_form) { create(:completed_application_form, references_count: 0) }
 
+  describe 'personal_details_completed' do
+    it 'sets the personal details section to incomplete if nationality is not UK/Irish' do
+      ApplicationForm.with_unsafe_application_choice_touches do
+        original_application_form.update!(
+          first_nationality: 'Indian',
+          personal_details_completed: true,
+          recruitment_cycle_year: 2021,
+        )
+        described_class.new(original_application_form).call
+      end
+      carried_over_application_form = ApplicationForm.last
+
+      expect(carried_over_application_form.personal_details_completed).to be(false)
+    end
+  end
+
   context 'when application is waiting for references' do
     it 'sets the reference to the not_requested state' do
       create(:reference, feedback_status: :feedback_provided, application_form:)
@@ -72,34 +88,6 @@ RSpec.describe CarryOverApplication do
       carried_over_application_form = ApplicationForm.last
 
       expect(carried_over_application_form.application_work_experiences.count).to eq(2)
-    end
-
-    describe 'personal_details_completed' do
-      it 'sets the personal details section to incomplete if nationality is not UK/Irish for 2021-22 carry over' do
-        ApplicationForm.with_unsafe_application_choice_touches do
-          original_application_form.update!(
-            first_nationality: 'Indian',
-            personal_details_completed: true,
-            recruitment_cycle_year: 2021,
-          )
-          described_class.new(original_application_form).call
-        end
-        carried_over_application_form = ApplicationForm.last
-
-        expect(carried_over_application_form.personal_details_completed).to be(false)
-      end
-
-      it 'does NOT set the personal details section to incomplete if nationality is UK/Irish for 2021-22 carry over' do
-        original_application_form.update!(
-          first_nationality: 'British',
-          personal_details_completed: true,
-          recruitment_cycle_year: 2021,
-        )
-        described_class.new(original_application_form).call
-        carried_over_application_form = ApplicationForm.last
-
-        expect(carried_over_application_form.personal_details_completed).to be(true)
-      end
     end
 
     it 'only carries over required attributes' do

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -47,8 +47,14 @@ RSpec.shared_examples 'duplicates application form' do |expected_cycle|
     expect(duplicate_application_form.application_qualifications.count).to eq 3
   end
 
-  it 'does not carry over any equality and diversity data' do
-    expect(duplicate_application_form.equality_and_diversity).to be_nil
+  it 'handles equality and diversity data correctly' do
+    expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
+
+    if original_application_form.recruitment_cycle_year <= 2024
+      expect(duplicate_application_form.equality_and_diversity).to be_nil
+    else
+      expect(duplicate_application_form.equality_and_diversity).to be_present
+    end
     expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
   end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -303,7 +303,6 @@ RSpec.describe DuplicateApplication do
       create(:english_proficiency, :qualification_not_needed, application_form: @original_application_form)
       result = duplicate_application_form
 
-      expect(result.efl_completed).to be true
       expect(result.english_proficiency.present?).to be(true)
       expect(result.english_proficiency.efl_qualification).to be_nil
       expect(result.english_proficiency.qualification_not_needed).to be(true)
@@ -317,7 +316,6 @@ RSpec.describe DuplicateApplication do
       create(:english_proficiency, :with_toefl_qualification, application_form: @original_application_form)
       result = duplicate_application_form
 
-      expect(result.efl_completed).to be true
       expect(result.english_proficiency.present?).to be(true)
       expect(result.english_proficiency.efl_qualification.present?).to be(true)
       expect(result.english_proficiency.efl_qualification_type).to eq 'ToeflQualification'
@@ -338,7 +336,6 @@ RSpec.describe DuplicateApplication do
       )
       result = duplicate_application_form
 
-      expect(result.efl_completed).to be true
       expect(result.english_proficiency.present?).to be(true)
       expect(result.english_proficiency.has_qualification).to be(false)
       expect(result.english_proficiency.no_qualification).to be(false)
@@ -346,6 +343,24 @@ RSpec.describe DuplicateApplication do
       expect(result.english_proficiency.qualification_not_needed).to be(true)
       expect(result.english_proficiency.draft).to be(false)
       expect(result.english_proficiency.no_qualification_details).to eq('Work in progress')
+    end
+
+    context 'when efl is completed' do
+      let(:efl_completed) { true }
+
+      it 'does not carry over efl section completed' do
+        expect(duplicate_application_form).not_to be_efl_completed
+        expect(duplicate_application_form.efl_completed_at).to be_nil
+      end
+    end
+
+    context 'when efl_completed is nil' do
+      let(:efl_completed) { true }
+
+      it 'carries over the nil status' do
+        expect(duplicate_application_form.efl_completed).to be_nil
+        expect(duplicate_application_form.efl_completed_at).to be_nil
+      end
     end
   end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -56,6 +56,42 @@ RSpec.describe DuplicateApplication do
     end
   end
 
+  context 'when a candidate has english, maths or science gcse equivalents from a country for which we have structured qualification data and the qualification matches a known structured qualification' do
+    it 'carries them over and keeps the sections set to completed' do
+      create(:gcse_qualification, :non_uk, subject: 'english', institution_country: 'KE', non_uk_qualification_type: 'KCSE (Kenya Certificate of Secondary Education)', application_form: @original_application_form)
+      create(:gcse_qualification, :non_uk, subject: 'maths', institution_country: 'IN', non_uk_qualification_type: 'CBSE Class 10 (AISSE)', application_form: @original_application_form)
+      create(:gcse_qualification, :non_uk, subject: 'science', institution_country: 'GH', non_uk_qualification_type: 'WASSCE (West African Senior School Certificate Examination)', application_form: @original_application_form)
+
+      expect(duplicate_application_form.english_gcse_completed).to be true
+      expect(duplicate_application_form.maths_gcse_completed).to be true
+      expect(duplicate_application_form.science_gcse_completed).to be true
+    end
+  end
+
+  context 'when a candidate has english, maths or science gcse equivalents from a country for which we have structured qualification data and the qualification does not match a known structured qualification' do
+    it 'carries them over and sets the sections to incomplete' do
+      create(:gcse_qualification, :non_uk, subject: 'english', institution_country: 'KE', non_uk_qualification_type: 'Some Other English Qualification', application_form: @original_application_form)
+      create(:gcse_qualification, :non_uk, subject: 'maths', institution_country: 'IN', non_uk_qualification_type: 'Some Other Maths Qualification', application_form: @original_application_form)
+      create(:gcse_qualification, :non_uk, subject: 'science', institution_country: 'GH', non_uk_qualification_type: 'Some Other Science Qualification', application_form: @original_application_form)
+
+      expect(duplicate_application_form.english_gcse_completed).to be false
+      expect(duplicate_application_form.maths_gcse_completed).to be false
+      expect(duplicate_application_form.science_gcse_completed).to be false
+    end
+  end
+
+  context 'when a candidate has domestic english, maths or science gcses or equivalents' do
+    it 'carries them over and keeps the section set to completed' do
+      create(:gcse_qualification, subject: 'english', application_form: @original_application_form)
+      create(:gcse_qualification, subject: 'maths', application_form: @original_application_form)
+      create(:gcse_qualification, subject: 'science', application_form: @original_application_form)
+
+      expect(duplicate_application_form.english_gcse_completed).to be true
+      expect(duplicate_application_form.maths_gcse_completed).to be true
+      expect(duplicate_application_form.science_gcse_completed).to be true
+    end
+  end
+
   context 'when a candidate has a published opt out preference' do
     it 'does not duplicate the preference' do
       create(:candidate_preference, :published, :opt_out, application_form: @original_application_form)

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -44,13 +44,39 @@ RSpec.describe DuplicateApplication do
     expect(duplicate_application_form.becoming_a_teacher).to eq @original_application_form.becoming_a_teacher
   end
 
-  it 'does not carry over any equality and diversity data' do
-    expect(duplicate_application_form.equality_and_diversity).to be_nil
-    expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
-  end
-
   it 'does not carry over adviser response status' do
     expect(duplicate_application_form.adviser_interruption_response).to be_nil
+  end
+
+  context 'equality and diversity data' do
+    context 'when an application is from 2025 or later' do
+      it 'carries over any equality and diversity data but leaves it marked as incomplete' do
+        equality_and_diversity = {
+          'sex' => 'male',
+          'hesa_sex' => '11',
+          'disabilities' => ['Physical disability or mobility issue', 'Autistic spectrum condition or another condition affecting speech, language, communication or social skills', 'Deafness or a serious hearing impairment'],
+          'ethnic_group' => 'Mixed or multiple ethnic groups', 'hesa_ethnicity' => '140', 'ethnic_background' => 'Asian and White',
+          'hesa_disabilities' => %w[56 53 57]
+        }
+
+        @original_application_form.update(equality_and_diversity:, equality_and_diversity_completed: true)
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2026).duplicate
+
+        expect(result.equality_and_diversity).to eq equality_and_diversity
+        expect(result).not_to be_equality_and_diversity_completed
+        expect(result.equality_and_diversity_completed_at).to be_nil
+      end
+    end
+
+    context 'when an application is from 2024 or earlier' do
+      it 'does not carry over any equality and diversity data' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2024).duplicate
+
+        expect(result.equality_and_diversity).to be_nil
+        expect(result).not_to be_equality_and_diversity_completed
+        expect(result.equality_and_diversity_completed_at).to be_nil
+      end
+    end
   end
 
   context 'when candidates has degrees' do

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe DuplicateApplication do
           'hesa_disabilities' => %w[56 53 57]
         }
 
-        @original_application_form.update(equality_and_diversity:, equality_and_diversity_completed: true)
+        @original_application_form.update(recruitment_cycle_year: 2025, equality_and_diversity:, equality_and_diversity_completed: true)
         result = described_class.new(@original_application_form, recruitment_cycle_year: 2026).duplicate
 
         expect(result.equality_and_diversity).to eq equality_and_diversity
@@ -70,7 +70,8 @@ RSpec.describe DuplicateApplication do
 
     context 'when an application is from 2024 or earlier' do
       it 'does not carry over any equality and diversity data' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2024).duplicate
+        @original_application_form.update(recruitment_cycle_year: 2024)
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2025).duplicate
 
         expect(result.equality_and_diversity).to be_nil
         expect(result).not_to be_equality_and_diversity_completed
@@ -164,60 +165,131 @@ RSpec.describe DuplicateApplication do
     end
   end
 
-  context 'when a candidate published started previous_teacher_training' do
-    it 'does duplicate previous_teacher_training' do
-      previous_teacher_training = create(
-        :previous_teacher_training,
-        status: 'published',
-        application_form: @original_application_form,
-      )
+  context 'previous teacher training data' do
+    before do
+      @original_application_form.published_previous_teacher_trainings.delete_all
+    end
 
-      expect(duplicate_application_form.published_previous_teacher_trainings.last)
-        .to have_attributes(
+    context 'when a candidate published a single previous_teacher_training in 2025' do
+      it 'carries over their latest previous_teacher_training only' do
+        single_previous_teacher_training = create(
+          :previous_teacher_training,
+          status: 'published',
+          started_at: 2.years.ago,
+          ended_at: 1.year.ago,
+          application_form: @original_application_form,
+        )
+
+        @original_application_form.update(recruitment_cycle_year: 2025)
+        @original_application_form.reload
+
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2026).duplicate
+
+        expect(result.published_previous_teacher_trainings.count).to eq(1)
+        expect(result.published_previous_teacher_trainings.last).to have_attributes(
           status: 'published',
           started: 'yes',
-          started_at: previous_teacher_training.started_at,
-          ended_at: previous_teacher_training.ended_at,
-          provider_name: previous_teacher_training.provider_name,
-          details: previous_teacher_training.details,
+          started_at: single_previous_teacher_training.started_at,
+          ended_at: single_previous_teacher_training.ended_at,
+          provider_name: single_previous_teacher_training.provider_name,
+          details: single_previous_teacher_training.details,
         )
-      expect(duplicate_application_form.previous_teacher_training_completed).to be(true)
+        expect(result.previous_teacher_training_completed).to be(false)
+      end
     end
-  end
 
-  context 'when a candidate published not started previous_teacher_training' do
-    it 'does duplicate previous_teacher_training' do
-      create(
-        :previous_teacher_training,
-        :not_started,
-        status: 'published',
-        application_form: @original_application_form,
-      )
-
-      expect(duplicate_application_form.published_previous_teacher_trainings.last)
-        .to have_attributes(
+    context 'when a candidate published multiple previous_teacher_trainings in 2025' do
+      it 'carries over their latest previous_teacher_training only' do
+        create(
+          :previous_teacher_training,
           status: 'published',
-          started: 'no',
-          started_at: nil,
-          ended_at: nil,
-          provider_name: nil,
-          details: nil,
+          started_at: 3.years.ago,
+          ended_at: 2.years.ago,
+          application_form: @original_application_form,
         )
-      expect(duplicate_application_form.previous_teacher_training_completed).to be(true)
+
+        create(
+          :previous_teacher_training,
+          status: 'published',
+          started_at: 2.years.ago,
+          ended_at: 1.year.ago,
+          application_form: @original_application_form,
+        )
+
+        @original_application_form.update(recruitment_cycle_year: 2025)
+        @original_application_form.reload
+
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2026).duplicate
+
+        expect(result.published_previous_teacher_trainings.count).to eq(0)
+        expect(result.previous_teacher_training_completed).to be(false)
+      end
     end
-  end
 
-  context 'when a candidate did not publish previous_teacher_training' do
-    it 'does not duplicate previous_teacher_training' do
-      @original_application_form.previous_teacher_trainings.delete_all
-      create(
-        :previous_teacher_training,
-        status: 'draft',
-        application_form: @original_application_form,
-      )
+    context 'when a candidate published multiple previous_teacher_trainings beyond 2025' do
+      it 'carries over all of their previous_teacher_trainings' do
+        previous_teacher_training_one = create(
+          :previous_teacher_training,
+          status: 'published',
+          application_form: @original_application_form,
+        )
+        previous_teacher_training_two = create(
+          :previous_teacher_training,
+          status: 'published',
+          application_form: @original_application_form,
+        )
 
-      expect(duplicate_application_form.published_previous_teacher_trainings).to eq([])
-      expect(duplicate_application_form.previous_teacher_training_completed).to be(false)
+        @original_application_form.update(recruitment_cycle_year: 2026)
+
+        @original_application_form.reload
+
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2027).duplicate
+
+        expect(result.published_previous_teacher_trainings.count).to eq(2)
+        expect(result.published_previous_teacher_trainings.pluck(:details)).to contain_exactly(
+          previous_teacher_training_one.details,
+          previous_teacher_training_two.details,
+        )
+        expect(result.previous_teacher_training_completed).to be(true)
+      end
+    end
+
+    context 'when a candidate published not started previous_teacher_training' do
+      it 'carries over their response' do
+        create(
+          :previous_teacher_training,
+          :not_started,
+          status: 'published',
+          application_form: @original_application_form,
+        )
+
+        @original_application_form.reload
+
+        expect(duplicate_application_form.published_previous_teacher_trainings.last)
+          .to have_attributes(
+            status: 'published',
+            started: 'no',
+            started_at: nil,
+            ended_at: nil,
+            provider_name: nil,
+            details: nil,
+          )
+      end
+    end
+
+    context 'when a candidate did not publish previous_teacher_training' do
+      it 'does not duplicate previous_teacher_training' do
+        create(
+          :previous_teacher_training,
+          status: 'draft',
+          application_form: @original_application_form,
+        )
+
+        @original_application_form.reload
+
+        expect(duplicate_application_form.published_previous_teacher_trainings).to eq([])
+        expect(duplicate_application_form.previous_teacher_training_completed).to be(false)
+      end
     end
   end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe DuplicateApplication do
     end
   end
 
-  context 'when a candidate has a a published opt in preference for anywhere in england' do
+  context 'when a candidate has a published opt in preference for anywhere in england' do
     it 'duplicates the preference' do
       create(:candidate_preference, :published, :anywhere_in_england, application_form: @original_application_form)
       expect(duplicate_application_form.preferences.first)
@@ -194,6 +194,103 @@ RSpec.describe DuplicateApplication do
   context 'when candidates does not have degrees' do
     it 'does not set university degree' do
       expect(duplicate_application_form.university_degree).to be_nil
+    end
+  end
+
+  context 'immigration status and right to work or study carry over' do
+    before do
+      FeatureFlag.activate('2027_visa_expiry')
+
+      @original_application_form.update!(
+        first_nationality: 'Nigerian',
+        immigration_status: 'student_visa',
+        visa_expired_at: 1.year.from_now,
+        right_to_work_or_study: 'yes',
+        right_to_work_or_study_details: 'I can extend my visa',
+      )
+    end
+
+    context 'when a candidate holds British or Irish citizenship' do
+      it 'always marks personal details as complete' do
+        @original_application_form.update!(first_nationality: 'Irish')
+        result = described_class.new(@original_application_form).duplicate
+
+        expect(result.personal_details_completed).to be true
+      end
+    end
+
+    context 'when a candidate does not hold British or Irish citizenship' do
+      it 'always marks personal details as incomplete' do
+        result = described_class.new(@original_application_form).duplicate
+
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over with a non-expiring immigration status in any academic year' do
+      before do
+        @original_application_form.update!(immigration_status: 'eu_settled', visa_expired_at: nil)
+      end
+
+      it 'carries over immigration information' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
+
+        expect(result.immigration_status).to eq 'eu_settled'
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over to the 2027 cycle' do
+      it 'does not carry over temporary visa information' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2027).duplicate
+
+        expect(result.immigration_status).to be_nil
+        expect(result.visa_expired_at).to be_nil
+        expect(result.right_to_work_or_study).to be_nil
+        expect(result.right_to_work_or_study_details).to be_nil
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over to the 2027 cycle with a permanent immigration status' do
+      before do
+        @original_application_form.update!(immigration_status: 'indefinite_leave_to_remain_in_the_uk', visa_expired_at: nil)
+      end
+
+      it 'carries over immigration information' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2027).duplicate
+
+        expect(result.immigration_status).to eq 'indefinite_leave_to_remain_in_the_uk'
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over beyond 2027 with a temporary immigration status' do
+      it 'carries over visa information' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
+
+        expect(result.immigration_status).to eq 'student_visa'
+        expect(result.visa_expired_at).to eq @original_application_form.visa_expired_at
+        expect(result.right_to_work_or_study).to eq 'yes'
+        expect(result.right_to_work_or_study_details).to eq 'I can extend my visa'
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over beyond 2027 and the visa has expired' do
+      before do
+        @original_application_form.update!(visa_expired_at: 1.day.ago)
+      end
+
+      it 'does not carry over visa information' do
+        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
+
+        expect(result.immigration_status).to be_nil
+        expect(result.visa_expired_at).to be_nil
+        expect(result.right_to_work_or_study).to be_nil
+        expect(result.right_to_work_or_study_details).to be_nil
+        expect(result.personal_details_completed).to be false
+      end
     end
   end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe DuplicateApplication do
 
   let(:recruitment_cycle_year) { current_year - 1 }
 
+  it 'marks contact details as incomplete' do
+    expect(duplicate_application_form).not_to be_contact_details_completed
+  end
+
   it 'marks reference as incomplete' do
     expect(duplicate_application_form).not_to be_references_completed
   end

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -198,34 +198,6 @@ RSpec.describe DuplicateApplication do
       end
     end
 
-    context 'when a candidate published multiple previous_teacher_trainings in 2025' do
-      it 'carries over their latest previous_teacher_training only' do
-        create(
-          :previous_teacher_training,
-          status: 'published',
-          started_at: 3.years.ago,
-          ended_at: 2.years.ago,
-          application_form: @original_application_form,
-        )
-
-        create(
-          :previous_teacher_training,
-          status: 'published',
-          started_at: 2.years.ago,
-          ended_at: 1.year.ago,
-          application_form: @original_application_form,
-        )
-
-        @original_application_form.update(recruitment_cycle_year: 2025)
-        @original_application_form.reload
-
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2026).duplicate
-
-        expect(result.published_previous_teacher_trainings.count).to eq(0)
-        expect(result.previous_teacher_training_completed).to be(false)
-      end
-    end
-
     context 'when a candidate published multiple previous_teacher_trainings beyond 2025' do
       it 'carries over all of their previous_teacher_trainings' do
         previous_teacher_training_one = create(
@@ -288,7 +260,7 @@ RSpec.describe DuplicateApplication do
         @original_application_form.reload
 
         expect(duplicate_application_form.published_previous_teacher_trainings).to eq([])
-        expect(duplicate_application_form.previous_teacher_training_completed).to be(false)
+        expect(duplicate_application_form.previous_teacher_training_completed).to be(true)
       end
     end
   end
@@ -329,22 +301,29 @@ RSpec.describe DuplicateApplication do
       end
     end
 
-    context 'when carrying over with a non-expiring immigration status in any academic year' do
+    context 'when carrying over with a permanent immigration status' do
       before do
-        @original_application_form.update!(immigration_status: 'eu_settled', visa_expired_at: nil)
+        @original_application_form.update!(
+          immigration_status: 'eu_settled',
+          visa_expired_at: nil,
+        )
       end
 
       it 'carries over immigration information' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
+        result = described_class.new(@original_application_form).duplicate
 
         expect(result.immigration_status).to eq 'eu_settled'
         expect(result.personal_details_completed).to be false
       end
     end
 
-    context 'when carrying over to the 2027 cycle' do
-      it 'does not carry over temporary visa information' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2027).duplicate
+    context 'when carrying over with a temporary visa and no expiry date' do
+      before do
+        @original_application_form.update!(visa_expired_at: nil)
+      end
+
+      it 'does not carry over visa information' do
+        result = described_class.new(@original_application_form).duplicate
 
         expect(result.immigration_status).to be_nil
         expect(result.visa_expired_at).to be_nil
@@ -354,43 +333,30 @@ RSpec.describe DuplicateApplication do
       end
     end
 
-    context 'when carrying over to the 2027 cycle with a permanent immigration status' do
-      before do
-        @original_application_form.update!(immigration_status: 'indefinite_leave_to_remain_in_the_uk', visa_expired_at: nil)
-      end
-
-      it 'carries over immigration information' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2027).duplicate
-
-        expect(result.immigration_status).to eq 'indefinite_leave_to_remain_in_the_uk'
-        expect(result.personal_details_completed).to be false
-      end
-    end
-
-    context 'when carrying over beyond 2027 with a temporary immigration status' do
-      it 'carries over visa information' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
-
-        expect(result.immigration_status).to eq 'student_visa'
-        expect(result.visa_expired_at).to eq @original_application_form.visa_expired_at
-        expect(result.right_to_work_or_study).to eq 'yes'
-        expect(result.right_to_work_or_study_details).to eq 'I can extend my visa'
-        expect(result.personal_details_completed).to be false
-      end
-    end
-
-    context 'when carrying over beyond 2027 and the visa has expired' do
+    context 'when carrying over with a temporary visa and an expiry date in the past' do
       before do
         @original_application_form.update!(visa_expired_at: 1.day.ago)
       end
 
       it 'does not carry over visa information' do
-        result = described_class.new(@original_application_form, recruitment_cycle_year: 2028).duplicate
+        result = described_class.new(@original_application_form).duplicate
 
         expect(result.immigration_status).to be_nil
         expect(result.visa_expired_at).to be_nil
         expect(result.right_to_work_or_study).to be_nil
         expect(result.right_to_work_or_study_details).to be_nil
+        expect(result.personal_details_completed).to be false
+      end
+    end
+
+    context 'when carrying over with a temporary visa and an expiry date in the future' do
+      it 'carries over visa information' do
+        result = described_class.new(@original_application_form).duplicate
+
+        expect(result.immigration_status).to eq 'student_visa'
+        expect(result.visa_expired_at).to eq @original_application_form.visa_expired_at
+        expect(result.right_to_work_or_study).to eq 'yes'
+        expect(result.right_to_work_or_study_details).to eq 'I can extend my visa'
         expect(result.personal_details_completed).to be false
       end
     end

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
 
       when_i_sign_in_again
       and_i_navigate_to_my_details
+
+      when_i_view_my_contact_information
+      then_i_see_my_previously_saved_details
+      and_i_mark_them_as_complete
+
       when_i_view_referees
       then_i_can_see_the_referees_i_previously_added
       and_i_can_complete_the_references_section
@@ -37,7 +42,10 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
 
       when_i_sign_in_again
       and_i_navigate_to_my_details
-      then_i_see_my_details
+
+      when_i_view_my_contact_information
+      then_i_see_my_previously_saved_details
+      and_i_mark_them_as_complete
 
       when_i_view_referees
       then_i_can_see_the_referees_i_previously_added
@@ -58,11 +66,13 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
       :completed_application_form,
       :with_gcses,
       :with_degree,
+      :with_equality_and_diversity_data,
       date_of_birth: Date.new(1964, 9, 1),
       submitted_at: nil,
       candidate: @current_candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
       references_count: 0,
+      country_residency_since_birth: true,
     )
     @first_reference = create(
       :reference,
@@ -138,7 +148,8 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
 
   def and_i_can_complete_the_equality_and_diversity_section
     click_on 'Equality and diversity questions'
-    candidate_fills_in_diversity_information
+    choose 'Yes, I have completed this section'
+    click_link_or_button 'Continue'
   end
 
   def when_i_view_courses
@@ -208,5 +219,19 @@ RSpec.describe 'Carry over next cycle with cycle switcher' do
   def and_my_application_is_awaiting_provider_decision
     application_choice = @current_candidate.current_application.application_choices.first
     expect(application_choice.status).to eq('awaiting_provider_decision')
+  end
+
+  def when_i_view_my_contact_information
+    click_link_or_button 'Contact information'
+  end
+
+  def then_i_see_my_previously_saved_details
+    expect(page).to have_text(@application_form.address_line1)
+    expect(page).to have_text(@application_form.phone_number)
+  end
+
+  def and_i_mark_them_as_complete
+    choose 'Yes, I have completed this section'
+    click_link_or_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
@@ -49,7 +49,8 @@ private
 
   def complete_the_equality_and_diversity_section
     click_on 'Equality and diversity questions'
-    candidate_fills_in_diversity_information
+    choose 'Yes, I have completed this section'
+    click_link_or_button 'Continue'
   end
 
   def complete_the_references_section

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Carry over application and submit new application choices' do
 
   before do
     stub_bigquery_non_disclosure_trainee_withdrawals_request
+    FeatureFlag.activate('2027_international_qualifications_flow')
   end
 
   it 'Candidate carries over unsubmitted application with a course to new cycle', time: mid_cycle do
@@ -17,7 +18,13 @@ RSpec.describe 'Carry over application and submit new application choices' do
     when_i_sign_in_again
     then_i_see_the_your_applications_page
 
-    when_i_view_referees
+    when_i_view_my_details
+    and_i_view_my_contact_information
+    then_i_see_my_previously_saved_details
+    and_i_mark_them_as_complete
+
+    when_i_view_my_details
+    and_i_view_referees
     then_i_can_see_the_referees_i_previously_added
 
     when_i_view_courses
@@ -42,12 +49,14 @@ private
     @application_form = create(
       :completed_application_form,
       :eligible_for_free_school_meals,
+      :with_equality_and_diversity_data,
       :with_gcses,
       :with_degree,
       submitted_at: nil,
       candidate: @current_candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
       references_count: 0,
+      country_residency_since_birth: true,
     )
     @application_choice = create(
       :application_choice,
@@ -101,11 +110,28 @@ private
     expect(page).to have_title 'Your applications'
   end
 
-  def when_i_view_referees
+  def when_i_view_my_details
     click_on 'Your details'
+  end
+
+  def and_i_view_my_contact_information
+    click_link_or_button 'Contact information'
+  end
+
+  def then_i_see_my_previously_saved_details
+    expect(page).to have_text(@application_form.address_line1)
+    expect(page).to have_text(@application_form.phone_number)
+  end
+
+  def and_i_mark_them_as_complete
+    choose 'Yes, I have completed this section'
+    click_link_or_button 'Continue'
+  end
+
+  def and_i_view_referees
     click_link_or_button 'References to be requested if you accept an offer'
   end
-  alias_method :click_on_references, :when_i_view_referees
+  alias_method :click_on_references, :and_i_view_referees
 
   def then_i_can_see_the_referees_i_previously_added
     expect(page).to have_css('h2', text: @first_reference.name)
@@ -165,7 +191,8 @@ private
     complete_section
     click_on 'Your details'
     click_on 'Equality and diversity questions'
-    candidate_fills_in_diversity_information
+    choose 'Yes, I have completed this section'
+    click_link_or_button 'Continue'
   end
 
   def then_i_can_submit_my_application


### PR DESCRIPTION
## Context

Ahead of end of cycle, we're revising the carry over script to take account of changes made over the year.

## Changes proposed in this pull request

| Area | Agreed rule |
| --- | --- |
| International qualifications | Unmapped MVP qualification → carry over, incomplete |
| Visa (permanent status) | Carry over, unchanged |
| Visa (temporary visa, expiry date in future) | Carry over |
| Visa (temporary visa, no expiry date) | No carry over |
| Visa (temporary visa, expired) | No carry over |
| Residency length | Always incomplete |
| English as a foreign language | Carry over, incomplete |
| Equality and diversity (2025+) | Carry over, incomplete |
| Equality and diversity (2024-) | Do not carry over, incomplete |
| Previous ITT (2025) | 1 record → carry over, incomplete |
| Previous ITT (2025+) | Multiple records → carry over, complete |

## Guidance to review

The agreed rules are set out in the [Trello card](https://trello.com/c/K4Mr2Oye/1868-end-of-cycle-review-carry-over-script) and summarised above.

I have added comments where I can to help with navigating the rules but reviewing by commit - perhaps starting with the spec in each commit and comparing it with the rule - should be the easiest way to take each systematically.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
