### PR TITLE
Change international qualification interruption content

### DIFF
--- a/app/controllers/candidate_interface/gcse/new_international_flow/failing_grade_interruption_controller.rb
+++ b/app/controllers/candidate_interface/gcse/new_international_flow/failing_grade_interruption_controller.rb
@@ -6,6 +6,16 @@ module CandidateInterface
       @evidence_path = evidence_path
     end
 
+    def science_subject?
+      @science_subject ||= @subject == 'science'
+    end
+    helper_method :science_subject?
+
+    def english_subject?
+      @english_subject ||= @subject == 'english'
+    end
+    helper_method :english_subject?
+
   private
 
     def return_to

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -102,6 +102,15 @@ class ApplicationQualification < ApplicationRecord
 
   before_save :set_public_id, :set_mutual_exclusivity_not_completed_or_enic, :prevent_not_completed_explanation_if_passing_grade
 
+  def science_subject?
+    [
+      SCIENCE,
+      SCIENCE_SINGLE_AWARD,
+      SCIENCE_DOUBLE_AWARD,
+      SCIENCE_TRIPLE_AWARD,
+    ].include?(subject)
+  end
+
   def missing_qualification?
     qualification_type == 'missing'
   end

--- a/app/services/inspect_international_gcse_grade.rb
+++ b/app/services/inspect_international_gcse_grade.rb
@@ -62,7 +62,15 @@ private
       end
   end
 
+  def subject
+    if qualification.science_subject?
+      'science'
+    else
+      qualification.subject
+    end
+  end
+
   def finder
-    @finder ||= InternationalQualifications::StructuredGcseOptionFinder.new(qualification.institution_country, qualification.subject)
+    @finder ||= InternationalQualifications::StructuredGcseOptionFinder.new(qualification.institution_country, subject)
   end
 end

