### PR TITLE
Add h1 tag

### DIFF
--- a/app/views/candidate_interface/gcse/new_international_flow/evidence/_form.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/evidence/_form.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_area :evidence, label: { text: t('gcse_new_international_flow_evidence.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)), size: 'l' }, hint: { text: t("gcse_new_international_flow_evidence.caption#{'_english' if @subject == 'english'}", subject: (@subject == 'english' ? @subject.capitalize : @subject)) }, max_words: 400, threshold: 90 %>
+<%= f.govuk_text_area :evidence, label: { text: t('gcse_new_international_flow_evidence.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)), size: 'l', tag: 'h1' }, hint: { text: t("gcse_new_international_flow_evidence.caption#{'_english' if @subject == 'english'}", subject: (@subject == 'english' ? @subject.capitalize : @subject)) }, max_words: 400, threshold: 90 %>
 
 <%= f.govuk_submit t('gcse_new_international_flow_evidence.continue') %>


### PR DESCRIPTION
## Context

Found in the International Qualifications bug party.

The evidence step did not have an h1.

## Changes proposed in this pull request

- Add an h1 tag to the label 

## Guidance to review

- Check the code and inspect the page

<img width="702" height="693" alt="Screenshot 2026-08-11 at 14 51 17" src="https://github.com/user-attachments/assets/9ba6af27-ed7e-4009-a5b6-41ba03102a25" />

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
