### PR TITLE
Remove in_house_developers boolean from vendor_api_tokens

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -618,7 +618,6 @@ shared:
     - last_used_at
     - description
     - vendor_id
-    - in_house_developers
     - discarded_at
   :withdrawal_reasons:
     - id

--- a/db/migrate/20260903145931_remove_in_house_from_vendor_tokens.rb
+++ b/db/migrate/20260903145931_remove_in_house_from_vendor_tokens.rb
@@ -1,0 +1,7 @@
+class RemoveInHouseFromVendorTokens < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      remove_column :vendor_api_tokens, :in_house_developers, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_150126) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_145931) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -1407,7 +1407,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_150126) do
     t.string "description"
     t.datetime "discarded_at"
     t.string "hashed_token", null: false
-    t.boolean "in_house_developers", default: false, null: false
     t.datetime "last_used_at", precision: nil
     t.bigint "provider_id", null: false
     t.datetime "updated_at", null: false

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -468,7 +468,6 @@ erDiagram
 		boolean no_qualification
 		text no_qualification_details
 		boolean qualification_not_needed
-		string qualification_status
 	}
 	Feature {
 		boolean active
@@ -538,7 +537,6 @@ erDiagram
 		string reason
 	}
 	PoolEligibleApplicationForm {
-		integer application_form_id
 	}
 	PossiblePreviousTeacherTraining {
 		date ended_on
@@ -835,7 +833,6 @@ erDiagram
 		string description
 		datetime discarded_at
 		string hashed_token
-		boolean in_house_developers
 		datetime last_used_at
 	}
 	VendorApiUser {
@@ -863,7 +860,7 @@ erDiagram
 	"ActiveStorage::Blob" ||--}o "ActiveStorage::Attachment" : ""
 	"ActiveStorage::Blob" ||--}o "ActiveStorage::VariantRecord" : ""
 	"ActiveStorage::Blob" o|..|o "ActiveStorage::Blob" : ""
-	ApplicationForm ||--}o "Adviser::SignUpRequest" : ""
+	ApplicationForm ||--|o "Adviser::SignUpRequest" : ""
 	"Adviser::TeachingSubject" ||--}o "Adviser::SignUpRequest" : ""
 	Chased ||--}o ChaserSent : ""
 	ApplicationChoice ||--}o ChaserSent : ""
@@ -908,8 +905,10 @@ erDiagram
 	ApplicationForm o|..}o CandidateLocationPreference : ""
 	Notified ||--}o Notification : ""
 	ApplicationForm ||--}o Notification : ""
+	ApplicationForm ||--}o ProviderPoolAction : ""
 	ApplicationForm ||--}o ApplicationReference : ""
 	ApplicationForm o|--}o Email : ""
+	ApplicationForm ||--|o PoolEligibleApplicationForm : ""
 	ApplicationForm ||--|o CandidatePoolApplication : ""
 	ApplicationForm ||--}o PreviousTeacherTraining : ""
 	ApplicationForm o|--|o ApplicationForm : ""
@@ -949,7 +948,7 @@ erDiagram
 	Subject ||--}o CourseSubject : ""
 	DataExport o|..|o "ActiveStorage::Blob" : ""
 	ProviderUser ||--}o DeferredOfferConfirmation : ""
-	Offer ||--}o DeferredOfferConfirmation : ""
+	Offer ||--|o DeferredOfferConfirmation : ""
 	Course ||--}o DeferredOfferConfirmation : ""
 	Site ||--}o DeferredOfferConfirmation : ""
 	CourseOption ||--}o DeferredOfferConfirmation : ""
@@ -1001,7 +1000,6 @@ erDiagram
 	Provider ||--}o "Publications::ProviderRecruitmentPerformanceReport" : ""
 	ProviderUser ||--}o ProviderAgreement : ""
 	ProviderUser ||--}o ProviderPermissions : ""
-	ApplicationForm ||--}o ProviderPoolAction : ""
 	ProviderUser ||--}o ProviderPoolAction : ""
 	ProviderUser o|--}o Note : ""
 	ProviderUser ||--}o RegionalReportFilter : ""

--- a/terraform/aks/workspace_variables/airbyte_stream_config.json
+++ b/terraform/aks/workspace_variables/airbyte_stream_config.json
@@ -4272,11 +4272,6 @@
           },
           {
             "fieldPath": [
-              "in_house_developers"
-            ]
-          },
-          {
-            "fieldPath": [
               "discarded_at"
             ]
           }


### PR DESCRIPTION
## Context

After some discussions we decided we don't need this column. It's not used anywhere.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
