### PR TITLE
Show details of EFL no_qualification_details and no_assessment_plan_details

### DIFF
--- a/app/components/shared/efl_qualification_card_component.html.erb
+++ b/app/components/shared/efl_qualification_card_component.html.erb
@@ -33,11 +33,11 @@
       </div>
     </div>
   </div>
-<% elsif no_qualification? %>
+<% elsif details.present? %>
   <%= content_tag(
     sub_header_tag(header_tag:),
     'Details',
     class: 'govuk-heading-s govuk-!-margin-bottom-2',
   ) %>
-  <p class="govuk-body govuk-!-margin-bottom-0"><%= no_qualification_details %></p>
+  <p class="govuk-body govuk-!-margin-bottom-0"><%= details %></p>
 <% end %>

--- a/app/components/shared/efl_qualification_card_component.rb
+++ b/app/components/shared/efl_qualification_card_component.rb
@@ -105,9 +105,14 @@ class EflQualificationCardComponent < ApplicationComponent
     end
   end
 
+  def details
+    no_qualification_details.presence || no_assessment_plan_details
+  end
+
   delegate :name, :award_year, :grade, :unique_reference_number, to: :efl_qualification
   delegate(
     :no_qualification_details,
+    :no_assessment_plan_details,
     :has_qualification,
     :qualification_not_needed,
     to: :english_proficiency,

--- a/app/services/candidate_interface/update_english_proficiencies.rb
+++ b/app/services/candidate_interface/update_english_proficiencies.rb
@@ -40,7 +40,8 @@ module CandidateInterface
           new_english_proficiency.efl_qualification = nil
         end
 
-        if new_english_proficiency.qualification_not_needed && new_english_proficiency.no_qualification_details.present?
+        if new_english_proficiency.qualification_not_needed &&
+           (new_english_proficiency.no_qualification_details.present? || new_english_proficiency.no_assessment_plan_details.present?)
           new_english_proficiency.no_qualification_details = nil
           new_english_proficiency.no_assessment_plan_details = nil
         end

--- a/spec/components/utility/efl_qualification_card_component_spec.rb
+++ b/spec/components/utility/efl_qualification_card_component_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'returns nil' do
         expect(component.details).to be_nil
 
-        expect(rendered_component).not_to have_text('Details')
+        expect(rendered_component).to have_no_text('Details')
       end
     end
 

--- a/spec/components/utility/efl_qualification_card_component_spec.rb
+++ b/spec/components/utility/efl_qualification_card_component_spec.rb
@@ -283,4 +283,52 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       end
     end
   end
+
+  describe '.details' do
+    let(:component) { described_class.new(application_form) }
+    let(:rendered_component) { render_inline(component) }
+    let(:application_form) { create(:application_form, first_nationality: 'French') }
+    let(:english_proficiency) do
+      create(
+        :english_proficiency,
+        :no_qualification,
+        no_qualification_details:,
+        no_assessment_plan_details:,
+      )
+    end
+    let(:no_qualification_details) { nil }
+    let(:no_assessment_plan_details) { nil }
+
+    before { application_form.english_proficiency = english_proficiency }
+
+    context 'when the english proficiency has no details are given' do
+      it 'returns nil' do
+        expect(component.details).to be_nil
+
+        expect(rendered_component).not_to have_text('Details')
+      end
+    end
+
+    context 'when the english proficiency has no_qualification_details' do
+      let(:no_qualification_details) { 'Working on it' }
+
+      it 'returns the no_qualification_details' do
+        expect(component.details).to eq('Working on it')
+
+        expect(rendered_component).to have_text('Details')
+        expect(rendered_component).to have_text('Working on it')
+      end
+    end
+
+    context 'when the english proficiency has no_assessment_plan_details' do
+      let(:no_assessment_plan_details) { 'I have no plans' }
+
+      it 'returns the no_assessment_plan_details' do
+        expect(component.details).to eq('I have no plans')
+
+        expect(rendered_component).to have_text('Details')
+        expect(rendered_component).to have_text('I have no plans')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

- Show the details provided by the candidate to the provider when selecting "No" when planning on taking an assessment.

## Changes proposed in this pull request

- Show both `no_qualification_details` and `no_assessment_plan_details` to the provider

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/9IUSRra9/2036-bug-english-as-a-foreign-language-show-optional-input-from-selecting-no-to-providers

## Screenshots

<img width="994" height="513" alt="Screenshot 2026-07-27 at 11 25 34" src="https://github.com/user-attachments/assets/7d859010-f0ab-4d83-a266-06f5e9e0144f" />

<img width="652" height="195" alt="Screenshot 2026-07-27 at 11 25 45" src="https://github.com/user-attachments/assets/ecb9236e-a53b-49cc-9f32-a059e1b547d4" />
