### PR TITLE
Conditionally show heading in September component

### DIFF
--- a/app/components/candidate_interface/after_deadline_content_component.html.erb
+++ b/app/components/candidate_interface/after_deadline_content_component.html.erb
@@ -20,8 +20,7 @@
   <div>
     <%= render CandidateInterface::ApplicationChoices::SeptemberStartContentComponent.new(
       application_form: relative_application_form,
-      heading: 'What happens next?',
-      heading_class: 'govuk-heading-m',
+      render_heading: false,
       with_tabs: true,
     ) %>
   </div>

--- a/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
@@ -1,6 +1,8 @@
-<h2 class="<%= heading_class %>">
-  <%= heading %>
-</h2>
+<% if display_heading? %>
+  <h2 class="<%= heading_class %>">
+    <%= heading %>
+  </h2>
+<% end %>
 
 <% if reject_by_default_explanation.present? %>
   <p class="govuk-body"><%= reject_by_default_explanation %></p>

--- a/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
@@ -1,5 +1,5 @@
-<% if display_heading? %>
-  <h2 class="<%= heading_class %>">
+<% if render_heading %>
+  <h2 class="govuk-heading-l">
     <%= heading %>
   </h2>
 <% end %>

--- a/app/components/candidate_interface/application_choices/september_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.rb
@@ -95,7 +95,7 @@ private
   end
 
   def any_rejected_by_default?
-    @ny_rejected_by_default ||= application_choices.any?(&:rejected_by_default?)
+    @any_rejected_by_default ||= application_choices.any?(&:rejected_by_default?)
   end
 
   def any_declined_by_default?

--- a/app/components/candidate_interface/application_choices/september_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.rb
@@ -10,6 +10,13 @@ class CandidateInterface::ApplicationChoices::SeptemberStartContentComponent < A
     @heading_class = heading_class
   end
 
+  def display_heading?
+    return true if @heading.blank?
+
+    awaiting_provider_decision_content.present? || reject_by_default_explanation.present? ||
+      decline_by_default_explanation.present? || offered_content.present?
+  end
+
   def heading
     return @heading if @heading.present?
 
@@ -25,57 +32,77 @@ class CandidateInterface::ApplicationChoices::SeptemberStartContentComponent < A
   end
 
   def awaiting_provider_decision_content
-    if application_choices.any?(&:decision_pending?)
-      {
-        title: I18n.t('candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.title'),
-        content: I18n.t(
-          'candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.rejected automatically',
-          reject_by: recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first),
-        ),
-      }
-    end
+    return unless any_decision_pending?
+
+    @awaiting_provider_decision_content ||= {
+      title: I18n.t('candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.title'),
+      content: I18n.t(
+        'candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.rejected automatically',
+        reject_by: recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first),
+      ),
+    }
   end
 
   def reject_by_default_explanation
-    return unless application_choices.any?(&:rejected_by_default?)
+    return unless any_rejected_by_default?
 
-    I18n.t('candidate_interface.application_choices.september_start_component.reject_by_default_explanation')
+    @reject_by_default_explanation ||= I18n.t('candidate_interface.application_choices.september_start_component.reject_by_default_explanation')
   end
 
   def decline_by_default_explanation
-    return unless application_choices.any?(&:declined_by_default?)
+    return unless any_declined_by_default?
 
-    I18n.t('candidate_interface.application_choices.september_start_component.decline_by_default_explanation')
+    @decline_by_default_explanation ||= I18n.t('candidate_interface.application_choices.september_start_component.decline_by_default_explanation')
   end
 
   def offered_content
-    if application_choices.any?(&:offer?)
-      {
-        title: I18n.t('candidate_interface.application_choices.september_start_component.offered_content.title'),
-        content: I18n.t(
-          'candidate_interface.application_choices.september_start_component.offered_content.declined_automatically',
-          decline_by: recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first),
-        ),
-      }
-    end
+    return unless any_offers?
+
+    @offered_content ||= {
+      title: I18n.t('candidate_interface.application_choices.september_start_component.offered_content.title'),
+      content: I18n.t(
+        'candidate_interface.application_choices.september_start_component.offered_content.declined_automatically',
+        decline_by: recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first),
+      ),
+    }
   end
 
   def application_choices
-    cycle_year = if RecruitmentCycleTimetable.current_timetable.before_apply_opens?
-                   RecruitmentCycleTimetable.previous_year
-                 else
-                   RecruitmentCycleTimetable.current_year
-                 end
+    @application_choices ||= begin
+      cycle_year = if RecruitmentCycleTimetable.current_timetable.before_apply_opens?
+                     RecruitmentCycleTimetable.previous_year
+                   else
+                     RecruitmentCycleTimetable.current_year
+                   end
 
