### PR TITLE
Change govuk_link_to to link_to in filter component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,7 @@ Govuk/GovukLinkTo:
     - 'app/components/support_interface/tile_component.html.erb'
     # link_to in filter component
     - 'app/components/utility/filter_component.html.erb'
+    - 'app/components/provider_interface/find_candidates/filters_component.html.erb'
     # link_to in manual error summaries
     - 'app/views/candidate_interface/references/review/show.html.erb'
     - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'

--- a/app/components/provider_interface/find_candidates/filters_component.html.erb
+++ b/app/components/provider_interface/find_candidates/filters_component.html.erb
@@ -37,9 +37,8 @@
                   <div class="govuk-!-margin-bottom-3">
                     <% if value.is_a?(Array) %>
                       <% value.each do |filter_value| %>
-                        <%= govuk_link_to(
+                        <%= link_to(
                               path_to_remove_filter(name, filter_value),
-                              filter_value,
                               class: 'app-checkbox-filter__tag',
                             ) do %>
                           <span class="govuk-visually-hidden">
@@ -49,9 +48,8 @@
                         <% end %>
                       <% end %>
                     <% else %>
-                      <%= govuk_link_to(
+                      <%= link_to(
                             path_to_remove_location,
-                            value,
                             class: 'app-checkbox-filter__tag',
                           ) do %>
                           <span class="govuk-visually-hidden">


### PR DESCRIPTION
## Context

- Change `govuk_link_to` to `link_to` in the filter component.

## Changes proposed in this pull request

- Change `govuk_link_to` to `link_to` in the filter component. The `govuk_link_to` adds a class which changes to link colour.

## Guidance to review

- Visit https://apply-review-12258.test.teacherservices.cloud/support
- Sign in as a Support user
- Navigate to "Providers"
- Click on any provider
- Navigate to "Users"
- Click on any user
- Click "Sign in as this provider user"
- Click "Visit Manage"
- Navigate to "Find candidates"
- Enter an input into the filter
- Click "Apply filters"
- Check the CSS styling of the remove input tag

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Screenshots
_Before_
<img width="360" height="368" alt="image" src="https://github.com/user-attachments/assets/12bd0497-39df-4f75-9d30-c4a0b35d6a35" />


_After_
<img width="310" height="174" alt="Screenshot 2026-08-25 at 17 23 08" src="https://github.com/user-attachments/assets/e96a42d7-6199-46f0-b545-311f8dc9ae5b" />
