### PR TITLE
[lb/2087, 2088, 2090] Jan start date content changes

### DIFF
--- a/app/components/candidate_interface/after_deadline_content_component.html.erb
+++ b/app/components/candidate_interface/after_deadline_content_component.html.erb
@@ -5,7 +5,7 @@
 </h1>
 
 <p class="govuk-body">
-  The deadline for applying to courses in the <%= academic_year %> academic year has passed.
+  The deadline for submitting new applications for the <%= academic_year %> academic year has passed.
 </p>
 
 <% if january_courses? %>

--- a/app/components/candidate_interface/application_choices/january_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/january_start_content_component.rb
@@ -10,7 +10,15 @@ class CandidateInterface::ApplicationChoices::JanuaryStartContentComponent < App
   end
 
   def title
-    I18n.t('candidate_interface.application_choices.january_start_component.title', year: relative_next_year)
+    start_dates = application_choices.map do |ac|
+      ac.course.start_date.to_fs(:month_and_year)
+    end.uniq
+
+    if start_dates.many?
+      I18n.t('candidate_interface.application_choices.january_start_component.title_multiple_start_months', year: relative_next_year)
+    else
+      I18n.t('candidate_interface.application_choices.january_start_component.title_single_start_month', month_and_year: start_dates.first)
+    end
   end
 
   def provider_deadline_content

--- a/app/components/candidate_interface/application_choices/september_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.rb
@@ -11,8 +11,17 @@ class CandidateInterface::ApplicationChoices::SeptemberStartContentComponent < A
   end
 
   def heading
-    @heading.presence ||
-      I18n.t('candidate_interface.application_choices.september_start_component.heading', year: recruitment_cycle_year)
+    return @heading if @heading.present?
+
+    start_dates = application_choices.map do |ac|
+      ac.course.start_date.to_fs(:month_and_year)
+    end.uniq
+
+    if start_dates.many?
+      I18n.t('candidate_interface.application_choices.september_start_component.heading_multiple_start_months', year: recruitment_cycle_year)
+    else
+      I18n.t('candidate_interface.application_choices.september_start_component.heading_single_start_month', month_and_year: start_dates.first)
+    end
   end
 
   def awaiting_provider_decision_content

--- a/app/components/candidate_interface/applications_left_message_component.rb
+++ b/app/components/candidate_interface/applications_left_message_component.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     delegate :submitted?,
              :cannot_add_more_choices?,
              :number_of_slots_left,
+             :academic_year_range_name,
              to: :application_form
 
     def initialize(application_form)
@@ -32,7 +33,7 @@ module CandidateInterface
           t('candidate_interface.applications_left_message.can_not_add_more_message'),
         ]
       else
-        [t('candidate_interface.applications_left_message.can_add_more', count: number_of_slots_left)]
+        [t('candidate_interface.applications_left_message.can_add_more', count: number_of_slots_left, academic_year: academic_year_range_name)]
       end
     end
 

--- a/config/locales/candidate_interface/applications_left_message.yml
+++ b/config/locales/candidate_interface/applications_left_message.yml
@@ -3,8 +3,8 @@ en:
     applications_left_message:
       default_message: 'You can have up to %{maximum_number_of_course_choices} applications in progress at any time.'
       can_add_more:
-        one: 'You can submit %{count} more application.'
-        other: 'You can submit %{count} more applications.'
+        one: You can submit %{count} more application for courses starting in the %{academic_year} academic year.
+        other: You can submit %{count} more applications for courses starting in the %{academic_year} academic year.
       can_not_add_more_heading: 'You cannot add any more applications because you are waiting for decisions on %{maximum_number_of_course_choices} others.'
       can_not_add_more_message: 'If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.'
-      inactive_application_message: If an application becomes inactive, is withdrawn or rejected you can add another, up to a maximum of %{count} in a single recruitment cycle.
+      inactive_application_message: You can have up to 4 applications in progress at any time. If an application becomes inactive, is withdrawn or rejected, you can submit another one. You can submit up to %{count} in total for an academic year.

--- a/config/locales/candidate_interface/deadline_banner_component.yml
+++ b/config/locales/candidate_interface/deadline_banner_component.yml
@@ -1,5 +1,5 @@
 en:
   candidate_interface:
     deadline_banner_component:
-      heading: The deadline for applying to courses starting by the end of September %{recruitment_cycle_year} is %{deadline_time} on %{deadline_date}
+      heading: The deadline to submit new applications to courses starting by the end of September %{recruitment_cycle_year} is %{deadline_time} on %{deadline_date}
       text: Providers may close applications early if a course becomes full. You can check the number of available places with the provider.

