### PR TITLE
Nullify non_uk attributes when changing gcse from int qualification

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -69,6 +69,12 @@ module CandidateInterface
         attributes[:constituent_grades] = nil
       end
 
+      unless non_uk_qualification?
+        attributes[:institution_country] = nil
+        attributes[:enic_reason] = nil
+        attributes[:selected_grade_schema_id] = nil
+      end
+
       if missing_qualification?
         attributes.merge!(
           grade: nil,

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
 
     context 'when the qualification_type is updated from non_uk' do
       it 'updates the existing qualification and sets non_uk_qualification_type to nil' do
-        qualification = create(:gcse_qualification, :non_uk)
+        qualification = create(:gcse_qualification, :non_uk, selected_grade_schema_id: 12345)
 
         described_class.new(
           qualification_type: 'gcse',
@@ -160,6 +160,9 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
         expect(qualification.non_uk_qualification_type).to be_nil
         expect(qualification.enic_reference).to be_nil
         expect(qualification.comparable_uk_qualification).to be_nil
+        expect(qualification.institution_country).to be_nil
+        expect(qualification.enic_reason).to be_nil
+        expect(qualification.selected_grade_schema_id).to be_nil
       end
     end
 


### PR DESCRIPTION
## Context

- Nullify `non_uk` attributes from GCSE Application Qualifications when changing the qualification type from `non_uk`

## Changes proposed in this pull request

- Add conditional logic to nullify the `non_uk` attributes from a GCSE Application Qualifications when changing the qualification type from `non_uk`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/hc2a8nUM/2081-international-quals-bug-changing-between-qualification-types-remembered-country

## Screenshot

https://github.com/user-attachments/assets/ff60e52f-e5e2-45f8-a07d-2d7fa8d20b85


