### PR TITLE
Add fraud matches to analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -641,3 +641,14 @@ shared:
     - updated_at
     - winter_reject_by_default_at
     - winter_decline_by_default_at
+  fraud_matches:
+    - id
+    - candidate_last_contacted_at
+    - recruitment_cycle_year
+    - last_name
+    - date_of_birth
+    - postcode
+    - blocked
+    - created_at
+    - updated_at
+    - resolved

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -379,17 +379,6 @@
   :english_proficiencies:
   - no_qualification_details
   - no_assessment_plan_details
-  :fraud_matches:
-  - id
-  - candidate_last_contacted_at
-  - recruitment_cycle_year
-  - last_name
-  - date_of_birth
-  - postcode
-  - blocked
-  - created_at
-  - updated_at
-  - resolved
   :data_migrations:
   - id
   - service_name

--- a/terraform/aks/workspace_variables/airbyte_stream_config.json
+++ b/terraform/aks/workspace_variables/airbyte_stream_config.json
@@ -2318,11 +2318,6 @@
           },
           {
             "fieldPath": [
-              "is_send"
-            ]
-          },
-          {
-            "fieldPath": [
               "level"
             ]
           },
@@ -2444,6 +2439,11 @@
           {
             "fieldPath": [
               "visa_sponsorship_application_deadline_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "is_send"
             ]
           }
         ]
@@ -4426,6 +4426,85 @@
           {
             "fieldPath": [
               "winter_decline_by_default_at"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "fraud_matches",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "candidate_last_contacted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "recruitment_cycle_year"
+            ]
+          },
+          {
+            "fieldPath": [
+              "last_name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "date_of_birth"
+            ]
+          },
+          {
+            "fieldPath": [
+              "postcode"
+            ]
+          },
+          {
+            "fieldPath": [
+              "blocked"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "resolved"
             ]
           }
         ]


### PR DESCRIPTION
## Context

The analytics team needs access to the duplicates table (fraud_matches). 

## Changes proposed in this pull request

fraud_matches table added to the analytics list and the airbyte_stream_config list.

## Guidance to review




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
