### PR TITLE
EOC content improvements to clarify what will happen

### DIFF
--- a/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.html.erb
@@ -1,3 +1,7 @@
+<p class="govuk-body">
+  You can still manage existing applications and respond to offers.
+</p>
+
 <% if render_heading %>
   <h2 class="govuk-heading-l">
     <%= heading %>

--- a/app/components/candidate_interface/application_choices/september_start_content_component.rb
+++ b/app/components/candidate_interface/application_choices/september_start_content_component.rb
@@ -29,7 +29,7 @@ class CandidateInterface::ApplicationChoices::SeptemberStartContentComponent < A
     @awaiting_provider_decision_content ||= {
       title: I18n.t('candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.title'),
       content: I18n.t(
-        'candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.rejected automatically',
+        'candidate_interface.application_choices.september_start_component.awaiting_provider_decision_content.rejected_automatically',
         reject_by: recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first),
       ),
     }

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -43,7 +43,7 @@ en:
       name: Unknown!
       description: This application is in a state that we do not recognise. Please report this to a developer.
   candidate_application_states:
-    awaiting_provider_decision: Awaiting decision
+    awaiting_provider_decision: Awaiting provider decision
     inactive: Inactive
     interviewing: Interviewing
     cancelled: Application cancelled

--- a/config/locales/components/candidate_interface/application_choices/january_start_content_component.yml
+++ b/config/locales/components/candidate_interface/application_choices/january_start_content_component.yml
@@ -9,11 +9,11 @@ en:
         awaiting_provider_decision_content:
           title: Applications awaiting a provider decision
           rejected automatically:
-            Applications will be rejected automatically at %{reject_by} if providers do not respond.
+            Providers must make a decision on these applications by %{reject_by}. If a provider does not respond by then, the application will be rejected automatically.
         reject_by_default_explanation: Some of your applications have been rejected because the provider did not respond before the deadline.
         decline_by_default_explanation: Some of your offers have been declined because you did not respond before the deadline.
         offered_content:
           title: Offers awaiting your response
           declined automatically:
-            Offers will be declined automatically at %{decline_by} if you do not respond.
+            You must respond to offers by %{decline_by}. If you do not respond by then, they will be declined automatically.
 

--- a/config/locales/components/candidate_interface/application_choices/september_start_content_component.yml
+++ b/config/locales/components/candidate_interface/application_choices/september_start_content_component.yml
@@ -6,8 +6,8 @@ en:
         heading_single_start_month: Courses starting in %{month_and_year}
         awaiting_provider_decision_content:
           title: Applications awaiting a provider decision
-          rejected automatically:
-            Applications will be rejected automatically at %{reject_by} if providers do not respond.
+          rejected_automatically:
+            Providers must make a decision on these applications by %{reject_by}. If a provider does not respond by then, the application will be rejected automatically.
         reject_by_default_explanation:
           Some of your applications have been rejected because the provider did not respond before the deadline.
         decline_by_default_explanation:
@@ -15,4 +15,4 @@ en:
         offered_content:
           title: Offers awaiting your response
           declined_automatically:
-            Offers will be declined automatically at %{decline_by} if you do not respond.
+            You must respond to offers by %{decline_by}. If you do not respond by then, they will be declined automatically.

--- a/spec/components/candidate_interface/after_deadline_content_component_spec.rb
+++ b/spec/components/candidate_interface/after_deadline_content_component_spec.rb
@@ -65,9 +65,13 @@ RSpec.describe CandidateInterface::AfterDeadlineContentComponent do
       travel_temporarily_to(application_form.reject_by_default_at - 1.day) do
         component = render_inline(described_class.new(application_form:))
         expect(component).to have_no_link('Choose a course', class: 'govuk-button')
-        expect(component).to have_text application_form.reject_by_default_at.to_fs(:govuk_date_time_time_first)
         expect(component).to have_text(
-          'Applications awaiting a provider decision Applications will be rejected automatically',
+          'Applications awaiting a provider decision',
+        )
+        expect(component).to have_text(
+          'Providers must make a decision on these applications by ' \
+          "#{application_form.reject_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+          'If a provider does not respond by then, the application will be rejected automatically.',
         )
       end
     end
