### PR TITLE
Migration to remove feature flag

### DIFF
--- a/app/services/data_migrations/remove_english_as_a_foreign_language_feature_flag.rb
+++ b/app/services/data_migrations/remove_english_as_a_foreign_language_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveEnglishAsAForeignLanguageFeatureFlag
+    TIMESTAMP = 20260807103428
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: '2027_application_form_has_many_english_proficiencies')&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveEnglishAsAForeignLanguageFeatureFlag',
   'DataMigrations::ResolveMistakenlyUnresolvedDuplicates',
   'DataMigrations::ResolveDuplicateMatchesUnsubmitted2025OrBefore2025',
   'DataMigrations::ResolveDuplicateMatchesFrom2024AndEarlier',

--- a/spec/services/data_migrations/remove_english_as_a_foreign_language_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_english_as_a_foreign_language_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveEnglishAsAForeignLanguageFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: '2027_application_form_has_many_english_proficiencies')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: '2027_application_form_has_many_english_proficiencies')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've removed all the code related to the english proficiencies feature flag. 

## Changes proposed in this pull request

This PR removes the feature flag from the code base.

## Guidance to review

All pretty standard, really.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
