### PR TITLE
make references editing less restrictive

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -26,11 +26,4 @@ class Offer < ApplicationRecord
   def all_conditions_met?
     conditions.all?(&:met?)
   end
-
-  def all_references_conditions_met?
-    [
-      reference_condition,
-      conditions.filter(&:satisfactory_references?),
-    ].flatten.compact_blank.all?(&:met?)
-  end
 end

--- a/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
@@ -4,7 +4,7 @@
 
 <%= render CandidateInterface::ReferencesComponent.new(references: @references, reference_condition: @application_choice.offer.reference_condition) %>
 
-<% unless @application_choice.offer.all_references_conditions_met? %>
+<% unless @application_choice.recruited? || @application_choice.conditions_not_met? %>
   <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
 <% end %>
 

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -102,39 +102,4 @@ RSpec.describe Offer do
       expect(offer.all_conditions_met?).to be false
     end
   end
-
-  describe '#all_references_conditions_met?' do
-    it 'returns true if both reference condition and the satisfactory references condition are met' do
-      offer = create(
-        :offer,
-        conditions: [
-          build(:text_condition, status: 'met', description: 'Satisfactory references'),
-          build(:reference_condition, status: 'met'),
-        ],
-      )
-      expect(offer.all_references_conditions_met?).to be true
-    end
-
-    it 'returns false if the satisfactory references condition is not met' do
-      offer = create(
-        :offer,
-        conditions: [
-          build(:text_condition, status: 'pending', description: 'Satisfactory references'),
-          build(:reference_condition, status: 'met'),
-        ],
-      )
-      expect(offer.all_references_conditions_met?).to be false
-    end
-
-    it 'returns false if the references condition is not met' do
-      offer = create(
-        :offer,
-        conditions: [
-          build(:text_condition, status: 'met', description: 'Satisfactory references'),
-          build(:reference_condition, status: 'pending'),
-        ],
-      )
-      expect(offer.all_references_conditions_met?).to be false
-    end
-  end
 end


### PR DESCRIPTION
## Context

We were only showing the button to allow candidates to add new references on the offer page if the references conditions were unmet. However, if a provider makes an offer over the API, they can create offers without reference conditions. All the conditions are 'text' conditions and not identified as a reference condition.

## Changes proposed in this pull request

Show the Add new references button until the candidate has either been recruited or had their offer withdrawn for not meeting conditions. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
