### PR TITLE
Add inset text to clarify if updates effect existing applications

### DIFF
--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,6 +11,8 @@
     <%= t('page_titles.contact_information_review') %>
   </h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,6 +11,8 @@
         Check your answers to equality and diversity questions
       </h1>
 
+      <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
       <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @section_policy.can_edit?)) %>
       <% if @current_application.equality_and_diversity_answers_provided? %>

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -8,6 +8,8 @@
     <%= t('page_titles.interview_preferences.review') %>
   </h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -12,6 +12,8 @@
     <%= t('page_titles.personal_information.review') %>
   </h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -8,6 +8,8 @@
     <%= t('page_titles.personal_statement_review') %>
   </h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
+
   <% if @application_form.review_pending?(:becoming_a_teacher) %>
     <%= govuk_inset_text do %>
       <% rejection_reasons = @application_form.rejection_reasons(:becoming_a_teacher) %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -13,6 +13,8 @@
         <h1 class="govuk-heading-l"><%= t('page_titles.references') %></h1>
       <% end %>
 
+      <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
       <%= render CandidateInterface::AddNewReferenceComponent.new(current_application:) %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -10,6 +10,8 @@
     <h1 class="govuk-heading-xl"><%= t('page_titles.restructured_work_history_review') %></h1>
   <% end %>
 
+  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <% if @application_form.can_complete? && @section_policy.can_edit? %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -8,6 +8,8 @@
     <%= t('page_titles.training_with_a_disability_review') %>
   </h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -6,6 +6,8 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.volunteering.review') %></h1>
 
+  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
+
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <% if @application_form.application_volunteering_experiences.any? && @section_policy.can_edit? %>

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -24,6 +24,11 @@ en:
       yorkshire_and_the_humber: Yorkshire and the Humber
       european_economic_area: European Economic Area
       rest_of_the_world: Rest of the World
+    section:
+      applications_will_be_updated:
+        Your open applications will be updated with any changes you make in this section.
+      update_future_applications_only:
+        Changes you make in this section will only be included in future applications. Your open applications will not be updated.
 
   activemodel:
     errors:


### PR DESCRIPTION
## Context

- Add inset text to clarify if updates will affect existing applications
  - Will affect:
    - Personal information
    - Contact information
    - Tell providers about a support need (prev Ask for support if you are disabled)
    - Interview availability
    - References to be requested if you accept an offer
    - Equality and diversity questions
    
  - Will not affect:
    - Work history
    - Unpaid experience
    - Your personal statement

## Changes proposed in this pull request

- Add inset text to clarify whether or not updates will affect existing applications.

## Guidance to review

- Visit https://apply-review-12196.test.teacherservices.cloud/support/sign-in
- Sign in as a Support user
- Visit https://apply-review-12196.test.teacherservices.cloud/support/applications/71
- Click on "Sign in as this candidate"
- Navigate to "Your details"
- Click through the sections indicated above and check that the correct inset text appears


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/sHCAvvjq/2008-clarify-what-updates-do-dont-effect-existing-applications

## Screenshots
**Will be affected**
_Personal information_
<img width="1157" height="1297" alt="screencapture-localhost-3000-candidate-application-personal-information-review-2026-08-10-09_47_51" src="https://github.com/user-attachments/assets/c51d5a0f-ab02-41cb-a898-c443416ff541" />

_Contact information_
<img width="1157" height="1280" alt="screencapture-localhost-3000-candidate-application-contact-information-review-2026-08-10-09_49_08" src="https://github.com/user-attachments/assets/36b92fdd-d197-4168-a586-529e943701e0" />

_Tell providers about a support need (prev Ask for support if you are disabled)_
<img width="1157" height="1405" alt="screencapture-localhost-3000-candidate-application-additional-support-review-2026-08-10-09_49_57" src="https://github.com/user-attachments/assets/5f76adf2-9034-41c4-a870-8876b7cf86f9" />

_Interview availability_
<img width="1157" height="1280" alt="screencapture-localhost-3000-candidate-application-interview-availability-review-2026-08-10-09_50_28" src="https://github.com/user-attachments/assets/347fce0b-4876-474d-8e12-2a70b1705fed" />

_References to be requested if you accept an offer_
<img width="1155" height="540" alt="Screenshot 2026-08-10 at 09 51 30" src="https://github.com/user-attachments/assets/ec3c5f7a-54be-45d8-b5c6-897608e7209c" />

_Equality and diversity questions_
<img width="1157" height="1532" alt="screencapture-localhost-3000-candidate-application-equality-and-diversity-review-2026-08-10-09_52_11" src="https://github.com/user-attachments/assets/43bf5480-5163-4abb-82dc-0d3631df7afb" />

**Will NOT be affected**
_Work history_
<img width="1157" height="2747" alt="screencapture-localhost-3000-candidate-application-restructured-work-history-review-2026-08-10-09_53_07" src="https://github.com/user-attachments/assets/32bc4ca8-4e4e-454e-b3c9-3a5cc15a7300" />

_Unpaid experience_
<img width="1157" height="1668" alt="screencapture-localhost-3000-candidate-application-unpaid-experience-review-2026-08-10-09_53_35" src="https://github.com/user-attachments/assets/e566d575-2870-4d38-9c13-79b90b8de8c0" />

_Your personal statement_
<img width="1155" height="454" alt="Screenshot 2026-08-10 at 09 54 22" src="https://github.com/user-attachments/assets/ef54ec57-f4ac-4427-8445-3febf42cb153" />