--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -1,12 +1,12 @@
-<% content_for :title, t('gcse_new_international_flow_interruption.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %>
+<% content_for :title, t('gcse_new_international_flow_interruption.page_title', subject: (english_subject? ? @subject.capitalize : @subject)) %>
 <% content_for :before_content, govuk_back_link_to(@return_to) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="app-grid-column--grey">
-      <h1 class="govuk-heading-l"><%= t('gcse_new_international_flow_interruption.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></h1>
+      <h1 class="govuk-heading-l"><%= t('gcse_new_international_flow_interruption.page_title', subject: (english_subject? ? @subject.capitalize : @subject)) %></h1>
 
-      <% if @subject == 'science' %>
+      <% if science_subject? %>
         <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need_science') %></p>
       <% else %>
         <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need') %></p>
@@ -14,20 +14,20 @@
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_can') %></p>
       <ul class="govuk-body">
         <li><%= t('gcse_new_international_flow_interruption.option1') %></li>
-        <li><%= t('gcse_new_international_flow_interruption.option2', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
-        <li><%= t('gcse_new_international_flow_interruption.option3', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
+        <li><%= t('gcse_new_international_flow_interruption.option2', subject: (english_subject? ? @subject.capitalize : @subject)) %></li>
+        <li><%= t('gcse_new_international_flow_interruption.option3', subject: (english_subject? ? @subject.capitalize : @subject)) %></li>
       </ul>
 
       <p class="govuk-body">
         <%= t(
           'gcse_new_international_flow_interruption.none_of_these',
-          subject: @subject == 'english' ? @subject.capitalize : @subject,
+          subject: english_subject? ? @subject.capitalize : @subject,
         ) %>
       <p>
 
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.some_providers') %><p>
 
-      <% if @subject == 'science' %>
+      <% if science_subject? %>
         <h2 class="govuk-heading-s">
           <%= t('gcse_new_international_flow_interruption.apply_for_secondary_header') %>
         </h2>

--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -28,7 +28,7 @@
         </h2>
         <%= t(
           'gcse_new_international_flow_interruption.apply_for_secondary_html',
-          link: link_to('apply for a secondary teacher training course', candidate_interface_application_choices_path),
+          link: govuk_link_to('apply for a secondary teacher training course', candidate_interface_application_choices_path),
         ) %>
       <% end %>
     </div>

--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -6,15 +6,31 @@
     <div class="app-grid-column--grey">
       <h1 class="govuk-heading-l"><%= t('gcse_new_international_flow_interruption.page_title', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></h1>
 
-      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need') %></p>
+      <% if @subject == 'science' %>
+        <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need_science') %></p>
+      <% else %>
+        <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_need') %></p>
+      <% end %>
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.you_can') %></p>
       <ul class="govuk-body">
         <li><%= t('gcse_new_international_flow_interruption.option1') %></li>
         <li><%= t('gcse_new_international_flow_interruption.option2', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
         <li><%= t('gcse_new_international_flow_interruption.option3', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
       </ul>
-      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.none_of_these') %><p>
+
+      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.none_of_these', subject: @subject) %><p>
+
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.some_providers') %><p>
+
+      <% if @subject == 'science' %>
+        <h2 class="govuk-heading-s">
+          <%= t('gcse_new_international_flow_interruption.apply_for_secondary_header') %>
+        </h2>
+        <%= t(
+          'gcse_new_international_flow_interruption.apply_for_secondary_html',
+          link: link_to('apply for a secondary teacher training course', candidate_interface_application_choices_path),
+        ) %>
+      <% end %>
     </div>
 
     <div class="govuk-button-group app-course-choice__confirm-submission">

--- a/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
+++ b/app/views/candidate_interface/gcse/new_international_flow/failing_grade_interruption/show.html.erb
@@ -18,7 +18,12 @@
         <li><%= t('gcse_new_international_flow_interruption.option3', subject: (@subject == 'english' ? @subject.capitalize : @subject)) %></li>
       </ul>
 
-      <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.none_of_these', subject: @subject) %><p>
+      <p class="govuk-body">
+        <%= t(
+          'gcse_new_international_flow_interruption.none_of_these',
+          subject: @subject == 'english' ? @subject.capitalize : @subject,
+        ) %>
+      <p>
 
       <p class="govuk-body"><%= t('gcse_new_international_flow_interruption.some_providers') %><p>
 

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -100,7 +100,7 @@ en:
   gcse_edit_new_international_flow_grade:
     page_title: What grade did you get?
   gcse_new_international_flow_interruption:
-    page_title: This grade may not be equivalent to a GCSE in %{subject} at Grade 4 (C) or above
+    page_title: This grade may not be equivalent to a GCSE in %{subject} at grade 4 (C) or above
     you_need: You need the equivalent of a GCSE at grade 4 (C) or above to apply for teacher training. Providers are responsible for deciding if you meet this requirement.
     you_need_science: You need the equivalent of a GCSE at grade 4 (C) or above to apply for primary teacher training. Providers are responsible for deciding if you meet this requirement.
     you_can: "You can:"
@@ -112,7 +112,7 @@ en:
     provide_statement: Provide a statement of comparability
     provide_evidence: Continue without providing a statement of comparability
     apply_for_secondary_header: Apply for secondary teacher training
-    apply_for_secondary_html: You could %{link} instead. This does not require you to have a science qualification.
+    apply_for_secondary_html: <p class="govuk-body">You could %{link} instead. This does not require you to have a science qualification.</p>
   gcse_new_international_flow_evidence:
     page_title: Provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
     caption: Check with providers about what evidence they accept.

--- a/config/locales/candidate_interface/gcse_details.yml
+++ b/config/locales/candidate_interface/gcse_details.yml
@@ -102,14 +102,17 @@ en:
   gcse_new_international_flow_interruption:
     page_title: This grade may not be equivalent to a GCSE in %{subject} at Grade 4 (C) or above
     you_need: You need the equivalent of a GCSE at grade 4 (C) or above to apply for teacher training. Providers are responsible for deciding if you meet this requirement.
+    you_need_science: You need the equivalent of a GCSE at grade 4 (C) or above to apply for primary teacher training. Providers are responsible for deciding if you meet this requirement.
     you_can: "You can:"
     option1: provide a statement of comparability from UK ENIC
     option2: continue and provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
     option3: go back and enter a different %{subject} qualification equivalent to a GCSE
-    none_of_these: If you do none of these, providers may not be able to assess your English skills.
+    none_of_these: If you do none of these, providers may not be able to assess your %{subject} skills.
     some_providers: Some providers may let you do an equivalency test to show you have the required skills.
     provide_statement: Provide a statement of comparability
     provide_evidence: Continue without providing a statement of comparability
+    apply_for_secondary_header: Apply for secondary teacher training
+    apply_for_secondary_html: You could %{link} instead. This does not require you to have a science qualification.
   gcse_new_international_flow_evidence:
     page_title: Provide evidence that your %{subject} skills are at GCSE grade 4 (C) or above
     caption: Check with providers about what evidence they accept.

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_edits_international_gcse_spec.rb
@@ -219,7 +219,7 @@ private
   end
 
   def then_i_see_the_interruption_page
-    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at grade 4 (C) or above'
   end
 
   def when_i_click_to_provide_evidence

--- a/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/new_international_flow/candidate_enters_structured_international_gcse_spec.rb
@@ -380,11 +380,11 @@ private
   end
 
   def then_i_see_the_interruption_page
-    expect(page).to have_text 'This grade may not be equivalent to a GCSE in English at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in English at grade 4 (C) or above'
   end
 
   def then_i_see_the_interruption_page_maths
-    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at Grade 4 (C) or above'
+    expect(page).to have_text 'This grade may not be equivalent to a GCSE in maths at grade 4 (C) or above'
   end
 
   def when_i_click_provide_evidence_of_your_english_skills


### PR DESCRIPTION
## Context

Changed content and fixed a bug, more details in the code

Science interruption
<img width="640" height="692" alt="image" src="https://github.com/user-attachments/assets/50d935aa-801c-4e78-8350-1b74724316fa" />

Maths interruption. We do have structured data for this.
<img width="820" height="761" alt="image" src="https://github.com/user-attachments/assets/40455f4d-a10a-4b1b-83fc-2f51109c7d65" />


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
