### PR TITLE
Conditionally show jan start provider deadline content

### DIFF
--- a/app/components/candidate_interface/application_choices/january_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/january_start_content_component.rb
@@ -22,7 +22,7 @@ class CandidateInterface::ApplicationChoices::JanuaryStartContentComponent < App
   end
 
   def provider_deadline_content
-    return if after_winter_reject_by_default?
+    return if after_winter_reject_by_default? || application_choices.in_progress.blank?
 
     I18n.t(
       'candidate_interface.application_choices.january_start_component.provider_deadline_content',

--- a/app/components/candidate_interface/application_choices/january_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/january_start_content_component.rb
@@ -22,7 +22,7 @@ class CandidateInterface::ApplicationChoices::JanuaryStartContentComponent < App
   end
 
   def provider_deadline_content
-    return if after_winter_reject_by_default? || application_choices.in_progress.blank?
+    return if after_winter_reject_by_default?
 
     I18n.t(
       'candidate_interface.application_choices.january_start_component.provider_deadline_content',

--- a/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
@@ -75,20 +75,20 @@ RSpec.describe CandidateInterface::ApplicationChoices::JanuaryStartContentCompon
     before { application_choice }
 
     %i[awaiting_provider_decision interviewing offer pending_conditions recruited offer_deferred].each do |state|
-      context "when the application choice has state #{state.to_s}" do
+      context "when the application choice has state #{state}" do
         let(:application_choice) { create(:application_choice, state, course_option:, application_form:) }
 
         it 'returns content for providers regarding the winter reject by default date' do
           expect(component.provider_deadline_content).to eq(
-             "Providers have until #{recruitment_cycle_timetable.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)} " \
-               'to make decisions on these applications.',
-           )
+            "Providers have until #{recruitment_cycle_timetable.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)} " \
+            'to make decisions on these applications.',
+          )
         end
       end
     end
 
     %i[unsubmitted cancelled inactive rejected application_not_sent offer_withdrawn declined withdrawn conditions_not_met].each do |state|
-      context "when the application choice has state #{state.to_s}" do
+      context "when the application choice has state #{state}" do
         let(:application_choice) { create(:application_choice, state, course_option:, application_form:) }
 
         it 'returns nil' do

--- a/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/january_start_content_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CandidateInterface::ApplicationChoices::JanuaryStartContentCompon
 
     let(:course) { build(:course, start_date: "01/01/#{next_year}") }
     let(:course_option) { build(:course_option, course:) }
-    let(:application_choice) { create(:application_choice, course_option:, application_form:) }
+    let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option:, application_form:) }
     let(:rendered_component) { render_inline(described_class.new(application_form:)) }
 
     before { application_choice }
@@ -69,11 +69,32 @@ RSpec.describe CandidateInterface::ApplicationChoices::JanuaryStartContentCompon
   end
 
   describe '#provider_deadline_content' do
-    it 'returns content for providers regarding the winter reject by default date' do
-      expect(component.provider_deadline_content).to eq(
-        "Providers have until #{recruitment_cycle_timetable.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)} " \
-        'to make decisions on these applications.',
-      )
+    let(:course) { build(:course, start_date: "01/01/#{next_year}") }
+    let(:course_option) { build(:course_option, course:) }
+
+    before { application_choice }
+
+    %i[awaiting_provider_decision interviewing offer pending_conditions recruited offer_deferred].each do |state|
+      context "when the application choice has state #{state.to_s}" do
+        let(:application_choice) { create(:application_choice, state, course_option:, application_form:) }
+
+        it 'returns content for providers regarding the winter reject by default date' do
+          expect(component.provider_deadline_content).to eq(
+             "Providers have until #{recruitment_cycle_timetable.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)} " \
+               'to make decisions on these applications.',
+           )
+        end
+      end
+    end
+
+    %i[unsubmitted cancelled inactive rejected application_not_sent offer_withdrawn declined withdrawn conditions_not_met].each do |state|
+      context "when the application choice has state #{state.to_s}" do
+        let(:application_choice) { create(:application_choice, state, course_option:, application_form:) }
+
+        it 'returns nil' do
+          expect(component.provider_deadline_content).to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

- In the January Start Content Component
  - Only show Provider deadline content if an application choice in progress exists.

## Changes proposed in this pull request

- Only show Provider deadline content if an application choice exists in an "in progress" state. (See https://qa.apply-for-teacher-training.service.gov.uk/support/docs/application-states for states considered "in progress")

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/IgTvLRvK/2132-eoc-bug-party-1-deadline-content-for-jan-start-dates

## Screenshots
_Before_
<img width="1341" height="1255" alt="screencapture-localhost-3000-candidate-application-choices-2026-08-27-11_57_09" src="https://github.com/user-attachments/assets/80ad63b7-6a8d-4557-bafa-c9fac9e98c86" />

_After_
<img width="1341" height="1185" alt="screencapture-localhost-3000-candidate-application-choices-2026-08-27-11_56_22" src="https://github.com/user-attachments/assets/9435a066-5f1e-4eb9-9d3f-cf852a54cd20" />

