### PR TITLE
Write to course_status on courses table

### DIFF
--- a/app/services/data_migrations/backfill_courese_status.rb
+++ b/app/services/data_migrations/backfill_courese_status.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class BackfillCoureseStatus
+    TIMESTAMP = 20260817104904
+    MANUAL_RUN = false
+
+    def change
+      Course
+        .application_status_open
+        .course_status_closed
+        .update_all(course_status: 'open')
+    end
+  end
+end

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -91,6 +91,7 @@ module TeacherTrainingPublicAPI
       course.age_range = age_range_in_years(course_from_api)
       course.applications_open_from = timetable.find_opens_at
       course.application_status = course_from_api.application_status
+      course.course_status = course_from_api.application_status
       course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
       course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
       course.code = course_from_api.code

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillCoureseStatus',
   'DataMigrations::RemoveEnglishAsAForeignLanguageFeatureFlag',
   'DataMigrations::ResolveMistakenlyUnresolvedDuplicates',
   'DataMigrations::ResolveDuplicateMatchesUnsubmitted2025OrBefore2025',

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -27,12 +27,14 @@ FactoryBot.define do
 
     trait :open do
       application_status { 'open' }
+      course_status { 'open' }
       exposed_in_find { true }
       recruitment_cycle_year { CycleTimetableHelper.current_year }
     end
 
     trait :closed do
       application_status { 'closed' }
+      course_status { 'closed' }
     end
 
     trait :with_accredited_provider do

--- a/spec/services/data_migrations/backfill_courese_status_spec.rb
+++ b/spec/services/data_migrations/backfill_courese_status_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillCoureseStatus do
+  describe '#change' do
+    it 'Sets the course_status open to open courses' do
+      course_open = create(:course, :open, course_status: 'closed')
+      course_closed = create(:course, :closed)
+      course_already_opened = create(:course, :open)
+
+      expect { described_class.new.change }
+        .to change { course_open.reload.course_status }.from('closed').to('open')
+        .and(not_change { course_already_opened.reload.course_status })
+        .and(not_change { course_closed.reload.course_status })
+    end
+  end
+end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
       it 'updates the course to closed including the invite' do
         expect { perform_job }.not_to change(Course, :count)
         expect(course.reload.open?).to be(false)
+        expect(course.reload.course_status_open?).to be(false)
         expect(invite.reload.course_open).to be(false)
       end
     end
@@ -160,6 +161,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
 
         expect { perform_job }.not_to change(Course, :count)
         expect(course.reload.open?).to be(true)
+        expect(course.reload.course_status_open?).to be(true)
         expect(invite.reload.course_open).to be(true)
         expect(CandidateMailers::EnqueueVisaSponsorshipDeadlineChangeWorker).to(
           have_received(:perform_later).with(course.id),
@@ -286,6 +288,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
       it 'updates the course to closed including the invite' do
         expect { perform_job }.not_to change(Course, :count)
         expect(course.reload.open?).to be(true)
+        expect(course.reload.course_status_open?).to be(true)
         expect(invite.reload.course_open).to be(false)
       end
     end


### PR DESCRIPTION
## Context

We want to transition away from the application_status to the new course_status enum.

This will write the same value to the course_status and also backfill
the old records.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The publish sync has been tested on qa app, along with the migration.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
