### PR TITLE
Write to temporary VendorAPIRequest table

### DIFF
--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -10,7 +10,7 @@ module SupportInterface
                               VendorAPIRequest.none
                             end
 
-      @pagy, @vendor_api_requests = pagy(vendor_api_requests, limit: PAGY_PER_PAGE)
+      @pagy, @vendor_api_requests = pagy_array(vendor_api_requests, limit: PAGY_PER_PAGE)
     end
   end
 end

--- a/app/models/vendor_api_request_v2.rb
+++ b/app/models/vendor_api_request_v2.rb
@@ -1,0 +1,42 @@
+class VendorAPIRequestV2 < ApplicationRecord
+  belongs_to :provider, optional: true
+  scope :unprocessable_entities, -> { where(status_code: 422) }
+  scope :syncs, -> { where(request_path: '/api/v1/applications', request_method: 'GET') }
+  scope :decisions, -> { where(request_method: 'POST') }
+  scope :errors, -> { where.not(status_code: [200, 302, 301]) }
+  scope :successful, -> { where(status_code: [200]) }
+  scope :with_error_response_body, lambda {
+    select(:request_path, :response_body, Arel.sql("response_body -> 'errors' as response_errors"))
+      .where.not(response_body: [nil, {}])
+      .where("(response_body->'errors') IS NOT NULL")
+  }
+
+  def self.list_of_distinct_errors_with_count(requests = unprocessable_entities)
+    error_requests = requests.with_error_response_body
+    error_messages = error_requests.flat_map do |request|
+      request.response_errors.map do |response_error|
+        [request.request_path, response_error['error'], response_error['message']]
+      end
+    end
+
+    tally_errors(error_messages)
+  end
+
+  def self.search_validation_errors(params)
+    scope = unprocessable_entities
+    scope = scope.where(request_path: params[:request_path]) if params[:request_path]
+    scope = scope.where(provider_id: params[:provider_id]) if params[:provider_id]
+    scope = scope.where(id: params[:id]) if params[:id]
+    scope = scope.where('response_body@> ?', { errors: [{ error: params[:attribute] }] }.to_json) if params[:attribute]
+    scope
+  end
+
+  def self.tally_errors(error_messages)
+    error_messages
+      .tally
+      .sort_by { |_attributes, total| total }
+      .reverse
+  end
+
+  private_class_method :tally_errors
+end

--- a/app/queries/vendor_api_request_query.rb
+++ b/app/queries/vendor_api_request_query.rb
@@ -1,5 +1,7 @@
 class VendorAPIRequestQuery
   attr_reader :params
+  COLUMNS = %w[id created_at provider_id request_body request_headers request_method
+               request_path response_body response_headers status_code].freeze
 
   LIMIT = 5000
 
@@ -13,11 +15,35 @@ class VendorAPIRequestQuery
 
   def call
     scope = VendorAPIRequest.includes(:provider).order(id: :desc)
+    second_scope = VendorAPIRequestV2.includes(:provider).order(id: :desc)
+
     scope = search_scope(scope)
+    second_scope = search_scope(second_scope)
+
     scope = status_code_scope(scope)
+    second_scope = status_code_scope(second_scope)
+
     scope = request_method_scope(scope)
+    second_scope = request_method_scope(second_scope)
+
     scope = provider_scope(scope)
