### PR TITLE
Add pagination to duplicate candidate matches index

### DIFF
--- a/app/views/support_interface/duplicate_matches/index.html.erb
+++ b/app/views/support_interface/duplicate_matches/index.html.erb
@@ -30,7 +30,7 @@
     <% end %>
   <% else %>
     <%= render SupportInterface::DuplicateMatchesTableComponent.new(matches: @matches) %>
-    
+
     <%= govuk_pagination(pagy: @pagy) %>
   <% end %>
 <% end %>

--- a/app/views/support_interface/duplicate_matches/index.html.erb
+++ b/app/views/support_interface/duplicate_matches/index.html.erb
@@ -30,5 +30,7 @@
     <% end %>
   <% else %>
     <%= render SupportInterface::DuplicateMatchesTableComponent.new(matches: @matches) %>
+    
+    <%= govuk_pagination(pagy: @pagy) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Context

- Add missing pagination to Duplicate Candidate Matches index

## Changes proposed in this pull request

- Add missing pagination to Duplicate Candidate Matches index

## Guidance to review

https://github.com/user-attachments/assets/a13d8e1b-8664-41cc-9468-19b9545996fd

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/HQLWbtGL/1989-bug-fix-pagination-on-duplicate-matches-index