### PR TITLE
Remove 2026 specific carry over instructions

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -393,12 +393,6 @@ module CandidateInterface
         can_add_course_choice? # The apply deadline for this form has not passed
     end
 
-    def show_sections_not_carried_over_inset?
-      # This is shown primary when an application is carried over,
-      # when these sections may have been previously completed, but need to be revisited in the new year
-      incomplete_sections.map(&:name).sort == %i[equality_and_diversity previous_teacher_training references_selected]
-    end
-
     def show_previous_applications?
       return false unless candidate_has_previously_applied?
 

--- a/app/views/candidate_interface/details/index.html.erb
+++ b/app/views/candidate_interface/details/index.html.erb
@@ -33,40 +33,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @application_form_presenter.show_sections_not_carried_over_inset? %>
-      <%= govuk_inset_text do %>
-        <p class="govuk-body">
-          <%= t('.before_you_can_apply') %>
-          <%= govuk_list(
-                [
-                  t(
-                    '.confirm_references_html',
-                    references_link: govuk_link_to(
-                      t('.references_link_text'),
-                      candidate_interface_references_review_path,
-                    ),
-                  ),
-                  t(
-                    '.enter_equality_and_diversity_html',
-                    equality_and_diversity_information_link: govuk_link_to(
-                      t('.equality_and_diversity_link_text'),
-                      candidate_interface_start_equality_and_diversity_path,
-                    ),
-                  ),
-                  t(
-                    '.enter_previous_teacher_training_html',
-                    previous_teacher_training_link: govuk_link_to(
-                      t('.previous_teacher_training_link_text'),
-                      @application_form_presenter.path_to_previous_teacher_training,
-                    ),
-                  ),
-                ],
-                type: :bullet,
-              ) %>
-        </p>
-      <% end %>
-    <% end %>
-
     <% if @application_form_presenter.unsubmitted? && @application_form_presenter.completed_application_form? && @application_form_presenter.can_add_course_choice? %>
       <div class="app-grid-column--grey">
         <h2 class="govuk-heading-m"><%= t('.you_completed_your_details') %></h2>

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -9,13 +9,6 @@ en:
   candidate_interface:
     details:
       index:
-        before_you_can_apply: 'Before you can apply again, you need to:'
-        confirm_references_html: '%{references_link} are up to date'
-        references_link_text: confirm your references
-        enter_equality_and_diversity_html: enter or reconfirm your %{equality_and_diversity_information_link}.
-        equality_and_diversity_link_text: equality and diversity information
-        enter_previous_teacher_training_html: enter %{previous_teacher_training_link}
-        previous_teacher_training_link_text: whether you have started teacher training in the past
         you_completed_your_details: You have completed your details
         complete_your_details:
           one: Complete your details to continue your application.


### PR DESCRIPTION
## Context

This was specific 2026 carry over instruction. We now just show the carry over component and the content is more dynamic based on the various things that that are missing from the applciation.

## Changes proposed in this pull request

Just removing the 2026 specific instructions

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
