### PR TITLE
New vendor api requests table

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -175,6 +175,17 @@
   - provider_id
   - response_headers
   - created_at
+  :vendor_api_request_v2s:
+  - id
+  - request_path
+  - request_method
+  - status_code
+  - request_headers
+  - request_body
+  - response_body
+  - provider_id
+  - response_headers
+  - created_at
   :provider_pool_actions:
   - id
   - status

--- a/db/migrate/20260812124612_create_vendor_api_request_v2s.rb
+++ b/db/migrate/20260812124612_create_vendor_api_request_v2s.rb
@@ -1,0 +1,17 @@
+class CreateVendorAPIRequestV2s < ActiveRecord::Migration[8.1]
+  def change
+    create_table :vendor_api_request_v2s do |t|
+      t.references :provider, null: true
+      t.jsonb :request_body
+      t.jsonb :request_headers
+      t.string :request_method
+      t.string :request_path
+      t.jsonb :response_body
+      t.jsonb :response_headers
+      t.integer :status_code
+      t.index :status_code
+      t.index :request_path
+      t.datetime :created_at, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1365,6 +1365,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_143452) do
     t.index ["form_object"], name: "index_validation_errors_on_form_object"
   end
 
+  create_table "vendor_api_request_v2s", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.bigint "provider_id"
+    t.jsonb "request_body"
+    t.jsonb "request_headers"
+    t.string "request_method"
+    t.string "request_path"
+    t.jsonb "response_body"
+    t.jsonb "response_headers"
+    t.integer "status_code"
+    t.index ["provider_id"], name: "index_vendor_api_request_v2s_on_provider_id"
+    t.index ["request_path"], name: "index_vendor_api_request_v2s_on_request_path"
+    t.index ["status_code"], name: "index_vendor_api_request_v2s_on_status_code"
+  end
+
   create_table "vendor_api_requests", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.bigint "provider_id"

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -817,6 +817,15 @@ erDiagram
 		jsonb response_headers
 		integer status_code
 	}
+	VendorAPIRequestV2 {
+		jsonb request_body
+		jsonb request_headers
+		string request_method
+		string request_path
+		jsonb response_body
+		jsonb response_headers
+		integer status_code
+	}
 	VendorAPIToken {
 		string description
 		string hashed_token
@@ -917,6 +926,7 @@ erDiagram
 	"Adviser::TeachingSubject" ||--}o "Adviser::SignUpRequest" : ""
 	VendorAPIToken ||--}o VendorApiUser : ""
 	Provider ||--}o VendorAPIToken : ""
+	Provider o|--}o VendorAPIRequestV2 : ""
 	Provider o|--}o VendorAPIRequest : ""
 	Vendor o|--}o Provider : ""
 	User o|--}o ValidationError : ""


### PR DESCRIPTION
## Context

The VendorAPIRequest table is getting to big in production. Over 25GB. Most of the data in the table we don't need. So we want to delete it.

We will write vendor api requests to a new table for about 3 months and then drop the old, bloated table.

This does the migration. The rest of the work is here.
https://github.com/DFE-Digital/apply-for-teacher-training/pull/12213


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
