### PR TITLE
Jan Start/Find: Add previous find course url

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -85,6 +85,8 @@ module CandidateInterface
     end
 
     def course_row(application_choice)
+      return if course_row_value(application_choice).blank?
+
       {
         key: 'Course',
         value: course_row_value(application_choice),
@@ -109,15 +111,15 @@ module CandidateInterface
     end
 
     def course_row_value(application_choice)
-      if current_timetable.after_find_closes?
-        "#{application_choice.current_course.name} (#{application_choice.current_course.code})"
-      else
-        govuk_link_to(
-          "#{application_choice.current_course.name} (#{application_choice.current_course.code})",
-          application_choice.current_course.find_url,
-          new_tab: true,
-        )
-      end
+      @course_row_value ||= if current_timetable.after_find_closes?
+                              "#{application_choice.current_course.name} (#{application_choice.current_course.code})"
+                            elsif application_choice.current_course.find_url.present?
+                              govuk_link_to(
+                                "#{application_choice.current_course.name} (#{application_choice.current_course.code})",
+                                application_choice.current_course.find_url,
+                                new_tab: true,
+                              )
+                            end
     end
 
     def location_row(application_choice)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,7 +7,7 @@ class Course < ApplicationRecord
   has_many :course_subjects, dependent: nil
   has_many :subjects, through: :course_subjects
   has_one :recruitment_cycle_timetable, primary_key: :recruitment_cycle_year, foreign_key: :recruitment_cycle_year, dependent: nil
-  delegate :next_year?, :find_opens_at, to: :recruitment_cycle_timetable
+  delegate :next_year?, :find_opens_at, :current_year?, :previous_year?, to: :recruitment_cycle_timetable
 
   belongs_to :accredited_provider, class_name: 'Provider', optional: true
 
@@ -157,7 +157,19 @@ class Course < ApplicationRecord
             I18n.t('find_teacher_training.production_url')
           end
 
-    "#{url}course/#{provider.code}/#{code}"
+    if current_year?
+      "#{url}course/#{provider.code}/#{code}"
+    elsif previous_year? && after_september? && after_minimum_prev_find_cycle?
+      "#{url}course/#{provider.code}/#{code}/cycle/#{recruitment_cycle_year}"
+    end
+  end
+
+  def after_september?
+    start_date > Date.new(recruitment_cycle_year.to_i, 9, 30).at_end_of_day
+  end
+
+  def after_minimum_prev_find_cycle?
+    recruitment_cycle_year.to_i >= 2026
   end
 
   def in_previous_cycle

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Course do
+  include ActiveSupport::Testing::TimeHelpers
+
   subject(:course) { build(:course) }
 
   describe 'a valid course' do
@@ -190,14 +192,70 @@ RSpec.describe Course do
   end
 
   describe '#find_url' do
-    let(:course) { create(:course) }
+    let(:course) { create(:course, recruitment_cycle_year:, start_date:) }
+    let(:recruitment_cycle_year) { RecruitmentCycleTimetable.current_year }
+    let(:start_date) { "01/09/#{recruitment_cycle_year}" }
 
     it 'returns the sandbox url when in sandbox', :sandbox do
       expect(course.find_url).to include('sandbox')
+      expect(course.find_url).to eq(
+        "#{I18n.t('find_teacher_training.sandbox_url')}course/#{course.provider.code}/#{course.code}",
+      )
     end
 
     it 'returns the production url when not in sandbox', sandbox: false do
       expect(course.find_url).not_to include('sandbox')
+      expect(course.find_url).to eq(
+        "#{I18n.t('find_teacher_training.production_url')}course/#{course.provider.code}/#{course.code}",
+      )
+    end
+
+    context 'when the course is in the previous cycle', sandbox: false do
+      let(:recruitment_cycle_year) { 2026 }
+
+      context 'when the course starts after september' do
+        let(:start_date) { "01/10/#{recruitment_cycle_year}" }
+
+        it 'return the production url with the cycle argument' do
+          travel_to Time.zone.parse('2027-01-01 12:00:00') do
+            expect(course.find_url).to eq(
+              "#{I18n.t('find_teacher_training.production_url')}course/#{course.provider.code}/#{course.code}/cycle/#{recruitment_cycle_year}",
+            )
+          end
+        end
+      end
+
+      context 'when the course starts during september' do
+        let(:start_date) { "01/09/#{recruitment_cycle_year}" }
+
+        it 'return nil' do
+          travel_to Time.zone.parse('2027-01-01 12:00:00') do
+            expect(course.find_url).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when the course is in a recruitment cycle before 2026' do
+      let(:recruitment_cycle_year) { 2025 }
+      let(:start_date) { "01/01/#{recruitment_cycle_year.next}" }
+
+      it 'return nil' do
+        travel_to Time.zone.parse('2027-01-01 12:00:00') do
+          expect(course.find_url).to be_nil
+        end
+      end
+    end
+
+    context 'when the course is in the a recruitment cycle before the previous cycle' do
+      let(:recruitment_cycle_year) { 2026 }
+      let(:start_date) { "01/01/#{recruitment_cycle_year.next}" }
+
+      it 'return nil' do
+        travel_to Time.zone.parse('2028-01-01 12:00:00') do
+          expect(course.find_url).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -259,6 +259,54 @@ RSpec.describe Course do
     end
   end
 
+  describe '#after_september?' do
+    context 'when the course starts after september' do
+      let(:recruitment_cycle_year) { 2026 }
+      let(:course) { create(:course, recruitment_cycle_year:, start_date: "01/10/#{recruitment_cycle_year}") }
+
+      it 'returns true' do
+        expect(course.after_september?).to be(true)
+      end
+    end
+
+    context 'when the course starts during september' do
+      let(:recruitment_cycle_year) { 2026 }
+      let(:course) { create(:course, recruitment_cycle_year:, start_date: "01/09/#{recruitment_cycle_year}") }
+
+      it 'returns true' do
+        expect(course.after_september?).to be(false)
+      end
+    end
+  end
+
+  describe '#after_minimum_prev_find_cycle?' do
+    let(:course) { create(:course, recruitment_cycle_year:) }
+
+    context 'when the recruitment cycle year is before 2026' do
+      let(:recruitment_cycle_year) { 2025 }
+
+      it 'returns false' do
+        expect(course.after_minimum_prev_find_cycle?).to be(false)
+      end
+    end
+
+    context 'when the recruitment cycle year is 2026' do
+      let(:recruitment_cycle_year) { 2026 }
+
+      it 'returns true' do
+        expect(course.after_minimum_prev_find_cycle?).to be(true)
+      end
+    end
+
+    context 'when the recruitment cycle year after 2026' do
+      let(:recruitment_cycle_year) { 2027 }
+
+      it 'returns true' do
+        expect(course.after_minimum_prev_find_cycle?).to be(true)
+      end
+    end
+  end
+
   describe '#description_and_accredited_provider' do
     context 'when there is an accredited provider set' do
       let(:course) { build(:course, accredited_provider: build(:provider)) }


### PR DESCRIPTION
## Context

- Add conditional logic to return the Find URL for courses in the previous recruitment cycle.

## Changes proposed in this pull request

-  Add conditional logic to return the Find URL for courses in the previous recruitment cycle.

## Guidance to review

- Hard to test due to current restrictive logic in Find.
- Check that the code looks correct.


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency

## Trello

https://trello.com/c/kkPhAmkA/2150-jan-starts-view-courses-on-find-from-a-previous-year