### PR TITLE
Add previous last names to hidden pii list

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -7,6 +7,7 @@ shared:
     - first_name
     - last_name
     - date_of_birth
+    - previous_last_names
   candidates:
     - id
     - email_address


### PR DESCRIPTION
## Context

The previous_last_names column was missing from the analytics hidden pii list

## Changes proposed in this pull request

Add the relevant column to the hidden pii list. 

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
