### PR TITLE
correct Makefile set-pgserver to use long code for name eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,8 @@ composed-variables:
 	$(eval RESOURCE_GROUP_NAME=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg)
 
 set-pgserver:
-	$(eval SERVERNAME=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-psql)
+	$(eval SERVERNAME=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG}-psql)
+	echo "set-pgserver SERVERNAME: ${SERVERNAME}"
 
 list-pglogs: composed-variables set-pgserver set-azure-account
 	az postgres flexible-server server-logs list --resource-group ${RESOURCE_GROUP_NAME} --server-name ${SERVERNAME}


### PR DESCRIPTION
## Context
Correction to set-pgserver within makefile, DB is named using long config value.

## Changes proposed in this pull request

- set-pgserver correction within makefile, use long config

## Guidance to review
Ensure name produced matches deployed version:
<img width="261" height="226" alt="image" src="https://github.com/user-attachments/assets/7c89340f-033e-42a9-aa8c-e914fbb2eafc" />
Test locally for each environment using:
`make <env> set-pgserver`