-    CandidateInterface::SortApplicationChoices.call(
-      application_choices: application_form
-                             .application_choices
-                             .course_start_in_september(cycle_year)
-                             .for_sorting,
-    )
+      CandidateInterface::SortApplicationChoices.call(
+        application_choices: application_form
+                               .application_choices
+                               .course_start_in_september(cycle_year)
+                               .for_sorting,
+      )
+    end
   end
 
   def render?
     application_choices.present? && recruitment_cycle_timetable.current_year?
+  end
+
+private
+
+  def any_offers?
+    @any_offers ||= application_choices.any?(&:offer?)
+  end
+
+  def any_rejected_by_default?
+    @ny_rejected_by_default ||= application_choices.any?(&:rejected_by_default?)
+  end
+
+  def any_declined_by_default?
+    @any_declined_by_default ||= application_choices.any?(&:declined_by_default?)
+  end
+
+  def any_decision_pending?
+    @any_decision_pending ||= application_choices.any?(&:decision_pending?)
   end
 end

--- a/app/components/candidate_interface/application_choices/september_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.rb
@@ -1,24 +1,16 @@
 class CandidateInterface::ApplicationChoices::SeptemberStartContentComponent < ApplicationComponent
   delegate :recruitment_cycle_year, :recruitment_cycle_timetable, to: :application_form
 
-  attr_reader :application_form, :with_tabs, :heading_class
+  attr_reader :application_form, :with_tabs, :render_heading
 
-  def initialize(application_form:, with_tabs: false, heading: nil, heading_class: 'govuk-heading-l')
+  def initialize(application_form:, with_tabs: false, render_heading: true)
     @application_form = application_form
     @with_tabs = with_tabs
-    @heading = heading
-    @heading_class = heading_class
-  end
-
-  def display_heading?
-    return true if @heading.blank?
-
-    awaiting_provider_decision_content.present? || reject_by_default_explanation.present? ||
-      decline_by_default_explanation.present? || offered_content.present?
+    @render_heading = render_heading
   end
 
   def heading
-    return @heading if @heading.present?
+    return unless @render_heading
 
     start_dates = application_choices.map do |ac|
       ac.course.start_date.to_fs(:month_and_year)

--- a/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
@@ -126,11 +126,14 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
       end
     end
 
-    context 'when given a custom heading' do
-      let(:component) { described_class.new(application_form:, heading: 'What happens next?') }
+    context 'when render heading is false' do
+      let(:component) { described_class.new(application_form:, render_heading: false) }
+      let(:rendered_component) { render_inline(described_class.new(application_form:)) }
 
-      it 'renders the custom heading' do
-        expect(component.heading).to eq('What happens next?')
+      it 'does not render the heading' do
+        expect(component.heading).to be_nil
+        expect(rendered_component).to have_no_text 'Courses starting in September 2026'
+        expect(rendered_component).to have_no_text 'Courses starting by the end of September 2026'
       end
     end
   end
@@ -277,108 +280,6 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
 
           expect(component.application_choices).to contain_exactly(sept_application_choice)
         end
-      end
-    end
-  end
-
-  describe '#display_heading?' do
-    let(:component_with_heading) do
-      described_class.new(application_form:, heading: 'What happens next?')
-    end
-    let(:rendered_component_with_heading) { render_inline(component_with_heading) }
-    let(:course) { build(:course, start_date: "01/09/#{application_form.recruitment_cycle_year}") }
-    let(:course_option) { build(:course_option, course:) }
-
-    context 'when the candidate has no applications choices with offers, declined or rejected by default or decisions pending' do
-      before do
-        create(:application_choice, :unsubmitted, course_option:, application_form:)
-      end
-
-      it 'does not render the heading' do
-        expect(component_with_heading.display_heading?).to be(false)
-        expect(rendered_component_with_heading).not_to have_element(
-          :h2,
-          text: 'What happens next?',
-          class: 'govuk-heading-l',
-        )
-      end
-    end
-
-    context 'when the candidate has an applications choice pending a decisions' do
-      before do
-        create(:application_choice, :awaiting_provider_decision, course_option:, application_form:)
-      end
-
-      it 'does not render the heading' do
-        expect(component_with_heading.display_heading?).to be(true)
-        expect(rendered_component_with_heading).to have_element(
-          :h2,
-          text: 'What happens next?',
-          class: 'govuk-heading-l',
-        )
-      end
-    end
-
-    context 'when the candidate has an applications choice rejected by default' do
-      before do
-        create(:application_choice, :rejected_by_default, course_option:, application_form:)
-      end
-
-      it 'render the heading' do
-        expect(component_with_heading.display_heading?).to be(true)
-        expect(rendered_component_with_heading).to have_element(
-          :h2,
-          text: 'What happens next?',
-          class: 'govuk-heading-l',
-        )
-      end
-    end
-
-    context 'when the candidate has an applications choice declined by default' do
-      before do
-        create(:application_choice, :declined_by_default, course_option:, application_form:)
-      end
-
-      it 'renders the heading' do
-        expect(component_with_heading.display_heading?).to be(true)
-        expect(rendered_component_with_heading).to have_element(
-          :h2,
-          text: 'What happens next?',
-          class: 'govuk-heading-l',
-        )
-      end
-    end
-
-    context 'when the candidate has an applications choice with an offer' do
-      before do
-        create(:application_choice, :offered, course_option:, application_form:)
-      end
-
-      it 'renders the heading' do
-        expect(component_with_heading.display_heading?).to be(true)
-        expect(rendered_component_with_heading).to have_element(
-          :h2,
-          text: 'What happens next?',
-          class: 'govuk-heading-l',
-        )
-      end
-    end
-
-    context 'when a heading attribute is not given' do
-      let(:rendered_component) { render_inline(component) }
-
-      before do
-        create(:application_choice, course_option:, application_form:)
-      end
-
-      it 'renders the heading' do
-        expect(component.display_heading?).to be(true)
-
-        expect(rendered_component).to have_element(
-          :h2,
-          text: 'Courses starting in September 2026',
-          class: 'govuk-heading-l',
-        )
       end
     end
   end

