### PR TITLE
Add validation for support users reverting a rejection with an active duplicate application

### DIFF
--- a/app/forms/support_interface/application_forms/revert_rejection_form.rb
+++ b/app/forms/support_interface/application_forms/revert_rejection_form.rb
@@ -12,11 +12,27 @@ module SupportInterface
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
 
         return false unless valid?
+        return false if duplicate_application_for_course?(application_choice)
 
         SupportInterface::RevertRejection.new(
           application_choice:,
           zendesk_ticket: audit_comment_ticket,
         ).save!
+      end
+
+    private
+
+      def duplicate_application_for_course?(application_choice)
+        validator = ReapplyValidator.new
+        application_choice.status = :awaiting_provider_decision
+        validator.validate(application_choice)
+
+        if application_choice.errors.any?
+          errors.add(:base, :duplicate)
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/config/locales/support_interface/application_forms/revert_rejection_form.yml
+++ b/config/locales/support_interface/application_forms/revert_rejection_form.yml
@@ -6,4 +6,4 @@ en:
           attributes:
            base:
             duplicate:
-              This candidate has an active application for this course. You will need to delete the duplicate application before reverting this rejection.
+              This candidate has an active application for this course. They will need to delete the duplicate application before reverting this rejection.

--- a/config/locales/support_interface/application_forms/revert_rejection_form.yml
+++ b/config/locales/support_interface/application_forms/revert_rejection_form.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        support_interface/application_forms/revert_rejection_form:
+          attributes:
+           base:
+            duplicate:
+              This candidate has an active application for this course. You will need to delete the duplicate application before reverting this rejection.

--- a/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/revert_rejection_form_spec.rb
@@ -35,5 +35,18 @@ RSpec.describe SupportInterface::ApplicationForms::RevertRejectionForm, :with_au
 
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
     end
+
+    it 'returns false if the Application Choice has been duplicated for the same course' do
+      course_option = create(:course_option)
+      application_form = create(:completed_application_form)
+      application_choice = create(:application_choice, :rejected, course_option:, application_form:)
+      _duplicate_choice = create(:application_choice, :unsubmitted, course_option:, application_form:)
+      form = described_class.new(
+        audit_comment_ticket: zendesk_ticket,
+        accept_guidance: true,
+      )
+
+      expect(form.save(application_choice)).to be(false)
+    end
   end
 end

--- a/spec/system/support_interface/revert_rejection_spec.rb
+++ b/spec/system/support_interface/revert_rejection_spec.rb
@@ -21,25 +21,51 @@ RSpec.describe 'Revert an accidental rejection' do
     and_the_application_is_now_awaiting_provider_decision
   end
 
+  scenario 'Can not revert a rejected application with a duplicate choice on the same course', :with_audited do
+    given_i_am_a_support_user
+    and_there_is_a_rejected_application
+    and_there_is_a_duplicate_application_form_the_same_course
+
+    when_i_visit_the_application_page
+    then_i_see_a_revert_rejection_link
+
+    when_i_click_revert_rejection
+    then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+
+    when_i_add_an_audit_comment_and_click_continue
+    then_i_see_an_error_regarding_an_active_duplicate_application
+  end
+
+private
+
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
 
   def and_there_is_a_rejected_application
-    application_form = create(
+    @application_form = create(
       :application_form,
       submitted_at: Time.zone.now,
     )
     @application_choice = create(
       :application_choice,
       :awaiting_provider_decision,
-      application_form:,
+      application_form: @application_form,
     )
     @application_choice.update!(status: :rejected, rejected_at: Time.zone.now)
   end
 
+  def and_there_is_a_duplicate_application_form_the_same_course
+    _duplicate_application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application_form,
+      course_option: @application_choice.course_option,
+    )
+  end
+
   def when_i_visit_the_application_page
-    visit support_interface_application_form_path(@application_choice.application_form_id)
+    visit support_interface_application_form_path(@application_form.id)
   end
 
   def then_i_see_a_revert_rejection_link
@@ -53,7 +79,7 @@ RSpec.describe 'Revert an accidental rejection' do
   def then_i_see_a_confirmation_page_prompting_for_an_audit_comment
     expect(page).to have_current_path(
       support_interface_application_form_revert_rejection_path(
-        application_form_id: @application_choice.application_form_id,
+        application_form_id: @application_form.id,
         application_choice_id: @application_choice.id,
       ),
     )
@@ -67,7 +93,7 @@ RSpec.describe 'Revert an accidental rejection' do
   def then_i_see_a_validation_error
     expect(page).to have_current_path(
       support_interface_application_form_revert_rejection_path(
-        application_form_id: @application_choice.application_form_id,
+        application_form_id: @application_form.id,
         application_choice_id: @application_choice.id,
       ),
     )
@@ -82,10 +108,19 @@ RSpec.describe 'Revert an accidental rejection' do
   end
 
   def then_i_see_the_application_page
-    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+    expect(page).to have_current_path(support_interface_application_form_path(@application_form.id))
   end
 
   def and_the_application_is_now_awaiting_provider_decision
     expect(@application_choice.reload.awaiting_provider_decision?).to be true
+  end
+
+  def then_i_see_an_error_regarding_an_active_duplicate_application
+    within('.govuk-error-summary') do
+      expect(page).to have_text('There is a problem')
+      expect(page).to have_text(
+        'This candidate has an active application for this course. You will need to delete the duplicate application before reverting this rejection.',
+      )
+    end
   end
 end

--- a/spec/system/support_interface/revert_rejection_spec.rb
+++ b/spec/system/support_interface/revert_rejection_spec.rb
@@ -119,7 +119,7 @@ private
     within('.govuk-error-summary') do
       expect(page).to have_text('There is a problem')
       expect(page).to have_text(
-        'This candidate has an active application for this course. You will need to delete the duplicate application before reverting this rejection.',
+        'This candidate has an active application for this course. They will need to delete the duplicate application before reverting this rejection.',
       )
     end
   end


### PR DESCRIPTION
## Context

- Add validation handling to prevent 500 errors when a support user tries to revert the rejection of an application, with an active duplicate application for the same course.

## Changes proposed in this pull request

- Add validation handling to prevent 500 errors when a support user tries to revert the rejection of an application, with an active duplicate application for the same course.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/VOzUlfzV/2041-bug-error-handling-when-reverting-a-rejection

## Screenshot

<img width="1157" height="1323" alt="screencapture-localhost-3000-support-applications-69-revert-rejection-161-2026-08-11-10_59_00" src="https://github.com/user-attachments/assets/5e630cd9-e1fb-4569-9f0c-b878781b1cea" />

