### PR TITLE
Show EFL degree taugh in english to providers

### DIFF
--- a/app/components/shared/efl_qualification_card_component.html.erb
+++ b/app/components/shared/efl_qualification_card_component.html.erb
@@ -1,8 +1,8 @@
 <%= content_tag(
   header_tag,
-  'English as a foreign language',
+  'English language skills',
   class: "#{header_class} govuk-!-margin-top-6",
-  id: 'english-as-a-foreign-language',
+  id: 'english-language-skills',
 ) %>
 
 <% qualification_statuses.each do |status_content| %>

--- a/app/components/shared/efl_qualification_card_component.html.erb
+++ b/app/components/shared/efl_qualification_card_component.html.erb
@@ -36,7 +36,7 @@
 <% elsif details.present? %>
   <%= content_tag(
     sub_header_tag(header_tag:),
-    'Details',
+    'Further details',
     class: 'govuk-heading-s govuk-!-margin-bottom-2',
   ) %>
   <p class="govuk-body govuk-!-margin-bottom-0"><%= details %></p>

--- a/app/components/shared/efl_qualification_card_component.rb
+++ b/app/components/shared/efl_qualification_card_component.rb
@@ -45,7 +45,7 @@ class EflQualificationCardComponent < ApplicationComponent
     end
 
     if degree_taught_in_english
-      content << 'Candidate’s degree taught in English.'
+      content << 'Candidate’s degree was taught in English.'
     end
 
     if has_qualification

--- a/app/components/shared/efl_qualification_card_component.rb
+++ b/app/components/shared/efl_qualification_card_component.rb
@@ -44,6 +44,10 @@ class EflQualificationCardComponent < ApplicationComponent
       content << 'Candidate said that English is their main language.'
     end
 
+    if degree_taught_in_english
+      content << 'Candidate’s degree taught in English.'
+    end
+
     if has_qualification
       content << 'Candidate has done an English as a foreign language assessment.'
     end
