### PR TITLE
Use course_status on course

### DIFF
--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -80,7 +80,7 @@ module SupportInterface
         },
         {
           key: 'Closed by provider?',
-          value: course.application_status_open? ? govuk_tag(text: 'Open', colour: 'green') : govuk_tag(text: 'Closed', colour: 'red'),
+          value: course.course_status_open? ? govuk_tag(text: 'Open', colour: 'green') : govuk_tag(text: 'Closed', colour: 'red'),
         },
         {
           key: 'Find status',

--- a/app/components/support_interface/course_name_and_status_component.html.erb
+++ b/app/components/support_interface/course_name_and_status_component.html.erb
@@ -7,7 +7,7 @@
   <%= govuk_tag(text: 'Course removed from Find', colour: 'yellow') %>
 <% end %>
 
-<% if course_option.course_application_status_closed? %>
+<% if course_option.course_status_closed? %>
   <%= govuk_tag(text: 'Course closed by provider', colour: 'yellow') %>
 <% end %>
 

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -40,7 +40,7 @@ module SupportInterface
         govuk_tag(text: t('open.text'), colour: t('open.colour'))
       elsif !course.exposed_in_find?
         govuk_tag(text: t('hidden.text'), colour: t('hidden.colour'))
-      elsif course.application_status_closed?
+      elsif course.course_status_closed?
         govuk_tag(text: t('closed.text'), colour: t('closed.colour'))
       else # rubocop:disable Lint/DuplicateBranch
         govuk_tag(text: t('unpublished.text'), colour: t('unpublished.colour'))

--- a/app/forms/candidate_interface/course_choices/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/course_choices/which_course_are_you_applying_to_step.rb
@@ -53,7 +53,7 @@ module CandidateInterface
           :reached_reapplication_limit
         elsif duplicate_course?
           :duplicate_course_selection
-        elsif course.application_status_closed?
+        elsif course.course_status_closed?
           :closed_course_selection
         elsif !course.available?
           :full_course_selection
@@ -78,7 +78,7 @@ module CandidateInterface
       def next_step_path_arguments
         if completed?
           default_path_arguments
-        elsif duplicate_course? || reapplication_limit_reached? || !course.available? || course.application_status_closed? || multiple_study_modes?
+        elsif duplicate_course? || reapplication_limit_reached? || !course.available? || course.course_status_closed? || multiple_study_modes?
           { provider_id:, course_id: }
         elsif multiple_sites?
           { provider_id:, course_id:, study_mode: }
@@ -106,7 +106,7 @@ module CandidateInterface
     private
 
       def valid_course_choice
-        @valid_course_choice ||= !duplicate_course? && !reapplication_limit_reached? && course.available? && course.application_status_open?
+        @valid_course_choice ||= !duplicate_course? && !reapplication_limit_reached? && course.available? && course.course_status_open?
       end
 
       def duplicate_course?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -215,7 +215,7 @@ class ApplicationChoice < ApplicationRecord
     I18n.t('errors.application_choices.course_not_available', descriptor: course.provider_and_name_code)
   end
 
-  delegate :course_application_status_closed?, to: :course_option
+  delegate :course_status_closed?, to: :course_option
 
   def course_application_status_closed
     I18n.t(
@@ -262,7 +262,7 @@ class ApplicationChoice < ApplicationRecord
   def course_option_availability_error?
     [
       course_not_available?,
-      course_application_status_closed?,
+      course_status_closed?,
       course_full?,
       site_full?,
       study_mode_full?,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,7 +16,7 @@ class Course < ApplicationRecord
 
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
   scope :open_for_applications, -> { current_cycle }
-  scope :open, -> { application_status_open.exposed_in_find.current_cycle }
+  scope :open, -> { course_status_open.exposed_in_find.current_cycle }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.current_year) }
   scope :previous_cycle, -> { where(recruitment_cycle_year: RecruitmentCycleTimetable.previous_year) }
   scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }
@@ -148,7 +148,7 @@ class Course < ApplicationRecord
   end
 
   def open?
-    open_for_applications? && exposed_in_find && application_status_open?
+    open_for_applications? && exposed_in_find && course_status_open?
   end
 
   def open_for_applications?

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -28,7 +28,8 @@ class CourseOption < ApplicationRecord
     selectable.where(vacancy_status: 'vacancies')
   }
 
-  delegate :full?, :withdrawn?, :application_status_closed?, :not_available?, to: :course, prefix: true
+  delegate :full?, :withdrawn?, :not_available?, to: :course, prefix: true
+  delegate :course_status_closed?, to: :course
 
   def no_vacancies?
     vacancy_status == 'no_vacancies'

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -121,7 +121,7 @@ module CandidateInterface
 
           if choice.course_status_closed?
             error_list << ApplicationChoiceError.new(
-              choice.course_status_closed, choice.id
+              choice.course_application_status_closed, choice.id
             )
             next
           end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -119,9 +119,9 @@ module CandidateInterface
             next
           end
 
