### PR TITLE
Candidate review controller does not restrict to active application choices

### DIFF
--- a/app/controllers/candidate_interface/course_choices/review_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_controller.rb
@@ -5,7 +5,10 @@ module CandidateInterface
       skip_before_action :redirect_to_your_applications_if_cycle_is_over
 
       def show
-        @application_choice = active_application_choices.find(params[:application_choice_id])
+        @application_choice = current_candidate
+                                .application_choices
+                                .where(application_form: [current_application, current_candidate.previous_application])
+                                .find(params[:application_choice_id])
 
         if params['return_to'] == 'invite'
           invite = application_choice.published_invites.last

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -181,12 +181,12 @@ class Candidate < ApplicationRecord
     end
   end
 
-private
-
   def previous_application
     @previous_application ||= current_application.previous_application_form.presence ||
                               ordered_application_forms.joins(:application_choices).where.not(id: current_application).last
   end
+
+private
 
   def ordered_application_forms
     @ordered_application_forms ||= application_forms.order(:created_at, :id)

--- a/spec/system/candidate_interface/carry_over/candidate_views_an_unsent_application_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_an_unsent_application_after_apply_deadline_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Views an unsent application after the apply deadline', time: CycleTimetableHelper.mid_cycle do
+  include CandidateHelper
+
+  scenario 'candidate has a draft application' do
+    given_i_have_a_draft_application
+    and_the_apply_deadline_passes
+    when_i_sign_in
+    and_i_click_on_your_applications
+    then_i_see_my_applications_page
+    and_i_can_view_the_application
+  end
+
+private
+
+  def given_i_have_a_draft_application
+    @application_choice = create(:application_choice, :unsubmitted, :with_completed_application_form)
+    @application_form = @application_choice.application_form
+    @candidate = @application_form.candidate
+  end
+
+  def and_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
+    EndOfCycle::CancelUnsubmittedApplicationsWorker.perform_now
+  end
+
+  def when_i_sign_in
+    login_as @candidate
+    visit root_path
+  end
+
+  def and_i_click_on_your_applications
+    click_on 'Your applications'
+  end
+
+  def then_i_see_my_applications_page
+    expect(page).to have_current_path candidate_interface_application_choices_path
+    expect(page).to have_text 'Your applications'
+    expect(page).to have_text 'Application not sent'
+  end
+
+  def and_i_can_view_the_application
+    click_on @application_choice.provider.name
+    expect(page).to have_current_path(
+    candidate_interface_course_choices_course_review_path(
+      application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_title("Your application to #{@application_choice.provider.name}")
+    expect(page).to have_text('Application not sent')
+  end
+end

--- a/spec/system/candidate_interface/carry_over/candidate_views_an_unsent_application_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_an_unsent_application_after_apply_deadline_spec.rb
@@ -43,8 +43,8 @@ private
   def and_i_can_view_the_application
     click_on @application_choice.provider.name
     expect(page).to have_current_path(
-    candidate_interface_course_choices_course_review_path(
-      application_choice_id: @application_choice.id,
+      candidate_interface_course_choices_course_review_path(
+        application_choice_id: @application_choice.id,
       ),
     )
     expect(page).to have_title("Your application to #{@application_choice.provider.name}")


### PR DESCRIPTION
## Context

- Applications in the `application_not_sent` state are not included as `active_previous` statuses. This is preventing them from being shown in the review page.

## Changes proposed in this pull request

- Applications in either the current or previous application can be reviewed, regardless of status.

## Guidance to review

- Change controller to allow for any application choice in either the current or previous application.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
