### PR TITLE
Enable WAL in prep for Airbyte for QA and Staging

### DIFF
--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -21,4 +21,5 @@ module "postgres" {
   azure_maintenance_window       = var.azure_maintenance_window
   azure_extensions               = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "PGCRYPTO", "UNACCENT"]
   alert_window_size              = var.alert_window_size
+  use_airbyte                    = var.pg_airbyte_enabled
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -54,6 +54,8 @@ variable "redis_queue_sku_name" { default = "Standard" }
 variable "config_short" {}
 variable "service_short" {}
 variable "azure_maintenance_window" { default = null }
+# pg_airbyte_enabled used in the postgres module
+variable "pg_airbyte_enabled" { default = false }
 
 # NEW
 variable "service_name" {}

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -20,6 +20,7 @@
   "data_exports_storage_account_name": "s189t01attqaexp",
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
+  "pg_airbyte_enabled": "true",
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -17,6 +17,7 @@
   "data_exports_storage_account_name": "s189t01attstgexp",
   "enable_prometheus_monitoring": true,
   "enable_logit": true,
+  "pg_airbyte_enabled": "true",
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",


### PR DESCRIPTION
## Context

In preperation for Airbyte deployment, this change enables WAL via the `use_airbyte` flag in the DFE postgres module.

## Changes proposed in this pull request
- Add variable `pg_airbyte_enabled` with default of false linked to `use_airbyte` in DFE postgres module
- Set variable `pg_airbyte_enabled` to true for QA and Staging to enable

## Guidance to review
Test Terraform plan for each environment, there should only be changes for QA and Staging to Postgres setup
`make <env> terraform-plan`

No changes for environments other than QA and Staging.
Changes for QA and Staging should be equivalent to:
```
 # module.postgres.azurerm_postgresql_flexible_server_configuration.max_replication_slots[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_replication_slots" {
      + id        = (known after apply)
      + name      = "max_replication_slots"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_senders[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_senders" {
      + id        = (known after apply)
      + name      = "max_wal_senders"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "5"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.max_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "max_wal_size" {
      + id        = (known after apply)
      + name      = "max_wal_size"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "4096"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.min_wal_size[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "min_wal_size" {
      + id        = (known after apply)
      + name      = "min_wal_size"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "2048"
    }

  # module.postgres.azurerm_postgresql_flexible_server_configuration.wal_level[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
      + id        = (known after apply)
      + name      = "wal_level"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-att-qa-psql"
      + value     = "logical"
    }
```
