### PR TITLE
Additional custom logger to remove PII from Solid Queue logs

### DIFF
--- a/app/lib/custom_log_formatter.rb
+++ b/app/lib/custom_log_formatter.rb
@@ -10,6 +10,7 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     sanitize_payload_fields
     remove_post_params
     redact_mailer_arguments
+    remove_application_attributes
 
     hash.to_json
   end
@@ -51,6 +52,13 @@ private
     if hash.dig(:payload, :to).present?
       hash[:payload][:to] = REDACTED
     end
+  end
+
+  def remove_application_attributes
+    return if hash.dig(:payload, :adapter).blank? || hash.dig(:payload, :arguments).blank?
+    return unless hash.dig(:payload, :adapter).include? 'SolidQueue'
+
+    hash[:payload][:arguments] = REDACTED
   end
 
   def remove_post_params

--- a/spec/lib/custom_log_formatter_spec.rb
+++ b/spec/lib/custom_log_formatter_spec.rb
@@ -108,4 +108,14 @@ RSpec.describe CustomLogFormatter do
 
     expect(log_hash[:payload][:arguments]).to eq('[REDACTED]')
   end
+
+  it 'filters out solid queue arguments' do
+    log.message = 'Performed VendorAPIRequestWorker'
+    log.payload = {
+      job_class: 'VendorAPIRequestWorker',
+      adapter: 'SolidQueue',
+      arguments: 'PII',
+    }
+    expect(log_hash[:payload][:arguments]).to eq('[REDACTED]')
+  end
 end


### PR DESCRIPTION
## Context

Since adding solid queue, we have been alerted to some PII showing up in our logs. You can examine them at logit, filtering for things with the adapter == 'SolidQueue'

## Changes proposed in this pull request

The logs will redact the arguments included in the payload from SolidQueue logs.

## Guidance to review

1. Locally, pull this branch and then add this to your development.rb file so it acts like production logs:
```
config.log_tags = [ :request_id ]
  config.logger = ActiveSupport::Logger.new(STDOUT)
                                       .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
                                       .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
  config.log_format = :json                               # For parsing in Logit
  config.rails_semantic_logger.add_file_appender = false  # Don't log to file
  config.rails_semantic_logger.format = CustomLogFormatter.new
  config.semantic_logger.add_appender(
    io: $stdout,
    level: config.log_level,
    formatter: CustomLogFormatter.new
  )
```
3. Restart rails s and bin/jobs
4. Hit the vendor API endpoint locally `applications (+ a since param)` or `applications/:id` 
5. You should see the application data is redacted in the logs.




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