@@ -100,9 +104,10 @@ RSpec.describe CandidateInterface::AfterDeadlineContentComponent do
       travel_temporarily_to(application_form.decline_by_default_at - 1.day) do
         component = render_inline(described_class.new(application_form:))
         expect(component).to have_no_link('Choose a course', class: 'govuk-button')
-        expect(component).to have_text(application_form.decline_by_default_at.to_fs(:govuk_date_time_time_first))
         expect(component).to have_text(
-          "Offers will be declined automatically at #{application_form.decline_by_default_at.to_fs(:govuk_date_time_time_first)} if you do not respond.",
+          'You must respond to offers by ' \
+          "#{application_form.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+          'If you do not respond by then, they will be declined automatically.',
         )
       end
     end

--- a/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_choices/september_start_content_component_spec.rb
@@ -71,8 +71,9 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
           )
           expect(rendered_component).to have_element(
             :p,
-            text: 'Applications will be rejected automatically at ' \
-                  "#{recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)} if providers do not respond.",
+            text: 'Providers must make a decision on these applications by ' \
+                  "#{recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+                  'If a provider does not respond by then, the application will be rejected automatically.',
             class: 'govuk-body',
           )
         end
@@ -89,8 +90,9 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
           )
           expect(rendered_component).to have_element(
             :p,
-            text: 'Offers will be declined automatically at ' \
-                  "#{recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)} if you do not respond.",
+            text: 'You must respond to offers by ' \
+                  "#{recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+                  'If you do not respond by then, they will be declined automatically.',
             class: 'govuk-body',
           )
         end
@@ -150,8 +152,9 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
         content = component.awaiting_provider_decision_content
         expect(content[:title]).to eq('Applications awaiting a provider decision')
         expect(content[:content]).to eq(
-          'Applications will be rejected automatically at ' \
-          "#{recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)} if providers do not respond.",
+          'Providers must make a decision on these applications by ' \
+          "#{recruitment_cycle_timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+          'If a provider does not respond by then, the application will be rejected automatically.',
         )
       end
     end
@@ -225,8 +228,9 @@ RSpec.describe CandidateInterface::ApplicationChoices::SeptemberStartContentComp
         content = component.offered_content
         expect(content[:title]).to eq('Offers awaiting your response')
         expect(content[:content]).to eq(
-          'Offers will be declined automatically at ' \
-          "#{recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)} if you do not respond.",
+          'You must respond to offers by ' \
+          "#{recruitment_cycle_timetable.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+          'If you do not respond by then, they will be declined automatically.',
         )
       end
     end

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
         described_class.new(application_form:, editable: false, show_status: true),
       )
 
-      expect(rendered_component).to summarise(key: 'Status', value: 'Awaiting decision Application submitted today. If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.')
+      expect(rendered_component).to summarise(key: 'Status', value: 'Awaiting provider decision Application submitted today. If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.')
     end
 
     it 'renders component with a withdraw link' do

--- a/spec/components/candidate_interface/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/application_review_component_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe CandidateInterface::ApplicationReviewComponent do
     it_behaves_like 'course start date row'
 
     it 'shows the application status' do
-      expect(result.text).to include('StatusAwaiting decision')
+      expect(result.text).to include('StatusAwaiting provider decision')
     end
 
     it 'does not show change links' do

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, :mid_cycle, typ
       result = render_inline(described_class.new(application_form:, show_status: true))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Awaiting decision')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Awaiting provider decision')
     end
 
     it 'renders component with a withdraw link' do

