### PR TITLE
Add age group to FAC primary candidates

### DIFF
--- a/app/components/provider_interface/find_candidates/application_choices_component.rb
+++ b/app/components/provider_interface/find_candidates/application_choices_component.rb
@@ -51,7 +51,14 @@ private
   end
 
   def course_subject(choice)
-    subject_names = choice.course.subjects.pluck(:name).to_sentence
+    course = choice.course
+    subject_names = course.subjects.map do |subject|
+      if course.primary_course?
+        "#{subject.name} (#{course.age_range})"
+      else
+        subject.name
+      end
+    end.to_sentence
 
     {
       key: { text: t('.subject') },

--- a/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/application_choices_component_spec.rb
@@ -185,4 +185,42 @@ RSpec.describe ProviderInterface::FindCandidates::ApplicationChoicesComponent, t
       expect(page).to have_text('"Too many grammar mistakes"')
     end
   end
+
+  context 'when the course is primary' do
+    let(:course) { create(:course, :primary, provider: provider, age_range: '3 to 7') }
+    let(:course_option) { create(:course_option, course:) }
+    let!(:application_choice) do
+      create(:application_choice,
+             :withdrawn,
+             course_option:,
+             application_form:)
+    end
+
+    it 'renders the subject name and course age range' do
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_text('Subject')
+      subject_names = course.subjects.pluck(:name).to_sentence
+      expect(page).to have_text("#{subject_names} (3 to 7)")
+    end
+  end
+
+  context 'when the course is not primary' do
+    let(:course) { create(:course, :secondary, provider: provider) }
+    let(:course_option) { create(:course_option, course:) }
+    let!(:application_choice) do
+      create(:application_choice,
+             :withdrawn,
+             course_option:,
+             application_form:)
+    end
+
+    it 'renders the subject name only' do
+      render_inline(described_class.new(application_form:, provider_user:))
+
+      expect(page).to have_text('Subject')
+      subject_names = course.subjects.pluck(:name).to_sentence
+      expect(page).to have_text(subject_names)
+    end
+  end
 end


### PR DESCRIPTION
## Context

- Add age group to FAC candidate display when the candidate has chosen a primary course.

## Changes proposed in this pull request

- Change `course_subject` to return `subject.name` and `course.age_range` if the course is at the primary level.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/41guSD4S/2111-fac-add-primary-stage-to-previous-applications

## Screenshot

<img width="690" height="493" alt="Screenshot 2026-09-01 at 15 38 48" src="https://github.com/user-attachments/assets/8e2432a7-61ec-4bfc-afe8-88df6ce831df" />
