### PR TITLE
Content changes to Editable Warning Component

### DIFF
--- a/app/components/candidate_interface/editable_section_warning.html.erb
+++ b/app/components/candidate_interface/editable_section_warning.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-inset-text">
-  <% if @section_policy.personal_statement? %>
-    <%= t('editable_section_warning.not_included_in_submitted_personal_statement') %>
-  <% elsif @section_policy.work_history? %>
+  <% if @section_policy.personal_statement? || @section_policy.work_history? %>
     <%= t('editable_section_warning.not_included_in_submitted') %>
+  <% elsif active_previous_application.present? %>
+    <%= t('editable_section_warning.not_included_in_previous_application', current_recruitment_cycle_year_range:, previous_recruitment_cycle_year_range:) %>
   <% else %>
     <%= t('editable_section_warning.included_in_submitted') %>
   <% end %>

--- a/app/components/candidate_interface/editable_section_warning.rb
+++ b/app/components/candidate_interface/editable_section_warning.rb
@@ -2,13 +2,24 @@ module CandidateInterface
   class EditableSectionWarning < ApplicationComponent
     attr_accessor :section_policy, :current_application
 
+    delegate :candidate, :submitted_applications?, to: :current_application
+    delegate :active_previous_application, to: :candidate
+
     def initialize(current_application:, section_policy:)
       @current_application = current_application
       @section_policy = section_policy
     end
 
     def render?
-      @current_application.submitted_applications? && @section_policy.can_edit?
+      submitted_applications? && @section_policy.can_edit?
+    end
+
+    def current_recruitment_cycle_year_range
+      @current_application.academic_year_range_name
+    end
+
+    def previous_recruitment_cycle_year_range
+      active_previous_application.academic_year_range_name
     end
   end
 end

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,8 +11,6 @@
     <%= t('page_titles.contact_information_review') %>
   </h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,8 +11,6 @@
         Check your answers to equality and diversity questions
       </h1>
 
-      <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
       <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @section_policy.can_edit?)) %>
       <% if @current_application.equality_and_diversity_answers_provided? %>

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -8,8 +8,6 @@
     <%= t('page_titles.interview_preferences.review') %>
   </h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -12,8 +12,6 @@
     <%= t('page_titles.personal_information.review') %>
   </h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -8,8 +8,6 @@
     <%= t('page_titles.personal_statement_review') %>
   </h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
-
   <% if @application_form.review_pending?(:becoming_a_teacher) %>
     <%= govuk_inset_text do %>
       <% rejection_reasons = @application_form.rejection_reasons(:becoming_a_teacher) %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -13,8 +13,6 @@
         <h1 class="govuk-heading-l"><%= t('page_titles.references') %></h1>
       <% end %>
 
-      <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
       <%= render CandidateInterface::AddNewReferenceComponent.new(current_application:) %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -10,8 +10,6 @@
     <h1 class="govuk-heading-xl"><%= t('page_titles.restructured_work_history_review') %></h1>
   <% end %>
 
-  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <% if @application_form.can_complete? && @section_policy.can_edit? %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -8,8 +8,6 @@
     <%= t('page_titles.training_with_a_disability_review') %>
   </h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.applications_will_be_updated')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -6,8 +6,6 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.volunteering.review') %></h1>
 
-  <%= govuk_inset_text(text: t('application_form.section.update_future_applications_only')) %>
-
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <% if @application_form.application_volunteering_experiences.any? && @section_policy.can_edit? %>

--- a/config/locales/candidate_interface/application_form.yml
+++ b/config/locales/candidate_interface/application_form.yml
@@ -24,11 +24,6 @@ en:
       yorkshire_and_the_humber: Yorkshire and the Humber
       european_economic_area: European Economic Area
       rest_of_the_world: Rest of the World
-    section:
-      applications_will_be_updated:
-        Your open applications will be updated with any changes you make in this section.
-      update_future_applications_only:
-        Changes you make in this section will only be included in future applications. Your open applications will not be updated.
 
   activemodel:
     errors:

--- a/config/locales/components/candidate_interface/editable_section_warning.yml
+++ b/config/locales/components/candidate_interface/editable_section_warning.yml
@@ -1,5 +1,6 @@
 en:
   editable_section_warning:
-    not_included_in_submitted_personal_statement: Any changes you make to your personal statement will not be included in applications you have already submitted.
-    not_included_in_submitted: Any changes you make will not be included in applications you have already submitted.
-    included_in_submitted: Any changes you make will be included in applications you have already submitted.
+    not_included_in_submitted: Changes you make in this section will only be included in future applications. Your open applications will not be updated.
+    included_in_submitted: Your open applications will be updated with any changes you make in this section.
+    not_included_in_previous_application:
+      Changes you make in this section will update your open application for the %{current_recruitment_cycle_year_range} academic year. Your open applications for the %{previous_recruitment_cycle_year_range} academic year will not be updated.

