### PR TITLE
Bug fix: EnicSelectionForm handling empty attrs

### DIFF
--- a/app/forms/candidate_interface/gcse_enic_selection_form.rb
+++ b/app/forms/candidate_interface/gcse_enic_selection_form.rb
@@ -2,26 +2,29 @@ module CandidateInterface
   class GcseEnicSelectionForm
     include ActiveModel::Model
 
-    attr_accessor :enic_reason, :enic_reference, :comparable_uk_qualification
+    attr_accessor :enic_reason
 
     validates :enic_reason, presence: true
 
     def self.build_from_qualification(qualification)
       new(
         enic_reason: qualification.enic_reason,
-        enic_reference: qualification.enic_reference,
-        comparable_uk_qualification: qualification.comparable_uk_qualification,
       )
     end
 
     def save(qualification)
       return false unless valid?
 
-      qualification.update!(
-        enic_reason: enic_reason,
-        enic_reference: enic_reference,
-        comparable_uk_qualification: comparable_uk_qualification,
-      )
+      attrs = { enic_reason: enic_reason }
+
+      if enic_reason != 'obtained'
+        attrs.merge!(
+          enic_reference: nil,
+          comparable_uk_qualification: nil,
+        )
+      end
+
+      qualification.update!(attrs)
     end
   end
 end

--- a/spec/forms/candidate_interface/gcse_enic_selection_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_enic_selection_form_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseEnicSelectionForm do
+  describe 'validations' do
+    let(:form) { subject }
+
+    it { is_expected.to validate_presence_of(:enic_reason) }
+
+    describe '#build_from_qualification' do
+      it 'creates an object based on the provided ApplicationQualification' do
+        qualification = ApplicationQualification.new(
+          enic_reason: 'obtained',
+        )
+
+        enic_selection_form = described_class.build_from_qualification(
+          qualification,
+        )
+
+        expect(enic_selection_form.enic_reason).to eq qualification.enic_reason
+      end
+    end
+
+    describe '#save' do
+      it 'returns false if not valid' do
+        enic_selection_form = described_class.new
+
+        expect(
+          enic_selection_form.save(ApplicationQualification.new),
+        ).to be(false)
+      end
+
+      it 'updates the provided ApplicationQualification if valid' do
+        qualification = build(:gcse_qualification)
+
+        enic_selection_form = described_class.new(
+          enic_reason: 'obtained',
+        )
+
+        expect(
+          enic_selection_form.save(qualification),
+        ).to be(true)
+
+        expect(qualification.enic_reason).to eq('obtained')
+      end
+
+      it 'clears ENIC fields when enic_reason is not obtained' do
+        qualification = build(
+          :gcse_qualification,
+          enic_reference: '12345',
+          comparable_uk_qualification: 'GCSE (grades A*-C / 9-4)',
+        )
+
+        enic_selection_form = described_class.new(
+          enic_reason: 'waiting',
+        )
+
+        enic_selection_form.save(qualification)
+
+        expect(qualification.enic_reason).to eq('waiting')
+        expect(qualification.enic_reference).to be_nil
+        expect(qualification.comparable_uk_qualification).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

In the GCSE flow, the ENIC reference number was previously saved over with an empty attribute, even if the reason was unchanged. This bug fix brings behaviour in line with the ENIC flow for degrees.

**_Previous_**

https://github.com/user-attachments/assets/234d5c00-849c-402e-9d92-24dcf1005482


**_Now_**

https://github.com/user-attachments/assets/e7a827fb-5e3a-41c7-a7f0-58b7dce2dd58


## Changes proposed in this pull request

- Stop `EnicSelectionForm` from saving empty attrs unconditionally
- Conditionally nil out `enic_reference` and `compatible_uk_qualification` if the reason is not `obtained`

## Guidance to review

- Log in as a candidate with an unsubmitted application
- Visit the review page for an English, Maths or Science GCSE that holds an ENIC reference number 
- Click the change link next to the ENIC reason 'Yes, I have a statement of comparability'
- Don't change the reason but click 'Continue'
- You should see the ENIC reference has persisted
- Now change the reason and see that it has not been persisted
- Please now do the same but with `FeatureFlag.activate('2027_international_qualifications_flow` to make sure the bug has been resolved in both places the form is used.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
