### PR TITLE
Previous ITT search by previous last names

### DIFF
--- a/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
+++ b/app/lib/dfe/bigquery/non_disclosure_trainee_withdrawals.rb
@@ -58,9 +58,14 @@ module DfE
       end
 
       def last_names
-        @last_names ||= application_forms.map do |application_form|
-          CGI.escape(application_form.last_name&.downcase&.strip || '')
-        end.compact.uniq
+        @last_names ||= application_forms.flat_map do |application_form|
+          [
+            application_form.last_name,
+            *application_form.previous_last_names&.split(','),
+          ]
+        end.filter_map do |name| # rubocop:disable Style/MultilineBlockChain
+          CGI.escape(name.downcase.strip) if name.present?
+        end.uniq
       end
 
       def date_of_birth

--- a/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
+++ b/spec/lib/dfe/bigquery/non_disclosure_trainee_withdrawals_spec.rb
@@ -4,7 +4,16 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
   include DfE::Bigquery::TestHelper
 
   let(:candidate) { build(:candidate, email_address: 'john_doe@example.com') }
-  let!(:application_1) { create(:application_form, candidate:, first_name: 'John', last_name: 'Doe', date_of_birth: '01/01/1990') }
+  let!(:application_1) {
+    create(
+      :application_form,
+      candidate:,
+      first_name: 'John',
+      last_name: 'Doe',
+      date_of_birth: '01/01/1990',
+      previous_last_names: 'smith, doe, bean',
+    )
+  }
   let!(:application_2) { create(:application_form, candidate:, first_name: 'Johnny', last_name: 'Doe', date_of_birth: '01/01/1990') }
   let!(:application_3) { create(:application_form, first_name: 'Johnathan', last_name: 'Doe', date_of_birth: '01/01/1990') }
   let(:big_query_instance) { described_class.new(candidate:) }
@@ -51,7 +60,7 @@ RSpec.describe DfE::Bigquery::NonDisclosureTraineeWithdrawals do
       expect(Google::Apis::BigqueryV2::QueryRequest).to have_received(:new).with(query: <<~SQL, timeout_ms: 10_000, use_legacy_sql: false)
         SELECT trainee_start_date, accredited_provider.name, accredited_provider.code, withdraw.registered_date
         FROM `1_key_tables.non_disclosure_trainee_withdrawals`
-        WHERE email = 'john_doe%40example.com' OR (first_name IN #{first_names_sql} AND last_name IN ('doe') AND date_of_birth = '1990-01-01')
+        WHERE email = 'john_doe%40example.com' OR (first_name IN #{first_names_sql} AND last_name IN ('doe','smith','bean') AND date_of_birth = '1990-01-01')
       SQL
     end
 


### PR DESCRIPTION
## Context

We are asking for previous last names. We can use these names when searching for previous teacher training in BQ.  

## Changes proposed in this pull request

This just changes the BQ query to include previous last names.

## Guidance to review

Not sure how to test this one

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
