### PR TITLE
Remove Not applicable from nationalities

### DIFF
--- a/config/initializers/countries_and_territories.rb
+++ b/config/initializers/countries_and_territories.rb
@@ -7,6 +7,6 @@ COUNTRIES_AND_TERRITORIES = DfE::ReferenceData::CountriesAndTerritories::COUNTRI
 CODES_AND_NATIONALITIES = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES
                             .all_as_hash
                             .transform_values(&:citizen_names)
-                            .reject{ |_k, v| v == 'Not applicable' }
+                            .reject { |_k, v| v == 'Not applicable' }
 
 DOMICILES = DfE::ReferenceData::HESA::Domiciles::COUNTRIES_AND_TERRITORIES.all_as_hash.transform_values(&:name).freeze

--- a/config/initializers/countries_and_territories.rb
+++ b/config/initializers/countries_and_territories.rb
@@ -4,6 +4,9 @@ require 'dfe/reference_data/hesa/domiciles'
 COUNTRIES_AND_TERRITORIES = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES
   .all_as_hash.transform_values(&:name).freeze
 
-CODES_AND_NATIONALITIES = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all_as_hash.transform_values(&:citizen_names)
+CODES_AND_NATIONALITIES = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES
+                            .all_as_hash
+                            .transform_values(&:citizen_names)
+                            .reject{ |_k, v| v == 'Not applicable' }
 
 DOMICILES = DfE::ReferenceData::HESA::Domiciles::COUNTRIES_AND_TERRITORIES.all_as_hash.transform_values(&:name).freeze


### PR DESCRIPTION
## Context

- Filter out "Not applicable" from the `citizen names` passed by the `DfE::ReferenceData`

## Changes proposed in this pull request

- Filter out "Not applicable" from the `citizen names` passed by the `DfE::ReferenceData`

## Guidance to review

- Check the code.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/EESQAkKM/1966-bug-candidate-can-choose-not-applicable-for-nationality

## Screenshot

<img width="724" height="521" alt="Screenshot 2026-08-10 at 13 51 01" src="https://github.com/user-attachments/assets/ff28318b-de1f-4159-b9eb-7a1c7e7f49cf" />
