### PR TITLE
Lb/2160 data model for structured relevant subject data for degrees

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -68,6 +68,7 @@ class ApplicationQualification < ApplicationRecord
 
   belongs_to :application_form, touch: true
   has_one :candidate, through: :application_form
+  has_many :degree_subject_groups, dependent: :destroy
 
   scope :degrees, -> { where(level: 'degree') }
   scope :gcses, -> { where(level: 'gcse') }

--- a/app/models/degree_subject_group.rb
+++ b/app/models/degree_subject_group.rb
@@ -1,0 +1,3 @@
+class DegreeSubjectGroup < ApplicationRecord
+  belongs_to :application_qualification
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -652,3 +652,10 @@ shared:
     - created_at
     - updated_at
     - resolved
+  degree_subject_groups:
+    - id
+    - application_qualification_id
+    - name
+    - subject_group_uuid
+    - created_at
+    - updated_at

--- a/config/initializers/degree_subject_relevancy_groups.rb
+++ b/config/initializers/degree_subject_relevancy_groups.rb
@@ -1,0 +1,44 @@
+require 'dfe/reference_data/hardcoded_reference_list'
+
+module DfE
+  module ReferenceData
+    module DegreeSubjectRelevancyGroups
+      SUBJECT_GROUPS_SCHEMA = {
+        id: :string,
+        name: :string,
+      }.freeze
+
+      SUBJECT_GROUPS = HardcodedReferenceList.new(
+        {
+          '184896e8-4402-4211-85d3-9dff8259e294' => { name: 'Ancient Languages' },
+          'a2028760-4423-483d-8e34-86583876848c' => { name: 'Art and design' },
+          '4d782fe1-c896-436e-86b1-a6b6156780fd' => { name: 'Biology' },
+          '232f0713-29e7-4701-a30a-98b1f3b29e46' => { name: 'Business studies' },
+          'd7f1c6ec-0fca-40dc-ac40-42f4f612f330' => { name: 'Chemistry' },
+          '2b4fe6c8-3a57-4b32-9fda-5f06f45a96af' => { name: 'Citizenship' },
+          '9f1955aa-877e-424e-9781-964add16a289' => { name: 'Classics' },
+          '16b8b6c4-0ca8-4b85-81eb-6a75eaaa3db3' => { name: 'Communication and media studies' },
+          '74f15e5b-d9eb-4cd3-999d-b9de44882845' => { name: 'Computing' },
+          '5985133d-921e-4777-b97c-4387607fcc5c' => { name: 'Dance' },
+          '3cfa92d4-31ad-4714-b603-5ec408b99bb2' => { name: 'Design and technology' },
+          '5412cd5e-7344-4ebb-8748-dc93e36e4685' => { name: 'Drama' },
+          '3ca9e7ec-0cc5-47d6-8a4e-e47bf90f4186' => { name: 'Economics' },
+          '7e9e52d0-09bc-4a78-88b6-7b22e8fda6ac' => { name: 'English' },
+          '3e74e24c-656a-40f1-9bae-042213e5fb5f' => { name: 'Geography' },
+          'ccdc5b0d-b26e-4609-97ce-75ffe45b55ae' => { name: 'Health and social care' },
+          'b0c5eb9e-6354-490f-8595-e525af1e7975' => { name: 'History' },
+          '9819461c-d4b5-43c5-bf87-b5c08c01e1ae' => { name: 'Mathematics' },
+          '9c7f1516-4fc0-480c-9d84-c4627ebd3c05' => { name: 'Modern foreign languages' },
+          '56de0e2f-c5dd-4c40-874a-e50744f8c5a3' => { name: 'Music' },
+          '06d573a8-c662-47bc-976a-11fe2c91e264' => { name: 'Philosophy' },
+          '57e0d6bd-6b3e-4fbd-8060-5c4b01f23da3' => { name: 'Physical education' },
+          '047bf5ad-9d32-437f-8f69-7314829d99bd' => { name: 'Physics' },
+          '6968c8ea-254c-4c63-b91c-9d90ac28c683' => { name: 'Psychology' },
+          'e63aac7d-5e98-49df-a17e-4c599b16ca7d' => { name: 'Religious education' },
+          '2f3681f6-3d05-46a8-969c-ed6f11ad0a8f' => { name: 'Social sciences' },
+          schema: SUBJECT_GROUPS_SCHEMA,
+        },
+      )
+    end
+  end
+end

