### PR TITLE
Prevent stings being returned if values not present in fee row helper

### DIFF
--- a/app/components/candidate_interface/course_fee_row_helper.rb
+++ b/app/components/candidate_interface/course_fee_row_helper.rb
@@ -5,13 +5,20 @@ module CandidateInterface
 
       {
         key: I18n.t('course_fee_row_helper.course_fee'),
-        value: domestic_fee(course) + international_fee(course) +
-          funding_advice(application_choice, course),
+        value: course_fee_row_value(application_choice, course),
       }
     end
 
+    def course_fee_row_value(application_choice, course)
+      [
+        domestic_fee(course),
+        international_fee(course),
+        funding_advice(application_choice)
+      ].select(&:present?).reduce(:+)
+    end
+
     def domestic_fee(course)
-      return '' if course.fee_domestic.blank?
+      return nil if course.fee_domestic.blank?
 
       tag.p(
         I18n.t(
@@ -23,7 +30,7 @@ module CandidateInterface
     end
 
     def international_fee(course)
-      return '' if course.fee_international.blank?
+      return nil if course.fee_international.blank?
 
       tag.p(
         I18n.t(
@@ -34,8 +41,8 @@ module CandidateInterface
       )
     end
 
-    def funding_advice(application_choice, _course)
-      return '' if application_choice.application_form.british_or_irish?
+    def funding_advice(application_choice)
+      return nil if application_choice.application_form.british_or_irish?
 
       content_tag :p, class: 'govuk-body secondary-text' do
         concat(

--- a/app/components/candidate_interface/course_fee_row_helper.rb
+++ b/app/components/candidate_interface/course_fee_row_helper.rb
@@ -13,8 +13,8 @@ module CandidateInterface
       [
         domestic_fee(course),
         international_fee(course),
-        funding_advice(application_choice)
-      ].select(&:present?).reduce(:+)
+        funding_advice(application_choice),
+      ].compact_blank.reduce(:+)
     end
 
     def domestic_fee(course)


### PR DESCRIPTION
## Context

- An issue occurs when the `domestic_fee` and `international_fee` methods return strings. It forces the link into text.

## Changes proposed in this pull request

- Methods are selected only if they are present and then combined together.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/bFbk9V7E/2060-bug-missing-link-in-funding-text

## Screenshots

_Before_

<img width="729" height="149" alt="Screenshot 2026-08-26 at 11 40 21" src="https://github.com/user-attachments/assets/f3abdabc-016a-4dc6-a875-aecd280d7d88" />

_After_

<img width="738" height="149" alt="Screenshot 2026-08-26 at 11 40 58" src="https://github.com/user-attachments/assets/32b4dab1-6af9-4c24-938f-8493a1a5a312" />
