### PR TITLE
Bug fix: Handle raw input on GcseInstitutionCountryForm

### DIFF
--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -36,7 +36,7 @@ module CandidateInterface
 
     def institution_country_params
       strip_whitespace params
-        .expect(candidate_interface_gcse_institution_country_form: [:institution_country])
+        .expect(candidate_interface_gcse_institution_country_form: %i[institution_country institution_country_raw])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/new_international_flow/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/new_international_flow/institution_country_controller.rb
@@ -42,7 +42,7 @@ module CandidateInterface
 
     def institution_country_params
       strip_whitespace params
-        .expect(candidate_interface_gcse_institution_country_form: [:institution_country])
+        .expect(candidate_interface_gcse_institution_country_form: %i[institution_country institution_country_raw])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/new_international_flow/qualifications_controller.rb
+++ b/app/controllers/candidate_interface/gcse/new_international_flow/qualifications_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class Gcse::NewInternationalFlow::QualificationsController < Gcse::NewInternationalFlow::BaseController
     def new
-      @equivalent_qualification_form = GcseEquivalentQualificationForm.build_from_qualification(current_qualification, equivalent_qualifications: @equivalent_qualifications.map(&:name) || [])
+      @equivalent_qualification_form = GcseEquivalentQualificationForm.build_from_qualification(current_qualification, equivalent_qualifications: @equivalent_qualifications&.map(&:name) || [])
       @list_of_qualifications = @equivalent_qualifications&.any?
     end
 

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -2,12 +2,9 @@ module CandidateInterface
   class GcseInstitutionCountryForm
     include ActiveModel::Model
 
-    attr_accessor :institution_country
+    attr_accessor :institution_country, :institution_country_raw
 