--- a/config/locales/components/candidate_interface/after_deadline_content_component.yml
+++ b/config/locales/components/candidate_interface/after_deadline_content_component.yml
@@ -22,7 +22,7 @@ en:
       find_link_text: Find teacher training courses
       when_apply_opens: You can apply for courses from %{apply_opens_at}.
       application_deadline_has_passed_for_academic_year: >
-        The deadline for applying to courses in the %{academic_year} academic year has passed. You can no longer apply to
+        The deadline for submitting new applications for the %{academic_year} academic year has passed. You can no longer apply to
         courses starting in %{start_month_year}.
       what_happens_next: Apply to courses in the %{next_academic_year} academic year
       before_you_can_apply_again: 'Before you can apply again, you need to:'

--- a/config/locales/components/candidate_interface/application_choices/january_start_content_component.yml
+++ b/config/locales/components/candidate_interface/application_choices/january_start_content_component.yml
@@ -2,7 +2,8 @@ en:
   candidate_interface:
     application_choices:
       january_start_component:
-        title: Courses starting by January %{year}
+        title_multiple_start_months: Courses starting by the end of January %{year}
+        title_single_start_month: Courses starting in %{month_and_year}
         provider_deadline_content:
             Providers have until %{reject_by} to make decisions on these applications.
         awaiting_provider_decision_content:

--- a/config/locales/components/candidate_interface/application_choices/september_start_content_component.yml
+++ b/config/locales/components/candidate_interface/application_choices/september_start_content_component.yml
@@ -2,7 +2,8 @@ en:
   candidate_interface:
     application_choices:
       september_start_component:
-        heading: Courses starting by September %{year}
+        heading_multiple_start_months: Courses starting by the end of September %{year}
+        heading_single_start_month: Courses starting in %{month_and_year}
         awaiting_provider_decision_content:
           title: Applications awaiting a provider decision
           rejected automatically:

--- a/spec/components/candidate_interface/after_deadline_content_component_spec.rb
+++ b/spec/components/candidate_interface/after_deadline_content_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::AfterDeadlineContentComponent do
           component = render_inline(described_class.new(application_form:))
 
           expect(component).to have_element(:h1, text: 'Your applications', class: 'govuk-heading-xl')
-          expect(component).to have_element(:p, text: 'The deadline for applying to courses in the 2026 to 2027 academic year has passed.', class: 'govuk-body')
+          expect(component).to have_element(:p, text: 'The deadline for submitting new applications for the 2026 to 2027 academic year has passed.', class: 'govuk-body')
           expect(component).to have_no_link('Choose a course', class: 'govuk-button')
 
           expect(component).to have_element(:h2, text: 'Courses for the 2027 to 2028 academic year', class: 'govuk-heading-l')
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::AfterDeadlineContentComponent do
           component = render_inline(described_class.new(application_form:))
 
           expect(component).to have_element(:h1, text: 'Your applications', class: 'govuk-heading-xl')
-          expect(component).to have_element(:p, text: 'The deadline for applying to courses in the 2026 to 2027 academic year has passed.', class: 'govuk-body')
+          expect(component).to have_element(:p, text: 'The deadline for submitting new applications for the 2026 to 2027 academic year has passed.', class: 'govuk-body')
           expect(component).to have_link('Choose a course', class: 'govuk-button')
 
           expect(component).to have_element(:h2, text: 'Courses for the 2027 to 2028 academic year', class: 'govuk-heading-l')