-    scope.limit(LIMIT)
+    second_scope = provider_scope(second_scope)
+
+    sql = <<-SQL
+      (#{scope.reselect(COLUMNS).to_sql})
+      UNION ALL
+      (#{second_scope.reselect(COLUMNS).to_sql})
+      ORDER BY created_at DESC LIMIT #{LIMIT}
+    SQL
+
+    records = ActiveRecord::Base.connection.execute(sql)
+    providers_hash = Provider.where(
+      id: records.map { |r| r.fetch('provider_id') }.uniq,
+    ).index_by(&:id)
+
+    records.map do |record|
+      VendorAPIRequestPresenter.new(record, providers_hash:)
+    end
   end
 
 private
@@ -47,5 +73,24 @@ private
     return VendorAPIRequest.none if provider.nil?
 
     scope.where(provider_id: provider.id)
+  end
+end
+
+class VendorAPIRequestPresenter
+  attr_reader :id, :created_at, :provider, :request_body,
+              :request_headers, :request_method, :request_path, :response_body,
+              :response_headers, :status_code
+
+  def initialize(response_hash, providers_hash:)
+    @id = response_hash.fetch('id')
+    @created_at = response_hash.fetch('created_at')
+    @provider = providers_hash.fetch(response_hash.fetch('provider_id'))
+    @request_body = response_hash.fetch('request_body')
+    @request_headers = response_hash.fetch('request_headers')
+    @request_method = response_hash.fetch('request_method')
+    @request_path = response_hash.fetch('request_path')
+    @response_body = response_hash.fetch('response_body')
+    @response_headers = response_hash.fetch('response_headers')
+    @status_code = response_hash.fetch('status_code')
   end
 end

--- a/app/workers/support/delete_old_vendor_api_requests_worker.rb
+++ b/app/workers/support/delete_old_vendor_api_requests_worker.rb
@@ -1,0 +1,5 @@
+class Support::DeleteOldVendorAPIRequestsWorker < ApplicationJob
+  def perform
+    VendorAPIRequestV2.where('created_at < ?', 3.months.ago).delete_all
+  end
+end

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -23,7 +23,7 @@ class VendorAPIRequestWorker < ApplicationJob
       response_body = response_data
     end
 
-    VendorAPIRequest.create!(
+    VendorAPIRequestV2.create!(
       request_path: request_data['path'],
       request_headers:,
       request_body: request_body(request_data),

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -41,6 +41,7 @@ class Clock
   every(1.day, 'PromptInactiveProviderUsersWorker', at: '5:03') { PromptInactiveProviderUsersWorker.perform_later }
   every(1.day, 'RemoveInactiveProviderUsersWorker', at: '5:05') { RemoveInactiveProviderUsersWorker.perform_later }
   every(1.day, 'DeactivateStaleServiceAPITokensWorker', at: '5:06') { DeactivateStaleServiceAPITokensWorker.perform_later }
+  every(1.day, 'DeleteOldVendorAPIRequestsWorker', at: '5:07') { Support::DeleteOldVendorAPIRequestsWorker.perform_later }
   every(1.day, 'DeleteAllDrafts', at: '4:01') { DeleteAllDraftsWorker.perform_later }
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_later }
 

--- a/spec/factories/vendor_api_request_v2.rb
+++ b/spec/factories/vendor_api_request_v2.rb
@@ -1,0 +1,38 @@
+FactoryBot.define do
+  factory :vendor_api_request_v2 do
+    provider
+    request_path { '/api/v1/applications' }
+    request_method { 'GET' }
+    status_code { 200 }
+    request_headers { {} }
+    request_body { {} }
+    response_headers { {} }
+    response_body { {} }
+    created_at { Time.zone.now }
+
+    trait :sync do
+      request_path { '/api/v1/applications' }
+      request_method { 'GET' }
+      status_code { 200 }
+    end
+
+    trait :decision do
+      request_method { 'POST' }
+      status_code { 200 }
+    end
+
+    trait :with_validation_error do
+      status_code { 422 }
+      response_body do
+        {
+          'errors' => [
+            {
+              'error' => 'ValidationError',
+              'message' => 'Some error message',
+            },
+          ],
+        }
+      end
+    end
+  end
+end

--- a/spec/queries/vendor_api_request_query_spec.rb
+++ b/spec/queries/vendor_api_request_query_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe VendorAPIRequestQuery do
+RSpec.describe VendorAPIRequestQuery do # rubocop:disable RSpec/MultipleDescribes
   describe '.call' do
     subject(:call) { described_class.call(params:) }
 
@@ -17,26 +17,22 @@ RSpec.describe VendorAPIRequestQuery do
       end
 
       it 'returns the latest 5000 vendor API requests' do
-        recent_api_requests = VendorAPIRequest.where(id: vendor_api_requests.pluck(:id))
+        recent_api_requests = VendorAPIRequest.where(id: vendor_api_requests.pluck(:id)).ids
         results = call
-        expect(results).to match_array(recent_api_requests)
+        expect(results.map(&:id)).to match_array(recent_api_requests)
         expect(results.count).to eq(10)
       end
     end
 
     context 'when given a provider code param' do
       let(:provider) { create(:provider, code: 'ZZZ') }
-      let(:provider_api_request) { create(:vendor_api_request, provider:) }
-      let(:random_api_request) { create(:vendor_api_request) }
+      let!(:provider_api_request) { create(:vendor_api_request, provider:) }
+      let!(:second_provider_api_request) { create(:vendor_api_request_v2, provider:) }
+      let!(:random_api_request) { create(:vendor_api_request) }
       let(:params) { { provider_code: 'ZZZ' } }
 
-      before do
-        provider_api_request
-        random_api_request
-      end
-
       it 'returns only vendor API requests for the given provider' do
-        expect(call).to contain_exactly(provider_api_request)
+        expect(call.map(&:id)).to contain_exactly(provider_api_request.id, second_provider_api_request.id)
       end
 
       context 'when the provider code given does not match a provider' do
@@ -49,58 +45,89 @@ RSpec.describe VendorAPIRequestQuery do
     end
 
     context 'when given a request_path (:q) param' do
-      let(:vendor_api_request_1) { create(:vendor_api_request, request_path: 'api/records/ba') }
-      let(:vendor_api_request_2) { create(:vendor_api_request, request_path: 'api/records/foo') }
-      let(:vendor_api_request_3) { create(:vendor_api_request, request_path: 'api/something') }
+      let!(:vendor_api_request_1) { create(:vendor_api_request, request_path: 'api/records/ba') }
+      let!(:vendor_api_request_2) { create(:vendor_api_request, request_path: 'api/records/foo') }
+      let!(:vendor_api_request_3) { create(:vendor_api_request_v2, request_path: 'api/records/foo') }
+      let!(:vendor_api_request_4) { create(:vendor_api_request, request_path: 'api/something') }
       let(:params) { { q: 'api/records' } }
 
       it 'returns only vendor API requests matching the given request path' do
-        expect(call).to contain_exactly(vendor_api_request_1, vendor_api_request_2)
+        expect(call.map(&:id)).to contain_exactly(vendor_api_request_1.id, vendor_api_request_2.id, vendor_api_request_3.id)
       end
     end
 
     context 'when given a request_body (:q) param' do
-      let(:vendor_api_request_1) { create(:vendor_api_request, request_body: { 'data' => [1, 2, 3] }) }
-      let(:vendor_api_request_2) { create(:vendor_api_request, request_body: { 'data' => %w[a b c] }) }
-      let(:vendor_api_request_3) { create(:vendor_api_request, request_body: { 'errors' => [{ 'error' => 'Not found' }] }) }
+      let!(:vendor_api_request_1) { create(:vendor_api_request, request_body: { 'data' => [1, 2, 3] }) }
+      let!(:vendor_api_request_2) { create(:vendor_api_request, request_body: { 'data' => %w[a b c] }) }
+      let!(:vendor_api_request_3) { create(:vendor_api_request_v2, request_body: { 'data' => %w[a b c] }) }
+      let!(:vendor_api_request_4) { create(:vendor_api_request, request_body: { 'errors' => [{ 'error' => 'Not found' }] }) }
       let(:params) { { q: 'data' } }
 
       it 'returns only vendor API requests matching the given request body' do
-        expect(call).to contain_exactly(vendor_api_request_1, vendor_api_request_2)
+        expect(call.map(&:id)).to contain_exactly(vendor_api_request_1.id, vendor_api_request_2.id, vendor_api_request_3.id)
       end
     end
 
     context 'when given a response_body (:q) param' do
-      let(:vendor_api_request_1) { create(:vendor_api_request, response_body: { 'data' => [1, 2, 3] }) }
-      let(:vendor_api_request_2) { create(:vendor_api_request, response_body: { 'data' => %w[a b c] }) }
-      let(:vendor_api_request_3) { create(:vendor_api_request, response_body: { 'errors' => [{ 'error' => 'Not found' }] }) }
+      let!(:vendor_api_request_1) { create(:vendor_api_request, response_body: { 'data' => [1, 2, 3] }) }
+      let!(:vendor_api_request_2) { create(:vendor_api_request, response_body: { 'data' => %w[a b c] }) }
+      let!(:vendor_api_request_3) { create(:vendor_api_request_v2, response_body: { 'data' => %w[a b c] }) }
+      let!(:vendor_api_request_4) { create(:vendor_api_request, response_body: { 'errors' => [{ 'error' => 'Not found' }] }) }
       let(:params) { { q: 'data' } }
 
       it 'returns only vendor API requests matching the given response body' do
-        expect(call).to contain_exactly(vendor_api_request_1, vendor_api_request_2)
+        expect(call.map(&:id)).to contain_exactly(vendor_api_request_1.id, vendor_api_request_2.id, vendor_api_request_3.id)
       end
     end
 
     context 'when given a status code param' do
-      let(:vendor_api_request_1) { create(:vendor_api_request, status_code: 200) }
-      let(:vendor_api_request_2) { create(:vendor_api_request, status_code: 500) }
-      let(:vendor_api_request_3) { create(:vendor_api_request, status_code: 301) }
+      let!(:vendor_api_request_1) { create(:vendor_api_request, status_code: 200) }
+      let!(:vendor_api_request_2) { create(:vendor_api_request, status_code: 500) }
+      let!(:vendor_api_request_3) { create(:vendor_api_request_v2, status_code: 500) }
+      let!(:vendor_api_request_4) { create(:vendor_api_request, status_code: 301) }
       let(:params) { { status_code: [200, 500] } }
 
       it 'returns only vendor API requests matching the given status codes' do
-        expect(call).to contain_exactly(vendor_api_request_1, vendor_api_request_2)
+        expect(call.map(&:id)).to contain_exactly(vendor_api_request_1.id, vendor_api_request_2.id, vendor_api_request_3.id)
       end
     end
 
     context 'when given a request_method param' do
-      let(:vendor_api_request_1) { create(:vendor_api_request, request_method: 'GET') }
-      let(:vendor_api_request_2) { create(:vendor_api_request, request_method: 'POST') }
-      let(:vendor_api_request_3) { create(:vendor_api_request, request_method: 'DELETE') }
+      let!(:vendor_api_request_1) { create(:vendor_api_request, request_method: 'GET') }
+      let!(:vendor_api_request_2) { create(:vendor_api_request, request_method: 'POST') }
+      let!(:vendor_api_request_3) { create(:vendor_api_request_v2, request_method: 'POST') }
+      let!(:vendor_api_request_4) { create(:vendor_api_request, request_method: 'DELETE') }
       let(:params) { { request_method: %w[GET POST] } }
 
       it 'returns only vendor API requests matching the given request methods' do
-        expect(call).to contain_exactly(vendor_api_request_1, vendor_api_request_2)
+        expect(call.map(&:id)).to contain_exactly(vendor_api_request_1.id, vendor_api_request_2.id, vendor_api_request_3.id)
       end
+    end
+  end
+end
+
+RSpec.describe VendorAPIRequestPresenter do
+  let(:provider) { create(:provider, code: 'ZZZ') }
+  let(:provider_api_request) { create(:vendor_api_request, provider:) }
+  let(:model) {
+    described_class.new(
+      provider_api_request.as_json,
+      providers_hash: { provider.id => provider },
+    )
+  }
+
+  describe 'attributes' do
+    it 'has a set of predefined attributes' do
+      expect(model).to respond_to(:id)
+      expect(model).to respond_to(:created_at)
+      expect(model).to respond_to(:provider)
+      expect(model).to respond_to(:request_body)
+      expect(model).to respond_to(:request_headers)
+      expect(model).to respond_to(:request_method)
+      expect(model).to respond_to(:request_path)
+      expect(model).to respond_to(:response_body)
+      expect(model).to respond_to(:response_headers)
+      expect(model).to respond_to(:status_code)
     end
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer' 
 
       expect {
         post_api_request post_path, params: request_body
-      }.to change(VendorAPIRequest, :count)
+      }.to change(VendorAPIRequestV2, :count)
 
-      expect(VendorAPIRequest.first.request_path).to eq(post_path)
+      expect(VendorAPIRequestV2.first.request_path).to eq(post_path)
     end
   end
 
@@ -178,11 +178,11 @@ RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer' 
             'course' => course_option_to_course_payload(other_course_option),
           },
         }
