### PR TITLE
Interruption page content changes

### DIFF
--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -7,19 +7,19 @@
       <h1 class="govuk-heading-l"><%= t('gcse_new_international_flow_interruption.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></h1>
 
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need') %></p>
-        <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_can') %></p>
-        <ul class="govuk-body">
-          <li><%= t('gcse_new_international_flow_interruption.option1') %></li>
-          <li><%= t('gcse_new_international_flow_interruption.option2', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
-          <li><%= t('gcse_new_international_flow_interruption.option3', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
-        </ul>
-        <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.some_providers') %><p>
-      </div>
+      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_can') %></p>
+      <ul class="govuk-body">
+        <li><%= t('gcse_new_international_flow_interruption.option1') %></li>
+        <li><%= t('gcse_new_international_flow_interruption.option2', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
+        <li><%= t('gcse_new_international_flow_interruption.option3', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
+      </ul>
+      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.none_of_these') %><p>
+      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.some_providers') %><p>
+    </div>
 
-      <div class="govuk-button-group app-course-choice__confirm-submission">
-        <%= govuk_button_link_to(t('gcse_new_international_flow_interruption.provide_statement'), @enic_path) %>
-        <%= govuk_link_to(t('gcse_new_international_flow_interruption.provide_evidence', subject: (@subject == 'english' ? @subject.capitalize : @subject)), @evidence_path) %>
-      <div>
+    <div class="govuk-button-group app-course-choice__confirm-submission">
+      <%= govuk_button_link_to(t('gcse_new_international_flow_interruption.provide_statement'), @enic_path) %>
+      <%= govuk_link_to(t('gcse_new_international_flow_interruption.provide_evidence', subject: (@subject == 'english' ? @subject.capitalize : @subject)), @evidence_path) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -19,7 +19,7 @@
 
     <div class="govuk-button-group app-course-choice__confirm-submission">
       <%= govuk_button_link_to(t('gcse_new_international_flow_interruption.provide_statement'), @enic_path) %>
-      <%= govuk_link_to(t('gcse_new_international_flow_interruption.provide_evidence', subject: (@subject == 'english' ? @subject.capitalize : @subject)), @evidence_path) %>
+      <%= govuk_link_to(t('gcse_new_international_flow_interruption.provide_evidence'), @evidence_path) %>
     </div>
   </div>
 </div>

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -101,14 +101,15 @@ en:
     page_title: What grade did you get?
   gcse_new_international_flow_interruption:
     page_title: This grade may not be a equivalent to a GCSE in %{subject} at Grade 4 (C) or above
-    you_need: You need the equivalent of a GCSE at grade 4 (C) or above to apply for teacher training.
-    you_can: "You can either:"
-    option1: provide a statement of comparibility from UK ENIC
-    option2: provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
+    you_need: You need the equivalent of a GCSE at grade 4 (C) or above to apply for teacher training. Providers are responsible for deciding if you meet this requirement.
+    you_can: "You can:"
+    option1: provide a statement of comparability from UK ENIC
+    option2: continue and provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
     option3: go back and enter a different %{subject} qualification equivalent to a GCSE
+    none_of_these: If you do none of these, providers may not be able to assess your English skills.
     some_providers: Some providers may let you do an equivalency test to show you have the required skills.
     provide_statement: Provide a statement of comparability
-    provide_evidence: Provide evidence of %{subject} skills
+    provide_evidence: Continue without providing a statement of comparability
   gcse_new_international_flow_evidence:
     page_title: Provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
     caption: Check with providers about what evidence they accept.

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -100,7 +100,7 @@ en:
   gcse_edit_new_international_flow_grade:
     page_title: What grade did you get?
   gcse_new_international_flow_interruption:
-    page_title: This grade may not be a equivalent to a GCSE in %{subject} at Grade 4 (C) or above
+    page_title: This grade may not be equivalent to a GCSE in %{subject} at Grade 4 (C) or above
     you_need: You need the equivalent of a GCSE at grade 4 (C) or above to apply for teacher training. Providers are responsible for deciding if you meet this requirement.
     you_can: "You can:"
     option1: provide a statement of comparability from UK ENIC

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
@@ -223,7 +223,7 @@ private
   end
 
   def when_i_click_to_provide_evidence
-    click_link_or_button 'Provide evidence of maths skills'
+    click_link_or_button 'Continue without providing a statement of comparability'
   end
 
   def then_i_see_the_evidence_page

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
@@ -219,7 +219,7 @@ private
   end
 
   def then_i_see_the_interruption_page
-    expect(page).to have_text 'This grade may not be a equivalent to a GCSE in maths at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at Grade 4 (C) or above'
   end
 
   def when_i_click_to_provide_evidence

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
@@ -388,7 +388,7 @@ private
   end
 
   def when_i_click_provide_evidence_of_your_english_skills
-    click_link_or_button 'Provide evidence of English skills'
+    click_link_or_button 'Continue without providing a statement of comparability'
   end
 
   def then_i_see_the_evidence_page

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
@@ -380,11 +380,11 @@ private
   end
 
   def then_i_see_the_interruption_page
-    expect(page).to have_text 'This grade may not be a equivalent to a GCSE in English at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in English at Grade 4 (C) or above'
   end
 
   def then_i_see_the_interruption_page_maths
-    expect(page).to have_text 'This grade may not be a equivalent to a GCSE in maths at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at Grade 4 (C) or above'
   end
 
   def when_i_click_provide_evidence_of_your_english_skills


### PR DESCRIPTION
## Context

Some minor changes in the interruption page following a discussion with policy.

## Changes proposed in this pull request

| Before | After |
| ------ | ------ | 
| <img width="871" height="659" alt="image" src="https://github.com/user-attachments/assets/726411ab-b165-49d2-b23b-b89bbc9243c3" /> | <img width="857" height="772" alt="image" src="https://github.com/user-attachments/assets/14aefa98-0f86-4a1d-a4e5-74cdab14c81e" /> |

## Guidance to review
Make sure it matches the designs. 

[Trello card](https://trello.com/c/N0LKzs2H)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