--- a/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::ApplicationChoices::JanuaryStartContentCompon
 
         expect(rendered_component).to have_element(
           :h2,
-          text: "Courses starting by January #{next_year}",
+          text: "Courses starting in January #{next_year}",
           class: 'govuk-heading-l',
         )
         expect(rendered_component).to have_element(
@@ -48,8 +48,23 @@ RSpec.describe CandidateInterface::ApplicationChoices::JanuaryStartContentCompon
   end
 
   describe '#title' do
-    it 'returns the title of the component with the correct academic year' do
-      expect(component.title).to eq("Courses starting by January #{next_year}")
+    context 'all course start dates are in one month' do
+      it 'returns the title of the component with the specific month and year' do
+        course = create(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}")
+        create(:application_choice, application_form:, course_option: build(:course_option, course:))
+        expect(component.title).to eq("Courses starting in January #{next_year}")
+      end
+    end
+
+    context 'course start dates are in multiple months' do
+      let(:dec_course) { build(:course, start_date: "01/10/#{application_form.recruitment_cycle_year}") }
+      let(:jan_course) { build(:course, start_date: "01/01/#{application_form.recruitment_cycle_year + 1}") }
+
+      it 'returns generic title with correct year' do
+        create(:application_choice, course_option: build(:course_option, course: jan_course), application_form:)
+        create(:application_choice, course_option: build(:course_option, course: dec_course), application_form:)
+        expect(component.title).to eq("Courses starting by the end of January #{next_year}")
+      end
     end
   end
 

--- a/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
 
         expect(rendered_component).to have_element(
           :h2,
-          text: 'Courses starting by September 2026',
+          text: 'Courses starting in September 2026',
           class: 'govuk-heading-l',
         )
 
@@ -107,9 +107,22 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
   end
 
   describe '#heading' do
-    context 'when not given a custom heading' do
-      it 'renders the component heading containing the academic year' do
-        expect(component.heading).to eq('Courses starting by September 2026')
+    context 'all course start dates are in one month' do
+      it 'renders the component heading containing precise month and year' do
+        course = create(:course, start_date: "01/09/#{application_form.recruitment_cycle_year}")
+        create(:application_choice, application_form:, course_option: build(:course_option, course:))
+        expect(component.heading).to eq('Courses starting in September 2026')
+      end
+    end
+
+    context 'course start dates are in multiple months' do
+      let(:aug_course) { build(:course, start_date: "30/08/#{application_form.recruitment_cycle_year}") }
+      let(:sept_course) { build(:course, start_date: "30/09/#{application_form.recruitment_cycle_year}") }
+
+      it 'renders generic heading' do
+        create(:application_choice, course_option: build(:course_option, course: aug_course), application_form:)
+        create(:application_choice, course_option: build(:course_option, course: sept_course), application_form:)
+        expect(component.heading).to eq('Courses starting by the end of September 2026')
       end
     end
 

--- a/spec/components/candidate_interface/applications_left_message_component_spec.rb
+++ b/spec/components/candidate_interface/applications_left_message_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent do
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :rejected, application_form:)
         create(:application_choice, :inactive, application_form:)
-        expect(message).to include('You can submit 2 more applications.')
+        expect(message).to include("You can submit 2 more applications for courses starting in the #{application_form.academic_year_range_name} academic year.")
       end
     end
 

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
         academic_year = current_timetable.recruitment_cycle_year
 
         expect(result.text).to include(
-          "The deadline for applying to courses starting by the end of September #{academic_year} is #{deadline_time} on #{deadline_date}",
+          "The deadline to submit new applications to courses starting by the end of September #{academic_year} is #{deadline_time} on #{deadline_date}",
         )
         expect(result.text).to include(
           'Providers may close applications early if a course becomes full. You can check the number of available places with the provider.',

--- a/spec/components/candidate_interface/multiple_active_applications_content_component_spec.rb
+++ b/spec/components/candidate_interface/multiple_active_applications_content_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CandidateInterface::MultipleActiveApplicationsContentComponent do
 
       expect(rendered_component).to have_element(
         :h2,
-        text: "Courses starting by January #{application_form.recruitment_cycle_year}",
+        text: "Courses starting in January #{application_form.recruitment_cycle_year}",
         class: 'govuk-heading-l',
       )
       expect(rendered_component).to have_element(

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -858,7 +858,7 @@ module CandidateHelper
     expect(page).to have_current_path(candidate_interface_application_choices_path)
     expect(page).to have_text('You can have up to 4 applications in progress at any time.')
     expect(page).to have_text(
-      'If an application becomes inactive, is withdrawn or rejected you can add another, up to a maximum of 15 in a single recruitment cycle.',
+      'You can have up to 4 applications in progress at any time. If an application becomes inactive, is withdrawn or rejected, you can submit another one. You can submit up to 15 in total for an academic year.',
     )
     click_link_or_button 'Add application'
     expect(page).to have_current_path(candidate_interface_course_choices_do_you_know_the_course_path)

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -98,7 +98,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_before_apply_opens_spec.rb
@@ -82,7 +82,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -148,7 +148,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Carry over unsubmitted application' do
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
     next_cycle = RecruitmentCycleTimetable.next_timetable
     expect(page).to have_element(

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -158,7 +158,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -133,7 +133,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
@@ -91,7 +91,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -71,7 +71,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_form.academic_year_range_name} academic year has passed.",
     )
     expect(@candidate.current_application.id).not_to eq @application_form.id
   end

--- a/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_responds_to_an_invite_spec.rb
@@ -289,7 +289,7 @@ private
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{application_form.academic_year_range_name} academic year has passed.",
     )
   end
 