--- a/spec/components/candidate_interface/multiple_active_applications_content_component_spec.rb
+++ b/spec/components/candidate_interface/multiple_active_applications_content_component_spec.rb
@@ -89,8 +89,9 @@ RSpec.describe CandidateInterface::MultipleActiveApplicationsContentComponent do
           )
           expect(rendered_component).to have_element(
             :p,
-            text: 'Applications will be rejected automatically at ' \
-                  "#{previous_application.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)} if providers do not respond.",
+            text: 'Providers must make a decision on these applications by ' \
+                  "#{previous_application.winter_reject_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+                  'If a provider does not respond by then, the application will be rejected automatically.',
             class: 'govuk-body',
           )
         end
@@ -107,8 +108,9 @@ RSpec.describe CandidateInterface::MultipleActiveApplicationsContentComponent do
           )
           expect(rendered_component).to have_element(
             :p,
-            text: 'Offers will be declined automatically at ' \
-                  "#{previous_application.recruitment_cycle_timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first)} if you do not respond.",
+            text: 'You must respond to offers by ' \
+                  "#{previous_application.recruitment_cycle_timetable.winter_decline_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+                  'If you do not respond by then, they will be declined automatically.',
             class: 'govuk-body',
           )
         end

--- a/spec/components/previews/candidate_interface/application_choices/september_start_content_component_preview.rb
+++ b/spec/components/previews/candidate_interface/application_choices/september_start_content_component_preview.rb
@@ -3,15 +3,6 @@ class CandidateInterface::ApplicationChoices::SeptemberStartContentComponentPrev
     render PreviewSeptemberStartContentComponent.new(application_form:)
   end
 
-  def what_happens_next?
-    render PreviewSeptemberStartContentComponent.new(
-      application_form:,
-      heading: 'What happens next?',
-      heading_class: 'govuk-heading-m',
-      with_tabs: true,
-    )
-  end
-
   def after_reject_by_default
     render PreviewSeptemberStartContentComponent.new(application_form:, choice_state: :rejected_by_default)
   end
@@ -31,8 +22,8 @@ private
   end
 
   class PreviewSeptemberStartContentComponent < CandidateInterface::ApplicationChoices::SeptemberStartContentComponent
-    def initialize(application_form:, heading: nil, heading_class: 'govuk-heading-l', choice_state: :awaiting_provider_decision, with_tabs: false)
-      super(application_form:, heading:, heading_class:, with_tabs:)
+    def initialize(application_form:, choice_state: :awaiting_provider_decision, with_tabs: false)
+      super(application_form:, with_tabs:)
       @choice_state = choice_state
     end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -216,7 +216,7 @@ private
   end
 
   def then_my_application_is_awaiting_provider_decision
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
     expect(application_choice.status).to eq('awaiting_provider_decision')
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -148,7 +148,9 @@ private
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_text('Offers awaiting your response')
     expect(page).to have_text(
-      "Offers will be declined automatically at #{@application_form.decline_by_default_at.to_fs(:govuk_date_time_time_first)} if you do not respond.",
+      'You must respond to offers by ' \
+      "#{@application_form.decline_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+      'If you do not respond by then, they will be declined automatically.',
     )
   end
   alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -92,7 +92,7 @@ private
 
   def then_i_see_my_application_is_awaiting_provider_decision
     expect(page).to have_current_path candidate_interface_application_choices_path
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
   end
 
   def then_i_see_my_application_is_inactive
@@ -112,7 +112,9 @@ private
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_text('Applications awaiting a provider decision ')
     expect(page).to have_text(
-      "Applications awaiting a provider decision Applications will be rejected automatically at #{@timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)} if providers do not respond",
+      'Providers must make a decision on these applications by ' \
+      "#{@timetable.reject_by_default_at.to_fs(:govuk_date_time_time_first)}. " \
+      'If a provider does not respond by then, the application will be rejected automatically.',
     )
   end
   alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -41,7 +41,7 @@ private
   def then_i_see_my_applications_page
     expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_text 'Your applications'
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
   end
 
   def and_i_can_view_the_application
@@ -53,7 +53,7 @@ private
         ),
       )
     expect(page).to have_title("Your application to #{@application_choice.provider.name}")
