### PR TITLE
Allow offers to be made for January courses

### DIFF
--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -78,10 +78,6 @@ class OfferValidations
     if can_not_receive_other_offers?
       errors.add(:base, :other_offer_already_accepted)
     end
-
-    if application_choice.candidate.current_application_choices.exclude?(application_choice)
-      errors.add(:base, :only_latest_application_rejection_can_be_reverted_on_apply_2)
-    end
   end
 
 private

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -124,7 +124,6 @@ en:
               different_ratifying_provider: The offered course's ratifying provider must be the same as the one originally requested
               other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one
               application_rejected_by_default: You cannot make an offer because the application has been automatically rejected
-              only_latest_application_rejection_can_be_reverted_on_apply_2: You cannot make an offer because you can only do so for the most recent application
         provider_interface/recruit_with_pending_conditions_form:
           attributes:
             confirmation:

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -82,6 +82,33 @@ RSpec.describe MakeOffer do
         make_offer.save!
         expect(cancel_upcoming_interviews).to have_received(:call!)
       end
+
+      context 'if the offer is for a previous cycle, january start choice', time: mid_cycle do
+        let(:carry_over_form) { create(:application_form, :carry_over) }
+        let(:application_choice) {
+          create(
+            :application_choice,
+            :awaiting_provider_decision,
+            :previous_year_but_still_available,
+            application_form: carry_over_form.previous_application_form,
+          )
+        }
+
+        it 'then calls various services' do
+          send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
+
+          allow(SendNewOfferEmailToCandidate)
+            .to receive(:new).with(application_choice:)
+            .and_return(send_new_offer_email_to_candidate)
+          allow(application_choice).to receive(:update_course_option_and_associated_fields!)
+
+          make_offer.save!
+
+          expect(send_new_offer_email_to_candidate).to have_received(:call)
+          expect(update_conditions_service).to have_received(:save)
+          expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
+        end
+      end
     end
 
     describe 'audits', :with_audited do

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -148,23 +148,6 @@ RSpec.describe OfferValidations, type: :model do
         end
       end
 
-      context 'when a provider attempts to revert a rejection on an application that is not the last one on apply_2' do
-        let(:candidate) { create(:candidate) }
-        let(:application_choice) { build(:application_choice, :rejected, current_course_option: course_option, created_at: 1.day.ago) }
-        let(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
-        let!(:application_form) { create(:application_form, phase: 'apply_2', application_choices: [application_choice], created_at: 1.day.ago, candidate:) }
-        let!(:other_application_form) { create(:application_form, phase: 'apply_2', application_choices: [other_application_choice], candidate:) }
-      end
-
-      context 'when a provider attempts to revert an apply_1 rejection but there is an application in apply_2' do
-        let(:candidate) { create(:candidate) }
-        let(:application_choice) { build(:application_choice, :rejected, current_course_option: course_option) }
-        let!(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
-
-        let!(:application_form_apply_1) { create(:application_form, application_choices: [application_choice], candidate:) }
-        let!(:application_form_apply_2) { create(:application_form, phase: 'apply_2', application_choices: [other_application_choice], candidate:) }
-      end
-
       context 'when a provider attempts to revert an apply_2 rejection but there is an application in apply_1' do
         let(:candidate) { create(:candidate) }
         let(:other_application_choice) { build(:application_choice, :rejected) }

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -154,11 +154,6 @@ RSpec.describe OfferValidations, type: :model do
         let(:other_application_choice) { build(:application_choice, :awaiting_provider_decision) }
         let!(:application_form) { create(:application_form, phase: 'apply_2', application_choices: [application_choice], created_at: 1.day.ago, candidate:) }
         let!(:other_application_form) { create(:application_form, phase: 'apply_2', application_choices: [other_application_choice], candidate:) }
-
-        it 'adds an :only_latest_application_rejection_can_be_reverted_on_apply_2 error' do
-          expect(offer).not_to be_valid
-          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because you can only do so for the most recent application')
-        end
       end
 
       context 'when a provider attempts to revert an apply_1 rejection but there is an application in apply_2' do
@@ -168,11 +163,6 @@ RSpec.describe OfferValidations, type: :model do
 
         let!(:application_form_apply_1) { create(:application_form, application_choices: [application_choice], candidate:) }
         let!(:application_form_apply_2) { create(:application_form, phase: 'apply_2', application_choices: [other_application_choice], candidate:) }
-
-        it 'adds an :only_latest_application_rejection_can_be_reverted_on_apply_2 error' do
-          expect(offer).not_to be_valid
-          expect(offer.errors[:base]).to contain_exactly('You cannot make an offer because you can only do so for the most recent application')
-        end
       end
 
       context 'when a provider attempts to revert an apply_2 rejection but there is an application in apply_1' do

--- a/spec/system/vendor_api/vendor_reverts_a_rejection_spec.rb
+++ b/spec/system/vendor_api/vendor_reverts_a_rejection_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe 'Vendor reverts a rejection' do
 
   scenario 'A vendor reverts a rejection' do
     given_a_candidate_has_multiple_rejected_application_and_is_in_apply_2
-    when_i_try_to_revert_the_rejection_on(@initial_application_choice)
-    then_i_can_see_a_validation_error
-
     when_i_try_to_revert_the_rejection_on(@most_recent_application_choice)
     then_i_can_see_the_offer_was_made_successfully
   end
@@ -32,14 +29,6 @@ RSpec.describe 'Vendor reverts a rejection' do
     # Unset session headers
     Capybara.current_session.driver.header('Authorization', nil)
     Capybara.current_session.driver.header('Content-Type', nil)
-  end
-
-  def then_i_can_see_a_validation_error
-    parsed_response_body = JSON.parse(@api_response.body)
-    validation_errors = parsed_response_body['errors']
-
-    expect(@api_response.status).to eq 422
-    expect(validation_errors.first['message']).to eq('You cannot make an offer because you can only do so for the most recent application')
   end
 
   def then_i_can_see_the_offer_was_made_successfully


### PR DESCRIPTION
## Context

In our end of cycle bug party we discovered a bug where a provider cannot send an offer to an application_choice that is not in the current cycle.

We need to allow this to happen for January start date choices

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review app and send some offers to these choices.
https://apply-review-12264.test.teacherservices.cloud/support/applications/54


https://github.com/user-attachments/assets/d1fd5b01-438d-4d09-887a-a5a4f9d69698



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
