### PR TITLE
Fix whitespace strip

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -157,8 +157,8 @@ module CandidateInterface
     end
 
     def strip_whitespace(params)
-      StripWhitespace.from_hash(params)
-      StripInvisibleWhitespace.from_hash(params)
+      stripped_params = StripWhitespace.from_hash(params)
+      StripInvisibleWhitespace.from_hash(stripped_params)
     end
 
     def append_info_to_payload(payload)


### PR DESCRIPTION
## Context

- Fix issue with `strip_whitespace` method not stripping whitespace.

## Changes proposed in this pull request

- Pass whitespace-stripped params to the next method

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/2vE79RDa/2034-bug-english-as-a-foreign-language-strip-whitespace-from-efl-assessment-entry