### PR TITLE
Bug fix/intl qualifications: Make grade input ids unique

### DIFF
--- a/app/forms/candidate_interface/gcse_international_structured_grades_form.rb
+++ b/app/forms/candidate_interface/gcse_international_structured_grades_form.rb
@@ -21,7 +21,7 @@ module CandidateInterface
         grade: if percentage
                  grade&.delete_suffix('%')
                elsif structured
-                 grade
+                 encode_grade_for_radio(grade)
                else
                  (grade.present? ? 'other' : nil)
                end,
@@ -52,8 +52,20 @@ module CandidateInterface
       elsif non_structured?
         non_structured_grade
       else
-        grade
+        decode_grade_from_radio(grade)
       end
+    end
+
+    def decode_grade_from_radio(grade)
+      grade
+        &.gsub('_plus', '+')
+        &.gsub('_minus', '−')
+    end
+
+    def self.encode_grade_for_radio(grade)
+      grade
+        &.gsub('+', '_plus')
+        &.gsub('−', '_minus')
     end
   end
 end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -34,6 +34,12 @@ module GcseQualificationHelper
     subject == 'english' ? 'English' : subject
   end
 
+  def grade_radio_id(grade)
+    grade
+      .gsub('+', '_plus')
+      .gsub(/[−-]/, '_minus')
+  end
+
   def failing_grade_row_value(application_qualification)
     return application_qualification.not_completed_explanation if application_qualification.not_completed_explanation.present?
 

--- a/app/views/candidate_interface/gcse/new_international_flow/grades/_form.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/grades/_form.html.erb
@@ -5,7 +5,7 @@
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('gcse_edit_new_international_flow_grade.page_title'), size: 'l', tag: 'h1' } do %>
     <% if @list_of_grades %>
       <% @structured_grades.each_with_index do |grade, i| %>
-        <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero? %>
+        <%= f.govuk_radio_button :grade, grade, id: grade_radio_id(grade), label: { text: grade }, link_errors: i.zero? %>
       <% end %>
 
       <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/gcse/new_international_flow/grades/_form.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/grades/_form.html.erb
@@ -5,7 +5,7 @@
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('gcse_edit_new_international_flow_grade.page_title'), size: 'l', tag: 'h1' } do %>
     <% if @list_of_grades %>
       <% @structured_grades.each_with_index do |grade, i| %>
-        <%= f.govuk_radio_button :grade, grade, id: grade_radio_id(grade), label: { text: grade }, link_errors: i.zero? %>
+        <%= f.govuk_radio_button :grade, grade_radio_id(grade), label: { text: grade }, link_errors: i.zero? %>
       <% end %>
 
       <%= f.govuk_radio_divider %>

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
@@ -306,7 +306,7 @@ private
   end
 
   def when_i_choose_a_passing_grade
-    first('input[value="B+"]').choose
+    first('input[value="B_plus"]').choose
   end
 
   def when_i_choose_a_failing_grade


### PR DESCRIPTION
## Context

Found in the International Qualifications bug party. 

Grade ids were not unique when also listed in plus or minus form.

## Changes proposed in this pull request

Add a helper method to convert the symbol into a word and append it to the id.

## Guidance to review

- As a candidate, add or edit a GCSE qualification in English, Maths, or Science
- Select Kenya
- Select KCSE
- Inspect the B+ and B– grades and check that the ids are unique.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
