### PR TITLE
Move link to view your previous applications

### DIFF
--- a/app/views/candidate_interface/application_choices/_previous_applications_link.html.erb
+++ b/app/views/candidate_interface/application_choices/_previous_applications_link.html.erb
@@ -1,3 +1,11 @@
   <aside class="app-related" aria-labelledby="previous-applications-link">
-    <p class="govuk-body" id="previous-applications-link"><%= govuk_link_to('View your previous applications', candidate_interface_previous_applications_path) %></p>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="previous-applications-title">
+      <%= t('layout.previous_applications.title') %>
+    </h2>
+    <p class="govuk-body govuk-!-font-size-16" id="previous-applications-link">
+      <%= govuk_link_to(
+            t('layout.previous_applications.link_text'),
+            candidate_interface_previous_applications_path,
+          ) %>
+    </p>
   </aside>

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -6,9 +6,9 @@
   </div>
 
   <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-    <%= render 'candidate_interface/details/support', support_reference: @application_form_presenter.support_reference %>
     <% if @application_form_presenter.show_previous_applications? %>
       <%= render 'candidate_interface/application_choices/previous_applications_link', application_form_presenter: @application_form_presenter %>
     <% end %>
+    <%= render 'candidate_interface/details/support', support_reference: @application_form_presenter.support_reference %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,9 @@ en:
     add_references: Add your references
     check_and_submit: Check and submit your application
   layout:
+    previous_applications:
+      title: Previous applications
+      link_text: View your previous applications
     support:
       title: Get help
       telephone: Telephone


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

| Before | After |
| ----- | ----- | 
| <img width="1016" height="375" alt="image" src="https://github.com/user-attachments/assets/2cb3e7f8-b8e5-4182-beba-7252cbd8b6c5" /> | <img width="1020" height="360" alt="image" src="https://github.com/user-attachments/assets/3cafd886-76f0-4c52-9a09-4c8c0410de15" /> |

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Login as someone with a 2025 application (so you'll create a 2026 one). 
Navigate to your applications
You should see the updated link on the right side, above the Get help section.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
