### PR TITLE
Efl link is only shown to international candidates

### DIFF
--- a/app/components/candidate_interface/carry_over_task_list_component.rb
+++ b/app/components/candidate_interface/carry_over_task_list_component.rb
@@ -88,7 +88,7 @@ module CandidateInterface
     end
 
     def efl_link
-      if !application_form.efl_completed
+      if !application_form.efl_completed && application_form.international_applicant?
         Section.new(
           name: :efl,
           link: govuk_link_to(

--- a/spec/components/candidate_interface/carry_over_task_list_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_task_list_component_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe CandidateInterface::CarryOverTaskListComponent do
     end
 
     context 'when a candidate is british and has not completed the efl or visa section' do
+      before do
+        FeatureFlag.activate('2027_visa_expiry')
+      end
+
       let(:previous_application_form) { create(:application_form, :submitted, efl_completed: false) }
       let(:application_form) do
         create(

--- a/spec/components/candidate_interface/carry_over_task_list_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_task_list_component_spec.rb
@@ -100,5 +100,23 @@ RSpec.describe CandidateInterface::CarryOverTaskListComponent do
         expect(rendered_component).to have_no_text('Before you can apply again, you’ll need to:')
       end
     end
+
+    context 'when a candidate is british and has not completed the efl or visa section' do
+      let(:previous_application_form) { create(:application_form, :submitted, efl_completed: false) }
+      let(:application_form) do
+        create(
+          :application_form,
+          :minimum_info,
+          previous_application_form:,
+          first_nationality: 'British',
+        )
+      end
+
+      it 'they do not see the efl or visa link' do
+        expect(rendered_component).to have_link('confirm your contact information')
+        expect(rendered_component).to have_no_link('enter or confirm your visa information')
+        expect(rendered_component).to have_no_link('enter or confirm your English language skills')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We only ask international candidates (eg, not british or irish) to complete the EFL section. But in the Carry over list, we are showing the link to any candidate who hasn't completed it. 

## Changes proposed in this pull request

Adds the conditional to only show the link to international candidates who haven't completed the EFL section.

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
