### PR TITLE
Update content of Provider view of English is my main langugaes EFL

### DIFF
--- a/app/components/shared/efl_qualification_card_component.rb
+++ b/app/components/shared/efl_qualification_card_component.rb
@@ -41,7 +41,7 @@ class EflQualificationCardComponent < ApplicationComponent
     content = []
 
     if qualification_not_needed
-      content << 'Candidate said that English is not a foreign language to them.'
+      content << 'Candidate said that English is their main language.'
     end
 
     if has_qualification

--- a/spec/components/utility/efl_qualification_card_component_spec.rb
+++ b/spec/components/utility/efl_qualification_card_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
-        expect(result.text).to include 'Candidate said that English is not a foreign language to them.'
+        expect(result.text).to include 'Candidate said that English is their main language.'
         expect(result.text).not_to include 'Details'
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
-        expect(result.text).to include 'Candidate said that English is not a foreign language to them.'
+        expect(result.text).to include 'Candidate said that English is their main language.'
         expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
         expect(result.text).not_to include 'Details'
       end


### PR DESCRIPTION
## Context

- Update content on the Provider view of a candidate's EFL, when they have selected "English is my main language"

## Changes proposed in this pull request

- Update `EflQualificationCardComponent` content when they have selected "English is my main language"

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/ck2EmVOh/2038-bug-english-as-a-foreign-language-update-eflqualificationcardcomponent-to-show-updated-english-is-my-main-language-text

## Screenshot

<img width="467" height="93" alt="Screenshot 2026-07-27 at 13 18 04" src="https://github.com/user-attachments/assets/f9e6ccb1-f710-475d-bf10-d6614da857c7" />