--- a/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
+++ b/spec/system/candidate_interface/invites/candidate_views_their_invites_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'Candidate views their invites' do
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{previous_timetable} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{previous_timetable} academic year has passed.",
     )
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_has_an_application_become_inactive_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Candidate with submitted applications' do
   end
 
   def then_i_can_add_another_application
-    expect(page).to have_text('You can submit 1 more application.')
+    expect(page).to have_text("You can submit 1 more application for courses starting in the #{current_candidate.current_application.academic_year_range_name} academic year.")
   end
 
   def then_i_can_not_see_the_inactive_warning_text

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -210,7 +210,8 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   def and_i_can_see_i_have_three_choices_left
-    expect(page).to have_text 'You can submit 3 more applications.'
+    academic_year = @application_choice.application_form.academic_year_range_name
+    expect(page).to have_text "You can submit 3 more applications for courses starting in the #{academic_year} academic year."
   end
 
   def when_i_have_three_further_draft_choices
@@ -230,7 +231,8 @@ RSpec.describe 'Candidate submits the application' do
 
   def then_i_am_able_to_add_another_choice
     visit current_path
-    expect(page).to have_text 'You can submit 1 more application.'
+    academic_year = @current_candidate.current_application.academic_year_range_name
+    expect(page).to have_text "You can submit 1 more application for courses starting in the #{academic_year} academic year. "
   end
 
   def when_i_go_back

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   def and_i_can_see_i_have_three_choices_left
-    expect(page).to have_text 'You can submit 3 more applications.'
+    academic_year = @current_candidate.current_application.academic_year_range_name
+    expect(page).to have_text "You can submit 3 more applications for courses starting in the #{academic_year} academic year."
   end
 
   def when_i_have_three_further_draft_choices

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe 'Candidate submits the application' do
   end
 
   def and_i_can_see_i_have_three_choices_left
-    expect(page).to have_text 'You can submit 3 more applications.'
+    academic_year = @current_candidate.current_application.academic_year_range_name
+    expect(page).to have_text "You can submit 3 more applications for courses starting in the #{academic_year} academic year"
   end
 
   def when_my_application_is_rejected

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     expect(page).to have_element(:h1, text: 'Your applications')
     expect(page).to have_element(
       :p,
-      text: "The deadline for applying to courses in the #{@application_choice.application_form.academic_year_range_name} academic year has passed.",
+      text: "The deadline for submitting new applications for the #{@application_choice.application_form.academic_year_range_name} academic year has passed.",
     )
   end
 


### PR DESCRIPTION
## Context

After a research round on Jan start dates, we want to make some content changes to:
- clarify that the apply deadline is the submission deadline, not completion.
- provide candidates with a fuller picture related to application limits
- ensure start dates are more accurately reflected in headings

## Changes proposed in this pull request

| Before | After |
| ----- | ----- | 
| <img width="930" height="279" alt="image" src="https://github.com/user-attachments/assets/a71513b3-107b-4882-a128-f658f6f93909" /> | <img width="929" height="276" alt="image" src="https://github.com/user-attachments/assets/ed367b1a-141d-407f-ac91-355c0b54cca2" /> |
| <img width="620" height="234" alt="image" src="https://github.com/user-attachments/assets/78a643c3-bce8-4c90-9ad8-d7fe64023304" /> | <img width="608" height="298" alt="image" src="https://github.com/user-attachments/assets/e5cf4ad4-2188-4dc2-9394-64a284c95d9b" /> |
| <img width="774" height="950" alt="image" src="https://github.com/user-attachments/assets/f98c1777-c89f-4a4f-a058-b2d3743f2a3a" />| <img width="765" height="936" alt="image" src="https://github.com/user-attachments/assets/36c5b07e-eea0-403e-9118-87178fbd2771" /> |

## Guidance to review

Sign in as support and then sign in as [this candidate](https://apply-review-12236.test.teacherservices.cloud/support/applications/68). 

View their applications page. 
You'll see the changes to the deadline banner
You'll see the changes to the description of application limits

Then head back to support, and [change the 2026 apply deadline](https://apply-review-12236.test.teacherservices.cloud/support/settings/recruitment-cycle-timetable/2026) to yesterday
Now head back to the candidate. 
You'll see the applications split with the new headings.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
