### PR TITLE
Remove unused feature flags

### DIFF
--- a/app/services/data_migrations/remove_api_and_monthly_statistics_feature_flags.rb
+++ b/app/services/data_migrations/remove_api_and_monthly_statistics_feature_flags.rb
@@ -1,0 +1,11 @@
+module DataMigrations
+  class RemoveAPIAndMonthlyStatisticsFeatureFlags
+    TIMESTAMP = 20260901143758
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :api_token_management).destroy_all
+      Feature.where(name: :monthly_statistics_redirected).destroy_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveAPIAndMonthlyStatisticsFeatureFlags',
   'DataMigrations::RemoveEnglishAsAForeignLanguageFeatureFlag',
   'DataMigrations::ResolveMistakenlyUnresolvedDuplicates',
   'DataMigrations::ResolveDuplicateMatchesUnsubmitted2025OrBefore2025',

--- a/spec/services/data_migrations/remove_api_and_monthly_statistics_feature_flags_spec.rb
+++ b/spec/services/data_migrations/remove_api_and_monthly_statistics_feature_flags_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveAPIAndMonthlyStatisticsFeatureFlags do
+  context 'when the feature flags exist' do
+    it 'removes candidate_preference flag' do
+      create(:feature, name: 'api_token_management')
+      create(:feature, name: 'monthly_statistics_redirected')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-2)
+      expect(Feature.where(name: 'api_token_management')).to be_blank
+      expect(Feature.where(name: 'monthly_statistics_redirected')).to be_blank
+    end
+  end
+
+  context 'when the api feature flag have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following on from an earlier PR to remove these feature flags from the code base, this PR deletes them from the database.

## Changes proposed in this pull request

Migration to remove the feature flags.

## Guidance to review

Nothing too much to do here, just review the code.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