--- a/config/locales/components/candidate_interface/editable_section_warning.yml
+++ b/config/locales/components/candidate_interface/editable_section_warning.yml
@@ -3,4 +3,4 @@ en:
     not_included_in_submitted: Changes you make in this section will only be included in future applications. Your open applications will not be updated.
     included_in_submitted: Your open applications will be updated with any changes you make in this section.
     not_included_in_previous_application:
-      Changes you make in this section will update your open application for the %{current_recruitment_cycle_year_range} academic year. Your open applications for the %{previous_recruitment_cycle_year_range} academic year will not be updated.
+      Changes you make in this section will update your open applications for the %{current_recruitment_cycle_year_range} academic year. Your open applications for the %{previous_recruitment_cycle_year_range} academic year will not be updated.

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
 
         it 'renders message' do
           expect(result.text).to include(
-            "Changes you make in this section will update your open application for the #{current_application.academic_year_range_name} academic year. " \
+            "Changes you make in this section will update your open applications for the #{current_application.academic_year_range_name} academic year. " \
             "Your open applications for the #{previous_application_form.academic_year_range_name} academic year will not be updated.",
           )
         end

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -15,26 +15,63 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
 
       it 'renders message' do
         expect(result.text).to include(
-          'Any changes you make will be included in applications you have already submitted.',
+          'Your open applications will be updated with any changes you make in this section.',
         )
       end
 
-      context 'when the canidate can edit the section and it is the personal statement' do
+      context 'when the candidate can edit the section and it is the personal statement' do
         let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: true) }
 
         it 'renders message' do
           expect(result.text).to include(
-            'Any changes you make to your personal statement will not be included in applications you have already submitted.',
+            'Changes you make in this section will only be included in future applications. Your open applications will not be updated.',
           )
         end
       end
 
-      context 'when the canidate can edit the section and it is the work_history' do
+      context 'when the candidate can edit the section and it is the work_history' do
         let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false, work_history?: true) }
 
         it 'renders message' do
           expect(result.text).to include(
-            'Any changes you make will not be included in applications you have already submitted.',
+            'Changes you make in this section will only be included in future applications. Your open applications will not be updated.',
+          )
+        end
+      end
+
+      context 'when the candidate has an active previous application' do
+        let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false, work_history?: false) }
+
+        let(:previous_application_form) do
+          create(
+            :completed_application_form,
+            recruitment_cycle_year: current_application.recruitment_cycle_year.pred,
+            candidate: current_application.candidate,
+            created_at: current_application.created_at - 1.year,
+          )
+        end
+        let(:jan_course) do
+          create(
+            :course,
+            start_date: "01/01/#{current_application.recruitment_cycle_year}",
+            recruitment_cycle_year: previous_application_form.recruitment_cycle_year,
+          )
+        end
+        let(:previous_application_choice) do
+          create(
+            :application_choice,
+            :awaiting_provider_decision,
+            application_form: previous_application_form,
+            course_option: create(:course_option, course: jan_course),
+          )
+        end
+
+        before { previous_application_choice }
+
+        it 'renders message' do
+          expect(result.text).to include(
+            "Changes you make in this section will update your open application for the #{current_application.academic_year_range_name} academic year. " \
+            "Your open applications for the #{previous_application_form.academic_year_range_name} academic year will not be updated.",
           )
         end
       end

--- a/spec/components/previews/candidate_interface/editable_section_warning_preview.rb
+++ b/spec/components/previews/candidate_interface/editable_section_warning_preview.rb
@@ -3,33 +3,38 @@ module CandidateInterface
     def editable_section
       render PreviewEditableSectionWarning.new(
         current_application:,
-        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: false),
+        section_policy: section_policy(can_edit: true, personal_statement: false, work_history: false),
       )
     end
 
     def personal_statement
       render PreviewEditableSectionWarning.new(
         current_application:,
-        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: true, work_history?: false),
+        section_policy: section_policy(can_edit: true, personal_statement: true, work_history: false),
       )
     end
 
     def work_history
       render PreviewEditableSectionWarning.new(
         current_application:,
-        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: true),
+        section_policy: section_policy(can_edit: true, personal_statement: false, work_history: true),
       )
     end
 
     def active_previous_application_jan_start_dates
       render PreviewEditableSectionWarning.new(
         current_application:,
-        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: false),
-        active_previous_application: true
+        section_policy: section_policy(can_edit: true, personal_statement: false, work_history: false),
+        active_previous_application: true,
       )
     end
 
   private
