### PR TITLE
Change definition of deferred when determining if a choice can be touched

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -308,7 +308,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def cannot_touch_choices?
-    earlier_cycle? && prevent_unsave_touches? && !deferred?
+    earlier_cycle? && prevent_unsafe_touches? && !deferred?
   end
 
   def any_qualification_enic_reason_not_needed?
@@ -858,14 +858,15 @@ private
   end
 
   def deferred?
-    application_choices.pluck(:status).include?('offer_deferred')
+    application_choices.pluck(:status).include?('offer_deferred') ||
+      application_choices.any? { |ac| (ac.recruited? || ac.pending_conditions?) && ac.offer_deferred_at.present? }
   end
 
   def earlier_cycle?
     recruitment_cycle_year < RecruitmentCycleTimetable.current_year
   end
 
-  def prevent_unsave_touches?
+  def prevent_unsafe_touches?
     !RequestStore.store[:allow_unsafe_application_choice_touches]
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe ApplicationForm do
   describe 'callbacks' do
     before do
       allow(FeatureFlag).to receive(:active?)
-        .with('2027_application_form_contact_details_residency_questions')
-        .and_return(true)
+                              .with('2027_application_form_contact_details_residency_questions')
+                              .and_return(true)
     end
 
     describe 'set_residency_date_from' do
@@ -137,8 +137,8 @@ RSpec.describe ApplicationForm do
       context 'when the feature flag is off' do
         before do
           allow(FeatureFlag).to receive(:active?)
-            .with('2027_application_form_contact_details_residency_questions')
-            .and_return(false)
+                                  .with('2027_application_form_contact_details_residency_questions')
+                                  .and_return(false)
         end
 
         it 'does not run the callback' do
@@ -428,8 +428,8 @@ RSpec.describe ApplicationForm do
         expected_calls_to_worker = address_attributes.size # Each update excluding the initial create
         expect(GeocodeApplicationAddressWorker)
           .to have_been_enqueued
-          .with(application_form.id)
-          .exactly(expected_calls_to_worker).times
+                .with(application_form.id)
+                .exactly(expected_calls_to_worker).times
       end
 
       it 'does not invoke geocoding for international addresses' do
@@ -965,7 +965,7 @@ RSpec.describe ApplicationForm do
     it 'calls #hesa_code_for_country for international addresses' do
       application_form = build_stubbed(:completed_application_form, :international_address)
       allow(DomicileResolver).to receive(:hesa_code_for_country)
-                                 .with(application_form.country).and_return(':)')
+                                   .with(application_form.country).and_return(':)')
 
       expect(application_form.domicile).to eq(':)')
     end
@@ -973,7 +973,7 @@ RSpec.describe ApplicationForm do
     it 'calls #hesa_code_for_postcode for UK addresses' do
       application_form = create(:completed_application_form)
       allow(DomicileResolver).to receive(:hesa_code_for_postcode_or_region)
-                                 .with(application_form.postcode, application_form.region_code).and_return(':)')
+                                   .with(application_form.postcode, application_form.region_code).and_return(':)')
 
       expect(application_form.domicile).to eq(':)')
     end
@@ -1559,8 +1559,8 @@ RSpec.describe ApplicationForm do
     it 'returns true when the validation is valid' do
       application_form = build(:application_form)
       allow(Adviser::ApplicationFormValidations).to receive(:new)
-                                                .with(application_form)
-                                                .and_return(instance_double(Adviser::ApplicationFormValidations, valid?: true))
+                                                      .with(application_form)
+                                                      .and_return(instance_double(Adviser::ApplicationFormValidations, valid?: true))
 
       expect(application_form.eligible_and_unassigned_a_teaching_training_adviser?).to be true
     end
@@ -2281,6 +2281,42 @@ RSpec.describe ApplicationForm do
 
     it 'returns only the application choices with september start dates' do
       expect(application_form.september_application_choices).to contain_exactly(september_choice)
+    end
+  end
+
+  describe '#cannot_touch_choices?' do
+    before { RequestStore.store[:allow_unsafe_application_choice_touches] = false }
+
+    it 'allows touches on applications that has been deferred from a previous year' do
+      application_choice = create(
+        :application_choice,
+        :offer_deferred,
+        application_form: build(:application_form, recruitment_cycle_year: previous_year),
+      )
+
+      expect(application_choice.application_form.cannot_touch_choices?).to be(false)
+    end
+
+    it 'allows touches on applications that have been deferred and then confirmed to another course' do
+      application_choice = create(
+        :application_choice,
+        :recruited,
+        offer_deferred_at: 1.year.ago,
+        application_form: build(:application_form, recruitment_cycle_year: previous_year),
+      )
+
+      expect(application_choice.application_form.cannot_touch_choices?).to be(false)
+    end
+
+    it 'does not allow touches when application was recruited in a previous year, never deferred' do
+      application_choice = create(
+        :application_choice,
+        :recruited,
+        offer_deferred_at: nil,
+        application_form: build(:application_form, recruitment_cycle_year: previous_year),
+      )
+
+      expect(application_choice.application_form.cannot_touch_choices?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Context

We have got a number of support requests related to updating deferred applications where the provider has confirmed the candidate onto a new course. We allow for applications from a previous year to be touched if the application choice has been deferred, but we only look at the actual status to determine if the choice has been deferred. 

In practice, a choice is deferred, and then changed to the previous condition after it is confirmed. So the condition could be 'pending conditions' or 'recruited' but it is still legitimately deferred. 

## Changes proposed in this pull request

Allow applications that have previous been deferred to be touched. 

## Guidance to review
- Sign in as a provider [Cameron Carrot](https://apply-review-12217.test.teacherservices.cloud/support/users/provider/11) will do. and find a deferred application from a previous year (eg [Tamika Leuschke](https://apply-review-12217.test.teacherservices.cloud/provider/applications/4) or [Denny Wisozk](https://apply-review-12217.test.teacherservices.cloud/provider/applications/7) for instasnce
- Confirm them onto a course from this year
- Sign in as support and try to update the candidate's name. 
- You should be able to do so without error.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
