### PR TITLE
Add is_send to courses

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -378,6 +378,7 @@ shared:
     - fee_domestic
     - salary_details
     - visa_sponsorship_application_deadline_at
+    - is_send
   email_clicks:
     - id
     - email_id

--- a/db/migrate/20260904153546_add_is_send_to_courses.rb
+++ b/db/migrate/20260904153546_add_is_send_to_courses.rb
@@ -1,0 +1,5 @@
+class AddIsSendToCourses < ActiveRecord::Migration[8.1]
+  def change
+    add_column :courses, :is_send, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -550,6 +550,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_155945) do
     t.integer "fee_international"
     t.string "financial_support"
     t.string "funding_type"
+    t.boolean "is_send", default: false
     t.string "level"
     t.string "name"
     t.string "program_type"

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -355,6 +355,7 @@ erDiagram
 		integer fee_international
 		string financial_support
 		string funding_type
+		boolean is_send
 		string level
 		string name
 		string program_type


### PR DESCRIPTION
## Context

- Add `is_send` to the `courses` table in the database to better align with the Publish API.

## Changes proposed in this pull request

- Add `is_send` to the `courses` table in the database.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