--- a/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
@@ -280,4 +280,106 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
       end
     end
   end
+
+  describe '#display_heading?' do
+    let(:component_with_heading) do
+      described_class.new(application_form:, heading: 'What happens next?')
+    end
+    let(:rendered_component_with_heading) { render_inline(component_with_heading) }
+    let(:course) { build(:course, start_date: "01/09/#{application_form.recruitment_cycle_year}") }
+    let(:course_option) { build(:course_option, course:) }
+
+    context 'when the candidate has no applications choices with offers, declined or rejected by default or decisions pending' do
+      before do
+        create(:application_choice, :unsubmitted, course_option:, application_form:)
+      end
+
+      it 'does not render the heading' do
+        expect(component_with_heading.display_heading?).to be(false)
+        expect(rendered_component_with_heading).not_to have_element(
+          :h2,
+          text: 'What happens next?',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+
+    context 'when the candidate has an applications choice pending a decisions' do
+      before do
+        create(:application_choice, :awaiting_provider_decision, course_option:, application_form:)
+      end
+
+      it 'does not render the heading' do
+        expect(component_with_heading.display_heading?).to be(true)
+        expect(rendered_component_with_heading).to have_element(
+          :h2,
+          text: 'What happens next?',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+
+    context 'when the candidate has an applications choice rejected by default' do
+      before do
+        create(:application_choice, :rejected_by_default, course_option:, application_form:)
+      end
+
+      it 'render the heading' do
+        expect(component_with_heading.display_heading?).to be(true)
+        expect(rendered_component_with_heading).to have_element(
+          :h2,
+          text: 'What happens next?',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+
+    context 'when the candidate has an applications choice declined by default' do
+      before do
+        create(:application_choice, :declined_by_default, course_option:, application_form:)
+      end
+
+      it 'renders the heading' do
+        expect(component_with_heading.display_heading?).to be(true)
+        expect(rendered_component_with_heading).to have_element(
+          :h2,
+          text: 'What happens next?',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+
+    context 'when the candidate has an applications choice with an offer' do
+      before do
+        create(:application_choice, :offered, course_option:, application_form:)
+      end
+
+      it 'renders the heading' do
+        expect(component_with_heading.display_heading?).to be(true)
+        expect(rendered_component_with_heading).to have_element(
+          :h2,
+          text: 'What happens next?',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+
+    context 'when a heading attribute is not given' do
+      let(:rendered_component) { render_inline(component) }
+
+      before do
+        create(:application_choice, course_option:, application_form:)
+      end
+
+      it 'renders the heading' do
+        expect(component.display_heading?).to be(true)
+
+        expect(rendered_component).to have_element(
+          :h2,
+          text: 'Courses starting in September 2026',
+          class: 'govuk-heading-l',
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

- Conditionally show the heading in September component, only if there is content to display

## Changes proposed in this pull request

- Add logic to show the heading only if given as an argument and if there is content to display.

## Guidance to review

- TBC


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/ONXjvFqG/2133-eoc-bug-party-1-what-happens-next-content

## Screenshots
_Before_

<img width="1481" height="1513" alt="screencapture-localhost-3000-candidate-application-choices-2026-09-02-10_19_28" src="https://github.com/user-attachments/assets/4e603da2-2c8e-4a12-94d6-8166492d3edb" />

_After_

<img width="1481" height="1463" alt="screencapture-localhost-3000-candidate-application-choices-2026-09-02-10_18_49" src="https://github.com/user-attachments/assets/ef759ca5-e9d6-4f94-8ca8-b5b1c1222781" />
