### PR TITLE
update inactive calculator to work with january start dates

### DIFF
--- a/app/models/candidate_pool_application.rb
+++ b/app/models/candidate_pool_application.rb
@@ -102,6 +102,7 @@ class CandidatePoolApplication < ApplicationRecord
 
     CandidateInterface::InactiveDateCalculator.new(
       effective_date: timetable.apply_opens_at,
+      reject_by_default_date: timetable.reject_by_default_at,
     ).inactive_date
   end
 end

--- a/app/services/candidate_interface/inactive_date_calculator.rb
+++ b/app/services/candidate_interface/inactive_date_calculator.rb
@@ -2,8 +2,11 @@ module CandidateInterface
   class InactiveDateCalculator
     STANDARD_DAYS_UNTIL_INACTIVE = 30
 
-    def initialize(effective_date:)
+    attr_reader :reject_by_default_date
+
+    def initialize(effective_date:, reject_by_default_date:)
       @effective_date = effective_date.end_of_day
+      @reject_by_default_date = reject_by_default_date
     end
 
     def inactive_date
@@ -19,16 +22,6 @@ module CandidateInterface
       date = @effective_date.to_datetime.business_days_until inactive_date
       # if we've changed time zones, we need to subtract a date
       inactive_date.zone == @effective_date.zone ? date : date - 1
-    end
-
-    def reject_by_default_date
-      @reject_by_default_date ||= 0.business_days.before(
-        recruitment_cycle_timetable.reject_by_default_at.end_of_day,
-      )
-    end
-
-    def recruitment_cycle_timetable
-      @recruitment_cycle_timetable ||= RecruitmentCycleTimetable.find_timetable_by_datetime(@effective_date)
     end
   end
 end

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -6,7 +6,10 @@ module CandidateInterface
     def initialize(application_choice, inactive_date_calculator: InactiveDateCalculator)
       @application_choice = application_choice
       @application_form = application_choice.application_form
-      @inactive_date_calculator = inactive_date_calculator.new(effective_date:)
+      @inactive_date_calculator = inactive_date_calculator.new(
+        effective_date:,
+        reject_by_default_date: application_choice.reject_by_default_date,
+      )
     end
 
     def call

--- a/spec/services/candidate_interface/inactive_date_calculator_spec.rb
+++ b/spec/services/candidate_interface/inactive_date_calculator_spec.rb
@@ -1,8 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::InactiveDateCalculator do
-  subject(:calculator) { described_class.new(effective_date: Time.zone.now) }
+  subject(:calculator) {
+    described_class.new(
+      effective_date: Time.zone.now,
+      reject_by_default_date:,
+    )
+  }
 
+  let(:reject_by_default_date) { Time.zone.parse('25 Sep 2024 23:59:59 PM BST') }
   let(:application_choice) { create(:application_choice, :unsubmitted) }
 
   describe 'inactive calculation' do
@@ -21,6 +27,23 @@ RSpec.describe CandidateInterface::InactiveDateCalculator do
         travel_temporarily_to(Time.zone.parse(submitted)) do
           expect(calculator.inactive_date).to be_within(1.second).of(Time.zone.parse(correct_rbd))
           expect(calculator.inactive_days).to eq inactive_days
+        end
+      end
+    end
+
+    context 'winter reject by default' do
+      after_september_dates = [
+        ['12 January 2023 9:00:00 AM GMT', '20 January 2023 23:59:59 PM GMT', 6, 'Winter reject by default'],
+      ].freeze
+
+      let(:reject_by_default_date) { Time.zone.parse('20 January 2023 23:59:59 PM GMT') }
+
+      after_september_dates.each do |submitted, correct_rbd, inactive_days, test_case|
+        it "is correct when the application is delivered #{test_case}" do
+          travel_temporarily_to(Time.zone.parse(submitted)) do
+            expect(calculator.inactive_date).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+            expect(calculator.inactive_days).to eq inactive_days
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

This updates the inactive date calculator to work with January start dates.

The calculator will just accept a reject by default date and will spit out a date. 30 business days or reject_by_default_date, whichever is shorter.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Review code


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
