### PR TITLE
Return equality_and_diversity for application from 2024 onwards

### DIFF
--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -9,7 +9,7 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
 
   def equality_and_diversity
     return nil unless application_choice.state_offer_accepted? &&
-                      application_choice.application_form.recruitment_cycle_year == RecruitmentCycleTimetable.current_year
+                      application_choice.application_form.recruitment_cycle_year < 2024
 
     equality_and_diversity_data = application_form&.equality_and_diversity
 

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -9,7 +9,7 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
 
   def equality_and_diversity
     return nil unless application_choice.state_offer_accepted? &&
-                      application_choice.application_form.recruitment_cycle_year < 2024
+                      application_choice.application_form.recruitment_cycle_year > 2024
 
     equality_and_diversity_data = application_form&.equality_and_diversity
 


### PR DESCRIPTION
## Context

Hesa codes have changed during the 2023 recruitment cycle. To avoid errors, we only return equality_and_diversity information to vendors if the application choice is in current cycle.

But this causes issues with vendors as they can loose data from one cycle to another. So we decided to just show equality and diversity information if the choice is accepted and recruitment cycle year is greater than 2024.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review code and you can run this curl command, this application is in 2025 cycle. You should see equality_and_diversity

```curl https://apply-review-12167.test.teacherservices.cloud/api/v1.8/applications/9 -H "Authorization: Bearer sEYGCxkySgp-xAs7xkqd" | jq```


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
