### PR TITLE
FAC: Add visa details

### DIFF
--- a/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
@@ -3,10 +3,25 @@
     <% row.with_key { t('.visa_sponsorship') } %>
     <% row.with_value { visa_sponsorship_value } %>
   <% end %>
+
   <% unless application_form.requires_visa_sponsorship? %>
     <% summary_list.with_row do|row| %>
       <% row.with_key { t('.visa_or_immigration_status') } %>
       <% row.with_value { visa_status_value } %>
+    <% end %>
+  <% end %>
+
+  <% if application_form.visa_expired_at.present? %>
+    <% summary_list.with_row do|row| %>
+      <% row.with_key { t('.visa_expiry_date') } %>
+      <% row.with_value { visa_expiry_date } %>
+    <% end %>
+  <% end %>
+
+  <% if how_will_you_complete_your_studies.present? %>
+    <% summary_list.with_row do|row| %>
+      <% row.with_key { t('.how_will_you_complete_your_studies') } %>
+      <% row.with_value { how_will_you_complete_your_studies } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.html.erb
@@ -1,27 +1,31 @@
 <%= govuk_summary_list do |summary_list| %>
   <% summary_list.with_row do |row| %>
-    <% row.with_key { t('.visa_sponsorship') } %>
+    <% row.with_key { t('provider_interface.find_candidates.right_to_work_component.visa_sponsorship') } %>
     <% row.with_value { visa_sponsorship_value } %>
   <% end %>
 
   <% unless application_form.requires_visa_sponsorship? %>
     <% summary_list.with_row do|row| %>
-      <% row.with_key { t('.visa_or_immigration_status') } %>
+      <% row.with_key { t('provider_interface.find_candidates.right_to_work_component.visa_or_immigration_status') } %>
       <% row.with_value { visa_status_value } %>
     <% end %>
   <% end %>
 
   <% if application_form.visa_expired_at.present? %>
     <% summary_list.with_row do|row| %>
-      <% row.with_key { t('.visa_expiry_date') } %>
+      <% row.with_key { t('provider_interface.find_candidates.right_to_work_component.visa_expiry_date') } %>
       <% row.with_value { visa_expiry_date } %>
     <% end %>
   <% end %>
 
   <% if how_will_you_complete_your_studies.present? %>
     <% summary_list.with_row do|row| %>
-      <% row.with_key { t('.how_will_you_complete_your_studies') } %>
-      <% row.with_value { how_will_you_complete_your_studies } %>
+      <% row.with_key { t('provider_interface.find_candidates.right_to_work_component.how_will_you_complete_your_studies') } %>
+      <% row.with_value do %>
+        <% how_will_you_complete_your_studies.each do |complete_studies| %>
+          <p><%= complete_studies %></p>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/provider_interface/find_candidates/right_to_work_component.rb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.rb
@@ -20,4 +20,26 @@ class ProviderInterface::FindCandidates::RightToWorkComponent < ApplicationCompo
       t(".#{application_form.immigration_status.presence || 'unknown'}")
     end
   end
+
+  def visa_expiry_date
+    application_form.visa_expired_at.to_fs(:govuk_date)
+  end
+
+  def how_will_you_complete_your_studies
+    application_choice.pluck(:visa_explanation).map do |visa_explanation|
+      I18n.t(
+        "candidate_interface.visa_explanation_component.#{visa_explanation}",
+      )
+    end.to_sentence
+  end
+
+private
+
+  def application_choices
+    @application_choices ||= application_form
+                               .application_choices
+                               .where.not(sent_to_provider_at: nil)
+                               .order(:sent_to_provider_at)
+                               .reverse
+  end
 end

--- a/app/components/provider_interface/find_candidates/right_to_work_component.rb
+++ b/app/components/provider_interface/find_candidates/right_to_work_component.rb
@@ -7,17 +7,17 @@ class ProviderInterface::FindCandidates::RightToWorkComponent < ApplicationCompo
 
   def visa_sponsorship_value
     if application_form.requires_visa_sponsorship?
-      t('.required')
+      t('provider_interface.find_candidates.right_to_work_component.required')
     else
-      t('.not_required')
+      t('provider_interface.find_candidates.right_to_work_component.not_required')
     end
   end
 
   def visa_status_value
     if application_form.british_or_irish?
-      t('.british_or_irish')
+      t('provider_interface.find_candidates.right_to_work_component.british_or_irish')
     else
-      t(".#{application_form.immigration_status.presence || 'unknown'}")
+      t("provider_interface.find_candidates.right_to_work_component.#{application_form.immigration_status.presence || 'unknown'}")
     end
   end
 
@@ -26,11 +26,18 @@ class ProviderInterface::FindCandidates::RightToWorkComponent < ApplicationCompo
   end
 
   def how_will_you_complete_your_studies
-    application_choice.pluck(:visa_explanation).map do |visa_explanation|
-      I18n.t(
-        "candidate_interface.visa_explanation_component.#{visa_explanation}",
+    application_choices.map do |application_choice|
+      explanation = I18n.t(
+        "candidate_interface.visa_explanation_component.#{application_choice.visa_explanation}",
       )
-    end.to_sentence
+
+      if application_choice.visa_explanation_other?
+        tag.p("#{explanation}:", class: 'govuk-body govuk-!-margin-bottom-2') +
+          tag.p(application_choice.visa_explanation_details, class: 'govuk-body govuk-!-padding-left-3')
+      else
+        explanation
+      end
+    end
   end
 
 private
@@ -39,7 +46,7 @@ private
     @application_choices ||= application_form
                                .application_choices
                                .where.not(sent_to_provider_at: nil)
-                               .order(:sent_to_provider_at)
-                               .reverse
+                               .where.not(visa_explanation: nil)
+                               .in_order_of(:visa_explanation, ApplicationChoice.visa_explanations.values)
   end
 end

--- a/config/locales/components/provider_interface/find_candidates/en.yml
+++ b/config/locales/components/provider_interface/find_candidates/en.yml
@@ -30,6 +30,9 @@ en:
         refugee_status: Refugee status
         other: Other
         british_or_irish: British or Irish citizen
+        visa_expiry_date: Visa expiry date
+        how_will_you_complete_your_studies:
+          How will you complete your studies?
       application_choices_component:
         subtitle: Application %{counter}
         provider: Provider

--- a/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
@@ -20,4 +20,17 @@ class ProviderInterface::FindCandidates::RightToWorkComponentPreview < ViewCompo
 
     render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
   end
+
+  def candidate_has_visa_expiry
+    application_form = FactoryBot.build(
+      :application_form,
+      right_to_work_or_study: 'yes',
+      immigration_status: 'indefinite_leave_to_remain_in_the_uk',
+      visa_expired_at: '01/01/2028',
+    )
+
+    render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
+  end
+
+
 end

--- a/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
+++ b/spec/components/previews/provider_interface/find_candidates/right_to_work_component_preview.rb
@@ -32,5 +32,23 @@ class ProviderInterface::FindCandidates::RightToWorkComponentPreview < ViewCompo
     render ProviderInterface::FindCandidates::RightToWorkComponent.new(application_form:)
   end
 
+  def candidate_has_visa_explanation
+    application_form = FactoryBot.build(
+      :application_form,
+      right_to_work_or_study: 'yes',
+      immigration_status: 'indefinite_leave_to_remain_in_the_uk',
+      visa_expired_at: '01/01/2028',
+    )
 
+    render PreviewRightToWorkComponent.new(application_form:)
+  end
+
+  class PreviewRightToWorkComponent < ProviderInterface::FindCandidates::RightToWorkComponent
+    def application_choices
+      [
+        FactoryBot.build(:application_choice, :awaiting_provider_decision, visa_explanation: 'expires_after_course'),
+        FactoryBot.build(:application_choice, :awaiting_provider_decision, visa_explanation: 'other', visa_explanation_details: 'I have the right to work.'),
+      ]
+    end
+  end
 end

--- a/spec/components/provider_interface/find_candidates/right_to_work_component_spec.rb
+++ b/spec/components/provider_interface/find_candidates/right_to_work_component_spec.rb
@@ -35,4 +35,80 @@ RSpec.describe ProviderInterface::FindCandidates::RightToWorkComponent, type: :c
       expect(page).to have_no_text 'Visa or immigration status'
     end
   end
+
+  context 'candidate has entered their visa expiry' do
+    it 'renders the visa expiry date' do
+      application_form = build(
+        :application_form,
+        right_to_work_or_study: 'yes',
+        immigration_status: 'indefinite_leave_to_remain_in_the_uk',
+        visa_expired_at: '01/01/2028',
+      )
+
+      render_inline(described_class.new(application_form:))
+
+      expect(page).to have_text 'Not required'
+      expect(page).to have_text 'Visa or immigration status'
+      expect(page).to have_text 'Indefinite leave to remain in the UK'
+      expect(page).to have_text 'Visa expiry date'
+      expect(page).to have_text '1 January 2028'
+    end
+  end
+
+  context 'candidate has enter their visa explanation' do
+    let(:application_form) do
+      build(
+        :application_form,
+        right_to_work_or_study: 'yes',
+        immigration_status: 'indefinite_leave_to_remain_in_the_uk',
+        visa_expired_at: '01/01/2028',
+      )
+    end
+
+    context 'for one application choice' do
+      before do
+        create(:application_choice, :awaiting_provider_decision, application_form:, visa_explanation: 'expires_after_course')
+      end
+
+      it 'renders the visa explanation' do
+        render_inline(described_class.new(application_form:))
+
+        expect(page).to have_text 'Not required'
+        expect(page).to have_text 'Visa or immigration status'
+        expect(page).to have_text 'Indefinite leave to remain in the UK'
+        expect(page).to have_text 'Visa expiry date'
+        expect(page).to have_text '1 January 2028'
+        expect(page).to have_text 'How will you complete your studies?'
+        expect(page).to have_text 'My visa expires after the course ends'
+      end
+    end
+
+    context 'for mulitple application choices' do
+      before do
+        create(:application_choice, :awaiting_provider_decision, application_form:, visa_explanation: 'expires_after_course')
+        create(:application_choice, :awaiting_provider_decision, application_form:, visa_explanation: 'renew')
+        create(
+          :application_choice,
+          :awaiting_provider_decision,
+          application_form:,
+          visa_explanation: 'other',
+          visa_explanation_details: 'I have a right to work',
+        )
+      end
+
+      it 'renders the visa explanation for each application choice' do
+        render_inline(described_class.new(application_form:))
+
+        expect(page).to have_text 'Not required'
+        expect(page).to have_text 'Visa or immigration status'
+        expect(page).to have_text 'Indefinite leave to remain in the UK'
+        expect(page).to have_text 'Visa expiry date'
+        expect(page).to have_text '1 January 2028'
+        expect(page).to have_text 'How will you complete your studies?'
+        expect(page).to have_text 'My visa expires after the course ends'
+        expect(page).to have_text 'I will be able to renew or extend my current visa'
+        expect(page).to have_text 'Other:I have a right to work'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

- Add "Visa expiry date" and "How will you complete your studies?" to the `ProviderInterface::FindCandidates::RightToWorkComponent`

## Changes proposed in this pull request

- IF PRESENT:
  - Display the candidates "Visa expiry date" and "How will you complete your studies?", when a provider user is viewing a candidate in the FAC pool.

## Guidance to review

_Has visa expiry_
- Visit https://apply-review-12290.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/right_to_work_component/candidate_has_visa_expiry
- Check content

_Has visa explanations_
- Visit https://apply-review-12290.test.teacherservices.cloud/rails/view_components/provider_interface/find_candidates/right_to_work_component/candidate_has_visa_explanation
- Check content


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/2NNJQCXv/2110-fac-add-visa-details

## Screenshot

<img width="1020" height="309" alt="Screenshot 2026-09-03 at 09 49 15" src="https://github.com/user-attachments/assets/2c82de4f-1d3b-4f65-9275-ef156577ec55" />
