### PR TITLE
Remove ignore qualification status code

### DIFF
--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -1,6 +1,4 @@
 class EnglishProficiency < ApplicationRecord
-  self.ignored_columns += [:qualification_status]
-
   include TouchApplicationChoices
 
   audited associated_with: :application_form


### PR DESCRIPTION
## Context

- Remove ignore code from `EnglishProficiency` regarding `qualification_status` column.

## Changes proposed in this pull request

- Remove ignore code from `EnglishProficiency` regarding `qualification_status` column.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
