### PR TITLE
Fix run_winter_decline_by_default days

### DIFF
--- a/app/lib/end_of_cycle/winter_job_timetabler.rb
+++ b/app/lib/end_of_cycle/winter_job_timetabler.rb
@@ -24,7 +24,7 @@ module EndOfCycle
     def run_winter_decline_by_default?
       return false unless winter_decline_by_default_set?
 
-      current_time.between?(timetable.winter_decline_by_default_at, timetable.winter_decline_by_default_at + 1.month)
+      current_time.between?(timetable.winter_decline_by_default_at, timetable.winter_decline_by_default_at + 31.days)
     end
 
     def run_winter_cancel_reference_requests?


### PR DESCRIPTION
## Context

- Fix `run_winter_decline_by_default?` to work with days, not months

## Changes proposed in this pull request

- `1.month.ago` returns 30th when run on the 31st, this caused a bug.
- Resolve bug by changing the code to work with `+ 31.days`


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
