### PR TITLE
Candidates willing to locate appear at the end of the list

### DIFF
--- a/app/models/pool/candidates.rb
+++ b/app/models/pool/candidates.rb
@@ -1,6 +1,8 @@
 class Pool::Candidates
   attr_reader :filters, :provider_user, :with_statuses, :current_cycle
 
+  FURTHEST_DISTANCE = 20038 # The furthest distance between 2 points on earth in kilometers.
+
   def initialize(filters: {}, provider_user: nil, with_statuses: false)
     @filters = filters
     @provider_user = provider_user
@@ -129,7 +131,7 @@ private
         status: 'published',
         training_locations: 'anywhere',
       )
-      .select('candidate_preferences.application_form_id as application_form_id', '-1 as distance')
+      .select('candidate_preferences.application_form_id as application_form_id', "#{FURTHEST_DISTANCE} as distance")
 
     candidate_location_preferences_near_origin = CandidateLocationPreference
       .joins(:candidate_preference)

--- a/app/views/provider_interface/candidate_pool/candidates/index.html.erb
+++ b/app/views/provider_interface/candidate_pool/candidates/index.html.erb
@@ -48,7 +48,7 @@
             <%= row.with_cell(text: candidate_status(application_form:)) %>
             <%= row.with_cell do %>
               <% if @filter.applied_location_search? %>
-                <% if application_form.site_distance == -1 %>
+                <% if application_form.site_distance == Pool::Candidates::FURTHEST_DISTANCE %>
                   <%= t('.no_preferences') %>
                 <% else %>
                   <%= t('.miles', count: application_form.site_distance.round(1)) %>


### PR DESCRIPTION
## Context

- Reorder candidates in the FAC index to show candidates who will relocate last.

## Changes proposed in this pull request

- Change the number returned as `distance` when the candidate has selected `training_locations: 'anywhere'`, from `-1` to `20038`

## Guidance to review

- TBC


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/qetngYcP/2109-fac-list-regional-candidates-before-those-willing-to-relocate

## Screenshots

_Before_

<img width="2962" height="5120" alt="screencapture-localhost-3000-provider-find-candidates-2026-09-01-13_41_03" src="https://github.com/user-attachments/assets/47c3ba2b-1121-4d1e-a461-46de7678c2b0" />

_After_

<img width="2962" height="5120" alt="screencapture-localhost-3000-provider-find-candidates-2026-09-01-13_39_33" src="https://github.com/user-attachments/assets/4499b8c1-d22c-49fa-ad64-f9db91c29f65" />
