### PR TITLE
Content changes to offer accept references

### DIFF
--- a/app/views/candidate_interface/decisions/accept_offer.html.erb
+++ b/app/views/candidate_interface/decisions/accept_offer.html.erb
@@ -21,7 +21,7 @@
         </p>
 
       <p class="govuk-body">
-        <%= t('decisions.accept_offer.after_we_have_emailed') %>
+        <%= t('decisions.accept_offer.not_email_received_references') %>
       </p>
       </div>
     </div>

--- a/config/locales/candidate_interface/decisions.yml
+++ b/config/locales/candidate_interface/decisions.yml
@@ -13,9 +13,9 @@ en:
         Respond before %{date}. <br role="presentation">
         This offer will be rejected automatically after then.
     accept_offer:
-      references_description: When you accept your offer, we’ll send emails to the people you said could give you references.
-      change_reference_details: Until we email them you can change any details about them.
-      after_we_have_emailed: After we have emailed them you will not be able to make any changes.
+      references_description: When you accept your offer, we’ll email the people you’ve given as references.
+      change_reference_details: You can change their details until we’ve emailed them. After that, you will not be able to make changes.
+      not_email_received_references: We will not email anyone we’ve already received a reference from.
       confirm: Accept offer
     decline_offer:
       confirm: Yes I’m sure – decline this offer

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -209,6 +209,20 @@ RSpec.describe 'Candidate accepts an offer' do
   end
 
   def then_i_see_my_references
+    expect(page).to have_element(:h1, text: 'Confirm your reference details and accept your offer')
+    expect(page).to have_element(
+      :p,
+      text: 'When you accept your offer, we’ll email the people you’ve given as references.',
+    )
+    expect(page).to have_element(
+      :p,
+      text: 'You can change their details until we’ve emailed them. After that, you will not be able to make changes.',
+    )
+    expect(page).to have_element(
+      :p,
+      text: 'We will not email anyone we’ve already received a reference from.',
+    )
+
     @application_form.reload.application_references.creation_order.each do |reference|
       expect(page).to have_text(reference.name)
       expect(page).to have_text(reference.email_address)


### PR DESCRIPTION
## Context

- Content changes to the "Confirm your reference details and accept your offer" page

## Changes proposed in this pull request

- Content changes to the "Confirm your reference details and accept your offer" page

<img width="1150" height="2442" alt="screencapture-localhost-3000-candidate-application-choice-157-offer-accept-2026-08-03-09_44_56" src="https://github.com/user-attachments/assets/a9948edb-3004-4906-8165-a41a800bc921" />

<img width="669" height="305" alt="Screenshot 2026-08-03 at 10 49 39" src="https://github.com/user-attachments/assets/13a1f60e-b183-4d17-b02f-a0c6b1b32887" />

## Guidance to review

- See screenshots for content changes

- Visit https://apply-review-12174.test.teacherservices.cloud/support
- Sign in as a Support user
- Click on any candidate with an application with the status "Offer made"
- Click on "Sign in as this candidate"
- Click on the application with the status "Offer made"
- Choose "Accept offer and conditions"
- Click "Continue"
- Check the content on the "Confirm your reference details and accept your offer" page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/yy4Wli3o/1586-end-of-cycle-viewing-cancelled-references-on-a-carried-over-application