### PR TITLE
Save the body of every response in VendorAPIRequest table

### DIFF
--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -46,8 +46,6 @@ private
   end
 
   def response_hash(response_body, status)
-    return {} unless status > 299
-
     JSON.parse(response_body)
   rescue JSON::ParserError
     { body: "#{status} did not respond with JSON" }

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe VendorAPIRequestWorker do
     expect(vendor_api_request.response_body).to eq({ 'that' => 'this' })
   end
 
+  it 'saves body when status is 200' do
+    described_class.new.perform(
+      { 'path' => '/api/v1/foo' },
+      { 'headers' => { 'this' => 'that' }, 'body' => { 'that' => 'this' }.to_json },
+      200,
+      stringified_time,
+    )
+
+    vendor_api_request = VendorAPIRequestV2.find_by(request_path: '/api/v1/foo')
+
+    expect(vendor_api_request.response_headers).to eq({ 'this' => 'that' })
+    expect(vendor_api_request.response_body).to eq({ 'that' => 'this' })
+  end
+
   it 'saves the request method on the vendor api request' do
     described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, stringified_time)
 


### PR DESCRIPTION
## Context

Previously, we didn't save the response of a 200 vendor request in VendorAPIRequest. This will save every response. 

This way, we can better monitor our API.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
