### PR TITLE
2855 - Adds GCP credentials to fix delete

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -22,8 +22,8 @@ env:
   TERRAFORM_BASE: terraform/aks
   TF_FILE: provider.tf
   SERVICE_NAME: apply
-  RESOURCE_GROUP_NAME: s189d01-att-rv-rg
-  STORAGE_ACCOUNT_NAME: s189d01atttfstatervsa
+  RESOURCE_GROUP_NAME: s189t01-att-rv-rg
+  STORAGE_ACCOUNT_NAME: s189t01atttfstatervsa
   CONTAINER_NAME: att-tfstate
 
 jobs:
@@ -117,3 +117,5 @@ jobs:
           storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
           container-name: ${{ env.CONTAINER_NAME }}
           tf-state-file: pr-${{ matrix.pr_number }}.tfstate
+          gcp-project-id: rugged-abacus-218110
+          gcp-wip: projects/712009772377/locations/global/workloadIdentityPools/apply-for-teacher-training/providers/apply-for-teacher-training


### PR DESCRIPTION
## Context

Ongoing errors are being experienced when the scheduled review app reconciliation process runs. These errors are around the deletion process. Issues appear to be the lack of GCP credentials and an incorrect resource group/storage group name.

## Changes proposed in this pull request

Added GCP credentials to the workflow.
Corrected resource group and storage account name.

## Guidance to review

I have completed a [dry run](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/32838860659), but this does not run through the deletion process.

This cannot really be tested during the working day as it will delete deployed review apps, so it may be that we need to leave it to run as scheduled over the weekend, yet again.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally