### PR TITLE
enforce private link for prod and sandbox for postgres backup to azur…

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -67,5 +67,7 @@
   "pg_airbyte_enabled": "true",
   "airbyte_enabled": "true",
   "connection_status": "active",
-  "wal_threshold": 10000000000
+  "wal_threshold": 10000000000,
+  "azure_backup_storage_private_endpoint_enabled": "true",
+  "azure_backup_storage_public_network_access_enabled": "false"
 }

--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -46,5 +46,7 @@
         204421
       ]
     }
-  }
+  },
+  "azure_backup_storage_private_endpoint_enabled": "true",
+  "azure_backup_storage_public_network_access_enabled": "false"
 }

--- a/terraform/aks/workspace_variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox.tfvars.json
@@ -49,5 +49,7 @@
     }
   },
   "enable_logit": true,
-  "pg_airbyte_enabled": "true"
+  "pg_airbyte_enabled": "true",
+  "azure_backup_storage_private_endpoint_enabled": "true",
+  "azure_backup_storage_public_network_access_enabled": "false"
 }


### PR DESCRIPTION
## Context

This change forces use of Private link \ Private Endpoints for Azure Backup Storage for QA, production and sandbox, removing the need to use a publicly available storage account for postgres backup. This follows on from a previous [PR ](https://github.com/DFE-Digital/apply-for-teacher-training/pull/12223) to update for staging.

## Changes proposed in this pull request
- Setting  `azure_backup_storage_private_endpoint_enabled` to true for production and sandbox environments

## Guidance to review
As proof of concept, for staging:
- AKS based backup [job ](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/33650003244) is working demonstrating use of private link
- Verify Public network access is disabled on the storage account

Run plan for environments, there should be no changes for a staging, changes for qa, sandbox and production shown below.
`make <env> deploy-plan`

Expected changes:
New private endpoint creation
```
# module.postgres.azurerm_private_endpoint.storage[0] will be created
  + resource "azurerm_private_endpoint" "storage" {
```
public_network_access_enabled disabled
```
# module.postgres.azurerm_storage_account.backup[0] will be updated in-place
  ~ resource "azurerm_storage_account" "backup" {

      ~ public_network_access_enabled      = true -> false
```

## Post-Merge
- verify backup via AKS pod works and merge [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/12164)
