### PR TITLE
2855 - Fixes deletion step of review app reconcile

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -98,8 +98,8 @@ jobs:
           echo "AZURE_RESOURCE_PREFIX=${AZURE_RESOURCE_PREFIX}" >> $GITHUB_ENV
           echo "CONFIG_SHORT=${CONFIG_SHORT}" >> $GITHUB_ENV
           echo "SERVICE_SHORT=${SERVICE_SHORT}" >> $GITHUB_ENV
-          echo "DEPLOY_ENV=review-${matrix.pr_number}" >> $GITHUB_ENV
-          echo "TF_STATE_FILE=pr-${matrix.pr_number}.tfstate" >> $GITHUB_ENV
+          echo "DEPLOY_ENV=review-${PR_NUMBER}" >> $GITHUB_ENV
+          echo "TF_STATE_FILE=pr-${PR_NUMBER}.tfstate" >> $GITHUB_ENV
           echo "IMAGE_TAG=ignored" >> $GITHUB_ENV
 
       - name: Delete stale review app


### PR DESCRIPTION
## Context

Review app reconcile workflow ran as scheduled yesterday morning, but failed with an error when attempting to delete the stale review apps.

## Changes proposed in this pull request

A small amendment to the way the variable is presented in the workflow file has been applied to resolve this issue.

## Guidance to review

As it is in the deletion stage, there is no real way to test this without actually running the delete - which I am reticent to do, given the fact that we are in the middle of the day/start of the week.

This will have to be checked next Monday to see whether it ran successfully this coming Sunday morning.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally