### PR TITLE
Add instruction to start application details

### DIFF
--- a/app/components/candidate_interface/prepare_for_next_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/prepare_for_next_cycle_content_component.html.erb
@@ -33,4 +33,12 @@
   <p class="govuk-body">
     You will be able to apply from <%= apply_opens %>.
   </p>
+
+  <% if can_start_next_cycle_application? %>
+    <p class="govuk-body">
+      Before you apply, you will need to <%= govuk_link_to('update your details', candidate_interface_details_path) %>
+      if any section are incomplete.
+      You can do this now.
+    </p>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/prepare_for_next_cycle_content_component.html.erb
+++ b/app/components/candidate_interface/prepare_for_next_cycle_content_component.html.erb
@@ -37,7 +37,7 @@
   <% if can_start_next_cycle_application? %>
     <p class="govuk-body">
       Before you apply, you will need to <%= govuk_link_to('update your details', candidate_interface_details_path) %>
-      if any section are incomplete.
+      if any sections are incomplete.
       You can do this now.
     </p>
   <% end %>

--- a/app/components/candidate_interface/prepare_for_next_cycle_content_component.rb
+++ b/app/components/candidate_interface/prepare_for_next_cycle_content_component.rb
@@ -35,5 +35,9 @@ module CandidateInterface
       after_find_opens? && !next_recruitment_cycle.after_apply_deadline? &&
         application_form.can_submit_more_choices?
     end
+
+    def can_start_next_cycle_application?
+      application_form.recruitment_cycle_timetable == next_recruitment_cycle
+    end
   end
 end

--- a/spec/components/candidate_interface/prepare_for_next_cycle_content_component_spec.rb
+++ b/spec/components/candidate_interface/prepare_for_next_cycle_content_component_spec.rb
@@ -121,6 +121,40 @@ RSpec.describe CandidateInterface::PrepareForNextCycleContentComponent do
             text: "You will be able to apply from #{apply_opens}.",
             class: 'govuk-body',
           )
+          expect(rendered_component).to have_element(
+            :p,
+            text: 'Before you apply, you will need to update your details if any section are incomplete. You can do this now.',
+            class: 'govuk-body',
+          )
+        end
+      end
+
+      context 'when the application form has not been carried over' do
+        let(:not_carried_over_application_form) do
+          create(:application_form, recruitment_cycle_year: application_form.recruitment_cycle_year - 1)
+        end
+        let(:rendered_component) do
+          render_inline(described_class.new(application_form: not_carried_over_application_form))
+        end
+
+        it 'does not display the instructions to update details' do
+          travel_temporarily_to(application_form.find_opens_at - 2.minutes) do
+            expect(rendered_component).to have_element(
+              :p,
+              text: "You will be able to view courses starting in the #{academic_year_range_name} academic year from #{find_opens}.",
+              class: 'govuk-body',
+            )
+            expect(rendered_component).to have_element(
+              :p,
+              text: "You will be able to apply from #{apply_opens}.",
+              class: 'govuk-body',
+            )
+            expect(rendered_component).not_to have_element(
+              :p,
+              text: 'Before you apply, you will need to update your details if any section are incomplete. You can do this now.',
+              class: 'govuk-body',
+            )
+          end
         end
       end
     end

--- a/spec/components/candidate_interface/prepare_for_next_cycle_content_component_spec.rb
+++ b/spec/components/candidate_interface/prepare_for_next_cycle_content_component_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe CandidateInterface::PrepareForNextCycleContentComponent do
           )
           expect(rendered_component).to have_element(
             :p,
-            text: 'Before you apply, you will need to update your details if any section are incomplete. You can do this now.',
+            text: 'Before you apply, you will need to update your details if any sections are incomplete. You can do this now.',
             class: 'govuk-body',
           )
         end
@@ -151,7 +151,7 @@ RSpec.describe CandidateInterface::PrepareForNextCycleContentComponent do
             )
             expect(rendered_component).not_to have_element(
               :p,
-              text: 'Before you apply, you will need to update your details if any section are incomplete. You can do this now.',
+              text: 'Before you apply, you will need to update your details if any sections are incomplete. You can do this now.',
               class: 'govuk-body',
             )
           end


### PR DESCRIPTION
## Context

- IF the application has been carried over and Find is open:
  - Show content to instruct candidates to complete their incomplete details

## Changes proposed in this pull request

- Conditionally show content to instruct candidates to complete their incomplete details for carried-over applications.

## Guidance to review

- Visit https://apply-review-12286.test.teacherservices.cloud/support
- Sign in as a Support user
-------------
_Carried over application_
- Visit https://apply-review-12286.test.teacherservices.cloud/support/applications/71
- Click on "Sign in as this candidate"
- You will see "Before you apply, you will need to update your details if any sections are incomplete. You can do this now."
-----------
_NOT carried over application_
- Visit https://apply-review-12286.test.teacherservices.cloud/support/applications/54
- Click on "Sign in as this candidate"
- You will NOT see "Before you apply, you will need to update your details if any sections are incomplete. You can do this now."

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/M3hb6OcH/2135-eoc-bug-party-1-no-indication-that-i-can-start-working-on-my-2027-application

## Screenshots

_Application carried over_

<img width="1481" height="1335" alt="screencapture-localhost-3000-candidate-application-choices-2026-09-02-11_50_03" src="https://github.com/user-attachments/assets/e2635054-6b00-460d-b2cb-b65edb5c234a" />

_Application not carried over_

<img width="1481" height="1478" alt="screencapture-localhost-3000-candidate-application-choices-2026-09-02-11_54_50" src="https://github.com/user-attachments/assets/bd87d064-025f-412f-b8e4-a5d42dde660c" />
