### PR TITLE
More variety in the visa explanations

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -173,7 +173,7 @@ private
       application_choices = @application_form.application_choices
 
       if states == [:cancelled]
-        # The cancelled state doesn't exist anymore in the current system,
+        # The canceled state doesn't exist anymore in the current system,
         # so we have to set this manually.
         application_choices.each do |application_choice|
           application_choice.update!(
@@ -622,9 +622,18 @@ private
     end
 
     if FeatureFlag.active?('2027_visa_expiry')
+
+      visa_explanation = %w[expires_after_course renew leads_to_permanent_visa switch_to_different_visa not_sure other].sample
+
       application_form.application_choices.update_all(
-        visa_explanation: 'expires_after_course',
+        visa_explanation:,
       )
+
+      if visa_explanation == 'other'
+        application_form.application_choices.update_all(
+          visa_explanation_details: Faker::Lorem.sentence(word_count: 20),
+        )
+      end
     end
 
     return if application_form.english_proficiency.present?

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -52,7 +52,15 @@ RSpec.describe TestApplications do
           expect(application_form.visa_expired_at.to_date).to eq(2.years.from_now.to_date)
 
           application_choices = application_form.application_choices
-          expect(application_choices.pluck(:visa_explanation).uniq).to contain_exactly('expires_after_course')
+          visa_explanations = application_choices.pluck(:visa_explanation).uniq
+          expect(visa_explanations.count).to eq(1)
+          explanation = visa_explanations.first
+
+          if explanation == 'other'
+            expect(application_choices.pluck(:visa_explanation_details).uniq.first).not_to be_nil
+          else
+            expect(application_choices.pluck(:visa_explanation_details).uniq).to contain_exactly(nil)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

A vendor requested that we generate test data that has more variety in the visa explanation / and visa explanation details data to allow for more robust testing on their side. 

## Changes proposed in this pull request

Sampling form the possible visa explanations and if it's 'other', adding some text for the details.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