-          if choice.course_application_status_closed?
+          if choice.course_status_closed?
             error_list << ApplicationChoiceError.new(
-              choice.course_application_status_closed, choice.id
+              choice.course_status_closed, choice.id
             )
             next
           end

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def applications_to_closed_courses
       active_applications
         .joins(application_choices: { course_option: :course })
-        .where('courses.application_status' => 'closed')
+        .where('courses.course_status' => 'closed')
     end
 
     def applications_to_hidden_courses

--- a/app/validators/course_unavailable_validator.rb
+++ b/app/validators/course_unavailable_validator.rb
@@ -9,9 +9,10 @@ class CourseUnavailableValidator < ActiveModel::EachValidator
     return if !course.full? &&
               application_choice.course_option.site_still_valid? &&
               course.exposed_in_find? &&
-              course.application_status_open?
+              course.course_status_open?
 
-    if course.application_status_closed?
+
+    if course.course_status_closed?
       record.errors.add(
         attribute,
         :course_closed,

--- a/app/validators/course_unavailable_validator.rb
+++ b/app/validators/course_unavailable_validator.rb
@@ -11,7 +11,6 @@ class CourseUnavailableValidator < ActiveModel::EachValidator
               course.exposed_in_find? &&
               course.course_status_open?
 
-
     if course.course_status_closed?
       record.errors.add(
         attribute,

--- a/spec/components/support_interface/course_details_component_spec.rb
+++ b/spec/components/support_interface/course_details_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SupportInterface::CourseDetailsComponent do
   describe 'course closed by provider' do
     it 'displays the course is closed' do
       result = render_inline(
-        described_class.new(course: create(:course, application_status: 'closed')),
+        described_class.new(course: create(:course, course_status: 'closed')),
       )
 
       expect(result.text).to include('Closed by provider?Closed')
@@ -40,7 +40,7 @@ RSpec.describe SupportInterface::CourseDetailsComponent do
 
   describe 'Apply from Find Link row' do
     it 'displays the link from Find' do
-      course = create(:course, application_status: 'closed')
+      course = create(:course, course_status: 'closed')
       render_inline(
         described_class.new(course:),
       )

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       end
 
       context 'course is closed by provider' do
-        let(:course) { create(:course, :open, application_status: 'closed') }
+        let(:course) { create(:course, :open, course_status: 'closed') }
 
         it { is_expected.to include('Closed by provider') }
       end

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe CourseOption do
     it { is_expected.to delegate_method(:name).to(:site).with_prefix }
     it { is_expected.to delegate_method(:full_address).to(:site).with_prefix }
     it { is_expected.to delegate_method(:postcode).to(:site).with_prefix }
+    it { is_expected.to delegate_method(:course_status_closed?).to(:course) }
   end
 
   describe '.selectable' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Course do
   describe 'a valid course' do
     it { is_expected.to validate_presence_of :level }
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(%i[recruitment_cycle_year provider_id]) }
-    it { is_expected.to be_application_status_closed }
+    it { is_expected.to be_course_status_closed }
   end
 
   describe 'associations' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Course do
     end
 
     context 'when application_status is closed' do
-      let(:course) { create(:course, :open, application_status: 'closed') }
+      let(:course) { create(:course, :open, course_status: 'closed') }
 
       it 'returns false' do
         expect(course).not_to be_open
@@ -81,7 +81,7 @@ RSpec.describe Course do
     end
 
     context 'when course is closed by provider' do
-      let(:course) { create(:course, :open, application_status: 'closed') }
+      let(:course) { create(:course, :open, course_status: 'closed') }
 
       it 'does not return the course' do
         expect(described_class.open).not_to include(course)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Course do
       end
     end
 
-    context 'when application_status is closed' do
+    context 'when course_status is closed' do
       let(:course) { create(:course, :open, course_status: 'closed') }
 
       it 'returns false' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         course_full?: false,
         site_full?: false,
         study_mode_full?: false,
-        course_application_status_closed?: false,
+        course_status_closed?: false,
         site_invalid?: false,
       )
     end
@@ -457,7 +457,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         course_full?: false,
         site_full?: false,
         study_mode_full?: false,
-        course_application_status_closed?: false,
+        course_status_closed?: false,
         site_invalid?: false,
       )
     end
@@ -492,7 +492,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     context 'a course is closed on Apply' do
       before do
-        allow(application_choice_2).to receive_messages(course_application_status_closed?: true, course_application_status_closed: 'course_closed_by_provider')
+        allow(application_choice_2).to receive_messages(course_status_closed?: true, course_application_status_closed: 'course_closed_by_provider')
       end
 
       it 'returns the appropriate error' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     context 'a course is closed on Apply' do
       before do
