### PR TITLE
Add error prefix to header of review efl page

### DIFF
--- a/app/views/candidate_interface/english_proficiencies/review/show.html.erb
+++ b/app/views/candidate_interface/english_proficiencies/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.efl.check_your_english_language_skills') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.efl.check_your_english_language_skills'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_english_proficiencies_complete_path(@return_to[:params]), method: :patch do |f| %>


### PR DESCRIPTION
## Context

- Add `title_with_error_prefix` to EFL "Check your English language skills" page

## Changes proposed in this pull request

- Add `title_with_error_prefix` to show error validation when not selecting to complete the EFL section

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/am3D3dO7/2039-bug-english-as-a-foreign-language-review-page-header-not-containing-errors

## Screenshot

<img width="1451" height="514" alt="Screenshot 2026-07-27 at 09 51 49" src="https://github.com/user-attachments/assets/a6ded196-b5ce-4c8b-a1d4-99957c22b92c" />