-    expect(page).to have_text('Awaiting decision')
+    expect(page).to have_text('Awaiting provider decision')
   end
 
   def when_i_withdraw_my_application

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -195,13 +195,13 @@ RSpec.describe 'Candidate submits the application' do
     expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
     expect(page).to have_text 'Gorse SCITT'
     expect(page).to have_text 'Primary (2XT2)'
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
   end
 
   def then_i_can_review_my_submitted_application
     expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
     expect(page).to have_text 'Gorse SCITT'
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
     expect(page).to have_text @application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time)
     expect(page).to have_text 'Primary (2XT2)'
     expect(page).to have_text 'Full time'

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -119,13 +119,13 @@ RSpec.describe 'Candidate submits the application' do
     expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
     expect(page).to have_text 'Gorse SCITT'
     expect(page).to have_text 'Primary (2XT2)'
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
   end
 
   def then_i_can_review_my_submitted_application
     expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
     expect(page).to have_text 'Gorse SCITT'
-    expect(page).to have_text 'Awaiting decision'
+    expect(page).to have_text 'Awaiting provider decision'
     expect(page).to have_text @application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time)
     expect(page).to have_text 'Primary (2XT2)'
     expect(page).to have_text 'Full time'


### PR DESCRIPTION
## Context

- Amend EOC content to better clarify what will happen to certain applications.

## Changes proposed in this pull request

- Content changes to the EOC September and January start components.

## Guidance to review

**September Start Component**
_Awaiting provider decision_
- Visit https://apply-review-12316.test.teacherservices.cloud/rails/view_components/candidate_interface/application_choices/september_start_content_component/applications_awaiting_provider_decisions

_Offer_
- Visit https://apply-review-12316.test.teacherservices.cloud/rails/view_components/candidate_interface/application_choices/september_start_content_component/applications_offered

**January Start Component**
_Awaiting provider decision_
- Visit https://apply-review-12316.test.teacherservices.cloud/rails/view_components/candidate_interface/application_choices/january_start_content_component/winter_reject_by_default_approaching_awaiting_provider_decision

_Offer_
- Visit https://apply-review-12316.test.teacherservices.cloud/rails/view_components/candidate_interface/application_choices/january_start_content_component/winter_reject_by_default_approaching_offered_placement

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/h8eMZujy/2091-jan-starts-not-always-clear-which-deadlines-apply-to-which-applications

## Screenshots

**September Start Component**
_Awaiting provider decision_
<img width="1320" height="867" alt="screencapture-apply-review-12316-test-teacherservices-cloud-rails-view-components-candidate-interface-application-choices-september-start-content-component-applications-awaiting-provider-decisions-2026-09-08-15_16_33" src="https://github.com/user-attachments/assets/af725830-6b25-450e-8eef-8adca07c08b9" />

_Offer_
<img width="1320" height="867" alt="screencapture-apply-review-12316-test-teacherservices-cloud-rails-view-components-candidate-interface-application-choices-september-start-content-component-applications-offered-2026-09-08-15_17_05" src="https://github.com/user-attachments/assets/437910e6-71aa-42aa-85bf-94400da20e60" />

**January Start Component**
_Awaiting provider decision_
<img width="1320" height="857" alt="screencapture-apply-review-12316-test-teacherservices-cloud-rails-view-components-candidate-interface-application-choices-january-start-content-component-winter-reject-by-default-approaching-awaiting-provider-decision-2026-09-08-15_17_41" src="https://github.com/user-attachments/assets/6cb5c0f4-469d-4e86-bfa8-cc25cd26392e" />

_Offer_
<img width="1320" height="857" alt="screencapture-apply-review-12316-test-teacherservices-cloud-rails-view-components-candidate-interface-application-choices-january-start-content-component-winter-reject-by-default-approaching-offered-placement-2026-09-08-15_18_11" src="https://github.com/user-attachments/assets/de0ffc86-20fc-4946-aea6-28e1e9e9e17e" />
