### PR TITLE
Add is_send to candidate pool applications

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -208,6 +208,7 @@
   - subject_ids
   - rejected_provider_ids
   - course_funding_type_fee
+  - is_send
   :sessions:
   - id
   - candidate_id

--- a/db/migrate/20260904155945_add_is_send_to_candidate_pool_applications.rb
+++ b/db/migrate/20260904155945_add_is_send_to_candidate_pool_applications.rb
@@ -1,0 +1,5 @@
+class AddIsSendToCandidatePoolApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :candidate_pool_applications, :is_send, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_145931) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_04_155945) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -442,6 +442,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_145931) do
     t.boolean "course_type_postgraduate", default: false, null: false
     t.boolean "course_type_undergraduate", default: false, null: false
     t.datetime "created_at", null: false
+    t.boolean "is_send", default: false
     t.boolean "needs_visa", default: false, null: false
     t.bigint "rejected_provider_ids", default: [], null: false, array: true
     t.boolean "study_mode_full_time", default: false, null: false

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -312,6 +312,7 @@ erDiagram
 		boolean course_funding_type_fee
 		boolean course_type_postgraduate
 		boolean course_type_undergraduate
+		boolean is_send
 		boolean needs_visa
 		integer rejected_provider_ids
 		boolean study_mode_full_time
@@ -834,6 +835,7 @@ erDiagram
 		datetime discarded_at
 		string hashed_token
 		datetime last_used_at
+		integer vendor_id
 	}
 	VendorApiUser {
 		string email_address
@@ -1029,6 +1031,5 @@ erDiagram
 	Candidate o|--}o ValidationError : ""
 	ProviderUser o|--}o ValidationError : ""
 	SupportUser o|--}o ValidationError : ""
-	Vendor o|--}o VendorAPIToken : ""
 	Provider o|--}o VendorAPIRequestV2 : ""
 	VendorAPIToken ||--}o VendorApiUser : ""


### PR DESCRIPTION
## Context

- Add `is_send` to `candidate_pool_applications` table in the database. This will allow us to filter candidate by courses with SEND provisions.

## Changes proposed in this pull request

- Add `is_send` to `candidate_pool_applications` table in the database.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