@@ -113,6 +117,8 @@ class EflQualificationCardComponent < ApplicationComponent
   delegate(
     :no_qualification_details,
     :no_assessment_plan_details,
+    :degree_taught_in_english,
+    :no_qualification,
     :has_qualification,
     :qualification_not_needed,
     to: :english_proficiency,

--- a/spec/components/utility/efl_qualification_card_component_spec.rb
+++ b/spec/components/utility/efl_qualification_card_component_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
-        expect(result.text).to include 'Candidate’s degree taught in English.'
+        expect(result.text).to include 'Candidate’s degree was taught in English.'
         expect(result.text).to include 'Candidate plans to do an English as a foreign language assessment.'
         expect(result.text).to include 'Further details'
         expect(result.text).to include 'I will do one'
@@ -104,7 +104,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
-        expect(result.text).to include 'Candidate’s degree taught in English.'
+        expect(result.text).to include 'Candidate’s degree was taught in English.'
         expect(result.text).to include 'Candidate does not plan to do an English as a foreign language assessment.'
         expect(result.text).not_to include 'Further details'
       end

--- a/spec/components/utility/efl_qualification_card_component_spec.rb
+++ b/spec/components/utility/efl_qualification_card_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
         expect(result.text).to include 'Candidate said that English is their main language.'
-        expect(result.text).not_to include 'Details'
+        expect(result.text).not_to include 'Further details'
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
         result = render_inline(described_class.new(application_form))
         expect(result.text).to include 'Candidate said that English is their main language.'
         expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
-        expect(result.text).not_to include 'Details'
+        expect(result.text).not_to include 'Further details'
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
         expect(result.text).to include 'Candidate does not plan to do an English as a foreign language assessment.'
-        expect(result.text).not_to include 'Details'
+        expect(result.text).not_to include 'Further details'
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
         expect(result.text).to include 'Candidate plans to do an English as a foreign language assessment.'
-        expect(result.text).to include 'Details'
+        expect(result.text).to include 'Further details'
         expect(result.text).to include 'I will do one'
       end
     end
@@ -84,8 +84,9 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
+        expect(result.text).to include 'Candidate’s degree taught in English.'
         expect(result.text).to include 'Candidate plans to do an English as a foreign language assessment.'
-        expect(result.text).to include 'Details'
+        expect(result.text).to include 'Further details'
         expect(result.text).to include 'I will do one'
       end
     end
@@ -103,8 +104,9 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
+        expect(result.text).to include 'Candidate’s degree taught in English.'
         expect(result.text).to include 'Candidate does not plan to do an English as a foreign language assessment.'
-        expect(result.text).not_to include 'Details'
+        expect(result.text).not_to include 'Further details'
       end
     end
 
@@ -119,7 +121,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
           expect(result.text).not_to include 'Candidate said that English is not a foreign language to them.'
-          expect(result.text).not_to include 'Details'
+          expect(result.text).not_to include 'Further details'
           expect(result.text).not_to include 'Candidate does not plan to do an English as a foreign language assessment.'
 
           details_card = result.css('[data-qa="english-proficiency-qualification"]')
@@ -142,7 +144,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
           expect(result.text).not_to include 'Candidate said that English is not a foreign language to them.'
-          expect(result.text).not_to include 'Details'
+          expect(result.text).not_to include 'Further details'
           expect(result.text).not_to include 'Candidate does not plan to do an English as a foreign language assessment.'
 
           details_card = result.css('[data-qa="english-proficiency-qualification"]')
@@ -165,7 +167,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has done an English as a foreign language assessment.'
           expect(result.text).not_to include 'Candidate said that English is not a foreign language to them.'
-          expect(result.text).not_to include 'Details'
+          expect(result.text).not_to include 'Further details'
           expect(result.text).not_to include 'Candidate does not plan to do an English as a foreign language assessment.'
 
           details_card = result.css('[data-qa="english-proficiency-qualification"]')
@@ -305,7 +307,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'returns nil' do
         expect(component.details).to be_nil
 
-        expect(rendered_component).to have_no_text('Details')
+        expect(rendered_component).to have_no_text('Further details')
       end
     end
 
@@ -315,7 +317,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'returns the no_qualification_details' do
         expect(component.details).to eq('Working on it')
 
-        expect(rendered_component).to have_text('Details')
+        expect(rendered_component).to have_text('Further details')
         expect(rendered_component).to have_text('Working on it')
       end
     end
@@ -326,7 +328,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'returns the no_assessment_plan_details' do
         expect(component.details).to eq('I have no plans')
 
-        expect(rendered_component).to have_text('Details')
+        expect(rendered_component).to have_text('Further details')
         expect(rendered_component).to have_text('I have no plans')
       end
     end


### PR DESCRIPTION
## Context

- Show "Degree taught in English" to providers

## Changes proposed in this pull request

- Add code to show "Degree taught in English" to providers viewing an international application

## Guidance to review

- Visit https://apply-review-12175.test.teacherservices.cloud/support
- Sign in as a Support user
- Visit https://apply-review-12175.test.teacherservices.cloud/support/users/provider/17
- Click on "Sign in as this provider user"
- Visit https://apply-review-12175.test.teacherservices.cloud/provider/applications/158
- Check the content for the EFL
- Visit https://apply-review-12175.test.teacherservices.cloud/provider/applications/157
- Check the content for the EFL


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/okTxgBP8/2046-show-efl-studied-degree-in-english-value-to-providers

## Screenshots

<img width="656" height="235" alt="Screenshot 2026-08-05 at 10 55 19" src="https://github.com/user-attachments/assets/e6b6acc5-a4c3-4c88-8bcd-1319205208b9" />


<img width="596" height="228" alt="Screenshot 2026-08-05 at 10 56 34" src="https://github.com/user-attachments/assets/efda3d54-9f75-4412-bc20-61152f76a676" />