+
+    def section_policy(can_edit: true, personal_statement: false, work_history: false)
+      policy = Struct.new(:can_edit?, :personal_statement?, :work_history?)
+      policy.new(can_edit?: can_edit, personal_statement?: personal_statement, work_history?: work_history)
+    end
 
     def current_application
       FactoryBot.build(:completed_application_form, recruitment_cycle_year: 2026)

--- a/spec/components/previews/candidate_interface/editable_section_warning_preview.rb
+++ b/spec/components/previews/candidate_interface/editable_section_warning_preview.rb
@@ -1,0 +1,55 @@
+module CandidateInterface
+  class EditableSectionWarningPreview < ViewComponent::Preview
+    def editable_section
+      render PreviewEditableSectionWarning.new(
+        current_application:,
+        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: false),
+      )
+    end
+
+    def personal_statement
+      render PreviewEditableSectionWarning.new(
+        current_application:,
+        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: true, work_history?: false),
+      )
+    end
+
+    def work_history
+      render PreviewEditableSectionWarning.new(
+        current_application:,
+        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: true),
+      )
+    end
+
+    def active_previous_application_jan_start_dates
+      render PreviewEditableSectionWarning.new(
+        current_application:,
+        section_policy: OpenStruct.new(can_edit?: true, personal_statement?: false, work_history?: false),
+        active_previous_application: true
+      )
+    end
+
+  private
+
+    def current_application
+      FactoryBot.build(:completed_application_form, recruitment_cycle_year: 2026)
+    end
+
+    class PreviewEditableSectionWarning < CandidateInterface::EditableSectionWarning
+      def initialize(current_application:, section_policy:, active_previous_application: false)
+        super(current_application:, section_policy:)
+        @active_previous_application = active_previous_application
+      end
+
+      def render?
+        true
+      end
+
+      def active_previous_application
+        return unless @active_previous_application
+
+        FactoryBot.build(:completed_application_form, recruitment_cycle_year: 2025)
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -65,12 +65,10 @@ RSpec.describe 'A candidate can edit some sections after first submission' do
   def and_i_can_edit_the_section
     work_experiences = %i[unpaid_experience work_history]
 
-    expected_content = if @section.identifier == :personal_statement
-                         'Any changes you make to your personal statement will not be included in applications you have already submitted.'
-                       elsif work_experiences.include?(@section.identifier)
-                         'Any changes you make will not be included in applications you have already submitted.'
+    expected_content = if @section.identifier == :personal_statement || work_experiences.include?(@section.identifier)
+                         'Changes you make in this section will only be included in future applications. Your open applications will not be updated.'
                        else
-                         'Any changes you make will be included in applications you have already submitted.'
+                         'Your open applications will be updated with any changes you make in this section.'
                        end
 
     expect(page).to have_text(expected_content)


### PR DESCRIPTION
## Context

- Remove unnecessary inset text.
- Change content within the `CandidateInterface::EditableSectionWarning` component

## Changes proposed in this pull request

- Remove unnecessary inset text.
- Change content within the `CandidateInterface::EditableSectionWarning` component
- Add conditional logic to show specific content when the candidate has an active previous application

## Guidance to review

- Visit https://apply-review-12209.test.teacherservices.cloud/support
- Sign in as a Support user
-------
**Reviewing the component**
_Editable section_
- Visit https://apply-review-12209.test.teacherservices.cloud/rails/view_components/candidate_interface/editable_section_warning/editable_section

_Personal statement_
- Visit https://apply-review-12209.test.teacherservices.cloud/rails/view_components/candidate_interface/editable_section_warning/personal_statement

_Work history or Unpaid experience_
- Visit https://apply-review-12209.test.teacherservices.cloud/rails/view_components/candidate_interface/editable_section_warning/work_history

_Jan start dates_
- Visit https://apply-review-12209.test.teacherservices.cloud/rails/view_components/candidate_interface/editable_section_warning/active_previous_application_jan_start_dates

---------

**Review via review app**
_With previous application jan start_
- Visit https://apply-review-12209.test.teacherservices.cloud/support/applications/73
- Click on 'Sign in as this candidate'
- Navigate to "Your details"
- Click through the sections to make sure the correct content shows

_Without jan starts_
- Visit https://apply-review-12209.test.teacherservices.cloud/support/applications/72
- Click on 'Sign in as this candidate'
- Navigate to "Your details"
- Click through the sections to make sure the correct content shows

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/499l6Pvz/2010-update-content-for-updating-applications-in-jan-course-scenarios

## Screenshot

<img width="1458" height="1149" alt="screencapture-apply-review-12209-test-teacherservices-cloud-candidate-application-personal-information-review-2026-08-12-10_44_54" src="https://github.com/user-attachments/assets/5336c9d9-926b-4f8d-949a-617d010c8e00" />

