### PR TITLE
Fix enic_reason carry over bug

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -7,7 +7,7 @@ class DuplicateApplication
   end
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at contact_details_completed course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete efl_completed efl_completed_at feedback_form_complete equality_and_diversity_completed equality_and_diversity_completed_at adviser_interruption_response].freeze
-  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
+  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id].freeze
 
   def duplicate
     attrs = original_application_form.attributes.except(


### PR DESCRIPTION
## Context

Candidates that have a enic reason on their qualifications which carry will encounter a bug in the new cycle. Their application qualification will be marked as completed, but the enic_reason would be set to nil.


<img width="1629" height="736" alt="image" src="https://github.com/user-attachments/assets/0a3279c2-c6b0-4fb0-9cf4-961e69c642a0" />

There's this PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/9628/changes that ignored the enic_reason when carrying over. I don't think the issue that was fixed in this PR is relevant anymore. The enic_reason can be nil if it needs to be. So I think we are safe to do this change


## Changes proposed in this pull request


## Guidance to review

Review code


https://github.com/user-attachments/assets/f0254117-493f-437c-8014-e0bfe23130eb

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