-    validates :institution_country, presence: true
-
-    validates :institution_country,
-              inclusion: { in: COUNTRIES_AND_TERRITORIES }
+    validate :institution_country_selected
 
     def self.build_from_qualification(application_qualification)
       new(
@@ -32,6 +29,17 @@ module CandidateInterface
       application_qualification.update!(
         institution_country:,
       )
+    end
+
+  private
+
+    def institution_country_selected
+      if institution_country.blank? && institution_country_raw.blank?
+        errors.add(:institution_country, :blank)
+      elsif institution_country_raw.present? &&
+            CountryFinder.find_name_from_iso_code(institution_country) != institution_country_raw
+        errors.add(:institution_country, :inclusion)
+      end
     end
   end
 end

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -1,10 +1,21 @@
 module CandidateInterface
   class GcseInstitutionCountryForm
     include ActiveModel::Model
+    include FreeTextInputHelper
 
     attr_accessor :institution_country, :institution_country_raw
 
+    alias value institution_country
+    alias raw_input institution_country_raw
+
+    def valid_options
+      COUNTRIES_AND_TERRITORIES.map do |iso_code, country_name|
+        [country_name, iso_code]
+      end
+    end
+
     validate :institution_country_selected
+    validate :no_free_text_input
 
     def self.build_from_qualification(application_qualification)
       new(
@@ -32,6 +43,10 @@ module CandidateInterface
     end
 
   private
+
+    def no_free_text_input
+      errors.add(:institution_country, :inclusion) if invalid_raw_data?
+    end
 
     def institution_country_selected
       if institution_country.blank? && institution_country_raw.blank?

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -11,16 +11,25 @@ module CandidateInterface
     def valid_options
       COUNTRIES_AND_TERRITORIES.map do |iso_code, country_name|
         [country_name, iso_code]
-      end
+      end.unshift([nil, nil])
     end
 
-    validate :institution_country_selected
     validate :no_free_text_input
+    validates :institution_country, presence: true
 
     def self.build_from_qualification(application_qualification)
       new(
         institution_country: application_qualification.institution_country,
       )
+    end
+
+    def initialize(attributes = {})
+      super
+      if institution_country_raw.present?
+        @institution_country = COUNTRIES_AND_TERRITORIES.find do |_iso_code, country_name|
+          country_name == institution_country_raw
+        end&.first || institution_country_raw
+      end
     end
 
     def save(application_qualification)
@@ -49,12 +58,7 @@ module CandidateInterface
     end
 
     def institution_country_selected
-      if institution_country.blank? && institution_country_raw.blank?
-        errors.add(:institution_country, :blank)
-      elsif institution_country_raw.present? &&
-            CountryFinder.find_name_from_iso_code(institution_country) != institution_country_raw
-        errors.add(:institution_country, :inclusion)
-      end
+      errors.add(:institution_country, :blank) if institution_country_raw.blank?
     end
   end
 end

--- a/app/views/candidate_interface/gcse/institution_country/_form.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/_form.html.erb
@@ -1,10 +1,24 @@
 <%= f.govuk_error_summary %>
-<%= f.govuk_collection_select(
-  :institution_country,
-  select_degree_country_options,
-  :id,
-  :name,
-  label: { text: t('gcse_edit_institution_country.page_title', subject: @subject.capitalize), size: 'l', tag: 'h1' },
-  aria: { label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select' },
+<%= render DfE::Autocomplete::View.new(
+  f,
+  attribute_name: :institution_country,
+  form_field: f.govuk_collection_select(
+    :institution_country,
+    select_degree_country_options,
+    :id,
+    :name,
+    label: {
+      text: t(
+        'gcse_edit_institution_country.page_title',
+        subject: @subject.capitalize,
+      ),
+      size: 'l',
+      tag: 'h1',
+    },
+    aria: {
+      label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select',
+    },
+  ),
 ) %>
+
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/new_international_flow/institution_country/_form.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/institution_country/_form.html.erb
@@ -2,11 +2,11 @@
 <%= render DfE::Autocomplete::View.new(
   f,
   attribute_name: :institution_country,
-  form_field: f.govuk_collection_select(
+  form_field: f.govuk_select(
     :institution_country,
-    select_degree_country_options,
-    :id,
-    :name,
+    options_for_select(@institution_country_form.valid_options, @institution_country_form.institution_country),
+    data: { controller: 'autocomplete' },
+    aria: { label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select' },
     label: {
       text: t(
         'gcse_edit_institution_country.page_title',
@@ -14,9 +14,6 @@
       ),
       size: 'l',
       tag: 'h1',
-    },
-    aria: {
-      label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select',
     },
   ),
 ) %>

--- a/app/views/candidate_interface/gcse/new_international_flow/institution_country/_form.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/institution_country/_form.html.erb
@@ -1,10 +1,24 @@
 <%= f.govuk_error_summary %>
-<%= f.govuk_collection_select(
-  :institution_country,
-  select_degree_country_options,
-  :id,
-  :name,
-  label: { text: t('gcse_edit_institution_country.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)), size: 'l', tag: 'h1' },
-  aria: { label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select' },
+<%= render DfE::Autocomplete::View.new(
+  f,
+  attribute_name: :institution_country,
+  form_field: f.govuk_collection_select(
+    :institution_country,
+    select_degree_country_options,
+    :id,
+    :name,
+    label: {
+      text: t(
+        'gcse_edit_institution_country.page_title',
+        subject: (@subject == 'english' ? @subject.capitalize : @subject),
+      ),
+      size: 'l',
+      tag: 'h1',
+    },
+    aria: {
+      label: 'candidate-interface-gcse-institution-country-form-institution-country-field-select',
+    },
+  ),
 ) %>
+
 <%= f.govuk_submit t('save_and_continue') %>

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -1,22 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
-  let(:form_data) { { institution_country: COUNTRIES_AND_TERRITORIES.keys.sample } }
+  let(:form_data) do
+    country_code = COUNTRIES_AND_TERRITORIES.keys.sample
+
+    {
+      institution_country: country_code,
+      institution_country_raw: CountryFinder.find_name_from_iso_code(country_code),
+    }
+  end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:institution_country) }
+    it 'is invalid when no country is entered' do
+      form = described_class.new(
+        institution_country: '',
+        institution_country_raw: '',
+      )
 
-    it 'validates nationalities against the COUNTRIES_AND_TERRITORIES list' do
-      invalid_country = described_class.new(
-        institution_country: 'QQ',
+      form.validate
+
+      expect(form.errors.details[:institution_country]).to include(error: :blank)
+    end
+
+    it 'is invalid when a country not in the list is entered' do
+      form = described_class.new(
+        institution_country: '',
+        institution_country_raw: 'iojsocijasoijcod',
       )
-      valid_country = described_class.new(
-        institution_country: COUNTRIES_AND_TERRITORIES.keys.sample,
+
+      form.validate
+
+      expect(form.errors.details[:institution_country]).to include(error: :inclusion)
+    end
+
+    it 'is valid when a country is selected from the list' do
+      country_code = COUNTRIES_AND_TERRITORIES.keys.sample
+
+      form = described_class.new(
+        institution_country: country_code,
+        institution_country_raw: CountryFinder.find_name_from_iso_code(country_code),
       )
-      valid_country.validate
-      invalid_country.validate
-      expect(valid_country.errors.attribute_names).not_to include :institution_country
-      expect(invalid_country.errors.attribute_names).to include :institution_country
+
+      form.validate
+
+      expect(form.errors.attribute_names).not_to include(:institution_country)
+    end
+
+    it 'is invalid when the selected country and raw value do not match' do
+      form = described_class.new(
+        institution_country: 'LA',
+        institution_country_raw: 'iojsocijasoijcod',
+      )
+
+      form.validate
+
+      expect(form.errors.details[:institution_country]).to include(error: :inclusion)
     end
   end
 

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -22,14 +22,13 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       expect(form.errors.details[:institution_country]).to include(error: :blank)
     end
 
-    it 'is invalid when a country not in the list is entered' do
+    it 'is invalid when raw input does not match any country' do
       form = described_class.new(
         institution_country: '',
         institution_country_raw: 'iojsocijasoijcod',
       )
 
       form.validate
-
       expect(form.errors.details[:institution_country]).to include(error: :inclusion)
     end
 
@@ -44,6 +43,15 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       form.validate
 
       expect(form.errors.attribute_names).not_to include(:institution_country)
+    end
+
+    it 'is valid if country can be matched from raw data' do
+      form = described_class.new(
+        institution_country: '',
+        institution_country_raw: 'Ghana',
+      )
+      expect(form.institution_country).to eq 'GH'
+      expect(form.valid?).to be true
     end
 
     it 'is invalid when the selected country and raw value do not match' do


### PR DESCRIPTION
## Context

Raw input was not previously handled.

**_Before_**

https://github.com/user-attachments/assets/70469de0-e208-44c3-a628-c66c571cf9dc

**_After_**

https://github.com/user-attachments/assets/8a669663-8a7c-4933-a03a-6b26c83e67a9

## Changes proposed in this pull request

- Update from `govuk_collection_select` to `DfE::Autocomplete::View` and use the _raw param for validation.

## Guidance to review

- Recreate the bug as shown in your main branch
- Now open this branch and inspect how the raw data is handled
- This can be tested in either or both of the following: the existing English/Maths/Science GCSE flow or the new international GCSE flow.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
