### PR TITLE
Remove course application_status from sync

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -90,7 +90,6 @@ module TeacherTrainingPublicAPI
       course.additional_gcse_equivalencies = course_from_api.additional_gcse_equivalencies
       course.age_range = age_range_in_years(course_from_api)
       course.applications_open_from = timetable.find_opens_at
-      course.application_status = course_from_api.application_status
       course.course_status = course_from_api.application_status
       course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
       course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -195,7 +195,6 @@ RSpec.describe 'Sync courses', :with_cache do
     expect(course).not_to be_nil
     expect(course.can_sponsor_skilled_worker_visa).to be true
     expect(course.can_sponsor_student_visa).to be true
-    expect(course.application_status).to eq 'closed'
     expect(course.course_status).to eq 'closed'
   end
 
@@ -221,7 +220,6 @@ RSpec.describe 'Sync courses', :with_cache do
     expect(course.withdrawn).to be false
     expect(course.can_sponsor_skilled_worker_visa).to be false
     expect(course.can_sponsor_student_visa).to be false
-    expect(course.application_status).to eq 'open'
     expect(course.course_status).to eq 'open'
   end
 


### PR DESCRIPTION
## Context

We use course_status now

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
