### PR TITLE
Update qualification status order to display correctly

### DIFF
--- a/app/components/candidate_interface/english_proficiencies/review_component.rb
+++ b/app/components/candidate_interface/english_proficiencies/review_component.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         simple_format(
           english_proficiency.qualification_statuses.map do |status|
             I18n.t("candidate_interface.english_proficiencies.review_component.qualification_status.#{status}")
-          end.sort.join("\n"),
+          end.join("\n"),
           class: 'govuk-body',
         )
       end

--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -7,10 +7,10 @@ class EnglishProficiency < ApplicationRecord
   belongs_to :efl_qualification, polymorphic: true, optional: true, dependent: :destroy
 
   enum :qualification_status, {
-    has_qualification: 'has_qualification',
     no_qualification: 'no_qualification',
     qualification_not_needed: 'qualification_not_needed',
     degree_taught_in_english: 'degree_taught_in_english',
+    has_qualification: 'has_qualification',
   }
 
   scope :draft, -> { where(draft: true) }

--- a/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
+++ b/spec/components/candidate_interface/english_proficiencies/review_component_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe CandidateInterface::EnglishProficiencies::ReviewComponent, type: 
           expect(rendered_content).to have_css('dt.govuk-summary-list__key', text: 'Proving your English language skills')
           expect(rendered_content).to have_css(
             'dd.govuk-summary-list__value',
-            text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+            text: 'English is my main language My degree was taught in English I have an English as a foreign language (EFL) assessment',
           )
           expect(rendered_content).to have_css(
             'dt.govuk-summary-list__key',

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_and_english_is_my_first_language_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_and_english_is_my_first_language_spec.rb
@@ -164,7 +164,7 @@ private
       expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
-        text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+        text: 'English is my main language My degree was taught in English I have an English as a foreign language (EFL) assessment',
         class: 'govuk-summary-list__value',
       )
       expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')

--- a/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_spec.rb
+++ b/spec/system/candidate_interface/english_proficiencies/create_english_proficencies/candidate_enters_their_english_proficiency_as_has_ielts_qualification_and_degree_taught_in_english_spec.rb
@@ -154,7 +154,7 @@ private
       expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
       expect(page).to have_element(
         :dd,
-        text: 'I have an English as a foreign language (EFL) assessment My degree was taught in English',
+        text: 'My degree was taught in English I have an English as a foreign language (EFL) assessment',
         class: 'govuk-summary-list__value',
       )
       expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')

--- a/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
+++ b/spec/system/candidate_interface/reviewing/international_candidate/candidate_reviews_an_application_with_an_efl_qualification_spec.rb
@@ -213,7 +213,7 @@ private
     expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
-      text: 'I have an English as a foreign language (EFL) assessment My degree was taught in English',
+      text: 'My degree was taught in English I have an English as a foreign language (EFL) assessment',
       class: 'govuk-summary-list__value',
     )
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')
@@ -235,7 +235,7 @@ private
     expect(page).to have_element(:dt, text: 'Proving your English language skills', class: 'govuk-summary-list__key')
     expect(page).to have_element(
       :dd,
-      text: 'English is my main language I have an English as a foreign language (EFL) assessment My degree was taught in English',
+      text: 'English is my main language My degree was taught in English I have an English as a foreign language (EFL) assessment',
       class: 'govuk-summary-list__value',
     )
     expect(page).to have_element(:dt, text: 'Type of assessment', class: 'govuk-summary-list__key')


### PR DESCRIPTION
## Context

- Update qualification status order to display in the order presented in the selection form

## Changes proposed in this pull request

- Update the order qualification statuses appear in the enum

## Guidance to review

- See screenshots


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/5yYUeVi0/2035-bug-english-as-a-foreign-language-review-the-order-of-candidate-inputs-when-shown-on-the-review-page

## Screenshot

<img width="562" height="533" alt="Screenshot 2026-07-27 at 10 51 25" src="https://github.com/user-attachments/assets/f607e2fb-10ad-46af-874c-754ac5f3baf1" />


<img width="972" height="414" alt="Screenshot 2026-07-27 at 10 45 08" src="https://github.com/user-attachments/assets/1da13837-d9da-4d3b-a137-e97b39894c5c" />