-      }.to change(VendorAPIRequest, :count)
+      }.to change(VendorAPIRequestV2, :count)
 
       expect(response).to have_http_status(:unprocessable_entity)
 
-      logged_error = VendorAPIRequest.first.response_body['errors'].first['error']
+      logged_error = VendorAPIRequestV2.first.response_body['errors'].first['error']
 
       expect(logged_error).to eq('NotAuthorisedError')
     end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Vendor API Requests' do
 
   def and_vendor_api_requests_for_applications_have_been_made
     visit vendor_api_path('v1', @first_application_choice)
-    @unvalidated_request = VendorAPIRequest.last
+    @unvalidated_request = VendorAPIRequestV2.last
 
     @validated_provider = @last_application_choice.provider
     unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
@@ -81,7 +81,7 @@ RSpec.describe 'Vendor API Requests' do
     Capybara.current_session.driver.header('Authorization', "Bearer #{unhashed_token}")
 
     visit vendor_api_path('v1', @last_application_choice)
-    @validated_request = VendorAPIRequest.last
+    @validated_request = VendorAPIRequestV2.last
 
     Capybara.current_session.driver.header('Authorization', nil)
 

--- a/spec/workers/support/delete_old_vendor_api_requests_worker_spec.rb
+++ b/spec/workers/support/delete_old_vendor_api_requests_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Support::DeleteOldVendorAPIRequestsWorker do
+  describe '#perform' do
+    it 'deletes old vendor api requests' do
+      deletable_record = create(:vendor_api_request_v2, created_at: 4.months.ago)
+      create(:vendor_api_request_v2, created_at: 3.days.ago)
+
+      expect { described_class.new.perform }.to change { VendorAPIRequestV2.count }.by(-1)
+      expect { deletable_record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VendorAPIRequestWorker do
     it 'creates a VendorAPIRequest record' do
       expect {
         described_class.new.perform({}, {}.to_json, 401, stringified_time)
-      }.to change(VendorAPIRequest, :count).by(1)
+      }.to change(VendorAPIRequestV2, :count).by(1)
     end
 
     it 'detects the provider making the request from the authorization header' do
