### PR TITLE
Import SEND specialism when syncing courses

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -103,6 +103,7 @@ module TeacherTrainingPublicAPI
       course.fee_domestic = course_from_api.fee_domestic
       course.fee_international = course_from_api.fee_international
       course.funding_type = course_from_api.funding_type
+      course.is_send = course_from_api.is_send
       course.level = course_from_api.level
       course.name = course_from_api.name
       course.program_type = course_from_api.program_type

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
           visa_sponsorship_application_deadline_at: stubbed_sponsorship_application_deadline_at,
           applications_open_from: stubbed_applications_open_from,
           is_send: stubbed_is_send,
-        }
+        },
       ]
     end
     let(:stubbed_sponsorship_application_deadline_at) { nil }

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -13,9 +13,20 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
         updated_since:,
       )
     end
-    let(:stubbed_attributes) { [{ accredited_body_code: nil, state: stubbed_api_course_state, visa_sponsorship_application_deadline_at: stubbed_sponsorship_application_deadline_at, applications_open_from: stubbed_applications_open_from }] }
+    let(:stubbed_attributes) do
+      [
+        {
+          accredited_body_code: nil,
+          state: stubbed_api_course_state,
+          visa_sponsorship_application_deadline_at: stubbed_sponsorship_application_deadline_at,
+          applications_open_from: stubbed_applications_open_from,
+          is_send: stubbed_is_send,
+        }
+      ]
+    end
     let(:stubbed_sponsorship_application_deadline_at) { nil }
     let(:stubbed_applications_open_from) { nil }
+    let(:stubbed_is_send) { false }
 
     before do
       stub_teacher_training_api_courses(
@@ -290,6 +301,33 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses do
         expect(course.reload.open?).to be(true)
         expect(course.reload.course_status_open?).to be(true)
         expect(invite.reload.course_open).to be(false)
+      end
+    end
+
+    context 'when the course has a SEND specialism (is_send)' do
+      let(:stubbed_api_course_state) { 'published' }
+      let(:stubbed_is_send) { true }
+
+      it 'creates a course with a SEND specialism' do
+        perform_job
+
+        expect(provider.courses.where(is_send: true).count).to eq(1)
+      end
+
+      context 'when the course already exists' do
+        let(:uuid) { SecureRandom.uuid }
+        let!(:course) { create(:course, provider: provider, withdrawn: false, uuid: uuid, is_send: false) }
+        let(:stubbed_attributes) {
+          [
+            { accredited_body_code: nil, state: stubbed_api_course_state, uuid: uuid, is_send: true },
+          ]
+        }
+
+        it 'updates the course to have a SEND specialism' do
+          perform_job
+          course.reload
+          expect(course.is_send).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

- Import `is_send` attribute when syncing `courses`.

## Changes proposed in this pull request

- Add `is_send` to `TeacherTrainingPublicAPI::SyncCourses` worker.

## Guidance to review

- Run `bin/setup` which calls: 
```ruby
TeacherTrainingPublicAPI::SyncCourses.set(wait: @delay_by).perform_later(
          provider.id,
          @recruitment_cycle_year,
          updated_since:,
        )
```
- in the rails console run `Course.where(is_send: true).count`, you should result with some SEND courses. (I get 21)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