--- a/db/migrate/20260911151930_add_degree_subject_group_table.rb
+++ b/db/migrate/20260911151930_add_degree_subject_group_table.rb
@@ -1,0 +1,10 @@
+class AddDegreeSubjectGroupTable < ActiveRecord::Migration[8.1]
+  def change
+    create_table :degree_subject_groups do |t|
+      t.string :name
+      t.string :subject_group_uuid
+      t.references :application_qualification, null: false, foreign_key: { on_delete: :cascade }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_120634) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_151930) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -605,6 +605,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_120634) do
     t.index ["offered_course_option_id"], name: "index_deferred_offer_confirmations_on_offered_course_option_id"
     t.index ["provider_user_id"], name: "index_deferred_offer_confirmations_on_provider_user_id"
     t.index ["site_id"], name: "index_deferred_offer_confirmations_on_site_id"
+  end
+
+  create_table "degree_subject_groups", force: :cascade do |t|
+    t.bigint "application_qualification_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.string "subject_group_uuid"
+    t.datetime "updated_at", null: false
+    t.index ["application_qualification_id"], name: "index_degree_subject_groups_on_application_qualification_id"
   end
 
   create_table "deleted_candidates", force: :cascade do |t|
@@ -1476,6 +1485,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_120634) do
   add_foreign_key "deferred_offer_confirmations", "offers", on_delete: :cascade
   add_foreign_key "deferred_offer_confirmations", "provider_users"
   add_foreign_key "deferred_offer_confirmations", "sites"
+  add_foreign_key "degree_subject_groups", "application_qualifications", on_delete: :cascade
   add_foreign_key "email_clicks", "emails", on_delete: :cascade
   add_foreign_key "emails", "application_forms", on_delete: :cascade
   add_foreign_key "interviews", "application_choices", on_delete: :cascade

--- a/docs/domain-model.mmd
+++ b/docs/domain-model.mmd
@@ -426,6 +426,10 @@ erDiagram
 		integer site_id
 		string study_mode
 	}
+	DegreeSubjectGroup {
+		string name
+		string subject_group_uuid
+	}
 	DeletedCandidate {
 		integer candidate_id
 		jsonb deleted_records
@@ -909,6 +913,7 @@ erDiagram
 	ApplicationForm ||--}o EnglishProficiency : ""
 	ApplicationForm ||--}o "Pool::Invite" : ""
 	ApplicationQualification o|..}o Candidate : ""
+	ApplicationQualification ||--}o DegreeSubjectGroup : ""
 	ApplicationReference ||--}o ReferenceToken : ""
 	ApplicationReference o|..}o Candidate : ""
 	Candidate ||--}o AuthenticationToken : ""

--- a/terraform/aks/workspace_variables/airbyte_stream_config.json
+++ b/terraform/aks/workspace_variables/airbyte_stream_config.json
@@ -4510,6 +4510,65 @@
         ]
       },
       {
+        "name": "degree_subject_groups",
+        "syncMode": "incremental_append",
+        "cursorField": [
+          "_ab_cdc_lsn"
+        ],
+        "primaryKey": [
+          [
+            "id"
+          ]
+        ],
+        "selectedFields": [
+          {
+            "fieldPath": [
+              "_ab_cdc_lsn"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_deleted_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "_ab_cdc_updated_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "application_qualification_id"
+            ]
+          },
+          {
+            "fieldPath": [
+              "name"
+            ]
+          },
+          {
+            "fieldPath": [
+              "subject_group_uuid"
+            ]
+          },
+          {
+            "fieldPath": [
+              "created_at"
+            ]
+          },
+          {
+            "fieldPath": [
+              "updated_at"
+            ]
+          }
+        ]
+      },
+      {
         "name": "airbyte_heartbeat",
         "syncMode": "full_refresh_overwrite",
         "primaryKey": [


### PR DESCRIPTION
## Context

We will be asking candidates who enter free text for a degree subject to tell us what subject it is most relevant to. 

## Changes proposed in this pull request

This PR 
- creates a table for the degree subjects 
- and adds it to the airbyte and analytics data
- and captures the reference data that will be used to populate the tables. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
- [x] This code adds a column or table to the database
  - [x] This code does not rely on migrations in the same Pull Request
  - [x] decide whether it needs to be in analytics yml file or analytics blocklist
  - [x] data insights team has been informed of the change and have updated the pipeline
  - [ ] does the code safely backfill existing records for consistency