@@ -18,7 +18,7 @@ RSpec.describe VendorAPIRequestWorker do
       headers = { 'HTTP_AUTHORIZATION' => "Bearer #{unhashed_token}" }
       described_class.new.perform({ 'headers' => headers }, {}.to_json, 500, stringified_time)
 
-      expect(VendorAPIRequest.find_by(provider_id: provider.id)).not_to be_nil
+      expect(VendorAPIRequestV2.find_by(provider_id: provider.id)).not_to be_nil
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe VendorAPIRequestWorker do
       stringified_time,
     )
 
-    vendor_api_request = VendorAPIRequest.find_by(request_path: '/api/v1/foo')
+    vendor_api_request = VendorAPIRequestV2.find_by(request_path: '/api/v1/foo')
 
     expect(vendor_api_request.response_headers).to eq({ 'this' => 'that' })
     expect(vendor_api_request.response_body).to eq({ 'that' => 'this' })
@@ -39,12 +39,12 @@ RSpec.describe VendorAPIRequestWorker do
   it 'saves the request method on the vendor api request' do
     described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, stringified_time)
 
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_method).to eq('GET')
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').request_method).to eq('GET')
   end
 
   it 'saves the created at timestamp on the vendor api request' do
     described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, stringified_time)
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').created_at.to_s).to eq(stringified_time)
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').created_at.to_s).to eq(stringified_time)
   end
 
   it 'saves params from GET requests' do