-        allow(application_choice_2).to receive_messages(course_status_closed?: true, course_status_closed: 'course_closed_by_provider')
+        allow(application_choice_2).to receive_messages(course_status_closed?: true, course_application_status_closed: 'course_closed_by_provider')
       end
 
       it 'returns the appropriate error' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     context 'a course is closed on Apply' do
       before do
-        allow(application_choice_2).to receive_messages(course_status_closed?: true, course_application_status_closed: 'course_closed_by_provider')
+        allow(application_choice_2).to receive_messages(course_status_closed?: true, course_status_closed: 'course_closed_by_provider')
       end
 
       it 'returns the appropriate error' do

--- a/spec/queries/get_available_courses_for_provider_spec.rb
+++ b/spec/queries/get_available_courses_for_provider_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GetAvailableCoursesForProvider do
         exposed_in_find: true,
         name: 'Math',
         provider:,
-        application_status: 'closed',
+        course_status: 'closed',
       )
       _previous_cycle = create(:course, :previous_year, exposed_in_find: true, provider:)
 
@@ -42,7 +42,7 @@ RSpec.describe GetAvailableCoursesForProvider do
   describe '#open_courses' do
     it 'returns all open courses in the current cycle' do
       open = create(:course, :open, provider:)
-      _closed = create(:course, application_status: 'closed', provider:)
+      _closed = create(:course, course_status: 'closed', provider:)
       _closed_exposed_in_find = create(
         :course,
         :unavailable,

--- a/spec/services/support_interface/application_monitor_spec.rb
+++ b/spec/services/support_interface/application_monitor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationMonitor do
   let(:open_course) { create(:course, :open, :with_course_options) }
-  let(:closed_course) { create(:course, application_status: 'closed') }
+  let(:closed_course) { create(:course, course_status: 'closed') }
 
   let(:visible_course) { create(:course, :open, :with_course_options) }
   let(:hidden_course) { create(:course, :open, exposed_in_find: false) }

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Selecting a course' do
 
   def and_the_course_has_been_closed
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
-    @course = create(:course, :open, application_status: 'closed', name: 'Primary', code: '2XT2', provider: @provider)
+    @course = create(:course, :open, course_status: 'closed', name: 'Primary', code: '2XT2', provider: @provider)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -95,7 +95,7 @@ private
     )
     @unavailable_course_invite = create(
       :pool_invite,
-      course: create(:course, :unavailable, application_status: 'closed'),
+      course: create(:course, :unavailable, course_status: 'closed'),
       course_open: false,
       application_form:,
       status: 'published',
@@ -264,7 +264,7 @@ private
     )
     @unavailable_course_invite = create(
       :pool_invite,
-      course: create(:course, :unavailable, application_status: 'closed'),
+      course: create(:course, :unavailable, course_status: 'closed'),
       course_open: false,
       application_form:,
       status: 'published',

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Candidate tries to submit an application choice when the course 
   end
 
   def and_my_course_choice_becomes_closed
-    @application_choice.current_course.update(application_status: 'closed')
+    @application_choice.current_course.update(course_status: 'closed')
   end
 
   def and_my_course_choice_becomes_full

--- a/spec/system/support_interface/unavailable_choices_spec.rb
+++ b/spec/system/support_interface/unavailable_choices_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Unavailable choices' do
   def and_there_are_candidates_and_application_forms_in_the_system
     open_course = create(:course, :open, :with_course_options)
     hidden_course = create(:course, :open, :with_course_options, exposed_in_find: false)
-    closed_course = create(:course, :open, :with_course_options, application_status: 'closed')
+    closed_course = create(:course, :open, :with_course_options, course_status: 'closed')
 
     # application_to_open_course
     create(:application_choice, course: open_course, status: 'awaiting_provider_decision')

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe 'Sync courses', :with_cache do
     expect(course.can_sponsor_skilled_worker_visa).to be true
     expect(course.can_sponsor_student_visa).to be true
     expect(course.application_status).to eq 'closed'
+    expect(course.course_status).to eq 'closed'
   end
 
   def then_it_creates_one_undergraduate_course
@@ -221,6 +222,7 @@ RSpec.describe 'Sync courses', :with_cache do
     expect(course.can_sponsor_skilled_worker_visa).to be false
     expect(course.can_sponsor_student_visa).to be false
     expect(course.application_status).to eq 'open'
+    expect(course.course_status).to eq 'open'
   end
 
   def and_it_sets_the_last_synced_timestamp


### PR DESCRIPTION
## Context

Now that we have the course_status column on the course table populated, we can use it.

This PR changes all the places where the application_status is used, to course_status.

After this PR the application_status column will be removed. 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Sign up as a candidate on the review app and try to apply to Mathematics (9L7D), an open course. Durham University (D86)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
