### PR TITLE
Add course ids to candidate pool applications

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -209,6 +209,7 @@
   - rejected_provider_ids
   - course_funding_type_fee
   - is_send
+  - course_ids
   :sessions:
   - id
   - candidate_id

--- a/db/migrate/20260911120634_add_course_ids_to_candidate_pool_applications.rb
+++ b/db/migrate/20260911120634_add_course_ids_to_candidate_pool_applications.rb
@@ -1,0 +1,5 @@
+class AddCourseIdsToCandidatePoolApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :candidate_pool_applications, :course_ids, :bigint, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_09_104412) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_120634) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -439,6 +439,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_09_104412) do
     t.bigint "application_form_id", null: false
     t.bigint "candidate_id", null: false
     t.boolean "course_funding_type_fee"
+    t.bigint "course_ids", default: [], null: false, array: true
     t.boolean "course_type_postgraduate", default: false, null: false
     t.boolean "course_type_undergraduate", default: false, null: false
     t.datetime "created_at", null: false

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -310,6 +310,7 @@ erDiagram
 	}
 	CandidatePoolApplication {
 		boolean course_funding_type_fee
+		integer course_ids
 		boolean course_type_postgraduate
 		boolean course_type_undergraduate
 		boolean is_send


### PR DESCRIPTION
## Context

- Extract database migration from https://github.com/DFE-Digital/apply-for-teacher-training/pull/12327
- Add `course_ids` to `candidate_pool_applications` table.

## Changes proposed in this pull request

- Add `course_ids` to `candidate_pool_applications` table.

## Guidance to review

- Check the database migration

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
- [ ] This code adds a column or table to the database
  - [ ] This code does not rely on migrations in the same Pull Request
  - [ ] decide whether it needs to be in analytics yml file or analytics blocklist
  - [ ] data insights team has been informed of the change and have updated the pipeline
  - [ ] the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated
  - [ ] does the code safely backfill existing records for consistency