@@ -54,7 +54,7 @@ RSpec.describe VendorAPIRequestWorker do
       'method' => 'GET',
     }, {}.to_json, 500, stringified_time)
 
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
   end
 
   it 'saves request data from POST requests' do
@@ -64,7 +64,7 @@ RSpec.describe VendorAPIRequestWorker do
       'method' => 'POST',
     }, {}.to_json, 500, stringified_time)
 
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
   end
 
   it 'records when POST data is not valid JSON' do
@@ -74,7 +74,7 @@ RSpec.describe VendorAPIRequestWorker do
       'method' => 'POST',
     }, {}.to_json, 500, stringified_time)
 
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('error' => 'request data did not contain valid JSON')
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').request_body).to eq('error' => 'request data did not contain valid JSON')
   end
 
   it 'handles empty POST data' do
@@ -84,6 +84,6 @@ RSpec.describe VendorAPIRequestWorker do
       'method' => 'POST',
     }, {}.to_json, 500, stringified_time)
 
-    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to be_nil
+    expect(VendorAPIRequestV2.find_by(request_path: '/api/v1/bar').request_body).to be_nil
   end
 end

--- a/vendor_api_request_v2_spec.rb
+++ b/vendor_api_request_v2_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPIRequestV2 do
+  describe '.list_of_distinct_errors_with_count' do
+    it 'returns a list of grouped errors' do
+      create_list(:vendor_api_request_v2, 2, :with_validation_error)
+
+      expect(described_class.list_of_distinct_errors_with_count).to contain_exactly(
+        [
+          [
+            '/api/v1/applications',
+            'ValidationError',
+            'Some error message',
+          ],
+          2,
+        ],
+      )
+    end
+
+    it 'sorts the list of errors by occurrence' do
+      create(:vendor_api_request_v2, :with_validation_error, request_path: '/api/v1/applications/21629/reject')
+      create_list(:vendor_api_request_v2, 2, :with_validation_error)
+
+      expect(described_class.list_of_distinct_errors_with_count).to contain_exactly(
+        [
+          [
+            '/api/v1/applications',
+            'ValidationError',
+            'Some error message',
+          ],
+          2,
+        ],
+        [
+          [
+            '/api/v1/applications/21629/reject',
+            'ValidationError',
+            'Some error message',
+          ],
+          1,
+        ],
+      )
+    end
+
+    it 'extracts separate errors from the same request' do
+      response_body = {
+        'errors' => [
+          {
+            'error' => 'ValidationError',
+            'message' => 'Some error message',
+          },
+          {
+            'error' => 'ParameterMissing',
+            'message' => 'Some other error message',
+          },
+        ],
+      }
+      create(:vendor_api_request_v2, :with_validation_error, response_body:)
+
+      expect(described_class.list_of_distinct_errors_with_count).to contain_exactly(
+        [
+          [
+            '/api/v1/applications',
+            'ValidationError',
+            'Some error message',
+          ],
+          1,
+        ],
+        [
+          [
+            '/api/v1/applications',
+            'ParameterMissing',
+            'Some other error message',
+          ],
+          1,
+        ],
+      )
+    end
+
+    it 'does not return successful requests' do
+      create(:vendor_api_request_v2)
+
+      expect(described_class.list_of_distinct_errors_with_count).to be_empty
+    end
+  end
+
+  describe '.search_validation_errors' do
+    it 'does not return successful requests' do
+      create(:vendor_api_request_v2)
+
+      expect(described_class.search_validation_errors({})).to be_empty
+    end
+
+    it 'returns all validation error requests with empty params' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+
+      expect(described_class.search_validation_errors({})).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to request path' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+      params = { request_path: request.request_path }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to provider' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+      params = { provider_id: request.provider_id }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to request id' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+      params = { id: request.id }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to error name' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+      params = { attribute: 'ValidationError' }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to error name with multiple errors in same request' do
+      response_body = {
+        'errors' => [
+          {
+            'error' => 'ValidationError',
+            'message' => 'Some error message',
+          },
+          {
+            'error' => 'ParameterMissing',
+            'message' => 'Some other error message',
+          },
+        ],
+      }
+      request = create(:vendor_api_request_v2, :with_validation_error, response_body:)
+
+      params = { attribute: 'ParameterMissing' }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'returns validation errors scoped to multiple parameters' do
+      request = create(:vendor_api_request_v2, :with_validation_error)
+
+      create(:vendor_api_request_v2, :with_validation_error, request_path: '/api/v1/applications/21629/reject', provider: request.provider)
+
+      params = { provider: request.provider, request_path: '/api/v1/applications' }
+
+      expect(described_class.search_validation_errors(params)).to contain_exactly(request)
+    end
+
+    it 'does not return requests if none found' do
+      expect(described_class.search_validation_errors({})).to be_empty
+    end
+  end
+
+  describe '.syncs' do
+    it 'returns appropriate requests for GET /applications' do
+      sync_request = create(:vendor_api_request_v2, request_method: 'GET', request_path: '/api/v1/applications')
+      create(:vendor_api_request_v2, request_method: 'GET', request_path: '/api/v1/applications/123')
+
+      expect(described_class.syncs).to contain_exactly(sync_request)
+    end
+  end
+
+  describe '.errors' do
+    it 'returns requests which caused errors' do
+      create(:vendor_api_request_v2, status_code: 200)
+      create(:vendor_api_request_v2, status_code: 302)
+      error_response = create(:vendor_api_request_v2, status_code: 422)
+
+      expect(described_class.errors).to contain_exactly(error_response)
+    end
+  end
+
+  describe '.successful' do
+    it 'returns requests which caused errors' do
+      success = create(:vendor_api_request_v2, status_code: 200)
+      create(:vendor_api_request_v2, status_code: 302)
+
+      expect(described_class.successful).to contain_exactly(success)
+    end
+  end
+end


### PR DESCRIPTION
## Context

The VendorAPIRequest table is getting to big in production. Over 25GB. Most of the data in the table we don't need. So we want to delete it.

We will write vendor api requests to a new table for about 3 months and then drop the old, bloated table.

We will start deleting data that is older than 3 months in a background job.

For these 3 months we will have to search in to tables to show the vendor api requests in the support console.

After we drop the old table. We will rename the new table and change the SQL queries to only look in 1 table.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

If you want to test this. Go to the View the vendor api requests for UCL in the review app.

To make new requests you can run something like this
```curl https://apply-review-12213.test.teacherservices.cloud/api/v1.8/applications/11 -H "Authorization: Bearer mTba6p_KgfSuBjxgqEsF" | jq``` 

<img width="1855" height="1226" alt="image" src="https://github.com/user-attachments/assets/ee34e0b6-44d1-4b32-bc48-c7b91049fd56" />


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
