### PR TITLE
Remove qualification_status from english_proficiencies

### DIFF
--- a/db/migrate/20260907081806_remove_qualification_status_from_english_proficiencies.rb
+++ b/db/migrate/20260907081806_remove_qualification_status_from_english_proficiencies.rb
@@ -1,0 +1,5 @@
+class RemoveQualificationStatusFromEnglishProficiencies < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :english_proficiencies, :qualification_status, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_04_155945) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_081806) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -668,7 +668,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_155945) do
     t.boolean "no_qualification", default: false, null: false
     t.text "no_qualification_details"
     t.boolean "qualification_not_needed", default: false, null: false
-    t.string "qualification_status"
     t.datetime "updated_at", null: false
     t.index ["application_form_id"], name: "index_english_proficiencies_on_application_form_id"
     t.index ["degree_taught_in_english"], name: "index_english_proficiencies_on_degree_taught_in_english"


### PR DESCRIPTION
## Context

- Now we are certain Data Insights no longer need this column, remove `qualification_status` from `english_proficiencies`

## Changes proposed in this pull request

- Remove `qualification_status` from `english_proficiencies`


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
