### PR TITLE
Add cascade delete to deferred_offer_confirmation

### DIFF
--- a/db/migrate/20260828103941_add_cascade_delete_to_deferred_offer_confirmation.rb
+++ b/db/migrate/20260828103941_add_cascade_delete_to_deferred_offer_confirmation.rb
@@ -1,0 +1,6 @@
+class AddCascadeDeleteToDeferredOfferConfirmation < ActiveRecord::Migration[8.1]
+  def change
+    remove_foreign_key :deferred_offer_confirmations, :offers
+    add_foreign_key :deferred_offer_confirmations, :offers, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20260828104039_validate_deffered_offer_fk.rb
+++ b/db/migrate/20260828104039_validate_deffered_offer_fk.rb
@@ -1,0 +1,5 @@
+class ValidateDefferedOfferFk < ActiveRecord::Migration[8.1]
+  def change
+    validate_foreign_key :deferred_offer_confirmations, :offers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_134256) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_104039) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -1465,7 +1465,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_134256) do
   add_foreign_key "courses", "providers"
   add_foreign_key "deferred_offer_confirmations", "course_options", column: "offered_course_option_id"
   add_foreign_key "deferred_offer_confirmations", "courses"
-  add_foreign_key "deferred_offer_confirmations", "offers"
+  add_foreign_key "deferred_offer_confirmations", "offers", on_delete: :cascade
   add_foreign_key "deferred_offer_confirmations", "provider_users"
   add_foreign_key "deferred_offer_confirmations", "sites"
   add_foreign_key "email_clicks", "emails", on_delete: :cascade


### PR DESCRIPTION
## Context

This way we can safely delete a candidate

Previously, this table would thrown an error because we didn't delete cascade it.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
